### PR TITLE
[GPU] Treat clip==inf as no-clip in sequence/cell OneDNN gates

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
@@ -91,8 +91,10 @@ bool check_WRB(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared_ptr<
 bool is_equal_clip(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared_ptr<op_util::RNNCellBase>& cell_2) {
     const auto clip_1 = cell_1->get_clip();
     const auto clip_2 = cell_2->get_clip();
-    if (op_util::is_no_clip(clip_1) || op_util::is_no_clip(clip_2)) {
-        return op_util::is_no_clip(clip_1) && op_util::is_no_clip(clip_2);
+    const auto is_no_clip_1 = op_util::is_no_clip(clip_1);
+    const auto is_no_clip_2 = op_util::is_no_clip(clip_2);
+    if (is_no_clip_1 || is_no_clip_2) {
+        return is_no_clip_1 && is_no_clip_2;
     }
     return clip_1 == clip_2;
 }

--- a/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
@@ -86,19 +86,6 @@ bool check_WRB(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared_ptr<
     return is_equal;
 }
 
-// `clip == 0` and `clip == inf` both mean "no clipping" (see ov::op::util::is_no_clip), so cells carrying either
-// value are interchangeable and may be fused.
-bool is_equal_clip(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared_ptr<op_util::RNNCellBase>& cell_2) {
-    const auto clip_1 = cell_1->get_clip();
-    const auto clip_2 = cell_2->get_clip();
-    const auto is_no_clip_1 = op_util::is_no_clip(clip_1);
-    const auto is_no_clip_2 = op_util::is_no_clip(clip_2);
-    if (is_no_clip_1 || is_no_clip_2) {
-        return is_no_clip_1 && is_no_clip_2;
-    }
-    return clip_1 == clip_2;
-}
-
 bool is_equal_cells(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared_ptr<op_util::RNNCellBase>& cell_2) {
     bool is_equal = true;
     auto gru_cell_1 = ov::as_type_ptr<v3::GRUCell>(cell_1);
@@ -110,7 +97,8 @@ bool is_equal_cells(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared
                cell_1->get_hidden_size() == cell_2->get_hidden_size() &&
                cell_1->get_activations() == cell_2->get_activations() &&
                cell_1->get_activations_alpha() == cell_2->get_activations_alpha() &&
-               cell_1->get_activations_beta() == cell_2->get_activations_beta() && is_equal_clip(cell_1, cell_2) &&
+               cell_1->get_activations_beta() == cell_2->get_activations_beta() &&
+               op_util::are_clips_equal(cell_1->get_clip(), cell_2->get_clip()) &&
                check_WRB(cell_1, cell_2);
     return is_equal;
 }

--- a/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
@@ -22,6 +22,7 @@
 #include "openvino/op/split.hpp"
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "ov_ops/augru_cell.hpp"
 #include "ov_ops/augru_sequence.hpp"
@@ -85,6 +86,17 @@ bool check_WRB(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared_ptr<
     return is_equal;
 }
 
+// `clip == 0` and `clip == inf` both mean "no clipping" (see ov::op::util::is_no_clip), so cells carrying either
+// value are interchangeable and may be fused.
+bool is_equal_clip(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared_ptr<op_util::RNNCellBase>& cell_2) {
+    const auto clip_1 = cell_1->get_clip();
+    const auto clip_2 = cell_2->get_clip();
+    if (op_util::is_no_clip(clip_1) || op_util::is_no_clip(clip_2)) {
+        return op_util::is_no_clip(clip_1) && op_util::is_no_clip(clip_2);
+    }
+    return clip_1 == clip_2;
+}
+
 bool is_equal_cells(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared_ptr<op_util::RNNCellBase>& cell_2) {
     bool is_equal = true;
     auto gru_cell_1 = ov::as_type_ptr<v3::GRUCell>(cell_1);
@@ -96,8 +108,8 @@ bool is_equal_cells(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared
                cell_1->get_hidden_size() == cell_2->get_hidden_size() &&
                cell_1->get_activations() == cell_2->get_activations() &&
                cell_1->get_activations_alpha() == cell_2->get_activations_alpha() &&
-               cell_1->get_activations_beta() == cell_2->get_activations_beta() &&
-               cell_1->get_clip() == cell_2->get_clip() && check_WRB(cell_1, cell_2);
+               cell_1->get_activations_beta() == cell_2->get_activations_beta() && is_equal_clip(cell_1, cell_2) &&
+               check_WRB(cell_1, cell_2);
     return is_equal;
 }
 

--- a/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
@@ -98,8 +98,7 @@ bool is_equal_cells(const shared_ptr<op_util::RNNCellBase>& cell_1, const shared
                cell_1->get_activations() == cell_2->get_activations() &&
                cell_1->get_activations_alpha() == cell_2->get_activations_alpha() &&
                cell_1->get_activations_beta() == cell_2->get_activations_beta() &&
-               op_util::are_clips_equal(cell_1->get_clip(), cell_2->get_clip()) &&
-               check_WRB(cell_1, cell_2);
+               op_util::are_clips_equal(cell_1->get_clip(), cell_2->get_clip()) && check_WRB(cell_1, cell_2);
     return is_equal;
 }
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -40,6 +40,7 @@
 #include "openvino/op/tensor_iterator.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
@@ -1579,8 +1580,16 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
             return false;
         if (lstm_forward->get_activations() != lstm_reverse->get_activations())
             return false;
-        if (lstm_forward->get_clip() != lstm_reverse->get_clip())
+        // `clip == 0` and `clip == inf` both mean "no clipping" (see ov::op::util::is_no_clip), so the two directions
+        // still match when one carries 0 and the other inf.
+        const auto clip_forward = lstm_forward->get_clip();
+        const auto clip_reverse = lstm_reverse->get_clip();
+        if (op_util::is_no_clip(clip_forward) || op_util::is_no_clip(clip_reverse)) {
+            if (!op_util::is_no_clip(clip_forward) || !op_util::is_no_clip(clip_reverse))
+                return false;
+        } else if (clip_forward != clip_reverse) {
             return false;
+        }
 
         auto squeeze_forward = pattern_map.at(squeeze_forward_label);
         if (squeeze_forward->input_value(0) != lstm_forward->output(0))

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -1580,14 +1580,7 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
             return false;
         if (lstm_forward->get_activations() != lstm_reverse->get_activations())
             return false;
-        // `clip == 0` and `clip == inf` both mean "no clipping" (see ov::op::util::is_no_clip), so the two directions
-        // still match when one carries 0 and the other inf.
-        const auto clip_forward = lstm_forward->get_clip();
-        const auto clip_reverse = lstm_reverse->get_clip();
-        if (op_util::is_no_clip(clip_forward) || op_util::is_no_clip(clip_reverse)) {
-            if (!op_util::is_no_clip(clip_forward) || !op_util::is_no_clip(clip_reverse))
-                return false;
-        } else if (clip_forward != clip_reverse) {
+        if (!op_util::are_clips_equal(lstm_forward->get_clip(), lstm_reverse->get_clip())) {
             return false;
         }
 

--- a/src/common/transformations/src/transformations/op_conversions/gru_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/gru_cell_decomposition.cpp
@@ -18,6 +18,7 @@
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/split.hpp"
 #include "openvino/op/subtract.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/utils/utils.hpp"
 
@@ -64,9 +65,10 @@ ov::pass::GRUCellDecomposition::GRUCellDecomposition() {
         auto add_r_2 = std::make_shared<v1::Add>(Xt_W_zrh->output(1), add_r_1);
 
         auto clip = gru_cell->get_clip();
+        const bool apply_clip = !op_util::is_no_clip(clip);
         std::shared_ptr<Node> clamp_z = add_z_2;
         std::shared_ptr<Node> clamp_r = add_r_2;
-        if (clip > 0.f) {
+        if (apply_clip) {
             clamp_z = std::make_shared<v0::Clamp>(add_z_2, -clip, clip);
             clamp_r = std::make_shared<v0::Clamp>(add_r_2, -clip, clip);
             ov::copy_runtime_info(gru_cell, {clamp_z, clamp_r});
@@ -95,7 +97,7 @@ ov::pass::GRUCellDecomposition::GRUCellDecomposition() {
         }
         // ht = g(_h)
         std::shared_ptr<Node> clamp_h = _h;
-        if (clip > 0.f) {
+        if (apply_clip) {
             clamp_h = std::make_shared<v0::Clamp>(_h, -clip, clip);
             ov::copy_runtime_info(gru_cell, clamp_h);
         }
@@ -121,6 +123,8 @@ ov::pass::GRUCellDecomposition::GRUCellDecomposition() {
                                add_z_2,
                                add_r_1,
                                add_r_2,
+                               z_t,
+                               r_t,
                                h_t,
                                one,
                                sub,

--- a/src/common/transformations/src/transformations/op_conversions/gru_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/gru_cell_decomposition.cpp
@@ -65,7 +65,7 @@ ov::pass::GRUCellDecomposition::GRUCellDecomposition() {
         auto add_r_2 = std::make_shared<v1::Add>(Xt_W_zrh->output(1), add_r_1);
 
         auto clip = gru_cell->get_clip();
-        const bool apply_clip = op_util::requires_clip(clip);
+        const bool apply_clip = op_util::classify_rnn_clip(clip) == op_util::RNNClipMode::CLAMP;
         std::shared_ptr<Node> clamp_z = add_z_2;
         std::shared_ptr<Node> clamp_r = add_r_2;
         if (apply_clip) {

--- a/src/common/transformations/src/transformations/op_conversions/gru_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/gru_cell_decomposition.cpp
@@ -65,7 +65,7 @@ ov::pass::GRUCellDecomposition::GRUCellDecomposition() {
         auto add_r_2 = std::make_shared<v1::Add>(Xt_W_zrh->output(1), add_r_1);
 
         auto clip = gru_cell->get_clip();
-        const bool apply_clip = !op_util::is_no_clip(clip);
+        const bool apply_clip = op_util::requires_clip(clip);
         std::shared_ptr<Node> clamp_z = add_z_2;
         std::shared_ptr<Node> clamp_r = add_r_2;
         if (apply_clip) {

--- a/src/common/transformations/src/transformations/op_conversions/lstm_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/lstm_cell_decomposition.cpp
@@ -17,6 +17,7 @@
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/split.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/utils/utils.hpp"
 
@@ -57,7 +58,7 @@ ov::pass::LSTMCellDecomposition::LSTMCellDecomposition() {
         Output<Node> o = split->output(3);
 
         auto clip = lstm_cell->get_clip();
-        if (clip > 0.f) {
+        if (!op_util::is_no_clip(clip)) {
             auto clamp_f = std::make_shared<v0::Clamp>(f, -clip, clip);
             auto clamp_i = std::make_shared<v0::Clamp>(i, -clip, clip);
             auto clamp_c = std::make_shared<v0::Clamp>(c, -clip, clip);

--- a/src/common/transformations/src/transformations/op_conversions/lstm_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/lstm_cell_decomposition.cpp
@@ -58,7 +58,7 @@ ov::pass::LSTMCellDecomposition::LSTMCellDecomposition() {
         Output<Node> o = split->output(3);
 
         auto clip = lstm_cell->get_clip();
-        if (op_util::requires_clip(clip)) {
+        if (op_util::classify_rnn_clip(clip) == op_util::RNNClipMode::CLAMP) {
             auto clamp_f = std::make_shared<v0::Clamp>(f, -clip, clip);
             auto clamp_i = std::make_shared<v0::Clamp>(i, -clip, clip);
             auto clamp_c = std::make_shared<v0::Clamp>(c, -clip, clip);

--- a/src/common/transformations/src/transformations/op_conversions/lstm_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/lstm_cell_decomposition.cpp
@@ -58,7 +58,7 @@ ov::pass::LSTMCellDecomposition::LSTMCellDecomposition() {
         Output<Node> o = split->output(3);
 
         auto clip = lstm_cell->get_clip();
-        if (!op_util::is_no_clip(clip)) {
+        if (op_util::requires_clip(clip)) {
             auto clamp_f = std::make_shared<v0::Clamp>(f, -clip, clip);
             auto clamp_i = std::make_shared<v0::Clamp>(i, -clip, clip);
             auto clamp_c = std::make_shared<v0::Clamp>(c, -clip, clip);

--- a/src/common/transformations/src/transformations/op_conversions/rnn_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/rnn_cell_decomposition.cpp
@@ -47,7 +47,7 @@ ov::pass::RNNCellDecomposition::RNNCellDecomposition() {
         // f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)
         auto clip = rnn_cell->get_clip();
         std::shared_ptr<Node> clamp = i_t;
-        if (op_util::requires_clip(clip)) {
+        if (op_util::classify_rnn_clip(clip) == op_util::RNNClipMode::CLAMP) {
             clamp = std::make_shared<v0::Clamp>(i_t, -clip, clip);
             ov::copy_runtime_info(rnn_cell, clamp);
         }

--- a/src/common/transformations/src/transformations/op_conversions/rnn_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/rnn_cell_decomposition.cpp
@@ -13,6 +13,7 @@
 #include "openvino/op/clamp.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/rnn_cell.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/utils/utils.hpp"
 
@@ -20,6 +21,7 @@ using ov::pass::pattern::Matcher;
 
 namespace v0 = ov::op::v0;
 namespace v1 = ov::op::v1;
+namespace op_util = ov::op::util;
 ov::pass::RNNCellDecomposition::RNNCellDecomposition() {
     MATCHER_SCOPE(RNNCellDecomposition);
     auto rnn_cell = ov::pass::pattern::wrap_type<v0::RNNCell>();
@@ -45,7 +47,7 @@ ov::pass::RNNCellDecomposition::RNNCellDecomposition() {
         // f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)
         auto clip = rnn_cell->get_clip();
         std::shared_ptr<Node> clamp = i_t;
-        if (clip > 0.f) {
+        if (!op_util::is_no_clip(clip)) {
             clamp = std::make_shared<v0::Clamp>(i_t, -clip, clip);
             ov::copy_runtime_info(rnn_cell, clamp);
         }

--- a/src/common/transformations/src/transformations/op_conversions/rnn_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/rnn_cell_decomposition.cpp
@@ -47,7 +47,7 @@ ov::pass::RNNCellDecomposition::RNNCellDecomposition() {
         // f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)
         auto clip = rnn_cell->get_clip();
         std::shared_ptr<Node> clamp = i_t;
-        if (!op_util::is_no_clip(clip)) {
+        if (op_util::requires_clip(clip)) {
             clamp = std::make_shared<v0::Clamp>(i_t, -clip, clip);
             ov::copy_runtime_info(rnn_cell, clamp);
         }

--- a/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
+++ b/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
@@ -179,9 +179,7 @@ TEST_P(CellDecompositionClipTests, InvalidClipInsertsNoClamp) {
     // failure surfaces on its own instead of being masked by an uninitialized-model error from TearDown().
     test_skipped = true;
 
-    for (const float clip : {-1.f,
-                             -std::numeric_limits<float>::infinity(),
-                             std::numeric_limits<float>::quiet_NaN()}) {
+    for (const float clip : {-1.f, -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::quiet_NaN()}) {
         auto invalid_clip_model = p.makeModel(clip);
 
         ov::pass::Manager invalid_clip_manager;

--- a/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
+++ b/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
@@ -159,6 +159,24 @@ TEST_P(CellDecompositionClipTests, FiniteClipInsertsClamp) {
     test_skipped = true;
 }
 
+// Neither a negative nor a NaN clip describes usable bounds `[-clip, clip]`: Clamp rejects `min > max`, so a pass
+// that created one would throw during decomposition instead of leaving the graph unclipped. Both must be skipped.
+TEST_P(CellDecompositionClipTests, InvalidClipInsertsNoClamp) {
+    const auto& p = GetParam();
+    // This test drives its own models, so the fixture has nothing to compare. Set before the assertions below so a
+    // failure surfaces on its own instead of being masked by an uninitialized-model error from TearDown().
+    test_skipped = true;
+
+    for (const float clip : {-1.f, std::numeric_limits<float>::quiet_NaN()}) {
+        auto invalid_clip_model = p.makeModel(clip);
+
+        ov::pass::Manager invalid_clip_manager;
+        p.registerPass(invalid_clip_manager);
+        ASSERT_NO_THROW(invalid_clip_manager.run_passes(invalid_clip_model)) << "clip = " << clip;
+        EXPECT_EQ(count_ops_of_type<v0::Clamp>(invalid_clip_model), 0) << "clip = " << clip;
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(TransformationTests,
                          CellDecompositionClipTests,
                          ValuesIn(cell_params),

--- a/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
+++ b/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
@@ -35,15 +35,33 @@ constexpr size_t batch = 2;
 constexpr size_t input_size = 3;
 constexpr size_t hidden_size = 4;
 
-TEST(RNNClipUtilsTest, ClassifiesOnlyValidNoClipValues) {
+TEST(RNNClipUtilsTest, ClassifiesClipValues) {
+    using ov::op::util::classify_rnn_clip;
+    using ov::op::util::RNNClipMode;
+
     const auto infinity = std::numeric_limits<float>::infinity();
 
-    EXPECT_TRUE(ov::op::util::is_no_clip(0.f));
-    EXPECT_TRUE(ov::op::util::is_no_clip(infinity));
-    EXPECT_FALSE(ov::op::util::is_no_clip(1.f));
-    EXPECT_FALSE(ov::op::util::is_no_clip(-1.f));
-    EXPECT_FALSE(ov::op::util::is_no_clip(-infinity));
-    EXPECT_FALSE(ov::op::util::is_no_clip(std::numeric_limits<float>::quiet_NaN()));
+    EXPECT_EQ(RNNClipMode::NONE, classify_rnn_clip(0.f));
+    EXPECT_EQ(RNNClipMode::NONE, classify_rnn_clip(infinity));
+    EXPECT_EQ(RNNClipMode::CLAMP, classify_rnn_clip(1.f));
+    EXPECT_EQ(RNNClipMode::INVALID, classify_rnn_clip(-1.f));
+    EXPECT_EQ(RNNClipMode::INVALID, classify_rnn_clip(-infinity));
+    EXPECT_EQ(RNNClipMode::INVALID, classify_rnn_clip(std::numeric_limits<float>::quiet_NaN()));
+}
+
+TEST(RNNClipUtilsTest, ComparesClipValuesByMeaning) {
+    using ov::op::util::are_clips_equal;
+
+    const auto infinity = std::numeric_limits<float>::infinity();
+    const auto nan = std::numeric_limits<float>::quiet_NaN();
+
+    EXPECT_TRUE(are_clips_equal(0.f, infinity));
+    EXPECT_TRUE(are_clips_equal(infinity, 0.f));
+    EXPECT_TRUE(are_clips_equal(1.f, 1.f));
+    EXPECT_TRUE(are_clips_equal(-1.f, -1.f));
+    EXPECT_FALSE(are_clips_equal(0.f, 1.f));
+    EXPECT_FALSE(are_clips_equal(0.f, -1.f));
+    EXPECT_FALSE(are_clips_equal(nan, nan));
 }
 
 // Each *CellDecomposition pass inserts a Clamp only when `clip` actually requests clipping. `clip == 0` and

--- a/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
+++ b/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
@@ -1,0 +1,165 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/clamp.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/gru_cell.hpp"
+#include "openvino/op/lstm_cell.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/rnn_cell.hpp"
+#include "openvino/pass/manager.hpp"
+#include "transformations/op_conversions/gru_cell_decomposition.hpp"
+#include "transformations/op_conversions/lstm_cell_decomposition.hpp"
+#include "transformations/op_conversions/rnn_cell_decomposition.hpp"
+
+using namespace ov;
+using namespace testing;
+
+namespace v0 = ov::op::v0;
+namespace v3 = ov::op::v3;
+namespace v4 = ov::op::v4;
+
+namespace {
+constexpr size_t batch = 2;
+constexpr size_t input_size = 3;
+constexpr size_t hidden_size = 4;
+
+// Each *CellDecomposition pass inserts a Clamp only when `clip` actually requests clipping. `clip == 0` and
+// `clip == inf` both mean "no clipping" per the RNN/GRU/LSTM specs, so neither value may produce a Clamp.
+struct CellDecompositionClipParams {
+    std::string name;
+    std::function<std::shared_ptr<ov::Model>(float clip)> makeModel;
+    std::function<void(ov::pass::Manager&)> registerPass;
+};
+
+std::shared_ptr<ov::Model> makeRNNCellModel(float clip) {
+    const auto X = std::make_shared<v0::Parameter>(element::f32, Shape{batch, input_size});
+    const auto H = std::make_shared<v0::Parameter>(element::f32, Shape{batch, hidden_size});
+    const auto W = v0::Constant::create(element::f32, Shape{hidden_size, input_size}, {1.f});
+    const auto R = v0::Constant::create(element::f32, Shape{hidden_size, hidden_size}, {1.f});
+    const auto B = v0::Constant::create(element::f32, Shape{hidden_size}, {0.f});
+
+    const auto cell = std::make_shared<v0::RNNCell>(X,
+                                                    H,
+                                                    W,
+                                                    R,
+                                                    B,
+                                                    hidden_size,
+                                                    std::vector<std::string>{"tanh"},
+                                                    std::vector<float>{},
+                                                    std::vector<float>{},
+                                                    clip);
+    return std::make_shared<ov::Model>(cell->outputs(), ParameterVector{X, H});
+}
+
+std::shared_ptr<ov::Model> makeGRUCellModel(float clip) {
+    const auto X = std::make_shared<v0::Parameter>(element::f32, Shape{batch, input_size});
+    const auto H = std::make_shared<v0::Parameter>(element::f32, Shape{batch, hidden_size});
+    const auto W = v0::Constant::create(element::f32, Shape{3 * hidden_size, input_size}, {1.f});
+    const auto R = v0::Constant::create(element::f32, Shape{3 * hidden_size, hidden_size}, {1.f});
+    const auto B = v0::Constant::create(element::f32, Shape{3 * hidden_size}, {0.f});
+
+    const auto cell = std::make_shared<v3::GRUCell>(X,
+                                                    H,
+                                                    W,
+                                                    R,
+                                                    B,
+                                                    hidden_size,
+                                                    std::vector<std::string>{"sigmoid", "tanh"},
+                                                    std::vector<float>{},
+                                                    std::vector<float>{},
+                                                    clip,
+                                                    /*linear_before_reset=*/false);
+    return std::make_shared<ov::Model>(cell->outputs(), ParameterVector{X, H});
+}
+
+std::shared_ptr<ov::Model> makeLSTMCellModel(float clip) {
+    const auto X = std::make_shared<v0::Parameter>(element::f32, Shape{batch, input_size});
+    const auto H = std::make_shared<v0::Parameter>(element::f32, Shape{batch, hidden_size});
+    const auto C = std::make_shared<v0::Parameter>(element::f32, Shape{batch, hidden_size});
+    const auto W = v0::Constant::create(element::f32, Shape{4 * hidden_size, input_size}, {1.f});
+    const auto R = v0::Constant::create(element::f32, Shape{4 * hidden_size, hidden_size}, {1.f});
+    const auto B = v0::Constant::create(element::f32, Shape{4 * hidden_size}, {0.f});
+
+    const auto cell = std::make_shared<v4::LSTMCell>(X,
+                                                     H,
+                                                     C,
+                                                     W,
+                                                     R,
+                                                     B,
+                                                     hidden_size,
+                                                     std::vector<std::string>{"sigmoid", "tanh", "tanh"},
+                                                     std::vector<float>{},
+                                                     std::vector<float>{},
+                                                     clip);
+    return std::make_shared<ov::Model>(cell->outputs(), ParameterVector{X, H, C});
+}
+
+const std::vector<CellDecompositionClipParams> cell_params{
+    {"RNNCell",
+     makeRNNCellModel,
+     [](ov::pass::Manager& m) {
+         m.register_pass<ov::pass::RNNCellDecomposition>();
+     }},
+    {"GRUCell",
+     makeGRUCellModel,
+     [](ov::pass::Manager& m) {
+         m.register_pass<ov::pass::GRUCellDecomposition>();
+     }},
+    {"LSTMCell",
+     makeLSTMCellModel,
+     [](ov::pass::Manager& m) {
+         m.register_pass<ov::pass::LSTMCellDecomposition>();
+     }},
+};
+}  // namespace
+
+class CellDecompositionClipTests : public TransformationTestsF, public WithParamInterface<CellDecompositionClipParams> {
+public:
+    static std::string getTestCaseName(const TestParamInfo<CellDecompositionClipParams>& info) {
+        return info.param.name;
+    }
+};
+
+// clip == inf must decompose to exactly the same graph as clip == 0, i.e. without any Clamp.
+TEST_P(CellDecompositionClipTests, ClipInfDecomposesLikeClipZero) {
+    const auto& p = GetParam();
+    model = p.makeModel(std::numeric_limits<float>::infinity());
+    p.registerPass(manager);
+
+    // model_ref is the already-decomposed clip == 0 graph, so a Clamp appearing for inf fails the comparison.
+    ov::pass::Manager ref_manager;
+    p.registerPass(ref_manager);
+    model_ref = p.makeModel(0.f);
+    ref_manager.run_passes(model_ref);
+    ASSERT_EQ(count_ops_of_type<v0::Clamp>(model_ref), 0);
+}
+
+// A finite clip must still insert Clamp, so the check above is not vacuously true.
+TEST_P(CellDecompositionClipTests, FiniteClipInsertsClamp) {
+    const auto& p = GetParam();
+    model = p.makeModel(3.5f);
+
+    ov::pass::Manager clip_manager;
+    p.registerPass(clip_manager);
+    clip_manager.run_passes(model);
+    EXPECT_GT(count_ops_of_type<v0::Clamp>(model), 0);
+
+    // The fixture would otherwise compare `model` against a clone taken after the pass already ran.
+    test_skipped = true;
+}
+
+INSTANTIATE_TEST_SUITE_P(TransformationTests,
+                         CellDecompositionClipTests,
+                         ValuesIn(cell_params),
+                         CellDecompositionClipTests::getTestCaseName);

--- a/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
+++ b/src/common/transformations/tests/op_conversions/rnn_cell_decomposition_clip_test.cpp
@@ -17,6 +17,7 @@
 #include "openvino/op/lstm_cell.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/rnn_cell.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/op_conversions/gru_cell_decomposition.hpp"
 #include "transformations/op_conversions/lstm_cell_decomposition.hpp"
@@ -33,6 +34,17 @@ namespace {
 constexpr size_t batch = 2;
 constexpr size_t input_size = 3;
 constexpr size_t hidden_size = 4;
+
+TEST(RNNClipUtilsTest, ClassifiesOnlyValidNoClipValues) {
+    const auto infinity = std::numeric_limits<float>::infinity();
+
+    EXPECT_TRUE(ov::op::util::is_no_clip(0.f));
+    EXPECT_TRUE(ov::op::util::is_no_clip(infinity));
+    EXPECT_FALSE(ov::op::util::is_no_clip(1.f));
+    EXPECT_FALSE(ov::op::util::is_no_clip(-1.f));
+    EXPECT_FALSE(ov::op::util::is_no_clip(-infinity));
+    EXPECT_FALSE(ov::op::util::is_no_clip(std::numeric_limits<float>::quiet_NaN()));
+}
 
 // Each *CellDecomposition pass inserts a Clamp only when `clip` actually requests clipping. `clip == 0` and
 // `clip == inf` both mean "no clipping" per the RNN/GRU/LSTM specs, so neither value may produce a Clamp.
@@ -167,7 +179,9 @@ TEST_P(CellDecompositionClipTests, InvalidClipInsertsNoClamp) {
     // failure surfaces on its own instead of being masked by an uninitialized-model error from TearDown().
     test_skipped = true;
 
-    for (const float clip : {-1.f, std::numeric_limits<float>::quiet_NaN()}) {
+    for (const float clip : {-1.f,
+                             -std::numeric_limits<float>::infinity(),
+                             std::numeric_limits<float>::quiet_NaN()}) {
         auto invalid_clip_model = p.makeModel(clip);
 
         ov::pass::Manager invalid_clip_manager;

--- a/src/common/transformations/tests/sources.cmake
+++ b/src/common/transformations/tests/sources.cmake
@@ -236,6 +236,7 @@ set(OP_CONVERSIONS_TESTS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/op_conversions/normalize_l2_decomposition_test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op_conversions/reduce_l1_decomposition_test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op_conversions/reduce_l2_decomposition_test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op_conversions/rnn_cell_decomposition_clip_test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op_conversions/scaled_dot_product_decomposition_test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op_conversions/sdpa_to_paged_attention_test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op_conversions/simplify_ctc_greedy_decoder_seq_len_test.cpp

--- a/src/core/include/openvino/op/util/rnn_cell_base.hpp
+++ b/src/core/include/openvino/op/util/rnn_cell_base.hpp
@@ -34,6 +34,24 @@ inline bool is_no_clip(float clip) {
     return clip <= 0.f || std::isinf(clip);
 }
 
+/// \brief      Tells whether two RNN `clip` attribute values are equivalent for RNN transformation matching.
+///
+/// \note       All values reported by is_no_clip() are equivalent. Other values must match exactly. In particular,
+///             NaN is not equal to any value, including itself.
+///
+/// \param[in]  lhs  First `clip` attribute value.
+/// \param[in]  rhs  Second `clip` attribute value.
+///
+/// \return     True if both values are equivalent for matching.
+inline bool are_clips_equal(float lhs, float rhs) {
+    const bool lhs_is_no_clip = is_no_clip(lhs);
+    const bool rhs_is_no_clip = is_no_clip(rhs);
+    if (lhs_is_no_clip || rhs_is_no_clip) {
+        return lhs_is_no_clip && rhs_is_no_clip;
+    }
+    return lhs == rhs;
+}
+
 /// \brief      Tells whether an RNN `clip` attribute value asks for an actual Clamp.
 ///
 /// \note       Only a finite positive `clip` yields usable bounds `[-clip, clip]`. `0`, negative values and

--- a/src/core/include/openvino/op/util/rnn_cell_base.hpp
+++ b/src/core/include/openvino/op/util/rnn_cell_base.hpp
@@ -17,18 +17,35 @@
 namespace ov {
 namespace op {
 namespace util {
-/// \brief      Tells whether an RNN `clip` attribute value disables clipping.
+/// \brief      Tells whether an RNN `clip` attribute value is a valid request to disable clipping.
 ///
-/// \note       Per the RNN/GRU/LSTM specs, the default `clip` is *infinity*, which means "clipping is not applied";
-///             OpenVINO ops additionally treat `clip == 0` as no clipping (see RNNCellBase::clip). Both values must
-///             therefore be handled identically. `NaN` is not a valid clip value and is reported as "clipping
-///             requested" so that callers reject it instead of silently skipping the Clamp.
+/// \note       Per the RNN/GRU/LSTM specs the default `clip` is *infinity*, which means "clipping is not applied";
+///             OpenVINO ops additionally treat `clip == 0` as no clipping (see RNNCellBase::clip), so both values
+///             must be handled identically. A negative `clip` cannot describe bounds `[-clip, clip]` either, so it
+///             is reported as no clipping too - this matches the long-standing `clip > 0` checks in the
+///             decomposition passes. `NaN` is not a valid clip value and is deliberately *not* reported here, so
+///             that support gates reject the op instead of assuming it needs no clipping; use requires_clip() to
+///             decide whether a Clamp has to be created.
 ///
 /// \param[in]  clip  Value of the `clip` attribute.
 ///
-/// \return     True if no clipping should be applied.
+/// \return     True if `clip` validly expresses "no clipping".
 inline bool is_no_clip(float clip) {
-    return clip == 0.f || std::isinf(clip);
+    return clip <= 0.f || std::isinf(clip);
+}
+
+/// \brief      Tells whether an RNN `clip` attribute value asks for an actual Clamp.
+///
+/// \note       Only a finite positive `clip` yields usable bounds `[-clip, clip]`. `0`, negative values and
+///             infinity all mean "no clipping" (see is_no_clip), and `NaN` is invalid - none of them may produce a
+///             Clamp, because `Clamp` rejects `min > max` and both `NaN` and a negative `clip` would trip that
+///             check instead of simply skipping the clipping.
+///
+/// \param[in]  clip  Value of the `clip` attribute.
+///
+/// \return     True if a Clamp with bounds `[-clip, clip]` has to be applied.
+inline bool requires_clip(float clip) {
+    return clip > 0.f && !std::isinf(clip);
 }
 
 enum class LSTMWeightsFormat {

--- a/src/core/include/openvino/op/util/rnn_cell_base.hpp
+++ b/src/core/include/openvino/op/util/rnn_cell_base.hpp
@@ -17,50 +17,47 @@
 namespace ov {
 namespace op {
 namespace util {
-/// \brief      Tells whether an RNN `clip` attribute value is a valid request to disable clipping.
+enum class RNNClipMode {
+    NONE,
+    CLAMP,
+    INVALID,
+};
+
+/// \brief      Classifies an RNN `clip` attribute value.
 ///
-/// \note       Per the RNN/GRU/LSTM specs the default `clip` is *infinity*, which means "clipping is not applied";
-///             OpenVINO ops additionally treat `clip == 0` as no clipping (see RNNCellBase::clip), so both values
-///             must be handled identically. Negative values, negative infinity, and `NaN` are invalid and are not
-///             reported as valid no-clipping requests. Use requires_clip() to decide whether a Clamp can be created;
-///             callers may reject invalid values or deliberately ignore them for backward compatibility.
+/// \note       Per the RNN/GRU/LSTM specs the default `clip` is positive infinity, which means "clipping is not
+///             applied". OpenVINO ops additionally treat `clip == 0` as no clipping. Only finite positive values
+///             describe valid Clamp bounds; negative values, negative infinity, and `NaN` are invalid.
 ///
 /// \param[in]  clip  Value of the `clip` attribute.
 ///
-/// \return     True if `clip` validly expresses "no clipping".
-inline bool is_no_clip(float clip) {
-    return clip == 0.f || (clip > 0.f && std::isinf(clip));
+/// \return     The semantic mode represented by `clip`.
+inline RNNClipMode classify_rnn_clip(float clip) {
+    if (clip == 0.f || (clip > 0.f && std::isinf(clip))) {
+        return RNNClipMode::NONE;
+    }
+    if (clip > 0.f) {
+        return RNNClipMode::CLAMP;
+    }
+    return RNNClipMode::INVALID;
 }
 
 /// \brief      Tells whether two RNN `clip` attribute values are equivalent for RNN transformation matching.
 ///
-/// \note       All values reported by is_no_clip() are equivalent. Other values must match exactly. In particular,
-///             NaN is not equal to any value, including itself.
+/// \note       Values classified as RNNClipMode::NONE are equivalent. Other values must match exactly. In particular,
+///             `NaN` is not equal to any value, including itself.
 ///
 /// \param[in]  lhs  First `clip` attribute value.
 /// \param[in]  rhs  Second `clip` attribute value.
 ///
 /// \return     True if both values are equivalent for matching.
 inline bool are_clips_equal(float lhs, float rhs) {
-    const bool lhs_is_no_clip = is_no_clip(lhs);
-    const bool rhs_is_no_clip = is_no_clip(rhs);
-    if (lhs_is_no_clip || rhs_is_no_clip) {
-        return lhs_is_no_clip && rhs_is_no_clip;
+    const auto lhs_mode = classify_rnn_clip(lhs);
+    const auto rhs_mode = classify_rnn_clip(rhs);
+    if (lhs_mode == RNNClipMode::NONE || rhs_mode == RNNClipMode::NONE) {
+        return lhs_mode == rhs_mode;
     }
     return lhs == rhs;
-}
-
-/// \brief      Tells whether an RNN `clip` attribute value asks for an actual Clamp.
-///
-/// \note       Only a finite positive `clip` yields usable bounds `[-clip, clip]`. `0` and positive infinity mean
-///             "no clipping". Negative values, negative infinity, and `NaN` are invalid, but none of them may
-///             produce a Clamp: this preserves the long-standing `clip > 0` behavior and avoids invalid bounds.
-///
-/// \param[in]  clip  Value of the `clip` attribute.
-///
-/// \return     True if a Clamp with bounds `[-clip, clip]` has to be applied.
-inline bool requires_clip(float clip) {
-    return clip > 0.f && !std::isinf(clip);
 }
 
 enum class LSTMWeightsFormat {

--- a/src/core/include/openvino/op/util/rnn_cell_base.hpp
+++ b/src/core/include/openvino/op/util/rnn_cell_base.hpp
@@ -21,17 +21,15 @@ namespace util {
 ///
 /// \note       Per the RNN/GRU/LSTM specs the default `clip` is *infinity*, which means "clipping is not applied";
 ///             OpenVINO ops additionally treat `clip == 0` as no clipping (see RNNCellBase::clip), so both values
-///             must be handled identically. A negative `clip` cannot describe bounds `[-clip, clip]` either, so it
-///             is reported as no clipping too - this matches the long-standing `clip > 0` checks in the
-///             decomposition passes. `NaN` is not a valid clip value and is deliberately *not* reported here, so
-///             that support gates reject the op instead of assuming it needs no clipping; use requires_clip() to
-///             decide whether a Clamp has to be created.
+///             must be handled identically. Negative values, negative infinity, and `NaN` are invalid and are not
+///             reported as valid no-clipping requests. Use requires_clip() to decide whether a Clamp can be created;
+///             callers may reject invalid values or deliberately ignore them for backward compatibility.
 ///
 /// \param[in]  clip  Value of the `clip` attribute.
 ///
 /// \return     True if `clip` validly expresses "no clipping".
 inline bool is_no_clip(float clip) {
-    return clip <= 0.f || std::isinf(clip);
+    return clip == 0.f || (clip > 0.f && std::isinf(clip));
 }
 
 /// \brief      Tells whether two RNN `clip` attribute values are equivalent for RNN transformation matching.
@@ -54,10 +52,9 @@ inline bool are_clips_equal(float lhs, float rhs) {
 
 /// \brief      Tells whether an RNN `clip` attribute value asks for an actual Clamp.
 ///
-/// \note       Only a finite positive `clip` yields usable bounds `[-clip, clip]`. `0`, negative values and
-///             infinity all mean "no clipping" (see is_no_clip), and `NaN` is invalid - none of them may produce a
-///             Clamp, because `Clamp` rejects `min > max` and both `NaN` and a negative `clip` would trip that
-///             check instead of simply skipping the clipping.
+/// \note       Only a finite positive `clip` yields usable bounds `[-clip, clip]`. `0` and positive infinity mean
+///             "no clipping". Negative values, negative infinity, and `NaN` are invalid, but none of them may
+///             produce a Clamp: this preserves the long-standing `clip > 0` behavior and avoids invalid bounds.
 ///
 /// \param[in]  clip  Value of the `clip` attribute.
 ///

--- a/src/core/include/openvino/op/util/rnn_cell_base.hpp
+++ b/src/core/include/openvino/op/util/rnn_cell_base.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -16,6 +17,20 @@
 namespace ov {
 namespace op {
 namespace util {
+/// \brief      Tells whether an RNN `clip` attribute value disables clipping.
+///
+/// \note       Per the RNN/GRU/LSTM specs, the default `clip` is *infinity*, which means "clipping is not applied";
+///             OpenVINO ops additionally treat `clip == 0` as no clipping (see RNNCellBase::clip). Both values must
+///             therefore be handled identically. `NaN` is not a valid clip value and is reported as "clipping
+///             requested" so that callers reject it instead of silently skipping the Clamp.
+///
+/// \param[in]  clip  Value of the `clip` attribute.
+///
+/// \return     True if no clipping should be applied.
+inline bool is_no_clip(float clip) {
+    return clip == 0.f || std::isinf(clip);
+}
+
 enum class LSTMWeightsFormat {
     FICO,  // IE
     ICOF,  // PyTorch

--- a/src/core/reference/include/openvino/reference/gru_cell.hpp
+++ b/src/core/reference/include/openvino/reference/gru_cell.hpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/reference/add.hpp"
 #include "openvino/reference/clamp.hpp"
 #include "openvino/reference/matmul.hpp"
@@ -119,7 +120,7 @@ void gru_cell(const T* X,
     reference::split(reinterpret_cast<const char*>(B), B_shape, sizeof(T), 0, num_b_splits, pointers_biases.data());
 
     auto clip_activation = [&clip](std::vector<T>& gate, const std::string& activation) {
-        if (clip > 0.f) {
+        if (op::util::requires_clip(clip)) {
             reference::clamp(gate.data(), gate.data(), static_cast<T>(-clip), static_cast<T>(clip), gate.size());
         }
         if (activation == "relu") {

--- a/src/core/reference/include/openvino/reference/gru_cell.hpp
+++ b/src/core/reference/include/openvino/reference/gru_cell.hpp
@@ -120,7 +120,7 @@ void gru_cell(const T* X,
     reference::split(reinterpret_cast<const char*>(B), B_shape, sizeof(T), 0, num_b_splits, pointers_biases.data());
 
     auto clip_activation = [&clip](std::vector<T>& gate, const std::string& activation) {
-        if (op::util::requires_clip(clip)) {
+        if (op::util::classify_rnn_clip(clip) == op::util::RNNClipMode::CLAMP) {
             reference::clamp(gate.data(), gate.data(), static_cast<T>(-clip), static_cast<T>(clip), gate.size());
         }
         if (activation == "relu") {

--- a/src/core/reference/include/openvino/reference/lstm_cell.hpp
+++ b/src/core/reference/include/openvino/reference/lstm_cell.hpp
@@ -7,6 +7,7 @@
 #include <cmath>
 
 #include "openvino/op/lstm_cell.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/reference/add.hpp"
 #include "openvino/reference/clamp.hpp"
 #include "openvino/reference/matmul.hpp"
@@ -113,7 +114,7 @@ void lstm_cell(const T* X,
     reference::split(reinterpret_cast<char*>(XHB.data()), all_gates_shape, sizeof(T), 1, 4, pointers.data());
 
     auto clip_activation = [&clip](std::vector<T>& gate, const std::string& activation, bool enable_clip = true) {
-        if (clip > 0.f && enable_clip) {
+        if (op::util::requires_clip(clip) && enable_clip) {
             reference::clamp(gate.data(), gate.data(), static_cast<T>(-clip), static_cast<T>(clip), gate.size());
         }
         if (activation == "relu") {

--- a/src/core/reference/include/openvino/reference/lstm_cell.hpp
+++ b/src/core/reference/include/openvino/reference/lstm_cell.hpp
@@ -114,7 +114,7 @@ void lstm_cell(const T* X,
     reference::split(reinterpret_cast<char*>(XHB.data()), all_gates_shape, sizeof(T), 1, 4, pointers.data());
 
     auto clip_activation = [&clip](std::vector<T>& gate, const std::string& activation, bool enable_clip = true) {
-        if (op::util::requires_clip(clip) && enable_clip) {
+        if (op::util::classify_rnn_clip(clip) == op::util::RNNClipMode::CLAMP && enable_clip) {
             reference::clamp(gate.data(), gate.data(), static_cast<T>(-clip), static_cast<T>(clip), gate.size());
         }
         if (activation == "relu") {

--- a/src/core/reference/include/openvino/reference/rnn_cell.hpp
+++ b/src/core/reference/include/openvino/reference/rnn_cell.hpp
@@ -79,7 +79,7 @@ void rnn_cell(const T* X,
                    op::AutoBroadcastType::NUMPY);
 
     // f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)
-    if (op::util::requires_clip(clip)) {
+    if (op::util::classify_rnn_clip(clip) == op::util::RNNClipMode::CLAMP) {
         reference::clamp(i_t.data(), i_t.data(), static_cast<T>(-clip), static_cast<T>(clip), i_t.size());
     }
     if (activation_f == "relu") {

--- a/src/core/reference/include/openvino/reference/rnn_cell.hpp
+++ b/src/core/reference/include/openvino/reference/rnn_cell.hpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "openvino/reference/add.hpp"
 #include "openvino/reference/clamp.hpp"
 #include "openvino/reference/matmul.hpp"
@@ -78,7 +79,7 @@ void rnn_cell(const T* X,
                    op::AutoBroadcastType::NUMPY);
 
     // f(Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi)
-    if (clip != 0.f) {
+    if (op::util::requires_clip(clip)) {
         reference::clamp(i_t.data(), i_t.data(), static_cast<T>(-clip), static_cast<T>(clip), i_t.size());
     }
     if (activation_f == "relu") {

--- a/src/core/src/op/util/rnn_cell_base.cpp
+++ b/src/core/src/op/util/rnn_cell_base.cpp
@@ -169,7 +169,7 @@ std::shared_ptr<ov::Node> ov::op::util::RNNCellBase::mul(const Output<Node>& lhs
 }
 
 std::shared_ptr<ov::Node> ov::op::util::RNNCellBase::clip(const Output<Node>& data) const {
-    if (is_no_clip(m_clip)) {
+    if (!requires_clip(m_clip)) {
         return data.get_node_shared_ptr();
     }
 

--- a/src/core/src/op/util/rnn_cell_base.cpp
+++ b/src/core/src/op/util/rnn_cell_base.cpp
@@ -169,7 +169,7 @@ std::shared_ptr<ov::Node> ov::op::util::RNNCellBase::mul(const Output<Node>& lhs
 }
 
 std::shared_ptr<ov::Node> ov::op::util::RNNCellBase::clip(const Output<Node>& data) const {
-    if (!requires_clip(m_clip)) {
+    if (classify_rnn_clip(m_clip) != RNNClipMode::CLAMP) {
         return data.get_node_shared_ptr();
     }
 

--- a/src/core/src/op/util/rnn_cell_base.cpp
+++ b/src/core/src/op/util/rnn_cell_base.cpp
@@ -169,7 +169,7 @@ std::shared_ptr<ov::Node> ov::op::util::RNNCellBase::mul(const Output<Node>& lhs
 }
 
 std::shared_ptr<ov::Node> ov::op::util::RNNCellBase::clip(const Output<Node>& data) const {
-    if (m_clip == 0.f) {
+    if (is_no_clip(m_clip)) {
         return data.get_node_shared_ptr();
     }
 

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -542,11 +542,7 @@ RNN::RNN(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
     CPU_NODE_ASSERT(rnnCellBase, "does not have original layer for RNNCell.");
     const float clip = rnnCellBase->get_clip();
     if (!ov::op::util::requires_clip(clip) && !ov::op::util::is_no_clip(clip)) {
-        DEBUG_LOG("[",
-                  op->get_friendly_name(),
-                  "] Ignoring invalid RNN clip value ",
-                  clip,
-                  "; using no clipping");
+        DEBUG_LOG("[", op->get_friendly_name(), "] Ignoring invalid RNN clip value ", clip, "; using no clipping");
     }
 
     cell_type = ie2dnnl(op);

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -316,7 +316,7 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
         if (rnnCellBase) {
             // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
             const float clip = rnnCellBase->get_clip();
-            if (!(clip == 0.F || std::isinf(clip))) {
+            if (clip != 0.F && !std::isinf(clip)) {
                 errorMessage = "Clipping is not supported for RNN primitive.";
                 return false;
             }

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -7,6 +7,7 @@
 #include <oneapi/dnnl/dnnl_types.h>
 
 #include <algorithm>
+#include <cmath>
 #include <common/utils.hpp>
 #include <cstddef>
 #include <cstdint>
@@ -313,7 +314,9 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
 
         auto rnnCellBase = ov::as_type_ptr<const ov::op::util::RNNCellBase>(op);
         if (rnnCellBase) {
-            if (rnnCellBase->get_clip() != 0.F) {
+            // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
+            const float clip = rnnCellBase->get_clip();
+            if (!(clip == 0.F || std::isinf(clip))) {
                 errorMessage = "Clipping is not supported for RNN primitive.";
                 return false;
             }

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -7,6 +7,7 @@
 #include <oneapi/dnnl/dnnl_types.h>
 
 #include <algorithm>
+#include <cmath>
 #include <common/primitive_hashing.hpp>
 #include <common/utils.hpp>
 #include <cstddef>
@@ -313,7 +314,9 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
 
         auto rnnCellBase = ov::as_type_ptr<const ov::op::util::RNNCellBase>(op);
         if (rnnCellBase) {
-            if (rnnCellBase->get_clip() != 0.F) {
+            // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
+            const float clip = rnnCellBase->get_clip();
+            if (!(clip == 0.F || std::isinf(clip))) {
                 errorMessage = "Clipping is not supported for RNN primitive.";
                 return false;
             }

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -313,8 +313,8 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
 
         auto rnnCellBase = ov::as_type_ptr<const ov::op::util::RNNCellBase>(op);
         if (rnnCellBase) {
-            // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-            if (!ov::op::util::is_no_clip(rnnCellBase->get_clip())) {
+            // Only a finite positive clip requires fallback; invalid values are ignored as no-clip.
+            if (ov::op::util::requires_clip(rnnCellBase->get_clip())) {
                 errorMessage = "Clipping is not supported for RNN primitive.";
                 return false;
             }
@@ -540,6 +540,14 @@ RNN::RNN(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
 
     auto rnnCellBase = ov::as_type_ptr<ov::op::util::RNNCellBase>(op);
     CPU_NODE_ASSERT(rnnCellBase, "does not have original layer for RNNCell.");
+    const float clip = rnnCellBase->get_clip();
+    if (!ov::op::util::requires_clip(clip) && !ov::op::util::is_no_clip(clip)) {
+        DEBUG_LOG("[",
+                  op->get_friendly_name(),
+                  "] Ignoring invalid RNN clip value ",
+                  clip,
+                  "; using no clipping");
+    }
 
     cell_type = ie2dnnl(op);
     if (!rnnCellBase->get_activations().empty()) {

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -7,7 +7,6 @@
 #include <oneapi/dnnl/dnnl_types.h>
 
 #include <algorithm>
-#include <cmath>
 #include <common/primitive_hashing.hpp>
 #include <common/utils.hpp>
 #include <cstddef>
@@ -315,8 +314,7 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
         auto rnnCellBase = ov::as_type_ptr<const ov::op::util::RNNCellBase>(op);
         if (rnnCellBase) {
             // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-            const float clip = rnnCellBase->get_clip();
-            if (clip != 0.F && !std::isinf(clip)) {
+            if (!ov::op::util::is_no_clip(rnnCellBase->get_clip())) {
                 errorMessage = "Clipping is not supported for RNN primitive.";
                 return false;
             }

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -314,7 +314,7 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
         auto rnnCellBase = ov::as_type_ptr<const ov::op::util::RNNCellBase>(op);
         if (rnnCellBase) {
             // Only a finite positive clip requires fallback; invalid values are ignored as no-clip.
-            if (ov::op::util::requires_clip(rnnCellBase->get_clip())) {
+            if (ov::op::util::classify_rnn_clip(rnnCellBase->get_clip()) == ov::op::util::RNNClipMode::CLAMP) {
                 errorMessage = "Clipping is not supported for RNN primitive.";
                 return false;
             }
@@ -541,7 +541,7 @@ RNN::RNN(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
     auto rnnCellBase = ov::as_type_ptr<ov::op::util::RNNCellBase>(op);
     CPU_NODE_ASSERT(rnnCellBase, "does not have original layer for RNNCell.");
     const float clip = rnnCellBase->get_clip();
-    if (!ov::op::util::requires_clip(clip) && !ov::op::util::is_no_clip(clip)) {
+    if (ov::op::util::classify_rnn_clip(clip) == ov::op::util::RNNClipMode::INVALID) {
         DEBUG_LOG("[", op->get_friendly_name(), "] Ignoring invalid RNN clip value ", clip, "; using no clipping");
     }
 

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -7,7 +7,6 @@
 #include <oneapi/dnnl/dnnl_types.h>
 
 #include <algorithm>
-#include <cmath>
 #include <common/utils.hpp>
 #include <cstddef>
 #include <cstdint>
@@ -315,8 +314,7 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
         auto rnnCellBase = ov::as_type_ptr<const ov::op::util::RNNCellBase>(op);
         if (rnnCellBase) {
             // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-            const float clip = rnnCellBase->get_clip();
-            if (clip != 0.F && !std::isinf(clip)) {
+            if (!ov::op::util::is_no_clip(rnnCellBase->get_clip())) {
                 errorMessage = "Clipping is not supported for RNN primitive.";
                 return false;
             }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
 #include <vector>
 #include "single_op_tests/gru_sequence.hpp"
 #include "common_test_utils/test_constants.hpp"
@@ -12,6 +13,13 @@ using ov::test::utils::InputLayerType;
 using ov::test::utils::SequenceTestsMode;
 
 namespace {
+    class GRUSequenceNoClipCPUTest : public GRUSequenceTest {};
+
+    TEST_P(GRUSequenceNoClipCPUTest, InferenceKeepsSequencePrimitive) {
+        run();
+        ov::test::CheckNumberOfNodesWithType(compiledModel, "RNNSeq", 1);
+    }
+
     std::vector<SequenceTestsMode> mode{SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_CONST,
                                         SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_CONST,
                                         SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM,
@@ -107,6 +115,23 @@ namespace {
                                     ::testing::ValuesIn(direction_bi),
                                     ::testing::Values(InputLayerType::CONSTANT),
                                     ::testing::ValuesIn(netPrecisions),
+                                    ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                            GRUSequenceTest::getTestCaseName);
+
+    INSTANTIATE_TEST_SUITE_P(smoke_GRUSequenceNoClip, GRUSequenceNoClipCPUTest,
+                            ::testing::Combine(
+                                    ::testing::Values(SequenceTestsMode::PURE_SEQ),
+                                    ::testing::Values(ov::test::static_shapes_to_test_representation(
+                                            input_shapes_zero_clip_static.front())),
+                                    ::testing::Values(std::vector<std::string>{"sigmoid", "tanh"}),
+                                    ::testing::Values(std::numeric_limits<float>::infinity(),
+                                                      -1.f,
+                                                      -std::numeric_limits<float>::infinity(),
+                                                      std::numeric_limits<float>::quiet_NaN()),
+                                    ::testing::Values(true),
+                                    ::testing::Values(ov::op::RecurrentSequenceDirection::FORWARD),
+                                    ::testing::Values(InputLayerType::CONSTANT),
+                                    ::testing::Values(ov::element::f32),
                                     ::testing::Values(ov::test::utils::DEVICE_CPU)),
                             GRUSequenceTest::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
+
 #include "single_op_tests/lstm_sequence.hpp"
 #include "common_test_utils/test_constants.hpp"
 
@@ -9,6 +11,13 @@ namespace {
 using ov::test::LSTMSequenceTest;
 using ov::test::utils::SequenceTestsMode;
 using ov::test::utils::InputLayerType;
+
+class LSTMSequenceNoClipCPUTest : public LSTMSequenceTest {};
+
+TEST_P(LSTMSequenceNoClipCPUTest, InferenceKeepsSequencePrimitive) {
+        run();
+        ov::test::CheckNumberOfNodesWithType(compiledModel, "RNNSeq", 1);
+}
 
 std::vector<SequenceTestsMode> mode{
     SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_CONST,
@@ -79,6 +88,24 @@ INSTANTIATE_TEST_SUITE_P(smoke_LSTMSequenceCommonClip, LSTMSequenceTest,
                                 ::testing::ValuesIn(direction),
                                 ::testing::Values(InputLayerType::CONSTANT),
                                 ::testing::ValuesIn(model_types),
+                                ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                        LSTMSequenceTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_LSTMSequenceNoClip, LSTMSequenceNoClipCPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(SequenceTestsMode::PURE_SEQ),
+                                ::testing::Values(2),
+                                ::testing::Values(1),
+                                ::testing::Values(1),
+                                ::testing::Values(1),
+                                ::testing::Values(std::vector<std::string>{"sigmoid", "tanh", "tanh"}),
+                                ::testing::Values(std::numeric_limits<float>::infinity(),
+                                                  -1.f,
+                                                  -std::numeric_limits<float>::infinity(),
+                                                  std::numeric_limits<float>::quiet_NaN()),
+                                ::testing::Values(ov::op::RecurrentSequenceDirection::FORWARD),
+                                ::testing::Values(InputLayerType::CONSTANT),
+                                ::testing::Values(ov::element::f32),
                                 ::testing::Values(ov::test::utils::DEVICE_CPU)),
                         LSTMSequenceTest::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/rnn_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/rnn_sequence.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
 #include <vector>
 #include "openvino/op/util/attr_types.hpp"
 #include "single_op_tests/rnn_sequence.hpp"
@@ -13,6 +14,13 @@ using ov::test::utils::InputLayerType;
 using ov::op::RecurrentSequenceDirection;
 
 namespace {
+        class RNNSequenceNoClipCPUTest : public RNNSequenceTest {};
+
+        TEST_P(RNNSequenceNoClipCPUTest, InferenceKeepsSequencePrimitive) {
+                run();
+                ov::test::CheckNumberOfNodesWithType(compiledModel, "RNNSeq", 1);
+        }
+
     std::vector<SequenceTestsMode> mode{SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_CONST,
                                         SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_CONST,
                                         SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM,
@@ -61,6 +69,24 @@ namespace {
                                     ::testing::ValuesIn(direction),
                                     ::testing::Values(InputLayerType::CONSTANT),
                                     ::testing::ValuesIn(model_types),
+                                    ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                            RNNSequenceTest::getTestCaseName);
+
+    INSTANTIATE_TEST_SUITE_P(smoke_RNNSequenceNoClip, RNNSequenceNoClipCPUTest,
+                            ::testing::Combine(
+                                    ::testing::Values(SequenceTestsMode::PURE_SEQ),
+                                    ::testing::Values(2),
+                                    ::testing::Values(1),
+                                    ::testing::Values(1),
+                                    ::testing::Values(1),
+                                    ::testing::Values(std::vector<std::string>{"tanh"}),
+                                    ::testing::Values(std::numeric_limits<float>::infinity(),
+                                                      -1.f,
+                                                      -std::numeric_limits<float>::infinity(),
+                                                      std::numeric_limits<float>::quiet_NaN()),
+                                    ::testing::Values(RecurrentSequenceDirection::FORWARD),
+                                    ::testing::Values(InputLayerType::CONSTANT),
+                                    ::testing::Values(ov::element::f32),
                                     ::testing::Values(ov::test::utils::DEVICE_CPU)),
                             RNNSequenceTest::getTestCaseName);
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
@@ -3,6 +3,7 @@
 //
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <utility>
 
@@ -55,7 +56,9 @@ struct LSTMSeqImplementationManager : public ImplementationManager {
 
         const auto& lstm_node = node.as<lstm_seq>();
         const auto& lstm_prim = lstm_node.get_primitive();
-        if (lstm_prim->clip > 0.0f) {
+        // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
+        const float clip = lstm_prim->clip;
+        if (!(clip == 0.0f || std::isinf(clip))) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
@@ -3,12 +3,12 @@
 //
 
 #include <algorithm>
-#include <cmath>
 #include <memory>
 #include <utility>
 
 #include "intel_gpu/runtime/layout.hpp"
 #include "lstm_seq_inst.h"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "registry/implementation_manager.hpp"
 
 using namespace cldnn;  // TODO: Remove once namespaces are aligned
@@ -57,8 +57,7 @@ struct LSTMSeqImplementationManager : public ImplementationManager {
         const auto& lstm_node = node.as<lstm_seq>();
         const auto& lstm_prim = lstm_node.get_primitive();
         // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-        const float clip = lstm_prim->clip;
-        if (clip != 0.0f && !std::isinf(clip)) {
+        if (!ov::op::util::is_no_clip(lstm_prim->clip)) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
@@ -56,8 +56,8 @@ struct LSTMSeqImplementationManager : public ImplementationManager {
 
         const auto& lstm_node = node.as<lstm_seq>();
         const auto& lstm_prim = lstm_node.get_primitive();
-        // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-        if (ov::op::util::classify_rnn_clip(lstm_prim->clip) != ov::op::util::RNNClipMode::NONE) {
+        // Only a finite positive clip requests clipping and is unsupported; invalid values are ignored as no-clip.
+        if (ov::op::util::classify_rnn_clip(lstm_prim->clip) == ov::op::util::RNNClipMode::CLAMP) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
@@ -57,7 +57,7 @@ struct LSTMSeqImplementationManager : public ImplementationManager {
         const auto& lstm_node = node.as<lstm_seq>();
         const auto& lstm_prim = lstm_node.get_primitive();
         // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-        if (!ov::op::util::is_no_clip(lstm_prim->clip)) {
+        if (ov::op::util::classify_rnn_clip(lstm_prim->clip) != ov::op::util::RNNClipMode::NONE) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/xetla_lstm_seq.hpp
@@ -58,7 +58,7 @@ struct LSTMSeqImplementationManager : public ImplementationManager {
         const auto& lstm_prim = lstm_node.get_primitive();
         // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
         const float clip = lstm_prim->clip;
-        if (!(clip == 0.0f || std::isinf(clip))) {
+        if (clip != 0.0f && !std::isinf(clip)) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_cell.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_cell.cpp
@@ -4,12 +4,11 @@
 
 #include "openvino/op/lstm_cell.hpp"
 
-#include <cmath>
-
 #include "lstm/lstm_cell_and_seq_kernel_selector.h"
 #include "lstm/lstm_kernel_base.h"
 #include "lstm_cell.hpp"
 #include "lstm_cell_inst.h"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "primitive_base.hpp"
 
 namespace cldnn {
@@ -60,7 +59,7 @@ public:
         }
 
         // clip == 0 and clip == inf both mean "no clipping"; normalize inf to 0 so the kernel skips clamping
-        const float clip = std::isinf(primitive->clip) ? 0.0f : primitive->clip;
+        const float clip = ov::op::util::is_no_clip(primitive->clip) ? 0.0f : primitive->clip;
         if (clip > 0.0f) {
             params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -clip, clip);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_cell.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_cell.cpp
@@ -58,8 +58,9 @@ public:
             }
         }
 
-        // clip == 0 and clip == inf both mean "no clipping"; normalize inf to 0 so the kernel skips clamping
-        const float clip = ov::op::util::is_no_clip(primitive->clip) ? 0.0f : primitive->clip;
+        // Only a finite positive clip yields usable bounds; 0, inf and NaN must all leave the kernel unclamped,
+        // so normalize them to 0 instead of forwarding a value the clamp activation cannot express.
+        const float clip = ov::op::util::requires_clip(primitive->clip) ? primitive->clip : 0.0f;
         if (clip > 0.0f) {
             params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -clip, clip);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_cell.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_cell.cpp
@@ -53,14 +53,14 @@ public:
             OPENVINO_ASSERT(param_sz == 0 || a_sz == param_sz, "[GPU] Unexpected activation params count in lstm_cell impl: ", param_sz);
             for (size_t i = 0; i < a_sz; i++) {
                 params.activations.emplace_back(get_kernel_selector_activation_param(primitive->activations[i]),
-                                                         param_sz ? primitive->activation_params[i].a : 0.0f,
-                                                         param_sz ? primitive->activation_params[i].b : 0.0f);
+                                                param_sz ? primitive->activation_params[i].a : 0.0f,
+                                                param_sz ? primitive->activation_params[i].b : 0.0f);
             }
         }
 
         // Only a finite positive clip yields usable bounds; 0, inf and NaN must all leave the kernel unclamped,
         // so normalize them to 0 instead of forwarding a value the clamp activation cannot express.
-        const float clip = ov::op::util::requires_clip(primitive->clip) ? primitive->clip : 0.0f;
+        const float clip = ov::op::util::classify_rnn_clip(primitive->clip) == ov::op::util::RNNClipMode::CLAMP ? primitive->clip : 0.0f;
         if (clip > 0.0f) {
             params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -clip, clip);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_cell.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_cell.cpp
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "primitive_base.hpp"
+#include "openvino/op/lstm_cell.hpp"
 
-#include "lstm_cell_inst.h"
+#include <cmath>
+
 #include "lstm/lstm_cell_and_seq_kernel_selector.h"
 #include "lstm/lstm_kernel_base.h"
-#include "openvino/op/lstm_cell.hpp"
 #include "lstm_cell.hpp"
+#include "lstm_cell_inst.h"
+#include "primitive_base.hpp"
 
 namespace cldnn {
 namespace ocl {
@@ -57,12 +59,14 @@ public:
             }
         }
 
-        if (primitive->clip > 0.0f) {
-            params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -primitive->clip, primitive->clip);
+        // clip == 0 and clip == inf both mean "no clipping"; normalize inf to 0 so the kernel skips clamping
+        const float clip = std::isinf(primitive->clip) ? 0.0f : primitive->clip;
+        if (clip > 0.0f) {
+            params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -clip, clip);
         }
 
         params.SetOffsetOrder(static_cast<int32_t>(primitive->offset_order));
-        params.clip = primitive->clip;
+        params.clip = clip;
         params.direction = primitive->direction;
 
         return params;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rnn_seq.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rnn_seq.cpp
@@ -56,17 +56,17 @@ public:
         if (!primitive->activations.empty()) {
             auto a_sz = primitive->activations.size();
             auto param_sz = primitive->activation_params.size();
-            OPENVINO_ASSERT(param_sz == 0|| a_sz == param_sz, "[GPU] Unexpected activation params count in lstm_seq impl: ", param_sz);
+            OPENVINO_ASSERT(param_sz == 0 || a_sz == param_sz, "[GPU] Unexpected activation params count in lstm_seq impl: ", param_sz);
             for (size_t i = 0; i < a_sz; i++) {
                 params.activations.emplace_back(get_kernel_selector_activation_param(primitive->activations[i]),
-                                                         param_sz ? primitive->activation_params[i].a : 0.0f,
-                                                         param_sz ? primitive->activation_params[i].b : 0.0f);
+                                                param_sz ? primitive->activation_params[i].a : 0.0f,
+                                                param_sz ? primitive->activation_params[i].b : 0.0f);
             }
         }
 
         // Only a finite positive clip yields usable bounds; 0, inf and NaN must all leave the kernel unclamped,
         // so normalize them to 0 instead of forwarding a value the clamp activation cannot express.
-        const float clip = ov::op::util::requires_clip(primitive->clip) ? primitive->clip : 0.0f;
+        const float clip = ov::op::util::classify_rnn_clip(primitive->clip) == ov::op::util::RNNClipMode::CLAMP ? primitive->clip : 0.0f;
         if (clip > 0.0f) {
             params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -clip, clip);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rnn_seq.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rnn_seq.cpp
@@ -4,12 +4,11 @@
 
 #include "rnn_seq.hpp"
 
-#include <cmath>
-
 #include "lstm/lstm_cell_and_seq_kernel_selector.h"
 #include "lstm/lstm_kernel_base.h"
 #include "lstm_seq_inst.h"
 #include "openvino/op/lstm_sequence.hpp"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include "primitive_base.hpp"
 #include "registry/implementation_manager.hpp"
 
@@ -66,7 +65,7 @@ public:
         }
 
         // clip == 0 and clip == inf both mean "no clipping"; normalize inf to 0 so the kernel skips clamping
-        const float clip = std::isinf(primitive->clip) ? 0.0f : primitive->clip;
+        const float clip = ov::op::util::is_no_clip(primitive->clip) ? 0.0f : primitive->clip;
         if (clip > 0.0f) {
             params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -clip, clip);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rnn_seq.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rnn_seq.cpp
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "primitive_base.hpp"
-
-#include "lstm_seq_inst.h"
 #include "rnn_seq.hpp"
+
+#include <cmath>
+
 #include "lstm/lstm_cell_and_seq_kernel_selector.h"
 #include "lstm/lstm_kernel_base.h"
+#include "lstm_seq_inst.h"
 #include "openvino/op/lstm_sequence.hpp"
+#include "primitive_base.hpp"
 #include "registry/implementation_manager.hpp"
 
 namespace cldnn {
@@ -63,12 +65,14 @@ public:
             }
         }
 
-        if (primitive->clip > 0.0f) {
-            params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -primitive->clip, primitive->clip);
+        // clip == 0 and clip == inf both mean "no clipping"; normalize inf to 0 so the kernel skips clamping
+        const float clip = std::isinf(primitive->clip) ? 0.0f : primitive->clip;
+        if (clip > 0.0f) {
+            params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -clip, clip);
         }
 
         params.SetOffsetOrder(static_cast<int32_t>(primitive->offset_order));
-        params.clip = primitive->clip;
+        params.clip = clip;
         params.direction = primitive->direction;
         return params;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rnn_seq.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rnn_seq.cpp
@@ -64,8 +64,9 @@ public:
             }
         }
 
-        // clip == 0 and clip == inf both mean "no clipping"; normalize inf to 0 so the kernel skips clamping
-        const float clip = ov::op::util::is_no_clip(primitive->clip) ? 0.0f : primitive->clip;
+        // Only a finite positive clip yields usable bounds; 0, inf and NaN must all leave the kernel unclamped,
+        // so normalize them to 0 instead of forwarding a value the clamp activation cannot express.
+        const float clip = ov::op::util::requires_clip(primitive->clip) ? primitive->clip : 0.0f;
         if (clip > 0.0f) {
             params.activations.emplace_back(get_kernel_selector_activation_param(activation_func::clamp), -clip, clip);
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.cpp
@@ -7,6 +7,7 @@
 #include "common_tools.h"
 #include <string>
 #include <algorithm>
+#include <cmath>
 
 namespace kernel_selector {
 
@@ -68,7 +69,9 @@ JitConstants LSTMKernelBase::GetJitConstants(const lstm_params& params) const {
         jit.Merge(MakeActivationJitConstants(aparams, params.inputs[0].GetDType(), asuffixes[i]));
     }
 
-    if (params.clip <= 0) {
+    // clip == 0 and clip == inf both mean "no clipping" (see ov::op::util::is_no_clip). The plugin layer already
+    // normalizes inf to 0, but guard here as well so a raw inf never turns into a degenerate clamp in the kernel.
+    if (params.clip <= 0 || std::isinf(params.clip)) {
         jit.AddConstants({
                 MakeJitConstant("ACTIVATION_PARAMS_CLIP", ""),
                 MakeJitConstant("ACTIVATION_CLIP(x, p)", "(x)"),

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.cpp
@@ -9,7 +9,6 @@
 
 #include "common_tools.h"
 #include "kernel_selector_utils.h"
-#include "openvino/op/util/rnn_cell_base.hpp"
 
 namespace kernel_selector {
 
@@ -71,9 +70,7 @@ JitConstants LSTMKernelBase::GetJitConstants(const lstm_params& params) const {
         jit.Merge(MakeActivationJitConstants(aparams, params.inputs[0].GetDType(), asuffixes[i]));
     }
 
-    // Only a finite positive clip requests clamping. The plugin layer already
-    // normalizes 0/inf/NaN away, but guard here too so such a value never turns into a degenerate kernel clamp.
-    if (ov::op::util::classify_rnn_clip(params.clip) != ov::op::util::RNNClipMode::CLAMP) {
+    if (params.clip <= 0) {
         jit.AddConstants({
                 MakeJitConstant("ACTIVATION_PARAMS_CLIP", ""),
                 MakeJitConstant("ACTIVATION_CLIP(x, p)", "(x)"),

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.cpp
@@ -3,12 +3,13 @@
 //
 
 #include "lstm_kernel_base.h"
-#include "kernel_selector_utils.h"
-#include "common_tools.h"
-#include "openvino/op/util/rnn_cell_base.hpp"
-#include <string>
+
 #include <algorithm>
-#include <cmath>
+#include <string>
+
+#include "common_tools.h"
+#include "kernel_selector_utils.h"
+#include "openvino/op/util/rnn_cell_base.hpp"
 
 namespace kernel_selector {
 
@@ -70,9 +71,9 @@ JitConstants LSTMKernelBase::GetJitConstants(const lstm_params& params) const {
         jit.Merge(MakeActivationJitConstants(aparams, params.inputs[0].GetDType(), asuffixes[i]));
     }
 
-    // Only a finite positive clip requests clamping (see ov::op::util::requires_clip). The plugin layer already
+    // Only a finite positive clip requests clamping. The plugin layer already
     // normalizes 0/inf/NaN away, but guard here too so such a value never turns into a degenerate kernel clamp.
-    if (!ov::op::util::requires_clip(params.clip)) {
+    if (ov::op::util::classify_rnn_clip(params.clip) != ov::op::util::RNNClipMode::CLAMP) {
         jit.AddConstants({
                 MakeJitConstant("ACTIVATION_PARAMS_CLIP", ""),
                 MakeJitConstant("ACTIVATION_CLIP(x, p)", "(x)"),

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.cpp
@@ -5,6 +5,7 @@
 #include "lstm_kernel_base.h"
 #include "kernel_selector_utils.h"
 #include "common_tools.h"
+#include "openvino/op/util/rnn_cell_base.hpp"
 #include <string>
 #include <algorithm>
 #include <cmath>
@@ -69,9 +70,9 @@ JitConstants LSTMKernelBase::GetJitConstants(const lstm_params& params) const {
         jit.Merge(MakeActivationJitConstants(aparams, params.inputs[0].GetDType(), asuffixes[i]));
     }
 
-    // clip == 0 and clip == inf both mean "no clipping" (see ov::op::util::is_no_clip). The plugin layer already
-    // normalizes inf to 0, but guard here as well so a raw inf never turns into a degenerate clamp in the kernel.
-    if (params.clip <= 0 || std::isinf(params.clip)) {
+    // Only a finite positive clip requests clamping (see ov::op::util::requires_clip). The plugin layer already
+    // normalizes 0/inf/NaN away, but guard here too so such a value never turns into a degenerate kernel clamp.
+    if (!ov::op::util::requires_clip(params.clip)) {
         jit.AddConstants({
                 MakeJitConstant("ACTIVATION_PARAMS_CLIP", ""),
                 MakeJitConstant("ACTIVATION_CLIP(x, p)", "(x)"),

--- a/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
@@ -93,12 +93,12 @@ void GetGRUActivationParams(const std::shared_ptr<T>& op,
 }
 
 static float NormalizeRNNClip(float clip, const std::string& layer_name) {
-    const bool apply_clip = ov::op::util::requires_clip(clip);
-    if (!apply_clip && !ov::op::util::is_no_clip(clip)) {
+    const auto clip_mode = ov::op::util::classify_rnn_clip(clip);
+    if (clip_mode == ov::op::util::RNNClipMode::INVALID) {
         GPU_DEBUG_LOG << "[" << layer_name << "] Ignoring invalid RNN clip value " << clip
                       << "; using no clipping" << std::endl;
     }
-    return apply_clip ? clip : 0.0f;
+    return clip_mode == ov::op::util::RNNClipMode::CLAMP ? clip : 0.0f;
 }
 
 static void CreateGRUSequenceOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v5::GRUSequence>& op) {

--- a/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
@@ -92,6 +92,15 @@ void GetGRUActivationParams(const std::shared_ptr<T>& op,
     }
 }
 
+static float NormalizeRNNClip(float clip, const std::string& layer_name) {
+    const bool apply_clip = ov::op::util::requires_clip(clip);
+    if (!apply_clip && !ov::op::util::is_no_clip(clip)) {
+        GPU_DEBUG_LOG << "[" << layer_name << "] Ignoring invalid RNN clip value " << clip
+                      << "; using no clipping" << std::endl;
+    }
+    return apply_clip ? clip : 0.0f;
+}
+
 static void CreateGRUSequenceOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v5::GRUSequence>& op) {
     validate_inputs_count(op, {6});
     std::string layerName = layer_type_name_ID(op);
@@ -100,7 +109,7 @@ static void CreateGRUSequenceOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
     std::vector<cldnn::activation_func> activations;
     std::vector<cldnn::activation_additional_params> activation_params;
     GetGRUActivationParams(op, activations, activation_params);
-    float clip = op->get_clip();
+    const float clip = NormalizeRNNClip(op->get_clip(), layerName);
     if (op->get_input_shape(2).size() != 1 || op->get_input_shape(3).size() != 3 \
             || op->get_input_shape(4).size() != 3 || op->get_input_shape(5).size() != 2)
             OPENVINO_THROW("Wrong input shapes for GRUSequence op ", op->get_friendly_name());
@@ -121,7 +130,7 @@ static void CreateLSTMCellOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v4
     std::vector<cldnn::activation_func> activations;
     std::vector<cldnn::activation_additional_params> activation_params;
     GetLSTMActivationParams(op, activations, activation_params);
-    float clip = op->get_clip();
+    const float clip = NormalizeRNNClip(op->get_clip(), layerName);
     OPENVINO_ASSERT(!inputs[5].pid.empty());
     OPENVINO_ASSERT(p.use_new_shape_infer());
     p.add_primitive(*op, cldnn::lstm_cell(layerName, inputs[0], inputs[1], inputs[2], inputs[3], inputs[4], inputs[5], cldnn::input_info(),
@@ -136,7 +145,7 @@ static void CreateLSTMSequenceOp(ProgramBuilder& p, const std::shared_ptr<ov::op
     std::vector<cldnn::activation_func> activations;
     std::vector<cldnn::activation_additional_params> activation_params;
     GetLSTMActivationParams(op, activations, activation_params);
-    const float clip = op->get_clip();
+    const float clip = NormalizeRNNClip(op->get_clip(), layerName);
     OPENVINO_ASSERT(op->get_input_shape(2).size() == 3 && op->get_input_shape(3).size() == 1 && op->get_input_shape(4).size() == 3 &&
         op->get_input_shape(5).size() == 3 && op->get_input_shape(6).size() == 2, "Wrong input shapes for LSTMSequence op ", op->get_friendly_name());
     auto direction = op->get_direction();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1015,7 +1015,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     }
 
                     // Only a finite positive clip requires decomposition; invalid values are ignored as no-clip.
-                    if (ov::op::util::requires_clip(lstm_seq->get_clip())) {
+                    if (ov::op::util::classify_rnn_clip(lstm_seq->get_clip()) == ov::op::util::RNNClipMode::CLAMP) {
                         return false;
                     }
 
@@ -1140,7 +1140,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
             if (const auto& lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return ov::op::util::is_no_clip(lstm_cell_v1->get_clip()) &&
+                return ov::op::util::classify_rnn_clip(lstm_cell_v1->get_clip()) == ov::op::util::RNNClipMode::NONE &&
                        lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
             }
             return false;
@@ -1165,23 +1165,19 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             if (const auto& gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
                 // Invalid clip values are ignored as no-clip by the native primitive.
-                return !ov::op::util::requires_clip(gru_seq->get_clip()) &&
-                    gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} &&
-                    max_seq_len != 1 &&
-                    (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0),
-                                                        gru_seq->get_input_node_shared_ptr(2)) ||
-                    is_batch_one_with_dynamic_seq_len) &&
-                    gru_seq->get_linear_before_reset();
+                return ov::op::util::classify_rnn_clip(gru_seq->get_clip()) != ov::op::util::RNNClipMode::CLAMP &&
+                       gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} && max_seq_len != 1 &&
+                       (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0), gru_seq->get_input_node_shared_ptr(2)) ||
+                        is_batch_one_with_dynamic_seq_len) &&
+                       gru_seq->get_linear_before_reset();
             }
             if (const auto& lstm_seq = ov::as_type_ptr<const ov::op::v5::LSTMSequence>(node)) {
                 if (!data_pshape[1].is_static())
                     return false;
                 // Invalid clip values are ignored as no-clip by the native primitive.
-                return (!ov::op::util::requires_clip(lstm_seq->get_clip()) &&
-                    lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
-                    max_seq_len != 1 &&
-                    !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0),
-                                                        lstm_seq->get_input_node_shared_ptr(3)));
+                return (ov::op::util::classify_rnn_clip(lstm_seq->get_clip()) != ov::op::util::RNNClipMode::CLAMP &&
+                        lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} && max_seq_len != 1 &&
+                        !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0), lstm_seq->get_input_node_shared_ptr(3)));
             }
             return false;
         };

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1014,7 +1014,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
                     // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
                     const float clip = lstm_seq->get_clip();
-                    if (!(clip == 0.f || std::isinf(clip))) {
+                    if (clip != 0.f && !std::isinf(clip)) {
                         return false;
                     }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1014,8 +1014,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                         return false;
                     }
 
-                    // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip); only a finite clip is unsupported
-                    if (lstm_seq->get_clip() > 0.f && !std::isinf(lstm_seq->get_clip())) {
+                    // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
+                    const float clip = lstm_seq->get_clip();
+                    if (!(clip == 0.f || std::isinf(clip))) {
                         return false;
                     }
 
@@ -1140,8 +1141,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
             if (const auto& lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return (lstm_cell_v1->get_clip() == 0.0f || std::isinf(lstm_cell_v1->get_clip())) &&
-                       lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
+                const float clip = lstm_cell_v1->get_clip();
+                return (clip == 0.0f || std::isinf(clip)) && lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
             }
             return false;
         };
@@ -1165,7 +1166,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             if (const auto& gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return (gru_seq->get_clip() == 0.0f || std::isinf(gru_seq->get_clip())) &&
+                const float clip = gru_seq->get_clip();
+                return (clip == 0.0f || std::isinf(clip)) &&
                     gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} &&
                     max_seq_len != 1 &&
                     (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0),
@@ -1177,7 +1179,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 if (!data_pshape[1].is_static())
                     return false;
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return ((lstm_seq->get_clip() == 0.0f || std::isinf(lstm_seq->get_clip())) &&
+                const float clip = lstm_seq->get_clip();
+                return ((clip == 0.0f || std::isinf(clip)) &&
                     lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
                     max_seq_len != 1 &&
                     !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0),

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1012,8 +1012,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                         return false;
                     }
 
-                    // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip); only a finite clip is unsupported
-                    if (lstm_seq->get_clip() > 0.f && !std::isinf(lstm_seq->get_clip())) {
+                    // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
+                    const float clip = lstm_seq->get_clip();
+                    if (!(clip == 0.f || std::isinf(clip))) {
                         return false;
                     }
 
@@ -1139,8 +1140,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 return false;
             } else if (const auto &lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return (lstm_cell_v1->get_clip() == 0.0f || std::isinf(lstm_cell_v1->get_clip())) &&
-                       lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
+                const float clip = lstm_cell_v1->get_clip();
+                return (clip == 0.0f || std::isinf(clip)) && lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
             }
             return false;
         };
@@ -1163,8 +1164,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             } else if (const auto &gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return (gru_seq->get_clip() == 0.0f || std::isinf(gru_seq->get_clip())) &&
-                       gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} && max_seq_len != 1 &&
+                const float clip = gru_seq->get_clip();
+                return (clip == 0.0f || std::isinf(clip)) && gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} && max_seq_len != 1 &&
                        (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0), gru_seq->get_input_node_shared_ptr(2)) ||
                         is_batch_one_with_dynamic_seq_len) &&
                        gru_seq->get_linear_before_reset();
@@ -1172,9 +1173,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 if (!data_pshape[1].is_static())
                     return false;
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return ((lstm_seq->get_clip() == 0.0f || std::isinf(lstm_seq->get_clip())) &&
-                        lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} && max_seq_len != 1 &&
-                        !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0), lstm_seq->get_input_node_shared_ptr(3)));
+                const float clip = lstm_seq->get_clip();
+                return ((clip == 0.0f || std::isinf(clip)) && lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
+                        max_seq_len != 1 && !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0), lstm_seq->get_input_node_shared_ptr(3)));
             }
             return false;
         };

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1015,8 +1015,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     }
 
                     // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-                    const float clip = lstm_seq->get_clip();
-                    if (clip != 0.f && !std::isinf(clip)) {
+                    if (!ov::op::util::is_no_clip(lstm_seq->get_clip())) {
                         return false;
                     }
 
@@ -1141,8 +1140,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
             if (const auto& lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                const float clip = lstm_cell_v1->get_clip();
-                return (clip == 0.0f || std::isinf(clip)) && lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
+                return ov::op::util::is_no_clip(lstm_cell_v1->get_clip()) &&
+                       lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
             }
             return false;
         };
@@ -1166,8 +1165,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             if (const auto& gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                const float clip = gru_seq->get_clip();
-                return (clip == 0.0f || std::isinf(clip)) &&
+                return ov::op::util::is_no_clip(gru_seq->get_clip()) &&
                     gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} &&
                     max_seq_len != 1 &&
                     (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0),
@@ -1179,8 +1177,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 if (!data_pshape[1].is_static())
                     return false;
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                const float clip = lstm_seq->get_clip();
-                return ((clip == 0.0f || std::isinf(clip)) &&
+                return (ov::op::util::is_no_clip(lstm_seq->get_clip()) &&
                     lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
                     max_seq_len != 1 &&
                     !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0),

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1012,7 +1012,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                         return false;
                     }
 
-                    if (lstm_seq->get_clip() > 0.f) {
+                    // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip); only a finite clip is unsupported
+                    if (lstm_seq->get_clip() > 0.f && !std::isinf(lstm_seq->get_clip())) {
                         return false;
                     }
 
@@ -1137,7 +1138,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             } else if (const auto &lstm_cell = ov::as_type_ptr<const ov::op::v4::LSTMCell>(node)) {
                 return false;
             } else if (const auto &lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
-                return lstm_cell_v1->get_clip() == 0.0f && lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
+                // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
+                return (lstm_cell_v1->get_clip() == 0.0f || std::isinf(lstm_cell_v1->get_clip())) &&
+                       lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
             }
             return false;
         };
@@ -1159,21 +1162,19 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 return false;
             } else if (const auto &gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
-                return gru_seq->get_clip() == 0.0f &&
-                    gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} &&
-                    max_seq_len != 1 &&
-                    (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0),
-                                                        gru_seq->get_input_node_shared_ptr(2)) ||
-                    is_batch_one_with_dynamic_seq_len) &&
-                    gru_seq->get_linear_before_reset();
+                // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
+                return (gru_seq->get_clip() == 0.0f || std::isinf(gru_seq->get_clip())) &&
+                       gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} && max_seq_len != 1 &&
+                       (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0), gru_seq->get_input_node_shared_ptr(2)) ||
+                        is_batch_one_with_dynamic_seq_len) &&
+                       gru_seq->get_linear_before_reset();
             } else if (const auto &lstm_seq = ov::as_type_ptr<const ov::op::v5::LSTMSequence>(node)) {
                 if (!data_pshape[1].is_static())
                     return false;
-                return (lstm_seq->get_clip() == 0.0f &&
-                    lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
-                    max_seq_len != 1 &&
-                    !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0),
-                                                        lstm_seq->get_input_node_shared_ptr(3)));
+                // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
+                return ((lstm_seq->get_clip() == 0.0f || std::isinf(lstm_seq->get_clip())) &&
+                        lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} && max_seq_len != 1 &&
+                        !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0), lstm_seq->get_input_node_shared_ptr(3)));
             }
             return false;
         };

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1013,8 +1013,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     }
 
                     // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-                    const float clip = lstm_seq->get_clip();
-                    if (clip != 0.f && !std::isinf(clip)) {
+                    if (!ov::op::util::is_no_clip(lstm_seq->get_clip())) {
                         return false;
                     }
 
@@ -1140,8 +1139,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 return false;
             } else if (const auto &lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                const float clip = lstm_cell_v1->get_clip();
-                return (clip == 0.0f || std::isinf(clip)) && lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
+                return ov::op::util::is_no_clip(lstm_cell_v1->get_clip()) &&
+                       lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
             }
             return false;
         };
@@ -1164,8 +1163,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             } else if (const auto &gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                const float clip = gru_seq->get_clip();
-                return (clip == 0.0f || std::isinf(clip)) && gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} && max_seq_len != 1 &&
+                return ov::op::util::is_no_clip(gru_seq->get_clip()) &&
+                       gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} && max_seq_len != 1 &&
                        (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0), gru_seq->get_input_node_shared_ptr(2)) ||
                         is_batch_one_with_dynamic_seq_len) &&
                        gru_seq->get_linear_before_reset();
@@ -1173,9 +1172,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 if (!data_pshape[1].is_static())
                     return false;
                 // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                const float clip = lstm_seq->get_clip();
-                return ((clip == 0.0f || std::isinf(clip)) && lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
-                        max_seq_len != 1 && !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0), lstm_seq->get_input_node_shared_ptr(3)));
+                return (ov::op::util::is_no_clip(lstm_seq->get_clip()) &&
+                        lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} && max_seq_len != 1 &&
+                        !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0), lstm_seq->get_input_node_shared_ptr(3)));
             }
             return false;
         };

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1014,8 +1014,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                         return false;
                     }
 
-                    // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
-                    if (!ov::op::util::is_no_clip(lstm_seq->get_clip())) {
+                    // Only a finite positive clip requires decomposition; invalid values are ignored as no-clip.
+                    if (ov::op::util::requires_clip(lstm_seq->get_clip())) {
                         return false;
                     }
 
@@ -1152,8 +1152,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         // (WA) We can ignore real sequence_lengths input for batch_size == 1 case when seq_length in first input is dynamic.
         // This WA applies to GRUSequence only.
         // RNN Sequence is not supported in GPU plugin and is always converted to TensorIterator
-        // LSTM Sequence supported with clip == 0, and activations have default values (sigmoid, tanh, tanh)
-        // GRU Sequence supported with clip == 0, and activations have default values (sigmoid, tanh)
+        // LSTM Sequence is supported when clipping is not required and activations have default values.
+        // GRU Sequence is supported when clipping is not required and activations have default values.
         auto isSequencePrimitiveSupported = [](const_node_ptr &node) -> bool {
             const auto& data = node->input(0);
             const auto& data_pshape = data.get_partial_shape();
@@ -1164,8 +1164,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
             if (const auto& gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
-                // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return ov::op::util::is_no_clip(gru_seq->get_clip()) &&
+                // Invalid clip values are ignored as no-clip by the native primitive.
+                return !ov::op::util::requires_clip(gru_seq->get_clip()) &&
                     gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} &&
                     max_seq_len != 1 &&
                     (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0),
@@ -1176,8 +1176,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             if (const auto& lstm_seq = ov::as_type_ptr<const ov::op::v5::LSTMSequence>(node)) {
                 if (!data_pshape[1].is_static())
                     return false;
-                // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
-                return (ov::op::util::is_no_clip(lstm_seq->get_clip()) &&
+                // Invalid clip values are ignored as no-clip by the native primitive.
+                return (!ov::op::util::requires_clip(lstm_seq->get_clip()) &&
                     lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
                     max_seq_len != 1 &&
                     !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0),

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1014,7 +1014,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                         return false;
                     }
 
-                    if (lstm_seq->get_clip() > 0.f) {
+                    // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip); only a finite clip is unsupported
+                    if (lstm_seq->get_clip() > 0.f && !std::isinf(lstm_seq->get_clip())) {
                         return false;
                     }
 
@@ -1138,7 +1139,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 return false;
             }
             if (const auto& lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
-                return lstm_cell_v1->get_clip() == 0.0f && lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
+                // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
+                return (lstm_cell_v1->get_clip() == 0.0f || std::isinf(lstm_cell_v1->get_clip())) &&
+                       lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
             }
             return false;
         };
@@ -1161,7 +1164,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
             if (const auto& gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
-                return gru_seq->get_clip() == 0.0f &&
+                // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
+                return (gru_seq->get_clip() == 0.0f || std::isinf(gru_seq->get_clip())) &&
                     gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} &&
                     max_seq_len != 1 &&
                     (!ov::op::util::is_seq_len_provided(gru_seq->get_input_node_shared_ptr(0),
@@ -1172,7 +1176,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             if (const auto& lstm_seq = ov::as_type_ptr<const ov::op::v5::LSTMSequence>(node)) {
                 if (!data_pshape[1].is_static())
                     return false;
-                return (lstm_seq->get_clip() == 0.0f &&
+                // clip == 0 and clip == inf both mean "no clipping" (see RNNCellBase::clip), so treat inf as no-clip
+                return ((lstm_seq->get_clip() == 0.0f || std::isinf(lstm_seq->get_clip())) &&
                     lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
                     max_seq_len != 1 &&
                     !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0),

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1016,7 +1016,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
                     // clip == 0 and clip == inf both mean "no clipping"; only a finite clip is unsupported
                     const float clip = lstm_seq->get_clip();
-                    if (!(clip == 0.f || std::isinf(clip))) {
+                    if (clip != 0.f && !std::isinf(clip)) {
                         return false;
                     }
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
 #include <vector>
 #include "single_op_tests/gru_sequence.hpp"
 #include "common_test_utils/test_constants.hpp"
@@ -13,6 +14,13 @@ using ov::test::utils::InputLayerType;
 using ov::test::utils::SequenceTestsMode;
 
 namespace {
+        class GRUSequenceNoClipGPUTest : public GRUSequenceTest {};
+
+        TEST_P(GRUSequenceNoClipGPUTest, InferenceKeepsSequencePrimitive) {
+        run();
+        ov::test::CheckNumberOfNodesWithType(compiledModel, "GRU_Seq", 1);
+    }
+
     std::vector<SequenceTestsMode> mode{SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_CONST,
                                         SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_CONST,
                                         SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM,
@@ -152,6 +160,23 @@ namespace {
                                     ::testing::ValuesIn(direction_bi),
                                     ::testing::Values(InputLayerType::CONSTANT),
                                     ::testing::ValuesIn(netPrecisions),
+                                    ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                            GRUSequenceTest::getTestCaseName);
+
+        INSTANTIATE_TEST_SUITE_P(smoke_GRUSequenceNoClip, GRUSequenceNoClipGPUTest,
+                            ::testing::Combine(
+                                    ::testing::Values(SequenceTestsMode::PURE_SEQ),
+                                    ::testing::Values(ov::test::static_shapes_to_test_representation(
+                                            input_shapes_zero_clip_static.front())),
+                                    ::testing::Values(std::vector<std::string>{"sigmoid", "tanh"}),
+                                    ::testing::Values(std::numeric_limits<float>::infinity(),
+                                                      -1.f,
+                                                      -std::numeric_limits<float>::infinity(),
+                                                      std::numeric_limits<float>::quiet_NaN()),
+                                    ::testing::Values(true),
+                                    ::testing::Values(ov::op::RecurrentSequenceDirection::FORWARD),
+                                    ::testing::Values(InputLayerType::CONSTANT),
+                                    ::testing::Values(ov::element::f32),
                                     ::testing::Values(ov::test::utils::DEVICE_GPU)),
                             GRUSequenceTest::getTestCaseName);
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
 #include <vector>
 
 #include "single_op_tests/lstm_cell.hpp"
@@ -9,6 +10,12 @@
 
 namespace {
 using ov::test::LSTMCellTest;
+
+class LSTMCellClipInfGPUTest : public LSTMCellTest {};
+
+TEST_P(LSTMCellClipInfGPUTest, Inference) {
+        run();
+}
 
 std::vector<bool> should_decompose{false, true};
 std::vector<size_t> batch{5};
@@ -56,4 +63,20 @@ INSTANTIATE_TEST_SUITE_P(smoke_LSTMCellCommon, LSTMCellTest,
                                 ::testing::ValuesIn(netPrecisions),
                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         LSTMCellTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_LSTMCellClipInf, LSTMCellClipInfGPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(false),
+                                ::testing::Values(5),
+                                ::testing::Values(1),
+                                ::testing::Values(1),
+                                ::testing::Values(std::vector<std::string>{"sigmoid", "tanh", "tanh"}),
+                                ::testing::Values(std::numeric_limits<float>::infinity()),
+                                ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                ::testing::Values(ov::element::f32),
+                                ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                        LSTMCellTest::getTestCaseName);
+
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <limits>
+
 #include "single_op_tests/lstm_sequence.hpp"
 #include "openvino/op/lstm_sequence.hpp"
 #include "openvino/op/concat.hpp"
@@ -32,6 +34,13 @@ class LSTMSequenceGPUTest : public LSTMSequenceTest {
         }
      }
 };
+
+class LSTMSequenceNoClipGPUTest : public LSTMSequenceTest {};
+
+TEST_P(LSTMSequenceNoClipGPUTest, InferenceKeepsSequencePrimitive) {
+    run();
+    ov::test::CheckNumberOfNodesWithType(compiledModel, "LSTM_Seq", 1);
+}
 
 std::vector<ov::test::utils::SequenceTestsMode> mode{ov::test::utils::SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_CONST,
                                                      ov::test::utils::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_CONST,
@@ -145,6 +154,24 @@ INSTANTIATE_TEST_SUITE_P(LSTMSequenceCM, LSTMSequenceGPUTest,
                                 ::testing::ValuesIn(netPrecisions_cm),
                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         LSTMSequenceGPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_LSTMSequenceNoClip, LSTMSequenceNoClipGPUTest,
+                        ::testing::Combine(
+                                ::testing::Values(ov::test::utils::SequenceTestsMode::PURE_SEQ),
+                                ::testing::Values(2),
+                                ::testing::Values(10),
+                                ::testing::Values(1),
+                                ::testing::Values(10),
+                                ::testing::Values(std::vector<std::string>{"sigmoid", "tanh", "tanh"}),
+                                ::testing::Values(std::numeric_limits<float>::infinity(),
+                                                  -1.f,
+                                                  -std::numeric_limits<float>::infinity(),
+                                                  std::numeric_limits<float>::quiet_NaN()),
+                                ::testing::Values(ov::op::RecurrentSequenceDirection::FORWARD),
+                                ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                ::testing::Values(ov::element::f32),
+                                ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                        LSTMSequenceTest::getTestCaseName);
 
 class MultipleLSTMSequenceGPUTest : public LSTMSequenceTest {
 private:


### PR DESCRIPTION
### Details:
GRUSequence/LSTMSequence models whose IR carries `clip="inf"` hang for minutes during GPU model compilation.

Since #35490 (correct `inf`/`-inf`/`nan` IR deserialization), `get_clip()` returns `+inf` for `clip="inf"`; previously `"inf"` failed to parse in `stringToType` and silently became `0.0`. The GPU plugin's sequence/cell support gates in `transformations_pipeline.cpp` required `get_clip() == 0.0f` to keep the op on the fast OneDNN RNN primitive, so `clip=inf` now falls through to `ConvertSequenceToTensorIterator`. With a long sequence (e.g. 35456) the decomposed `TensorIterator`/`Loop` body triggers a multi-minute, single-threaded IGC/OpenCL compile.

`clip==0` and `clip==inf` are functionally identical for RNN clipping — both mean "no clipping" (see `RNNCellBase::clip`, which skips the `Clamp` when `m_clip == 0`). This PR makes the four GPU gates treat `inf` the same as `0`:
- Bidirectional LSTM XeTLA decomposition gate
- `isCellPrimitiveSupported` (LSTMCell v0)
- `isSequencePrimitiveSupported` (GRUSequence and LSTMSequence)

Verified on the affected model: patching the IR `clip="inf"` → `clip="0"` (functionally equivalent) took the OneDNN path and compiled in ~4s instead of hanging 10+ minutes; this fix reproduces that behavior for `clip="inf"` without editing the IR.

### Tickets:
 - 185594