### PR TITLE
[NPU][IE-MDK] Enable Blob Caching Test

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/work_with_devices.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/work_with_devices.cpp
@@ -9,9 +9,9 @@
 
 namespace {
 
-const std::vector<ov::AnyMap> configs = {
-    {{ov::intel_npu::bypass_umd_caching(true)}},
-};
+const std::vector<ov::AnyMap> configs = {{{ov::intel_npu::bypass_umd_caching(true),
+                                           // Test manipulates UMD caching, compiler needs to be set to CiD
+                                           ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          TestCompiledModelNPU,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -923,17 +923,6 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- E#210236-->
-    <skip_config>
-        <message>Test fails sporadically on NPU Windows drivers</message>
-        <enable_rules>
-            <operating_system>windows</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*samePlatformProduceTheSameBlobCacheEnabled.*</filter>
-        </filters>
-    </skip_config>
-
     <skip_config>
         <message>PV driver cannot compile models securely</message>
         <enable_rules>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -923,6 +923,19 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- E#210236-->
+    <skip_config>
+        <message>Test fails sporadically on NPU Windows drivers older than 07 2026</message>
+        <enable_rules>
+            <operating_system>windows</operating_system>
+            <driver_version>1688</driver_version>
+            <driver_version>2020568</driver_version>
+        </enable_rules>
+        <filters>
+            <filter>.*samePlatformProduceTheSameBlobCacheEnabled.*</filter>
+        </filters>
+    </skip_config>
+
     <skip_config>
         <message>PV driver cannot compile models securely</message>
         <enable_rules>


### PR DESCRIPTION
### Details:
 - samePlatformProduceTheSameBlobCacheEnabled runs 3 compilations and expects one of them to retrieve the blob from the UMD cache
 - Force compiler type = DRIVER, otherwise test won't actually use UMD cache
 - PR depends on having the Driver tagged LATEST be updated in a separate config file

### Tickets:
 - E 210236

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
