### PR TITLE
[pyAPI] Release GIL in AsyncInferQueue destructor to prevent deadlocks

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp
+++ b/src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp
@@ -41,6 +41,9 @@ public:
     }
 
     ~AsyncInferQueue() {
+        // Release the GIL before destroying requests. m_requests.clear() triggers a C++ destructor chain that
+        // eventually joins plugin executor threads (via CoreImpl dtor).
+        py::gil_scoped_release release;
         m_requests.clear();
     }
 

--- a/src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp
+++ b/src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #include "pyopenvino/core/async_infer_queue.hpp"
 

--- a/src/bindings/python/src/pyopenvino/core/async_infer_queue.hpp
+++ b/src/bindings/python/src/pyopenvino/core/async_infer_queue.hpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
+//
 
 #pragma once
 

--- a/tests/samples_tests/smoke_tests/test_classification_sample_async.py
+++ b/tests/samples_tests/smoke_tests/test_classification_sample_async.py
@@ -38,12 +38,10 @@ test_data_fp16 = get_tests({
 class TestClassification(SamplesCommonTestClass):
     sample_name = 'classification_sample_async'
 
-    @pytest.mark.skip(reason="CVS-188974")
     @pytest.mark.parametrize("param", test_data_fp32)
     def test_classification_sample_async_fp32(self, param, cache):
         _check_output(self, param, '215', cache)
 
-    @pytest.mark.skip(reason="CVS-188974")
     @pytest.mark.parametrize("param", test_data_fp16)
     def test_classification_sample_async_fp16(self, param, cache):
         _check_output(self, param, '215', cache)


### PR DESCRIPTION
### Details:
- Thread Safety Improvement:
  In the destructor of `AsyncInferQueue` (`src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp`), added a `py::gil_scoped_release` to release the GIL before clearing `m_requests`, ensuring safe interaction with C++ threads during destruction.
  
 - CVS-188974
 - CVS-189144

### AI Assistance:
 - *AI assistance used: yes*
 - *Debug and reproduce*
