### PR TITLE
[GPU] Fix Incompatible MatMul batch dimension in GRUSequence / LSTMSequence FC lowering

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -130,8 +130,12 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
     }
 
     if (weights_pshape.size() != 2) {
-        // Detect 3D weights being passed to oneDNN
-        if (supports_immad && weights_pshape.size() == 4 && weights_layout.batch() > 1 && weights_layout.spatial(1) == feature) {
+        // Detect real 3D+ weights passed to oneDNN. For legacy static shape infer,
+        // plain 2D weights may be represented as 4D layout (e.g. [3,1,1,1]);
+        // that case must be reshaped back to 2D instead of taking batched MatMul path.
+        if (supports_immad && desc->weights_rank > 2 &&
+            weights_pshape.size() == 4 && weights_layout.batch() > 1 &&
+            weights_layout.spatial(1) == feature) {
             return calc_output_layouts<ov::PartialShape>(node, impl_param)[0];
         } else {
             weights_layout.set_partial_shape(reshape_to_2d(weights_pshape, feature));


### PR DESCRIPTION
### Details
Gate the oneDNN batched-MatMul path in fully_connected_inst::calc_output_layout on weights_rank > 2 so plain 2D GRU/LSTM gate weights that happen to carry a 4D layout are no longer misrouted to a batched MatMul with an incompatible batch dimension.

### Description of the issue
#### Symptom
On dGPU (devices with supports_immad, i.e. oneDNN/IMAD path), the GRUSequence / LSTMSequence clip functional tests fail during graph compilation. It will report an error with `Incompatible MatMul batch dimension. Can't merge first input dimension=10 with second input dimension=4 at index=0`. The affected instances include:
```
smoke_GRUSequenceCommonZeroClip
smoke_GRUSequenceCommonZeroClipBidirect
smoke_GRUSequenceCommonClip
smoke_GRUSequenceCommonClipBidirect
smoke_LSTMSequenceCommonClip
```

#### Root cause
On dGPU, GRUSequence/LSTMSequence clip cases are lowered to a FullyConnected whose plain 2D gate weights carry a 4D layout with a leading dim > 1; this was misclassified as a 3D batched weight and routed to oneDNN batched MatMul with an incompatible batch dimension.

#### How to fix it
Gate the oneDNN batched-MatMul path in fully_connected_inst::calc_output_layout on weights_rank > 2 so plain 2D GRU/LSTM gate weights that happen to carry a 4D layout are no longer misrouted to a batched MatMul with an incompatible batch dimension.

#### Reproduction step and snapshot
./bin/intel64/Release/ov_gpu_func_tests \
  --gtest_filter='*GRUSequenceCommonZeroClip*:*GRUSequenceCommonZeroClipBidirect*;*GRUSequenceCommonClip*:*GRUSequenceCommonClipBidirect*:*LSTMSequenceCommonClip*'

#### Checklist 
 - [x] Is it a proper fix? (not a workaround) 
 - [ ] Did you include test case for this fix, if necessary? 
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - CVS-191333

### AI Assistance:
 - *AI assistance used: yes*
 - *AI help to root cause and human verify it*