### PR TITLE
[GPU][CLANG-TIDY] Enable readability-else-after-return and readability-qualified-auto

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -16,7 +16,9 @@ Checks: >
   modernize-use-using
   modernize-redundant-void-arg
   readability-container-size-empty
-  readability-redundant-string-cstr
+  readability-redundant-string-cstr,
+  readability-else-after-return,
+  readability-qualified-auto
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
@@ -149,10 +149,10 @@ struct kernel_impl_params final {
     }
 
     bool is_dynamic() const {
-        for (auto& i : input_layouts)
+        for (const auto& i : input_layouts)
             if (i.is_dynamic())
                 return true;
-        for (auto& i : output_layouts)
+        for (const auto& i : output_layouts)
             if (i.is_dynamic())
                 return true;
         return false;

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/layout_serializer.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/layout_serializer.hpp
@@ -52,11 +52,11 @@ public:
         buffer << traits.internal_order;
         buffer << traits.desc_size;
         buffer << traits.block_sizes.size();
-        for (auto& block_size : traits.block_sizes) {
+        for (const auto& block_size : traits.block_sizes) {
             buffer << block_size.first;
             buffer << block_size.second;
         }
-        for (auto& block_size : traits.logic_block_sizes) {
+        for (const auto& block_size : traits.logic_block_sizes) {
             buffer << block_size.first;
             buffer << block_size.second;
         }

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/output_memory_block.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/output_memory_block.hpp
@@ -65,7 +65,7 @@ public:
 
     /// @return Raw data pointer of the current buffer, for alias detection.
     void* rawPtr() const {
-        auto& mem = m_buffers[m_buff_idx];
+        const auto& mem = m_buffers[m_buff_idx];
         return mem ? mem->buffer_ptr() : nullptr;
     }
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/condition.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/condition.hpp
@@ -44,12 +44,12 @@ struct condition : public primitive_base<condition> {
 
         void save(BinaryOutputBuffer& ob) const {
             ob << input_map.size();
-            for (auto& input_pair : input_map) {
+            for (const auto& input_pair : input_map) {
                 ob << input_pair.first;
                 ob << input_pair.second;
             }
             ob << output_map.size();
-            for (auto& output_pair : output_map) {
+            for (const auto& output_pair : output_map) {
                 ob << output_pair.first;
                 ob << output_pair.second;
             }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
@@ -158,7 +158,7 @@ struct custom_gpu_primitive : public primitive_base<custom_gpu_primitive> {
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, kernel_entry_point);
-        for (auto& args : kernel_arguments) {
+        for (const auto& args : kernel_arguments) {
             seed = hash_combine(seed, args.index);
             seed = hash_combine(seed, args.type);
             seed = hash_combine(seed, args.size_expr);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -67,15 +67,15 @@ public:
                 mapped_memory->data() + bin_offset,
                 original_size,
                 mapped_memory);
-        } else {
-            auto model_ptr = std::get<std::shared_ptr<const ov::Model>>(weights_memory);
-            auto const_it = offset_to_constant_map.find(bin_offset);
-            if (const_it == offset_to_constant_map.end()) {
-                OPENVINO_THROW("Constant with bin_offset ", bin_offset, " not found in the model");
-            }
-            auto const_ptr = const_it->second;
-            return const_ptr;
         }
+        auto model_ptr = std::get<std::shared_ptr<const ov::Model>>(weights_memory);
+        auto const_it = offset_to_constant_map.find(bin_offset);
+        if (const_it == offset_to_constant_map.end()) {
+            OPENVINO_THROW("Constant with bin_offset ", bin_offset, " not found in the model");
+        }
+        auto const_ptr = const_it->second;
+        return const_ptr;
+
     }
 
 private:
@@ -104,7 +104,7 @@ private:
                         auto const_ptr = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
                         offset_to_constant_map.emplace(attr.bin_offset, const_ptr);
                     }
-                } else if (auto ti = ov::as_type<const ov::op::v0::TensorIterator>(node.get())) {
+                } else if (const auto *ti = ov::as_type<const ov::op::v0::TensorIterator>(node.get())) {
                     auto ti_body = ti->get_body();
                     fill_offset_to_constant_map(ti_body);
                 }
@@ -253,10 +253,10 @@ private:
             if (std::holds_alternative<std::shared_ptr<ov::op::v0::Constant>>(constant_ptr)) {
                 auto cptr = std::get<std::shared_ptr<ov::op::v0::Constant>>(constant_ptr);
                 return reinterpret_cast<const uint8_t*>(cptr->get_data_ptr());
-            } else {
-                auto shared_buf = std::get<shared_mapped_memory_ptr>(constant_ptr);
-                return shared_buf->get_ptr<uint8_t>();
             }
+            auto shared_buf = std::get<shared_mapped_memory_ptr>(constant_ptr);
+            return shared_buf->get_ptr<uint8_t>();
+
         };
 
         // Note: this works only until the data is copied to dst_mem.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/eltwise.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/eltwise.hpp
@@ -196,7 +196,7 @@ struct eltwise : public primitive_base<eltwise> {
         size_t seed = primitive::hash();
         seed = cldnn::hash_combine(seed, mode);
         seed = cldnn::hash_range(seed, coefficients.begin(), coefficients.end());
-        for (auto& s : stride) {
+        for (const auto& s : stride) {
             seed = cldnn::hash_combine(seed, s.hash());
         }
         seed = cldnn::hash_combine(seed, m_pythondiv);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
@@ -249,13 +249,14 @@ private:
         if (rank == order_idx[rank]) {
             // normal
             return TransposeType::X_LAST;
-        } else if (rank == order_idx[rank - 1]) {
+        }
+        if (rank == order_idx[rank - 1]) {
             // the second last dim is moved to the last
             return TransposeType::Y_LAST;
-        } else {
-            // other
-            return TransposeType::OTHER;
         }
+        // other
+        return TransposeType::OTHER;
+
     }
 };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/kv_cache.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/kv_cache.hpp
@@ -140,9 +140,9 @@ struct kv_cache : public primitive_base<kv_cache> {
     size_t get_compression_scales_inputs_num() const {
         if (compressed) {
             return 1;
-        } else {
-            return 0;
         }
+        return 0;
+
     }
 
     size_t get_compression_zp_inputs_num() const {
@@ -150,9 +150,9 @@ struct kv_cache : public primitive_base<kv_cache> {
             quantization_attributes.quantization_type == ov::op::internal::DynamicQuantize::QuantizationType::Asymmetric &&
             quantization_attributes.output_storage_type == ov::op::internal::DynamicQuantize::OutputStorageType::Planar) {
             return 1;
-        } else {
-            return 0;
         }
+        return 0;
+
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
@@ -277,7 +277,7 @@ protected:
         auto ret = std::map<size_t, const input_info*>{};
         auto idx = input.size();
 
-        for (auto& mapping : input_primitive_maps) {
+        for (const auto& mapping : input_primitive_maps) {
             auto found = std::any_of(input.begin(), input.end(), [&](const input_info& info) {
                 return info.pid == mapping.external_id.pid;
             });

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_mask_gen.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_mask_gen.hpp
@@ -57,7 +57,7 @@ struct moe_mask_gen : public primitive_base<moe_mask_gen> {
     bool operator==(const primitive& rhs) const override {
         if (!compare_common_params(rhs))
             return false;
-        if (auto rhs_casted = dynamic_cast<const moe_mask_gen*>(&rhs)) {
+        if (const auto *rhs_casted = dynamic_cast<const moe_mask_gen*>(&rhs)) {
             return num_total_experts == rhs_casted->num_total_experts &&
                    num_experts_per_token == rhs_casted->num_experts_per_token &&
                    onednn_grouped_gemm_used == rhs_casted->onednn_grouped_gemm_used;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/mvn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/mvn.hpp
@@ -83,9 +83,9 @@ struct mvn : public primitive_base<mvn> {
         int64_t channel_axis = 1;
         if (std::find(reduction_axes.begin(), reduction_axes.end(), channel_axis) != reduction_axes.end()) {
             return true;
-        } else {
-            return false;
         }
+        return false;
+
     }
 
     bool requires_alignment(const ov::PartialShape& shape) const {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
@@ -57,11 +57,12 @@ struct input_info {
         bool operator() (const input_info a, const input_info b) {
             if (a.pid < b.pid) {
                 return true;
-            } else if (a.pid == b.pid) {
-                return a.idx < b.idx;
-            } else {
-                return false;
             }
+            if (a.pid == b.pid) {
+                return a.idx < b.idx;
+            }
+            return false;
+
         }
     };
 
@@ -248,7 +249,7 @@ public:
         ob << origin_op_type_name;
         ob << output_paddings;
         ob << output_data_types.size();
-        for (auto& output_data_type : output_data_types) {
+        for (const auto& output_data_type : output_data_types) {
             if (output_data_type.has_value()) {
                 ob << true;
                 ob << make_data(&output_data_type.value(), sizeof(data_types));
@@ -289,17 +290,17 @@ public:
     virtual padding get_output_padding(size_t idx) const {
         if (idx < output_paddings.size()) {
             return output_paddings[idx];
-        } else {
-            return padding();
         }
+        return padding();
+
     }
 
     virtual optional_data_type get_output_data_type(size_t idx) const {
         if (idx < output_data_types.size()) {
             return output_data_types[idx];
-        } else {
-            return optional_data_type();
         }
+        return optional_data_type();
+
     }
 
     /// @brief Returns mutable reference to input dependency at given index.

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/rnn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/rnn.hpp
@@ -103,7 +103,7 @@ struct RNNParams : public primitive_base<PType> {
         seed = hash_combine(seed, !B.pid.empty());
         seed = hash_combine(seed, clip);
         seed = hash_range(seed, activations.begin(), activations.end());
-        for (auto& act_param : activation_params) {
+        for (const auto& act_param : activation_params) {
             seed = hash_combine(seed, act_param.a);
             seed = hash_combine(seed, act_param.b);
         }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp
@@ -205,9 +205,9 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
     size_t get_compression_scales_inputs_num() const {
         if (is_kv_compressed) {
             return 2;
-        } else {
-            return 0;
         }
+        return 0;
+
     }
 
     size_t get_compression_zp_inputs_num() const {
@@ -215,9 +215,9 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
             quantization_attributes.quantization_type == ov::op::internal::DynamicQuantize::QuantizationType::Asymmetric &&
             quantization_attributes.output_storage_type == ov::op::internal::DynamicQuantize::OutputStorageType::Planar) {
             return 2;
-        } else {
-            return 0;
         }
+        return 0;
+
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device.hpp
@@ -43,11 +43,12 @@ public:
 inline size_t get_device_priority(const cldnn::device_info& info) {
     if (info.vendor_id == cldnn::INTEL_VENDOR_ID && info.dev_type == cldnn::device_type::integrated_gpu) {
         return 0;
-    } else if (info.vendor_id == cldnn::INTEL_VENDOR_ID) {
-        return 1;
-    } else {
-        return std::numeric_limits<size_t>::max();
     }
+    if (info.vendor_id == cldnn::INTEL_VENDOR_ID) {
+        return 1;
+    }
+    return std::numeric_limits<size_t>::max();
+
 }
 
 inline std::vector<device::ptr> sort_devices(const std::vector<device::ptr>& devices_list) {

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
@@ -191,7 +191,7 @@ struct padding {
     friend bool operator<(const padding& lhs, const padding& rhs) {
         // Compare only actual padding size not _dynamic_dims_mask
         if (lhs._lower_size < rhs._lower_size) return true;
-        else if (lhs._lower_size > rhs._lower_size) return false;
+        if (lhs._lower_size > rhs._lower_size) return false;
         if (lhs._upper_size < rhs._upper_size) return true;
         return false;
     }
@@ -342,9 +342,9 @@ struct layout {
             auto desc_size = format.traits().desc_size;
             OPENVINO_ASSERT(desc_size > 0, "[GPU] Invalid layout descriptor size: ", desc_size);
             return desc_size > bytes_of_layout ? desc_size : bytes_of_layout;
-        } else {
-            return (ov::element::Type(data_type).bitwidth() * get_linear_size() + 7) >> 3;
         }
+        return (ov::element::Type(data_type).bitwidth() * get_linear_size() + 7) >> 3;
+
     }
 
     const cldnn::format& get_format() const;
@@ -432,7 +432,7 @@ struct layout {
         }
 
         if (format == format::custom) {
-            for (auto& bs : format.traits().block_sizes) {
+            for (const auto& bs : format.traits().block_sizes) {
                 seed = hash_combine(seed, bs.first);
                 seed = hash_combine(seed, bs.second);
             }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
@@ -39,9 +39,9 @@ public:
     std::pair<Key, Value> get_lru_element() const {
         if (!_lru_data_list.empty()) {
             return _lru_data_list.back();
-        } else {
-            return std::make_pair(Key(), Value());
         }
+        return std::make_pair(Key(), Value());
+
     }
 
     /**

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -251,28 +251,28 @@ inline std::vector<T> read_vector(cldnn::memory::ptr mem, const cldnn::stream& s
     if (mem->get_allocation_type() == allocation_type::usm_host || mem->get_allocation_type() == allocation_type::usm_shared) {
         switch (mem_dtype) {
             case data_types::i32: {
-                auto p_mem = reinterpret_cast<int32_t*>(mem->buffer_ptr());
+                auto *p_mem = reinterpret_cast<int32_t*>(mem->buffer_ptr());
                 for (size_t i = 0; i < mem->count(); ++i) {
                     out_vecs.push_back(static_cast<T>(p_mem[i]));
                 }
                 break;
             }
             case data_types::i64: {
-                auto p_mem = reinterpret_cast<int64_t*>(mem->buffer_ptr());
+                auto *p_mem = reinterpret_cast<int64_t*>(mem->buffer_ptr());
                 for (size_t i = 0; i < mem->count(); ++i) {
                     out_vecs.push_back(static_cast<T>(p_mem[i]));
                 }
                 break;
             }
             case data_types::f16: {
-                auto p_mem = reinterpret_cast<uint16_t*>(mem->buffer_ptr());
+                auto *p_mem = reinterpret_cast<uint16_t*>(mem->buffer_ptr());
                 for (size_t i = 0; i < mem->count(); ++i) {
                     out_vecs.push_back(static_cast<T>(ov::float16::from_bits(p_mem[i])));
                 }
                 break;
             }
             case data_types::f32: {
-                auto p_mem = reinterpret_cast<float*>(mem->buffer_ptr());
+                auto *p_mem = reinterpret_cast<float*>(mem->buffer_ptr());
                 for (size_t i = 0; i < mem->count(); ++i) {
                     out_vecs.push_back(static_cast<T>(p_mem[i]));
                 }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/profiling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/profiling.hpp
@@ -139,17 +139,17 @@ struct perf_counter_hash {
         seed = hash_combine(seed, static_cast<std::underlying_type<instrumentation::pipeline_stage>::type>(k.stage));
         seed = hash_combine(seed, static_cast<int>(k.cache_hit));
         seed = hash_combine(seed, k.iteration_num);
-        for (auto& layout : k.network_input_layouts) {
+        for (const auto& layout : k.network_input_layouts) {
             for (auto& d : layout.get_shape()) {
                 seed = hash_combine(seed, d);
             }
         }
-        for (auto& layout : k.input_layouts) {
+        for (const auto& layout : k.input_layouts) {
             for (auto& d : layout.get_shape()) {
                 seed = hash_combine(seed, d);
             }
         }
-        for (auto& layout : k.output_layouts) {
+        for (const auto& layout : k.output_layouts) {
             for (auto& d : layout.get_shape()) {
                 seed = hash_combine(seed, d);
             }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor_accessor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor_accessor.hpp
@@ -25,7 +25,7 @@ struct TensorsContainer final {
         , m_memories(deps_map.begin(), deps_map.end()) { }
 
     ~TensorsContainer() {
-        for (auto& port : m_locked_memories) {
+        for (const auto& port : m_locked_memories) {
             m_memories.at(port)->unlock(*m_stream);
         }
     }
@@ -51,13 +51,13 @@ struct TensorsContainer final {
         if (m_memories.count(port) > 0) {
             m_locked_memories.insert(port);
             auto mem = m_memories.at(port);
-            auto ptr = mem->lock(*m_stream, cldnn::mem_lock_type::read);
+            auto *ptr = mem->lock(*m_stream, cldnn::mem_lock_type::read);
             return make_tensor(mem->get_layout(), ptr);
-        } else if (m_tensors.count(port) > 0) {
-            return m_tensors.at(port);
-        } else {
-            return ov::Tensor{};
         }
+        if (m_tensors.count(port) > 0) {
+            return m_tensors.at(port);
+        }             return ov::Tensor{};
+
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/adaptive_pooling.cpp
@@ -35,7 +35,7 @@ std::vector<layout> adaptive_pooling_inst::calc_output_layouts(adaptive_pooling_
     std::vector<ShapeType> output_shapes = {ShapeType()};
     std::unordered_map<size_t, ov::Tensor> const_data;
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
 
     if (memory_deps.count(1)) {
         auto pooledVector_mem = memory_deps.at(1);
@@ -77,7 +77,7 @@ std::string adaptive_pooling_inst::to_string(adaptive_pooling_node const& node) 
     std::stringstream primitive_description;
 
     json_composite info;
-    const auto mode = prim->mode == adaptive_pooling_mode::max ? "max" : "average";
+    const auto *const mode = prim->mode == adaptive_pooling_mode::max ? "max" : "average";
     info.add("mode", mode);
     info.add("output_size", prim->output_size);
 

--- a/src/plugins/intel_gpu/src/graph/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/arg_max_min.cpp
@@ -85,7 +85,7 @@ std::vector<layout> arg_max_min_inst::calc_output_layouts(arg_max_min_node const
         ShapeType{}
     };
 
-    auto& constant_mem = impl_param.memory_deps;
+    const auto& constant_mem = impl_param.memory_deps;
     if (desc->top_k > 0) {
         std::unordered_map<size_t, ov::Tensor> const_data;
         auto topk = desc->top_k;

--- a/src/plugins/intel_gpu/src/graph/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/batch_to_space.cpp
@@ -85,7 +85,7 @@ std::vector<layout> batch_to_space_inst::calc_output_layouts(batch_to_space_node
     auto input0_size = input0_shape.size();
     auto input0_format = input0_layout.format;
 
-    auto& constant_mem = impl_param.memory_deps;
+    const auto& constant_mem = impl_param.memory_deps;
     auto block_data = desc->block_shape;
     auto begin_data = desc->crops_begin;
     auto end_data = desc->crops_end;
@@ -118,9 +118,9 @@ std::vector<layout> batch_to_space_inst::calc_output_layouts(batch_to_space_node
         auto begin_sizes = tensor_to_vec(begin_data, input0_format);
         auto end_sizes = tensor_to_vec(end_data, input0_format);
 
-        auto block_values = static_cast<void*>(block_sizes.data());
-        auto begin_values = static_cast<void*>(begin_sizes.data());
-        auto end_values = static_cast<void*>(end_sizes.data());
+        auto *block_values = static_cast<void*>(block_sizes.data());
+        auto *begin_values = static_cast<void*>(begin_sizes.data());
+        auto *end_values = static_cast<void*>(end_sizes.data());
 
         auto block_tensor = make_tensor({ block_shape, data_types::i32, input0_format }, block_values);
         auto begin_tensor = make_tensor({ begin_shape, data_types::i32, input0_format }, begin_values);

--- a/src/plugins/intel_gpu/src/graph/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/border.cpp
@@ -53,7 +53,7 @@ std::vector<layout> border_inst::calc_output_layouts(border_node const& /*node*/
     const size_t begin_mem_idx = is_begin_mem ? 1 : 0;
     const size_t end_mem_idx = is_begin_mem ? 2 : 1;
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
     if ((is_begin_mem && memory_deps.count(begin_mem_idx) == 0) ||
         (is_end_mem && memory_deps.count(end_mem_idx) == 0)) {
         return {layout{ShapeType::dynamic(static_cast<int64_t>(in_rank)), input0_layout.data_type, input0_layout.format}};

--- a/src/plugins/intel_gpu/src/graph/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/broadcast.cpp
@@ -37,9 +37,9 @@ layout broadcast_inst::calc_output_layout(broadcast_node const& node, kernel_imp
         return { output_type,
                  input_layout.format,
                  tensor(format::get_default_format(dims_converted.size()), dims_converted) };
-    } else {
-        return { output_type, input_layout.format, desc->broadcast_sizes };
     }
+    return { output_type, input_layout.format, desc->broadcast_sizes };
+
 }
 
 template<typename ShapeType>
@@ -77,7 +77,7 @@ std::vector<layout> broadcast_inst::calc_output_layouts(broadcast_node const& /*
         const_data.emplace(2, axes_mapping_tensor);
     }
 
-    auto& constant_mem = impl_param.memory_deps;
+    const auto& constant_mem = impl_param.memory_deps;
     if (constant_mem.count(1)) {
         auto target_shape_mem = constant_mem.at(1);
         cldnn::mem_lock<uint8_t, mem_lock_type::read> target_shape_lock(target_shape_mem, impl_param.get_stream());

--- a/src/plugins/intel_gpu/src/graph/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/concatenation.cpp
@@ -152,11 +152,11 @@ concatenation_inst::typed_primitive_inst(network& network, concatenation_node co
         build_deps();
         std::list<std::vector<std::pair<primitive_inst*, int32_t>>*> stack = {&_deps};
         while (!stack.empty()) {
-            auto nodes_list = stack.front();
+            auto *nodes_list = stack.front();
             stack.pop_front();
 
             for (const auto& processed_nodes : *nodes_list) {
-                auto processed_node = processed_nodes.first;
+                auto *processed_node = processed_nodes.first;
                 processed_node->_outputs = _outputs;
                 if (processed_node->type() == concatenation::type_id() && processed_node->can_be_optimized()) {
                     if (!processed_node->_deps.empty())

--- a/src/plugins/intel_gpu/src/graph/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/condition.cpp
@@ -25,7 +25,7 @@ static std::map<primitive_id, layout> get_out_layout_map(cldnn::program::ptr pro
 
 static std::map<primitive_id, layout> get_out_layout_map(cldnn::network::ptr net) {
     std::map<primitive_id, layout> out_layout_map;
-    for (auto& o : net->get_outputs()) {
+    for (const auto& o : net->get_outputs()) {
         out_layout_map.insert({o->id(), o->get_output_layout()});
     }
     return out_layout_map;
@@ -34,7 +34,7 @@ static std::map<primitive_id, layout> get_out_layout_map(cldnn::network::ptr net
 static std::vector<layout> get_output_layouts(std::map<primitive_id, layout>&& outputs, const std::map<size_t, cldnn::primitive_id> &io_output_map) {
     std::vector<layout> out_layouts;
     for (auto out : outputs) {
-        for (auto& io_output : io_output_map) {
+        for (const auto& io_output : io_output_map) {
             auto inner_prim_id = io_output.second;
             if (out.first == inner_prim_id) {
                 out_layouts.push_back(out.second);
@@ -113,9 +113,9 @@ static ov::PartialShape resolve_shape(const ov::PartialShape& true_pshape, const
         // Union of scalar and 1D case
         if (then_rank.get_length() <= 1 && else_rank.get_length() <= 1) {
             return ov::PartialShape::dynamic(1);
-        } else {
-            return ov::PartialShape::dynamic();
         }
+        return ov::PartialShape::dynamic();
+
     }
     std::vector<ov::Dimension> new_dims;
 
@@ -171,29 +171,29 @@ std::vector<layout> condition_inst::calc_output_layouts(condition_node const& /*
             }
         }
         return output_layouts;
-    } else {
-        auto layouts_true  = get_output_layouts(get_out_layout_map(impl_param.inner_nets[idx_branch_true]),  impl_param.io_output_maps[idx_branch_true]);
-        auto layouts_false = get_output_layouts(get_out_layout_map(impl_param.inner_nets[idx_branch_false]), impl_param.io_output_maps[idx_branch_false]);
-        const size_t num_outputs = impl_param.output_layouts.size();
-        OPENVINO_ASSERT((num_outputs == layouts_true.size() && num_outputs == layouts_false.size()),
-                            "The number of outputs for each branch should be same!");
-
-        auto& memory_deps = impl_param.memory_deps;
-        OPENVINO_ASSERT(memory_deps.count(0) > 0, "The count of memory deps should not be zero");
-        auto mem_ptr = memory_deps.at(0);
-        auto pred = condition_inst::get_pred_from_memory(mem_ptr, impl_param.get_stream());
-        std::vector<layout> output_layouts;
-        if (pred) {
-            for (size_t i = 0; i < num_outputs; i++) {
-                output_layouts.push_back(condition_inst::adjust_scalar_to_1d_layout(layouts_true[i], layouts_false[i]));
-            }
-        } else {
-            for (size_t i = 0; i < num_outputs; i++) {
-                output_layouts.push_back(condition_inst::adjust_scalar_to_1d_layout(layouts_false[i], layouts_true[i]));
-            }
-        }
-        return output_layouts;
     }
+    auto layouts_true  = get_output_layouts(get_out_layout_map(impl_param.inner_nets[idx_branch_true]),  impl_param.io_output_maps[idx_branch_true]);
+    auto layouts_false = get_output_layouts(get_out_layout_map(impl_param.inner_nets[idx_branch_false]), impl_param.io_output_maps[idx_branch_false]);
+    const size_t num_outputs = impl_param.output_layouts.size();
+    OPENVINO_ASSERT((num_outputs == layouts_true.size() && num_outputs == layouts_false.size()),
+                        "The number of outputs for each branch should be same!");
+
+    const auto& memory_deps = impl_param.memory_deps;
+    OPENVINO_ASSERT(memory_deps.count(0) > 0, "The count of memory deps should not be zero");
+    auto mem_ptr = memory_deps.at(0);
+    auto pred = condition_inst::get_pred_from_memory(mem_ptr, impl_param.get_stream());
+    std::vector<layout> output_layouts;
+    if (pred) {
+        for (size_t i = 0; i < num_outputs; i++) {
+            output_layouts.push_back(condition_inst::adjust_scalar_to_1d_layout(layouts_true[i], layouts_false[i]));
+        }
+    } else {
+        for (size_t i = 0; i < num_outputs; i++) {
+            output_layouts.push_back(condition_inst::adjust_scalar_to_1d_layout(layouts_false[i], layouts_true[i]));
+        }
+    }
+    return output_layouts;
+
 }
 
 template std::vector<layout> condition_inst::calc_output_layouts<ov::PartialShape>(condition_node const& node, const kernel_impl_params& impl_param);

--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -133,7 +133,7 @@ std::vector<layout> crop_inst::calc_output_layouts(const crop_node& /*node*/, co
 
     // update split offsets
     if (is_output_static) {
-        auto p_param = const_cast<kernel_impl_params*>(&impl_param);
+        auto *p_param = const_cast<kernel_impl_params*>(&impl_param);
         ov::Shape startOffset(p_param->input_layouts[0].get_partial_shape().size());
         auto input_shape = p_param->input_layouts[0].get_partial_shape();
         auto dims = p_param->input_layouts[0].get_partial_shape().size();

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -119,14 +119,13 @@ std::pair<float, float> validate_data_range(memory::ptr mem, stream& stream, con
     auto data_type = data_layout.data_type;
     if (data_type == cldnn::data_types::f32)
         return __validate_data_range<float>(mem, stream, data_layout, info);
-    else if (data_type == cldnn::data_types::f16)
+    if (data_type == cldnn::data_types::f16)
         return __validate_data_range<ov::float16>(mem, stream, data_layout, info);
-    else if (data_type == cldnn::data_types::i8)
+    if (data_type == cldnn::data_types::i8)
         return __validate_data_range<int8_t>(mem, stream, data_layout, info);
-    else if (data_type == cldnn::data_types::u8)
+    if (data_type == cldnn::data_types::u8)
         return __validate_data_range<uint8_t>(mem, stream, data_layout, info);
-    else
-        GPU_DEBUG_INFO << "Unsupport data type for validating data range " << data_type << std::endl;
+    GPU_DEBUG_INFO << "Unsupport data type for validating data range " << data_type << std::endl;
     return {0.0f, 0.0f};
 }
 
@@ -232,7 +231,7 @@ void dump_i4u4(cldnn::data_types type, memory::ptr mem, stream& stream, std::ofs
     }
 
     mem_lock<uint8_t, mem_lock_type::read> lock(mem, stream);
-    auto mem_ptr = lock.data();
+    auto *mem_ptr = lock.data();
     std::stringstream buffer;
 
     if (dump_raw) {
@@ -600,7 +599,7 @@ NodeDebugHelper::~NodeDebugHelper() {
                     continue;
                 }
 
-                auto& output_layout = output_mem->get_layout();
+                const auto& output_layout = output_mem->get_layout();
                 if (config.get_dump_tensors_format() == ov::intel_gpu::DumpFormat::binary) {
                     // Binary dump : raw
                     auto filename = get_file_path_for_binary_dump(output_layout, name, config.get_dump_tensors_path());
@@ -627,7 +626,7 @@ NodeDebugHelper::~NodeDebugHelper() {
                         continue;
                     }
 
-                    auto& output_layout = m_inst.get_input_layout(i);
+                    const auto& output_layout = m_inst.get_input_layout(i);
                     if (config.get_dump_tensors_format() == ov::intel_gpu::DumpFormat::binary) {
                         // Binary dump : raw
                         auto filename = get_file_path_for_binary_dump(output_layout, name, config.get_dump_tensors_path());
@@ -664,7 +663,7 @@ NetworkDebugHelper::NetworkDebugHelper(network& net)
     auto net_id = m_network.get_id();
     const auto& config = m_network.get_config();
     if (config.get_dump_memory_pool()) {
-        auto& iters = config.get_dump_iterations();
+        const auto& iters = config.get_dump_iterations();
         if (iters.empty() || iters.find(m_iter) != iters.end()) {
             GPU_DEBUG_COUT << "============================================================================" << std::endl;
             GPU_DEBUG_COUT << "Start network execution (net_id : " << net_id << ", iter :" << m_iter << ")" << std::endl;
@@ -682,18 +681,18 @@ NetworkDebugHelper::NetworkDebugHelper(network& net)
         for (auto& inst : m_network._exec_order) {
             GPU_DEBUG_COUT << inst->id() << std::endl;
             if (inst->get_node().is_type<loop>()) {
-                auto& loop_node = inst->get_node().as<loop>();
-                for (auto& prim : loop_node.get_body_program()->get_processing_order()) {
+                const auto& loop_node = inst->get_node().as<loop>();
+                for (const auto& prim : loop_node.get_body_program()->get_processing_order()) {
                     GPU_DEBUG_COUT << "\t" << prim->id() << std::endl;
                 }
             } else if (inst->get_node().is_type<condition>()) {
-                auto& cond_node = inst->get_node().as<condition>();
+                const auto& cond_node = inst->get_node().as<condition>();
                 GPU_DEBUG_COUT << "* Branch_True" << std::endl;
-                for (auto& prim : cond_node.get_branch_true().inner_program->get_processing_order()) {
+                for (const auto& prim : cond_node.get_branch_true().inner_program->get_processing_order()) {
                     GPU_DEBUG_COUT << "\t" << prim->id() << std::endl;
                 }
                 GPU_DEBUG_COUT << "* Branch_False" << std::endl;
-                for (auto& prim : cond_node.get_branch_false().inner_program->get_processing_order()) {
+                for (const auto& prim : cond_node.get_branch_false().inner_program->get_processing_order()) {
                     GPU_DEBUG_COUT << "\t" << prim->id() << std::endl;
                 }
             }
@@ -704,7 +703,7 @@ NetworkDebugHelper::NetworkDebugHelper(network& net)
 }
 
 NetworkDebugHelper::~NetworkDebugHelper() {
-    auto prog = m_network.get_program().get();
+    auto *prog = m_network.get_program().get();
     auto net_id = m_network.get_id();
     const auto& config = prog->get_config();
     // print '-data_shape' option for benchmark_app
@@ -746,7 +745,7 @@ NetworkDebugHelper::~NetworkDebugHelper() {
     }
 
     if (config.get_dump_memory_pool()) {
-        auto& iters = config.get_dump_iterations();
+        const auto& iters = config.get_dump_iterations();
         if (iters.empty() || iters.find(m_iter) != iters.end()) {
             dump_memory_pool(config.get_dump_memory_pool_path(), m_iter);
             GPU_DEBUG_COUT << "============================================================================" << std::endl;
@@ -761,7 +760,7 @@ NetworkDebugHelper::~NetworkDebugHelper() {
 }
 
 void NetworkDebugHelper::dump_memory_pool(std::string dump_path, int64_t curr_iter) const {
-    auto prog = m_network.get_program().get();
+    auto *prog = m_network.get_program().get();
     const auto& config = prog->get_config();
 
     // Dump detailed entries in memory pool
@@ -782,7 +781,7 @@ void NetworkDebugHelper::dump_memory_pool(std::string dump_path, int64_t curr_it
     };
     auto get_variables_mem_size = [&](allocation_type type) -> size_t {
         size_t mem_size = 0;
-        for (auto& var : m_network.get_variables()) {
+        for (const auto& var : m_network.get_variables()) {
             if (var.second->get_memory() && var.second->get_memory()->get_allocation_type() == type)
                 mem_size += var.second->get_actual_mem_size();
         }

--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -162,7 +162,7 @@ std::vector<layout> deconvolution_inst::calc_output_layouts(deconvolution_node c
         input_layout.get<ShapeType>()
     };
     std::vector<ShapeType> output_shapes;
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
     // Dimensions order of weights is IOYX, but the selected format is OIYX by default and I/O dimensions are
     // already swapped when creating constant op. So we need to swap I/O dimensions according to the original
     // dimension order for shape inference.

--- a/src/plugins/intel_gpu/src/graph/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/detection_output.cpp
@@ -86,12 +86,12 @@ template std::vector<layout> detection_output_inst::calc_output_layouts<ov::Part
 std::string detection_output_inst::to_string(detection_output_node const& node) {
     auto node_info = node.desc_to_json();
     auto desc = node.get_primitive();
-    auto share_location = desc->share_location ? "true" : "false";
-    auto variance_encoded = desc->variance_encoded_in_target ? "true" : "false";
-    auto prior_is_normalized = desc->prior_is_normalized ? "true" : "false";
-    auto decrease_label_id = desc->decrease_label_id ? "true" : "false";
-    auto clip_before_nms = desc->clip_before_nms ? "true" : "false";
-    auto clip_after_nms = desc->clip_after_nms ? "true" : "false";
+    const auto *share_location = desc->share_location ? "true" : "false";
+    const auto *variance_encoded = desc->variance_encoded_in_target ? "true" : "false";
+    const auto *prior_is_normalized = desc->prior_is_normalized ? "true" : "false";
+    const auto *decrease_label_id = desc->decrease_label_id ? "true" : "false";
+    const auto *clip_before_nms = desc->clip_before_nms ? "true" : "false";
+    const auto *clip_after_nms = desc->clip_after_nms ? "true" : "false";
     auto& input_location = node.location();
     auto& input_prior_box = node.prior_box();
     auto& input_confidence = node.confidence();

--- a/src/plugins/intel_gpu/src/graph/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/dft.cpp
@@ -68,17 +68,17 @@ std::vector<layout> dft_inst::calc_output_layouts(dft_node const& /*node*/, kern
     std::unordered_map<size_t, ov::Tensor> const_data;
     ov::Tensor axes_tensor, signal_size_tensor;
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
 
     // Consider axes and signal_size are constant case
     if ((!primitive->axes.empty()) &&
         ((impl_param.input_layouts.size() == 2) || (!primitive->signal_size.empty()))) {
-        auto axes_ptr = reinterpret_cast<uint8_t*>(const_cast<int64_t*>(primitive->axes.data()));
+        auto *axes_ptr = reinterpret_cast<uint8_t*>(const_cast<int64_t*>(primitive->axes.data()));
         axes_tensor = ov::Tensor(ov::element::i64, ov::Shape({primitive->axes.size()}), axes_ptr, {});
         const_data.emplace(1, axes_tensor);
 
         if (!primitive->signal_size.empty()) {
-            auto signal_size_ptr = reinterpret_cast<uint8_t*>(const_cast<int64_t*>(primitive->signal_size.data()));
+            auto *signal_size_ptr = reinterpret_cast<uint8_t*>(const_cast<int64_t*>(primitive->signal_size.data()));
             signal_size_tensor = ov::Tensor(ov::element::i64, ov::Shape({primitive->signal_size.size()}), signal_size_ptr, {});
             const_data.emplace(2, signal_size_tensor);
         }

--- a/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
@@ -25,7 +25,7 @@ static bool should_skip_execution(const dynamic_quantize_node& node, const layou
         return false;
 
     // Do not skip dynamic quantization if any user node is not fully connected.(such as SDPA)
-    for (auto& user : node.get_users()) {
+    for (const auto& user : node.get_users()) {
         if (!user->is_type<fully_connected>())
             return false;
     }

--- a/src/plugins/intel_gpu/src/graph/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/graph/embedding_bag.cpp
@@ -24,7 +24,7 @@ std::vector<layout> embedding_bag_inst::calc_output_layouts(embedding_bag_node c
     const auto& input_layout = impl_param.get_input_layout();
     auto desc = impl_param.typed_desc<embedding_bag>();
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
     std::vector<ShapeType> input_shapes;
     for (size_t i = 0; i < desc->input_size(); i++) {
         input_shapes.push_back(impl_param.get_input_layout(i).get<ShapeType>());

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_prior_grid_generator.cpp
@@ -18,14 +18,14 @@ std::vector<layout> experimental_detectron_prior_grid_generator_inst::calc_outpu
     if (desc->flatten) {
         int64_t flattened_dim = desc->featmap_width * desc->featmap_height * data_layout.get_partial_shape()[0].get_length();
         return { layout(ov::PartialShape{flattened_dim, 4}, data_layout.data_type, format::bfyx) };
-    } else {
-        return { layout(ov::PartialShape{static_cast<int64_t>(desc->featmap_height),
-                                         static_cast<int64_t>(desc->featmap_width),
-                                         static_cast<int64_t>(data_layout.get_partial_shape()[0].get_length()),
-                                         4},
-                       data_layout.data_type,
-                       format::bfyx) };
     }
+    return { layout(ov::PartialShape{static_cast<int64_t>(desc->featmap_height),
+                                     static_cast<int64_t>(desc->featmap_width),
+                                     static_cast<int64_t>(data_layout.get_partial_shape()[0].get_length()),
+                                     4},
+                   data_layout.data_type,
+                   format::bfyx) };
+
 }
 template std::vector<layout>
 experimental_detectron_prior_grid_generator_inst::calc_output_layouts<ov::PartialShape>(
@@ -39,14 +39,14 @@ layout experimental_detectron_prior_grid_generator_inst::calc_output_layout(
         return layout(data_layout.data_type,
                       format::bfyx,
                       {static_cast<int>(desc->featmap_width * desc->featmap_height * data_layout.batch()), 4, 1, 1});
-    } else {
-        return layout(data_layout.data_type,
-                      format::bfyx,
-                      {static_cast<int>(desc->featmap_height),
-                       static_cast<int>(desc->featmap_width),
-                       4,
-                       static_cast<int>(data_layout.batch())});
     }
+    return layout(data_layout.data_type,
+                  format::bfyx,
+                  {static_cast<int>(desc->featmap_height),
+                   static_cast<int>(desc->featmap_width),
+                   4,
+                   static_cast<int>(data_layout.batch())});
+
 }
 
 std::string experimental_detectron_prior_grid_generator_inst::to_string(

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_roi_feature_extractor.cpp
@@ -17,9 +17,9 @@ size_t experimental_detectron_roi_feature_extractor_inst::inputs_memory_count() 
 memory::ptr experimental_detectron_roi_feature_extractor_inst::second_output_memory() const {
     if (desc()->num_outputs == 1) {
         return input_memory_ptr(parent::inputs_memory_count() - 1);
-    } else {
-        return output_memory_ptr(1);
     }
+    return output_memory_ptr(1);
+
 }
 
 memory::ptr experimental_detectron_roi_feature_extractor_inst::rois_memory() const {

--- a/src/plugins/intel_gpu/src/graph/eye.cpp
+++ b/src/plugins/intel_gpu/src/graph/eye.cpp
@@ -22,7 +22,7 @@ std::vector<layout> eye_inst::calc_output_layouts(eye_node const& /*node*/, cons
     const auto& input_layout = impl_param.get_input_layout();
     TensorsContainer const_data(&impl_param.get_stream());
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
     for (size_t i = 0; i < 4; i++) {
         if (memory_deps.count(i) > 0)
             const_data.emplace(i, memory_deps.at(i));

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -134,9 +134,9 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
         if (supports_immad && desc->weights_rank == 3 && weights_pshape.size() == 4 &&
             weights_layout.batch() > 1 && weights_layout.spatial(1) == feature) {
             return calc_output_layouts<ov::PartialShape>(node, impl_param)[0];
-        } else {
-            weights_layout.set_partial_shape(reshape_to_2d(weights_pshape, feature));
         }
+        weights_layout.set_partial_shape(reshape_to_2d(weights_pshape, feature));
+
     }
 
     if (supports_immad) {
@@ -156,25 +156,25 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
         format output_format = get_preferred_format(node, impl_param);
 
         return layout(out_pshape, output_type, output_format);
-    } else {
-        if (desc->input_size > 5) {
-            input_layout.set_partial_shape(reshape_to_2d(input_pshape, feature));
-        }
-
-        auto out_features = desc->weights_transposed ? weights_layout.batch() : weights_layout.feature();
-        auto output_size = tensor(input_layout.batch(), out_features, 1, 1);
-        if (desc->input_size == 3) {
-            output_size = tensor(input_layout.batch(), input_layout.feature(), 1, out_features);
-        } else if (desc->input_size == 4) {
-            output_size = tensor(input_layout.batch(), input_layout.feature(), out_features, input_layout.spatial(1));
-        } else if (desc->input_size == 5) {
-            output_size = tensor(input_layout.batch(), input_layout.feature(), out_features, input_layout.spatial(1), input_layout.spatial(2));
-        }
-
-        format output_format = get_preferred_format(node, impl_param);
-
-        return layout(output_type, output_format, output_size);
     }
+    if (desc->input_size > 5) {
+        input_layout.set_partial_shape(reshape_to_2d(input_pshape, feature));
+    }
+
+    auto out_features = desc->weights_transposed ? weights_layout.batch() : weights_layout.feature();
+    auto output_size = tensor(input_layout.batch(), out_features, 1, 1);
+    if (desc->input_size == 3) {
+        output_size = tensor(input_layout.batch(), input_layout.feature(), 1, out_features);
+    } else if (desc->input_size == 4) {
+        output_size = tensor(input_layout.batch(), input_layout.feature(), out_features, input_layout.spatial(1));
+    } else if (desc->input_size == 5) {
+        output_size = tensor(input_layout.batch(), input_layout.feature(), out_features, input_layout.spatial(1), input_layout.spatial(2));
+    }
+
+    format output_format = get_preferred_format(node, impl_param);
+
+    return layout(output_type, output_format, output_size);
+
 }
 
 template<typename ShapeType>
@@ -200,7 +200,7 @@ std::vector<layout> fully_connected_inst::calc_output_layouts(fully_connected_no
 
     std::vector<ShapeType> output_shapes = ov::op::v0::shape_infer(&matmul_op, input_shapes);
     bool has_swiglu = false;
-    auto& fused_prims = node.get_fused_primitives();
+    const auto& fused_prims = node.get_fused_primitives();
     for (auto f : fused_prims) {
         if (f.is_type<swiglu>()) {
             has_swiglu = true;
@@ -254,7 +254,7 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         can_apply_fake_alignment &= orig_output_layout.data_padding._lower_size[1] == 0 &&
                                     orig_output_layout.data_padding._upper_size[1] == 0;
 
-    for (auto& fused_desc : orig_impl_param.fused_desc) {
+    for (const auto& fused_desc : orig_impl_param.fused_desc) {
         if (fused_desc.has_outer_dep()) {
             auto fused_op_input_layout = orig_impl_param.input_layouts[fused_desc.outer_dep_start_idx];
             // Check fused desc's input is still dynamic, then do not fake alignment

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -308,10 +308,10 @@ std::string gemm_inst::to_string(gemm_node const& node) {
     auto node_info = node.desc_to_json();
     auto alpha = desc->alpha;
     auto beta = desc->beta;
-    auto transpose_input0 = desc->transpose_input0 ? " true" : "false";
-    auto transpose_input1 = desc->transpose_input1 ? " true" : "false";
-    auto indirect_input0 = desc->indirect_a ? " true" : "false";
-    auto indirect_input1 = desc->indirect_b ? " true" : "false";
+    const auto *transpose_input0 = desc->transpose_input0 ? " true" : "false";
+    const auto *transpose_input1 = desc->transpose_input1 ? " true" : "false";
+    const auto *indirect_input0 = desc->indirect_a ? " true" : "false";
+    const auto *indirect_input1 = desc->indirect_b ? " true" : "false";
     std::stringstream primitive_description;
 
     json_composite gemm_info;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_onednn_optimization_attributes.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_onednn_optimization_attributes.cpp
@@ -13,7 +13,7 @@ using namespace cldnn;
 
 void add_onednn_optimization_attributes::run(program& p) {
 #ifdef ENABLE_ONEDNN_FOR_GPU
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         if (node->get_preferred_impl_type() == impl_types::onednn
             && !node->is_dynamic()) {
             node->init_onednn_primitive_attributes();

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -52,8 +52,8 @@ void eliminate_pad_for_onednn_impl(program& p, program_node& node) {
             if (!input.is_in_data_flow() || input.is_constant())
                 continue;
 
-            auto& in_layout = input.get_output_layout(false, port);
-            auto& in_padding = in_layout.data_padding;
+            const auto& in_layout = input.get_output_layout(false, port);
+            const auto& in_padding = in_layout.data_padding;
             if (static_cast<bool>(in_padding)) {
                 bool spatial_padding = false;
                 for (size_t i = 0; i < in_layout.get_spatial_rank(); ++i) {
@@ -147,7 +147,7 @@ bool add_required_reorders::test_format(cldnn::program_node& node, format reques
 
     for (size_t i = 0; i < node.get_dependencies().size(); i++) {
         const auto& dep_with_port = node.get_dependency_with_port(i);
-        auto& dep = dep_with_port.first;
+        const auto& dep = dep_with_port.first;
 
         auto current_format = dep->get_output_layout(false, dep_with_port.second).format;
 
@@ -155,7 +155,7 @@ bool add_required_reorders::test_format(cldnn::program_node& node, format reques
             continue;
 
         if (dep->is_type<reorder>()) {
-            auto& port = dep_with_port.second;
+            const auto& port = dep_with_port.second;
             auto new_layout = dep->get_output_layout(false, port);
             new_layout.format = requested_format;
             dep->set_output_layout(new_layout, false, port);
@@ -171,7 +171,7 @@ void add_required_reorders::run(program& p) {
     bool optimize_data = p.get_config().get_optimize_data();
     auto usr_itr = p.get_processing_order().begin();
     while (usr_itr != p.get_processing_order().end()) {
-        auto& usr = *usr_itr++;
+        const auto& usr = *usr_itr++;
         if (usr->get_dependencies().empty())
             continue;  // only nodes with dependencies
         if (usr->is_type<data>())
@@ -283,7 +283,7 @@ void add_required_reorders::run(program& p) {
 
         layout original_layout = usr->get_output_layout();
 
-        for (auto& node : usr->get_dependencies()) {
+        for (const auto& node : usr->get_dependencies()) {
             if (!node.first->is_in_data_flow() && !weights_data) {
                 if (cldnn::format::dimension(original_layout.format) == cldnn::format::dimension(node.first->get_output_layout().format)) {
                     /*
@@ -305,7 +305,7 @@ void add_required_reorders::run(program& p) {
         if (!correct_layout_selected) {
             std::vector<cldnn::format> preferred_layout_formats;
             size_t max_in_dims = std::max(cldnn::format::dimension(original_layout.format), static_cast<size_t>(4));
-            for (auto& node : usr->get_dependencies()) {
+            for (const auto& node : usr->get_dependencies()) {
                 if (format::is_weights_format(node.first->get_output_layout().format))
                     continue;
                 max_in_dims = std::max(cldnn::format::dimension(node.first->get_output_layout().format), max_in_dims);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/basic_memory_dependencies.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/basic_memory_dependencies.cpp
@@ -17,7 +17,7 @@ void basic_memory_dependencies::run(program& p) {
     auto itr = p.get_processing_order().begin();
     std::vector<size_t> past_outputs;
     while (itr != p.get_processing_order().end()) {
-        auto& node = *itr;
+        const auto& node = *itr;
         itr++;
 
         // data primitive can't be reused
@@ -59,7 +59,7 @@ void basic_memory_dependencies::run(program& p) {
                     }
                     root->can_share_buffer(false);
 
-                    for (auto& user : node->get_users()) {
+                    for (const auto& user : node->get_users()) {
                         add_memory_dependency(user, &eltw_node);
                         add_memory_dependency(user, node);
                     }
@@ -75,7 +75,7 @@ void basic_memory_dependencies::run(program& p) {
             past_outputs.push_back(node->get_unique_id());
             if (node->is_type<mutable_data>()) {
                 // if output is mutable data, then propagate output flag to its dependencies
-                for (auto& dep : node->get_dependencies()) {
+                for (const auto& dep : node->get_dependencies()) {
                     dep.first->set_output(true);
                 }
             }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/build_implementations.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/build_implementations.cpp
@@ -21,15 +21,15 @@ void build_implementations::run(program& p) {
     }
 
     auto& cache = p.get_kernels_cache();
-    for (auto& n : p.get_processing_order()) {
-        if (auto impl = n->get_selected_impl()) {
+    for (const auto& n : p.get_processing_order()) {
+        if (auto *impl = n->get_selected_impl()) {
             auto params = n->get_kernel_impl_params();
             cache.add_kernels_source(*params, impl->get_kernels_source());
         }
     }
     cache.build_all();
-    for (auto& n : p.get_processing_order()) {
-        if (auto impl = n->get_selected_impl()) {
+    for (const auto& n : p.get_processing_order()) {
+        if (auto *impl = n->get_selected_impl()) {
             auto params = n->get_kernel_impl_params();
             impl->init_kernels(cache, *params);
             impl->reset_kernels_source();

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
@@ -18,7 +18,7 @@ void compile_graph::run(program& p) {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, "pass::CompileGraph");
     const auto& forcing_map = p.get_config().get_force_implementations();
 
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         node->set_unique_id();
         if (!node->is_type<data>()) {
             node->get_output_layout();

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/concat_input_order.cpp
@@ -47,7 +47,7 @@ bool can_shuffle_features(program_node& node, program_node& concat_node, stream&
     pass_through &= !node.is_output() && node.get_dependencies().size() == 1 && !node.has_fused_primitives();
     if (pass_through) {
         // Primitives that are feature order invariant, pass-through shuffled features to users
-        for (auto& user : node.get_users()) {
+        for (const auto& user : node.get_users()) {
             if (!can_shuffle_features(*user, node, stream))
                 return false;
         }
@@ -68,12 +68,12 @@ void shuffle_weights(data_node& node, const std::vector<shuffle_range>& ranges, 
     auto bytes_per_elem = data_type_traits::size_of(wei_layout.data_type);
     mem_lock<uint8_t, mem_lock_type::read> old_weights_memory_lock{old_weights_memory, stream};
     mem_lock<uint8_t, mem_lock_type::write> new_weights_memory_lock{new_weights_memory, stream};
-    auto old_ptr = old_weights_memory_lock.data();
-    auto new_ptr = new_weights_memory_lock.data();
+    auto *old_ptr = old_weights_memory_lock.data();
+    auto *new_ptr = new_weights_memory_lock.data();
 
     for (int32_t ofi = 0; ofi < wei_layout.batch(); ++ofi) {
         int32_t new_ifi = 0;
-        for (auto& range : ranges) {
+        for (const auto& range : ranges) {
             const int32_t range_begin = static_cast<int32_t>(range.first);
             const int32_t range_end = static_cast<int32_t>(range.second);
             for (int32_t ifi = range_begin; ifi < range_end; ++ifi, ++new_ifi) {
@@ -108,7 +108,7 @@ void shuffle_features(program_node& node, const std::vector<shuffle_range>& rang
         shuffle_weights(fc.weights().as<data>(), ranges, stream);
     } else {
         // General case for pass-through layers
-        for (auto& user : node.get_users()) {
+        for (const auto& user : node.get_users()) {
             shuffle_features(*user, ranges, stream);
         }
     }
@@ -117,7 +117,7 @@ void shuffle_features(program_node& node, const std::vector<shuffle_range>& rang
 }  // namespace
 
 void concat_input_order::run(program& p) {
-    for (auto node : p.get_processing_order()) {
+    for (auto *node : p.get_processing_order()) {
         // Check that optimization can be performed:
         // 1. Not an output
         // 2. Concatenation along features
@@ -162,7 +162,7 @@ void concat_input_order::run(program& p) {
         }
         // Check that we can fuse shuffling to users
         bool can_shuffle_users = true;
-        for (auto user : concat_node.get_users()) {
+        for (auto *user : concat_node.get_users()) {
             can_shuffle_users &= can_shuffle_features(*user, concat_node, p.get_stream());
         }
 
@@ -201,7 +201,7 @@ void concat_input_order::run(program& p) {
             new_dependencies.push_back({concat_node.get_dependency_with_port(ord).first, concat_node.get_dependency_with_port(ord).second});
         }
         // Update in place with const cast instead of replacing
-        auto& dependencies = concat_node.get_dependencies();
+        const auto& dependencies = concat_node.get_dependencies();
         auto& mutable_dependencies = const_cast<std::vector<std::pair<program_node*, int32_t>>&>(dependencies);
         for (size_t i = 0; i < new_dependencies.size(); ++i) {
             mutable_dependencies[i] = new_dependencies[i];
@@ -214,7 +214,7 @@ void concat_input_order::run(program& p) {
         auto mutable_prim = std::const_pointer_cast<concatenation>(prim);
         mutable_prim->input = new_input_info;
         // Correct users for shuffled features
-        for (auto& user : concat_node.get_users()) {
+        for (const auto& user : concat_node.get_users()) {
             shuffle_features(*user, shuffled_ranges, p.get_stream());
         }
     }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/fuse_primitives_with_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/fuse_primitives_with_layout.cpp
@@ -30,7 +30,7 @@ void fuse_primitives_with_layout::run(program& p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
         auto node_itr = itr++;
-        auto& node = (*node_itr);
+        const auto& node = (*node_itr);
 
         if (node->is_output() || node->is_constant())
             continue;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
@@ -22,7 +22,7 @@ void handle_reshape::run(program& p) {
     // Remove reshapes that don't change the layout of output
     auto node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto node = (*node_itr++);
+        auto *node = (*node_itr++);
         program_helpers::do_for_types<reshape>(*node, [&p](reshape_node& node) {
             auto& input_node = node.input();
             auto input_lay = input_node.get_output_layout();
@@ -50,12 +50,12 @@ void handle_reshape::run(program& p) {
     // permute+reshape+reshape in cldnn and can be simplified to permute+reshape.
     node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto& node = (*node_itr++);
+        const auto& node = (*node_itr++);
         program_helpers::do_for_types<reshape>(*node, [&p](reshape_node& node) {
             if (node.is_output() || node.get_users().size() > 1 || node.has_fused_primitives() || node.is_dynamic())
                 return;
 
-            auto& out_node = node.get_users().front();
+            const auto& out_node = node.get_users().front();
 
             if (!out_node->is_type<reshape>())
                 return;
@@ -77,7 +77,7 @@ void handle_reshape::run(program& p) {
         if (node->is_type<reshape>()) {
             const auto& dep = node->get_dependency_with_port(0);
             auto& input_node = *dep.first;
-            auto& input_port = dep.second;
+            const auto& input_port = dep.second;
 
             if (input_node.is_type<reorder>())
                 continue;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
@@ -28,7 +28,7 @@ void mark_runtime_skippable_nodes::run(program& p) {
     auto itr = p.get_processing_order().begin();
 
     while (itr != p.get_processing_order().end()) {
-        auto& node = *itr++;
+        const auto& node = *itr++;
         // Set gathers that might be skipped at runtime as can_be_optimized.
         // If not set, memory dependency will not work for the nodes that are skipped at runtime
         if (node->is_type<data>() || node->is_constant())
@@ -37,7 +37,7 @@ void mark_runtime_skippable_nodes::run(program& p) {
         std::function<bool(const program_node& node)> all_users_are_shape_of = [&](const program_node& node) {
             if (node.is_input() || node.is_output())
                 return false;
-            for (auto& u : node.get_users()) {
+            for (const auto& u : node.get_users()) {
                 if (!u->is_type<shape_of>())
                     return false;
             }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_shape_of_subgraphs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_shape_of_subgraphs.cpp
@@ -50,7 +50,7 @@ void mark_shape_of_subgraphs::look_for_shape_of_subgraph(program_node& node) {
     // Check if all dependencies are constant or marked as a part of shape_of subgraph
     bool can_execute_in_subgraph = true;
     bool has_shape_of_subgraph_dep = false;
-    for (auto& dependency : node.get_dependencies()) {
+    for (const auto& dependency : node.get_dependencies()) {
         if (dependency.first->is_in_shape_of_subgraph()) {
             has_shape_of_subgraph_dep = true;
         } else if (!dependency.first->is_constant()) {
@@ -92,7 +92,7 @@ bool mark_shape_of_subgraphs::can_mark_node(const program_node& node) {
     // couldn't save result in int8 data type (as it requested by GPU plugin,
     // because we use it instead of boolean data type)
     if (node.is_type<eltwise>()) {
-        auto& eltwise_node = node.as<eltwise>();
+        const auto& eltwise_node = node.as<eltwise>();
         auto eltwise_mode = eltwise_node.get_primitive()->mode;
         if (eltwise::eltwise_bool_modes.find(eltwise_mode) != eltwise::eltwise_bool_modes.end())
             return false;
@@ -100,7 +100,7 @@ bool mark_shape_of_subgraphs::can_mark_node(const program_node& node) {
 
     // Exclude gather_compressed primitive because gather_cpu_impl doesn't support it.
     if (node.is_type<gather>()) {
-        auto& gather_node = node.as<gather>();
+        const auto& gather_node = node.as<gather>();
         auto gather_compressed_weight_mode = gather_node.get_primitive()->compressed_weights;
         if (gather_compressed_weight_mode)
             return false;
@@ -114,7 +114,7 @@ bool mark_shape_of_subgraphs::can_mark_node(const program_node& node) {
     }
 
     // skip mark_node for broadcast node if dependency nodes are data and shape_of
-    auto& dependencies = node.get_dependencies();
+    const auto& dependencies = node.get_dependencies();
     if (node.is_type<broadcast>() && dependencies.size() == 2) {
         if (dependencies[0].first->is_type<data>() && dependencies[1].first->is_type<shape_of>() && (dependencies[1].first->get_users().size() == 1))
             return false;
@@ -134,7 +134,7 @@ void mark_shape_of_subgraphs::mark_node(program_node& node) {
     // Add parent shape_of nodes from other dependencies if there are any
     for (auto dep : node.get_dependencies()) {
         if (dep.first->is_in_shape_of_subgraph()) {
-            for (auto shape_of : dep.first->get_dependant_shape_of_nodes()) {
+            for (const auto *shape_of : dep.first->get_dependant_shape_of_nodes()) {
                 node.add_dependant_shape_of_node(shape_of);
             }
         }
@@ -143,7 +143,7 @@ void mark_shape_of_subgraphs::mark_node(program_node& node) {
 
 void mark_shape_of_subgraphs::run(program& p) {
     if (p.is_new_shape_infer()) {
-        for (auto& node : p.get_processing_order()) {
+        for (const auto& node : p.get_processing_order()) {
             look_for_shape_of_subgraph(*node);
         }
     }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_state_init_subgraphs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_state_init_subgraphs.cpp
@@ -22,13 +22,12 @@ void mark_state_init_subgraphs::mark_init_subgraph(program& p, read_value_node& 
         if (p.has_state_initializers(variable_id, dep_node->id()))
             return false;
 
-        for (auto& u : dep_node->get_users()) {
+        for (const auto& u : dep_node->get_users()) {
             if (u == &node)
                 continue;
             if (p.has_state_initializers(variable_id, u->id()))
                 continue;
-            else
-                return false;
+            return false;
         }
         GPU_DEBUG_TRACE_DETAIL << "marked " << dep_node->id() << " as node in a init_subgraph for " << node.id() << std::endl;
         return true;
@@ -39,7 +38,7 @@ void mark_state_init_subgraphs::mark_init_subgraph(program& p, read_value_node& 
         for (size_t i = 0; i < cur_size; ++i) {
             auto& cur_node = q.front();
             q.pop();
-            for (auto& dep : cur_node->get_dependencies()) {
+            for (const auto& dep : cur_node->get_dependencies()) {
                 if (can_be_marked(dep.first)) {
                     p.set_state_initializers(variable_id, dep.first->id());
                     q.push(dep.first);
@@ -52,7 +51,7 @@ void mark_state_init_subgraphs::mark_init_subgraph(program& p, read_value_node& 
 void mark_state_init_subgraphs::run(program& p) {
     auto rit = p.get_processing_order().rbegin();
     for (; rit != p.get_processing_order().rend(); rit++) {
-        auto& node = *rit;
+        const auto& node = *rit;
         if (node->is_type<read_value>()) {
             mark_init_subgraph(p, node->as<read_value>());
         }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/oooq_memory_dependencies.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/oooq_memory_dependencies.cpp
@@ -72,7 +72,7 @@ void oooq_memory_dependencies::run(program& p) {
     // giving us mapping of node to set of all users that can be reached from this node.
     auto& processing_order = p.get_processing_order();
     std::list<program_node*> processing_order_except_const;
-    for (auto n : processing_order) {
+    for (auto *n : processing_order) {
         if (!n->is_type<data>()) {
             processing_order_except_const.push_back(n);
         }
@@ -81,7 +81,7 @@ void oooq_memory_dependencies::run(program& p) {
     // maps program nodes to bimap vector ids
     auto user_map = std::unordered_map<program_node*, unsigned int>();
     unsigned int processing_order_idx = 0;
-    for (auto node : processing_order_except_const) {
+    for (auto *node : processing_order_except_const) {
         user_map[node] = processing_order_idx++;
     }
     unsigned int num_nodes = static_cast<unsigned int>(user_map.size());
@@ -164,7 +164,7 @@ void oooq_memory_dependencies::run(program& p) {
                 add_memory_dependency(*itr_A, *itr_B);
                 add_memory_dependency(*itr_B, *itr_A);
             } else {
-                for (auto u : (*itr_A)->get_users()) {
+                for (auto *u : (*itr_A)->get_users()) {
                     if (u != (*itr_B) && !are_connected(B, user_map[u]) && !are_connected(user_map[u], B)) {
                         add_memory_dependency(*itr_A, *itr_B);
                         add_memory_dependency(*itr_B, *itr_A);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/post_input_reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/post_input_reorder.cpp
@@ -45,18 +45,18 @@ program_node& post_input_reorder::add_reorder(program& p,
 void post_input_reorder::run(program& p) {
     auto node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto& node = *node_itr++;
-        const auto impl = node->get_selected_impl();
+        const auto& node = *node_itr++;
+        auto *const impl = node->get_selected_impl();
         // add a reorder if primitive's input format doesn't match implementation's input format
         if (node->is_type<fully_connected>()) {
-            const auto fc_impl = dynamic_cast<ocl::typed_primitive_impl_ocl<fully_connected>*>(impl);
+            auto *const fc_impl = dynamic_cast<ocl::typed_primitive_impl_ocl<fully_connected>*>(impl);
             if (!fc_impl || node->can_be_optimized())
                 continue;
             const auto& fc_params =
                 *static_cast<kernel_selector::fully_connected_params*>(fc_impl->_kernel_data.params.get());
 
             auto layout_format = from_data_layout(fc_params.inputs[0].GetLayout());
-            auto& input = node->get_dependencies()[0].first;
+            const auto& input = node->get_dependencies()[0].first;
             auto input_layout = input->get_output_layout();
 
             if (input_layout.format != layout_format) {
@@ -70,7 +70,7 @@ void post_input_reorder::run(program& p) {
                 reorder.get_output_layout(false);
                 node->set_output_layout(previous_layout, false);
                 reorder.set_selected_impl(reorder.type()->create_impl(reorder));
-                if (auto impl = reorder.get_selected_impl()) {
+                if (auto *impl = reorder.get_selected_impl()) {
                     auto params = reorder.get_kernel_impl_params();
                     p.get_kernels_cache().add_kernels_source(*params, impl->get_kernels_source());
                 }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp
@@ -72,7 +72,7 @@ void post_optimize_weights::optimize_weights(T& node, program& p) {
             auto reorder_impl = weights_reorder_node.type()->create_impl(weights_reorder_node);
 
             weights_reorder_node.set_selected_impl(std::move(reorder_impl));
-            if (auto impl = weights_reorder_node.get_selected_impl()) {
+            if (auto *impl = weights_reorder_node.get_selected_impl()) {
                 auto params = weights_reorder_node.get_kernel_impl_params();
                 p.get_kernels_cache().add_kernels_source(*params, impl->get_kernels_source());
             }
@@ -161,7 +161,7 @@ void post_optimize_weights::optimize_weights(T& node, program& p) {
 
 void post_optimize_weights::select_implementation(program& p, program_node& node) {
     node.set_selected_impl(node.type()->create_impl(node));
-    if (auto impl = node.get_selected_impl()) {
+    if (auto *impl = node.get_selected_impl()) {
         auto params = node.get_kernel_impl_params();
         p.get_kernels_cache().add_kernels_source(*params, impl->get_kernels_source());
     }
@@ -308,7 +308,7 @@ void post_optimize_weights::add_lstm_bias_reorder(primitive_id input_id, std::sh
 
 void post_optimize_weights::run(program& p) {
     bool found_lstm = false;
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         if (node->is_type<convolution>()) {
             optimize_weights(node->as<convolution>(), p);
         } else if (node->is_type<deconvolution>()) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -161,7 +161,7 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
             // cascaded concat opt is not supported for dynamic shape yet
             if (concat_node.is_dynamic() || is_runtime)
                 return false;
-            else if (pred.first->as<concatenation>().get_primitive()->axis != concat_axis)
+            if (pred.first->as<concatenation>().get_primitive()->axis != concat_axis)
                 return false;
         }
         // Check that input isn't optimized out non-concatenation.
@@ -213,8 +213,7 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
                 auto add_type = onednn_add_fusing_helpers::get_add_fusing_type(*pred.first, fused_op);
                 if (add_type == add_fusing_type::sum)
                     return false;
-                else
-                    continue;
+                continue;
             }
 
             // Optimized-out input node is no longer onednn impl.
@@ -249,15 +248,15 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
         if (concat_node.is_dynamic() && !is_runtime) {
             // Return true in build time, it will be checked again in runtime
             return true;
-        } else {
-            if (concat_out_l.batch() > 1)
-                return false;
-            const auto& dims_order = concat_out_l.format.dims_order();
-            for (auto dim : dims_order) {
-                if (dim == 0) continue;
-                return dim == 1;
-            }
         }
+        if (concat_out_l.batch() > 1)
+            return false;
+        const auto& dims_order = concat_out_l.format.dims_order();
+        for (auto dim : dims_order) {
+            if (dim == 0) continue;
+            return dim == 1;
+        }
+
     }
     return true;
 }
@@ -272,7 +271,7 @@ void concat_in_place_optimization::optimize_cascade(concatenation_node& node, st
     layout concat_layout = node.get_output_layout();
     update_in_place_concat_paddings(concat_layout, preds_layouts, node.get_primitive()->axis, false);
     size_t i = 0;
-    for (auto& dep : node.get_dependencies()) {
+    for (const auto& dep : node.get_dependencies()) {
         dep.first->set_output_layout(preds_layouts[i]);
         dep.first->can_share_buffer(false);
         ++i;
@@ -391,7 +390,7 @@ static bool is_optimizable_padding_for_crop(const crop_node& node,
         (input_layout.spatial(1) - offsets.spatial[1] - output_layout.get_tensor().spatial[1]) != 0));
 
     if (is_input_lower_pad || is_input_upper_pad) {
-        for (auto user : node.get_users()) {
+        for (const auto *user : node.get_users()) {
             if (user->is_type<gemm>() && user->get_dependency_index(node) < 2) {
                 return false;
             }
@@ -402,7 +401,7 @@ static bool is_optimizable_padding_for_crop(const crop_node& node,
     auto opt_upper_pad = input_layout.feature() - offsets.feature[0] - crop_layout.get_tensor().feature[0];
 
     // do not optimize crop if paddings are not properly aligned
-    for (auto& usr : node.get_users()) {
+    for (const auto& usr : node.get_users()) {
         auto usr_layout = usr->get_output_layout();
         if (usr_layout.format == format::b_fs_yx_fsv16 &&
             (opt_lower_pad % 16 != 0 || opt_upper_pad % 16 != 0))
@@ -450,7 +449,7 @@ bool crop_in_place_optimization::can_crop_be_optimized_simple_data_format(const 
 
 static bool can_read_value_be_optimize(const read_value_node& node) {
     std::unordered_set<const cldnn::program_node*> unique_users;
-    for (const auto user : node.get_users()) {
+    for (const auto *const user : node.get_users()) {
         if (!user->is_type<shape_of>()) {
             unique_users.insert(user);
         }
@@ -466,12 +465,12 @@ static bool can_read_value_be_optimize(const read_value_node& node) {
     //       |         v
     //       ------> kvcache
     if (unique_users.size() == 2) {
-        const auto user0 = *unique_users.begin();
-        const auto user1 = *(++unique_users.begin());
+        const auto *const user0 = *unique_users.begin();
+        const auto *const user1 = *(++unique_users.begin());
         const bool is_user0_kvcache = user0->is_type<kv_cache>();
-        const auto kvcache = is_user0_kvcache ? user0 : (user1->is_type<kv_cache>() ? user1 : nullptr);
+        const auto *const kvcache = is_user0_kvcache ? user0 : (user1->is_type<kv_cache>() ? user1 : nullptr);
         if (kvcache) {
-            const auto other_user = is_user0_kvcache ? user1 : user0;
+            const auto *const other_user = is_user0_kvcache ? user1 : user0;
             const bool only_used_by_kvcache = std::none_of(other_user->get_users().begin(), other_user->get_users().end(), [kvcache](const auto user) {
                 return user != kvcache && !user->template is_type<shape_of>();
             });
@@ -488,7 +487,7 @@ static void propagate_padding_to_opt_out_users(program_node& node, cldnn::paddin
     if (padding_data == cldnn::padding())
         return;
 
-    for (auto user : node.get_users()) {
+    for (auto *user : node.get_users()) {
         if (user->can_be_optimized()) {
             user->merge_output_padding(padding_data);
             propagate_padding_to_opt_out_users(*user, padding_data);
@@ -521,7 +520,7 @@ bool crop_in_place_optimization::match(const program_node& node,
                             node.get_dependency(0).is_dynamic());
 
     const auto& crop_layout = crop_params.get_output_layout();
-    for (auto user : node.get_users()) {
+    for (const auto *user : node.get_users()) {
         // If the user node's output shape is already static, the padding
         // w/ dyn pad mask will not be propagated properly at runtime
         if (dyn_aware && !user->get_output_pshape().is_dynamic())
@@ -545,7 +544,7 @@ bool crop_in_place_optimization::match(const program_node& node,
             // runtime buffer fusing is only handled when there is only one reshape user
             if (dyn_aware && node.get_users().size() != 1)
                 return false;
-            auto& reshape_node = user->as<reshape>();
+            const auto& reshape_node = user->as<reshape>();
             if (can_reshape_be_optimized(reshape_node) &&
                 (!dyn_aware || !reshape_node.is_runtime_propagatable_padding()))
                 return false;
@@ -573,7 +572,7 @@ bool crop_in_place_optimization::match(const program_node& node,
     // do not optimize variadic_split crop when either input1 or input2 is not constant.
     // VariadicSplit ngraph shape infer requires value of axis(input1) and split_lengths(input2).
     // And non_constant input1/input2 makes risky execution of runtime buffer fusing.
-    auto& crop_node = node.as<crop>();
+    const auto& crop_node = node.as<crop>();
     if ((crop_node.get_primitive()->op_mode == cldnn::crop_ngraph_op_mode::variadic_split) &&
         (!crop_node.get_dependency(1).is_constant() || !crop_node.get_dependency(2).is_constant()))
         return false;
@@ -896,7 +895,7 @@ void prepare_buffer_fusing::run(program& p) {
     // [2] Then try to optimize all crops
     auto node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto& node = (*node_itr++);
+        const auto& node = (*node_itr++);
         if (!node->is_valid_output_layout())
             continue;
         if (!can_optimize(node))
@@ -942,7 +941,7 @@ void prepare_buffer_fusing::run(program& p) {
                 // it transforms to extend to 4 dims by adding 1 to begin().
                 // Therefore, the padding of crop_layout should be shifted properly.
                 const size_t TDIM = 4;
-                auto user = node.get_users().front();
+                auto *user = node.get_users().front();
                 bool allow_new_shape_infer = node.get_program().is_new_shape_infer();
                 if (!allow_new_shape_infer && user->is_type<gemm>() && user->get_dependency(1).id().compare(node.id()) == 0) {
                     auto input_rank = user->get_kernel_impl_params()->typed_desc<gemm>()->weight_rank;
@@ -969,7 +968,7 @@ void prepare_buffer_fusing::run(program& p) {
     // [3] Optimize all other primitives
     node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto& node = (*node_itr++);
+        const auto& node = (*node_itr++);
         if (!node->is_valid_output_layout())
             continue;
 
@@ -1097,7 +1096,7 @@ void prepare_buffer_fusing::run(program& p) {
                 return;
             }
 
-            auto &users = node.get_users();
+            const auto &users = node.get_users();
             if (users.size() != 1 || !users.front()->is_type<permute>()) {
                 return;
             }
@@ -1106,8 +1105,8 @@ void prepare_buffer_fusing::run(program& p) {
                 return;
             }
 
-            auto &input_layout = node.get_input_layout(0);
-            auto &output_layout = node.get_output_layout(false);
+            const auto &input_layout = node.get_input_layout(0);
+            const auto &output_layout = node.get_output_layout(false);
             if (!format::is_simple_data_format(input_layout.format) || input_layout.data_type != output_layout.data_type) {
                 return;
             }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
@@ -84,7 +84,7 @@ void prepare_padding::run(program& p) {
                 // Add extra reorder for cldnn primitive to handle required padding if needed
                 auto& input = node.get_dependency(0);
                 bool is_usr_onednn = false;
-                for (auto& input_usr : input.get_users())
+                for (const auto& input_usr : input.get_users())
                     if (input_usr->get_preferred_impl_type() == impl_types::onednn)
                         is_usr_onednn = true;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -103,7 +103,7 @@ static std::optional<size_t> find_eltwise_const_dep_idx(const eltwise_node& node
 void prepare_primitive_fusing::remove_redundant_reshape(program &p) {
     auto node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto node = (*node_itr++);
+        auto *node = (*node_itr++);
         program_helpers::do_for_types<reshape>(*node, [&p](reshape_node& node) {
             for (const auto& prev : node.get_dependencies()) {
                 if (!prev.first->is_type<reshape>())
@@ -122,7 +122,7 @@ void prepare_primitive_fusing::remove_redundant_reshape(program &p) {
 
     node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto node = (*node_itr++);
+        auto *node = (*node_itr++);
         program_helpers::do_for_types<reshape>(*node, [&p](reshape_node& node) {
             auto input_lay = node.get_input_layout();
             auto output_lay = node.get_output_layout();
@@ -139,14 +139,14 @@ void prepare_primitive_fusing::remove_redundant_reshape(program &p) {
 
     node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto node = (*node_itr++);
+        auto *node = (*node_itr++);
         program_helpers::do_for_types<reorder>(*node, [&p](reorder_node& node) {
             auto& input_node = node.input();
             if (input_node.get_users().size() > 1 || node.get_users().size() > 1 || node.is_endpoint() || input_node.is_input())
                 return;
             auto input_lay = input_node.get_output_layout();
             auto output_lay = node.get_output_layout();
-            auto user_node = *node.get_users().begin();
+            auto *user_node = *node.get_users().begin();
             if (input_lay.identical(output_lay)) {
                 if (node.has_mean() || !node.get_primitive()->subtract_per_feature.empty()) {
                     return;
@@ -166,7 +166,7 @@ void prepare_primitive_fusing::fuse_reorders(program &p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
         auto node_itr = itr++;
-        auto& node = (*node_itr);
+        const auto& node = (*node_itr);
 
         if (node->is_output())
             continue;
@@ -212,7 +212,7 @@ void prepare_primitive_fusing::fuse_swiglu(program &p) {
     std::map<primitive_id, std::vector<std::pair<primitive_id, size_t>>> fusing_history;
     while (itr != p.get_processing_order().end()) {
         auto node_itr = itr++;
-        auto& node = (*node_itr);
+        const auto& node = (*node_itr);
         if (!node->is_type<swiglu>())
             continue;
 
@@ -263,7 +263,7 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
         auto node_itr = itr++;
-        auto& node = (*node_itr);
+        const auto& node = (*node_itr);
 
         if (node->is_output() || node->is_constant() || !node->is_type<eltwise>())
             continue;
@@ -282,7 +282,7 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
 
         auto non_const_dep_idx = 1 - const_dep_idx.value();
 
-        for (auto& dep : eltw_node.get_dependencies()) {
+        for (const auto& dep : eltw_node.get_dependencies()) {
             auto& fused_prims = dep.first->get_fused_primitives();
             if (std::any_of(fused_prims.begin(), fused_prims.end(), [](const fused_primitive_desc& f_desc) {
                 return f_desc.is_type<swiglu>();
@@ -534,7 +534,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
         auto node_itr = itr++;
-        auto& node = (*node_itr);
+        const auto& node = (*node_itr);
 
         if (node->is_output() || node->is_constant())
             continue;
@@ -607,10 +607,10 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             if (lo.has_all_enabled_onednn_impls_optimization_attribute() &&
                 lo.get_preferred_impl_type(node, format::any /*dummy*/) == impl_types::onednn) {
                 return true;
-            } else {
-                auto in_dt = node.get_input_layout(0).data_type;
-                return node.is_dynamic() || data_type_traits::is_i8_u8(in_dt);
             }
+            auto in_dt = node.get_input_layout(0).data_type;
+            return node.is_dynamic() || data_type_traits::is_i8_u8(in_dt);
+
         };
 
         auto gemm_supports_fusings = [](gemm_node& node) -> bool {
@@ -660,7 +660,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             if (input_conv && out_eltw) {
                 if (node.is_dynamic())
                     return false;
-                auto& eltw = static_cast<const eltwise&>(*node.get_users().front()->get_primitive());
+                const auto& eltw = static_cast<const eltwise&>(*node.get_users().front()->get_primitive());
                 auto& conv = node.get_dependency(0).as<convolution>();
                 auto eltw_mode = eltw.mode == eltwise_mode::sum;
                 auto conv_size = conv.get_input_layout(0).spatial(0) % 128 == 0 &&
@@ -1142,8 +1142,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                         return false;
                     bool compatible = true;
                     for (size_t i = 0; i < out_shape.size(); i++) {
-                        auto& od = out_shape[i];
-                        auto& id = in_shape[i];
+                        const auto& od = out_shape[i];
+                        const auto& id = in_shape[i];
 
                         if (od.is_static() && id.is_static()) {
                             compatible &= od.get_length() == id.get_length();
@@ -1223,8 +1223,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 std::swap(fused_idx, peer_idx);
             }
 
-            auto fused_node = parents[fused_idx].first;
-            auto peer_node = parents[peer_idx].first;
+            auto *fused_node = parents[fused_idx].first;
+            auto *peer_node = parents[peer_idx].first;
 
             // Avoid fusing with GEMM from the LoRA pattern, that can be optimized in case of empty adapters
             if (fused_node->is_type<gemm>()) {
@@ -1340,7 +1340,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 merge_allowed = fused_node->get_users().size() == 1;
             } else {
                 merge_allowed = fused_node->get_users().size() == 1;
-                for (auto& parent : fused_node->get_dependencies())
+                for (const auto& parent : fused_node->get_dependencies())
                     if (parent.first->id() == peer_node->id())
                         merge_allowed = false;
             }
@@ -1390,7 +1390,7 @@ void prepare_primitive_fusing::fuse_constant_transposes(program& p) {
             size_t weights_offset = next_node->get_primitive()->input_size();
             std::vector<size_t> valid_weights_indices = {next_node->get_primitive()->input_size()};
             if (next_node->is_type<fully_connected>()) {
-                auto& fc = next_node->as<fully_connected>();
+                const auto& fc = next_node->as<fully_connected>();
                 auto desc = fc.get_primitive();
                 if (desc->compressed_weights) {
                     size_t scale_idx = weights_offset + (fc.bias_term() ? 2 : 1);
@@ -1431,14 +1431,14 @@ void prepare_primitive_fusing::fuse_constant_transposes(program& p) {
     auto& proc_order = p.get_processing_order();
     auto itr = proc_order.begin();
     while (itr != proc_order.end()) {
-        auto& node = *itr++;
+        const auto& node = *itr++;
 
         if (!node->is_type<permute>())
             continue;
 
         auto& permute_node = node->as<permute>();
 
-        auto weightable_node = get_weightable_node(&permute_node);
+        const auto *weightable_node = get_weightable_node(&permute_node);
 
         if (weightable_node == nullptr || !permute_node.get_dependency(0).is_type<data>())
             continue;
@@ -1482,7 +1482,7 @@ void prepare_primitive_fusing::fuse_constant_transposes(program& p) {
 
         // Add format reorder in case of onednn to avoid overhead during execution on weights memory allocation
         if (lo.get_preferred_impl_type(const_cast<program_node&>(*weightable_node), format::any /*dummy*/) == impl_types::onednn) {
-            auto next_node = new_const_node.get_users().front();
+            auto *next_node = new_const_node.get_users().front();
             bool can_be_fused = next_node->is_type<reorder>() &&
                                 next_node->as<reorder>().is_simple_reorder() &&
                                 next_node->get_users().size() == 1;
@@ -1515,7 +1515,7 @@ void prepare_primitive_fusing::optimize_fused_ops(program& p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
         auto node_itr = itr++;
-        auto& node = (*node_itr);
+        const auto& node = (*node_itr);
 
         if (!node->has_fused_primitives())
             continue;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -72,7 +72,7 @@ void prepare_primitive_fusing_through::run(program& p) {
 
     auto node_itr = p.get_processing_order().begin();
     while (node_itr != p.get_processing_order().end()) {
-        auto node = (*node_itr++);
+        auto *node = (*node_itr++);
         cldnn::program_node* input_node;
 
         if (node->is_output() || node->is_constant())
@@ -125,8 +125,8 @@ void prepare_primitive_fusing_through::run(program& p) {
         if (static_cast<bool>(node->get_output_layout().data_padding))
             continue;
 
-        auto new_prev = fuse_through_order[fuse_through_order.size() - 1];
-        auto new_next = fuse_through_order[fuse_through_order.size() - 2];
+        auto *new_prev = fuse_through_order[fuse_through_order.size() - 1];
+        auto *new_next = fuse_through_order[fuse_through_order.size() - 2];
 
         // For per-channel quantize, allow only when the fused target's output shape
         // matches the quantize's current input shape. This ensures per-channel
@@ -152,18 +152,18 @@ void prepare_primitive_fusing_through::run(program& p) {
             continue;
 
         std::vector<cldnn::program_node*> dependencies;
-        for (auto& dep : node->get_dependencies()) {
+        for (const auto& dep : node->get_dependencies()) {
             if (dep.first == input_node)
                 continue;
             dependencies.push_back(dep.first);
         }
 
-        for (auto dep : dependencies)
+        for (auto *dep : dependencies)
             p.remove_connection(*dep, *node);
 
         p.move_node(*node, *new_prev, *new_next);
 
-        for (auto dep : dependencies)
+        for (auto *dep : dependencies)
             p.add_connection(*dep, *node);
 
         // Update node's layout and keep original data type
@@ -175,7 +175,7 @@ void prepare_primitive_fusing_through::run(program& p) {
         // Update intermediate nodes
         auto node_itr = std::next(fuse_through_order.rbegin());
         while (node_itr != fuse_through_order.rend()) {
-            auto itermediate_node = *node_itr++;
+            auto *itermediate_node = *node_itr++;
 
             if (itermediate_node->is_type<reorder>()) {
                 // We can't modify reorder's output type directly, so replace old node with new one

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -352,7 +352,7 @@ void prepare_quantization::prepare_dequantize_merge(program& p, eltwise_node& el
     auto& input = eltwise_node.input();
     const auto& stream = p.get_stream();
 
-    for (auto& user : input.get_users()) {
+    for (const auto& user : input.get_users()) {
         if (user == &eltwise_node)
             continue;
 
@@ -384,8 +384,8 @@ void prepare_quantization::prepare_dequantize_merge(program& p, eltwise_node& el
 
             mem_lock<uint8_t, mem_lock_type::read> mem0_lock{mem0, stream};
             mem_lock<uint8_t, mem_lock_type::read> mem1_lock{mem1, stream};
-            auto ptr0 = mem0_lock.data();
-            auto ptr1 = mem1_lock.data();
+            auto *ptr0 = mem0_lock.data();
+            auto *ptr1 = mem1_lock.data();
 
             for (size_t j = 0; j < mem0->get_layout().bytes_count(); j++) {
                 if (ptr0[j] != ptr1[j]) {
@@ -417,7 +417,7 @@ void prepare_quantization::remove_fake_reorders(program& p, reorder_node& reorde
         return;
     }
 
-    auto &usr = reorder_node.get_users().front();
+    const auto &usr = reorder_node.get_users().front();
     auto &dep = reorder_node.get_dependency(0);
     if (!(usr->is_type<convolution>() && usr->get_input_layout(1).data_type == data_types::i8) ||
         !dep.is_input() ||
@@ -438,7 +438,7 @@ bool prepare_quantization::optimize_quantize(program &p, quantize_node& quantize
 
     auto& input = quantize_node.get_dependency(0);
     auto parallel_quantizes_num = 0;
-    for (auto& usr : input.get_users()) {
+    for (const auto& usr : input.get_users()) {
         if (usr->is_type<quantize>())
             parallel_quantizes_num++;
     }
@@ -469,7 +469,7 @@ bool prepare_quantization::optimize_quantize(program &p, quantize_node& quantize
     mem_lock<uint8_t, mem_lock_type::read> mem_output_high_lock_first{mem_output_high_first, stream};
 
     program_node* same_quantize = nullptr;
-    for (auto& usr : input.get_users()) {
+    for (const auto& usr : input.get_users()) {
         if (!usr->is_type<quantize>() || usr == &quantize_node)
             continue;
 
@@ -670,7 +670,7 @@ static void optimize_moe_3gemm_fused_decompression_parameters(moe_node& node, pr
 void prepare_quantization::run(program& p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto &node = (*itr++);
+        const auto &node = (*itr++);
         if (node->is_type<quantize>()) {
             handle_quantize_node(p, node->as<quantize>());
         } else if (node->is_type<eltwise>()) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/propagate_constants.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/propagate_constants.cpp
@@ -36,7 +36,7 @@ void try_reselect_impl_for_node(program_node* node) {
     if (!can_select_impl)
         return;
 
-    auto selected_impl = node->get_selected_impl();
+    auto *selected_impl = node->get_selected_impl();
     bool has_selected_impl = selected_impl != nullptr;
     bool need_new_impl_selection = !has_selected_impl;
 
@@ -91,7 +91,7 @@ void try_reselect_impl_for_node(program_node* node) {
 // ToDo remove friendship relation from  program_node and program
 void propagate_constants::run(program& p) {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, "pass::PropagateConstants");
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         if (node->is_constant())
             handle_constant(p, *node);
     }
@@ -106,7 +106,7 @@ void propagate_constants::run(program& p) {
     // than removed (see next loop)
     auto proc_itr = p.get_processing_order().begin();
     while (proc_itr != p.get_processing_order().end()) {
-        auto& node = (*proc_itr++);
+        const auto& node = (*proc_itr++);
         if (!node->is_constant())
             continue;
         if (has_non_const_user(*node) || (node->is_output() && !node->is_type<data>()))
@@ -184,7 +184,7 @@ void propagate_constants::run(program& p) {
         // Only users of constants that transitioned from dynamic to static need impl reselection.
         if (was_dynamic && !new_node.get_output_layout(false).is_dynamic()) {
             std::queue<program_node*> queue;
-            for (auto& user : new_node.get_users()) {
+            for (const auto& user : new_node.get_users()) {
                 queue.push(user);
             }
             while (!queue.empty()) {
@@ -194,7 +194,7 @@ void propagate_constants::run(program& p) {
                     continue;
                 reselection_targets.insert(n);
                 if (!n->is_all_valid_output_layouts()) {
-                    for (auto& user : n->get_users()) {
+                    for (const auto& user : n->get_users()) {
                         queue.push(user);
                     }
                 }
@@ -213,7 +213,7 @@ void propagate_constants::run(program& p) {
 bool propagate_constants::has_non_const_user(program_node& node) const {
     if (!node.is_constant())
         return true;
-    for (auto& user : node.get_users()) {
+    for (const auto& user : node.get_users()) {
         if (!user->is_constant())
             return true;
     }
@@ -322,7 +322,7 @@ void propagate_constants::add_deps_to_tpl(program& prog, const std::vector<std::
     /   \
     A     B
     */
-    for (auto& dep : deps) {
+    for (const auto& dep : deps) {
         if (dep.first->is_type<data>()) {
             auto dep_ptr = prog.get_node_ptr(dep.first->get_primitive()->id);
             if (nodes.find(dep_ptr) == nodes.end()) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -36,7 +36,7 @@ using namespace cldnn;
 namespace {
 
 bool does_any_user_have_impl_type(program_node& node, impl_types impl) {
-    for (auto& user : node.get_users()) {
+    for (const auto& user : node.get_users()) {
         if (user->get_preferred_impl_type() == impl)
             return true;
     }
@@ -59,7 +59,7 @@ void remove_redundant_reorders::run(program& p) {
 
         node.set_unique_id();
         node.set_selected_impl(node.type()->create_impl(node));
-        if (auto impl = node.get_selected_impl()) {
+        if (auto *impl = node.get_selected_impl()) {
             auto params = node.get_kernel_impl_params();
             p.get_kernels_cache().add_kernels_source(*params, impl->get_kernels_source());
         }
@@ -69,7 +69,7 @@ void remove_redundant_reorders::run(program& p) {
     auto itr = p.get_processing_order().begin();
     if (enable_reorder_fusing) {
         while (itr != p.get_processing_order().end()) {
-            auto node_ptr = *itr++;
+            auto *node_ptr = *itr++;
             if (!node_ptr->is_type<reorder>())  // only care for reorders
                 continue;
 
@@ -83,7 +83,7 @@ void remove_redundant_reorders::run(program& p) {
 
             std::function<bool(program_node&)> has_quantize_user;
             has_quantize_user = [&has_quantize_user](program_node& node) -> bool {
-                auto& users = node.get_users();
+                const auto& users = node.get_users();
                 if (users.size() != 1)
                     return false;
                 if (users.front()->is_type<quantize>())
@@ -109,7 +109,7 @@ void remove_redundant_reorders::run(program& p) {
             bool all_users_fuse = true;
             std::vector<program_node*> recalc_list;
 
-            for (auto usr : node.get_users()) {
+            for (auto *usr : node.get_users()) {
                 if (!lo.can_fuse_reorder(input, *usr, input.get_output_layout().format, usr->get_output_layout().format)) {
                     all_users_fuse = false;
                     break;
@@ -141,7 +141,7 @@ void remove_redundant_reorders::run(program& p) {
             LOG_NODE_REMOVAL(node.id());
             p.extract_and_remove(node);
 
-            for (auto rl : recalc_list) {
+            for (auto *rl : recalc_list) {
                 rl->recalc_output_layout(true);
             }
         }
@@ -150,7 +150,7 @@ void remove_redundant_reorders::run(program& p) {
     // Shrink reorder chains
     itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto node = *itr++;
+        auto *node = *itr++;
         if (!node->is_type<reorder>())  // only care for reorders
             continue;
         auto& r_node = node->as<reorder>();
@@ -226,7 +226,7 @@ void remove_redundant_reorders::run(program& p) {
     // Reorder (nv12_uint8 -> bfyx_uint8) /|
     itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto node = *itr++;
+        auto *node = *itr++;
         if (!node->is_type<reorder>())
             continue;
 
@@ -273,7 +273,7 @@ void remove_redundant_reorders::run(program& p) {
     // Optimize reorders not changing memory layout
     itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto node = *itr++;
+        auto *node = *itr++;
         if (!node->is_type<reorder>())  // only care for reorders
             continue;
 
@@ -382,7 +382,7 @@ void remove_redundant_reorders::run(program& p) {
     // This pass removes redundant reorders in case when several users of a node have the same input reorders
     itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto& node = *itr++;
+        const auto& node = *itr++;
         if (!node->is_type<reorder>())
             continue;
 
@@ -396,7 +396,7 @@ void remove_redundant_reorders::run(program& p) {
 
         auto& dep = node->get_dependency(0);
 
-        for (auto& user : dep.get_users()) {
+        for (const auto& user : dep.get_users()) {
             if (user->is_type<reorder>() &&
                 user != node &&
                 !user->is_output() &&
@@ -420,7 +420,7 @@ void remove_redundant_reorders::run(program& p) {
 
         auto rem_itr = r_nodes_to_remove.begin();
         while (rem_itr != r_nodes_to_remove.end()) {
-            auto remove_reorder_node = *rem_itr++;
+            auto *remove_reorder_node = *rem_itr++;
             // Outer loop iterator has been already moved, so if we try to remove a node which the iterator
             // pointing to, we should increment it again
             if (remove_reorder_node == *itr)
@@ -438,7 +438,7 @@ void remove_redundant_reorders::run(program& p) {
     itr = p.get_processing_order().begin();
     if (enable_reorder_fusing) {
         while (itr != p.get_processing_order().end()) {
-            auto& node_ptr = *itr++;
+            const auto& node_ptr = *itr++;
             if (!node_ptr->is_type<reorder>())  // only care for reorders
                 continue;
 
@@ -503,7 +503,7 @@ void remove_redundant_reorders::run(program& p) {
     // This pass removed reorder if the next node supports reorder's input format and data type doesn't change
     itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto& node_ptr = *itr++;
+        const auto& node_ptr = *itr++;
         if (!node_ptr->is_type<reorder>() || !node_ptr->is_in_data_flow() || node_ptr->get_users().size() != 1 ||
             node_ptr->get_dependencies().size() != 1 || node_ptr->is_dynamic())
             continue;
@@ -511,7 +511,7 @@ void remove_redundant_reorders::run(program& p) {
         auto& node = node_ptr->as<reorder>();
         auto prim_desc = node.get_primitive();
 
-        auto& usr = node_ptr->get_users().front();
+        const auto& usr = node_ptr->get_users().front();
         auto& dep = node_ptr->get_dependency(0);
 
         auto quantize_opt = usr->is_type<quantize>() &&
@@ -543,7 +543,7 @@ void remove_redundant_reorders::run(program& p) {
         if (node->get_users().size() != 1)
             return false;
 
-        auto& usr = node->get_users().front();
+        const auto& usr = node->get_users().front();
         auto& dep = node->get_dependency(0);
         auto  dep_layout = dep.get_output_layout();
 
@@ -564,7 +564,7 @@ void remove_redundant_reorders::run(program& p) {
             if (update_implementations)
                 return false;
 
-            for (auto user : dep.get_users()) {
+            for (auto *user : dep.get_users()) {
                 if (user != node) {
                     if (user->can_be_optimized())
                         return false;
@@ -619,7 +619,7 @@ void remove_redundant_reorders::run(program& p) {
             input_dep.get_output_layout().data_type == data_types::i8)
             return false;
 
-        for (auto& user : node->get_users()) {
+        for (const auto& user : node->get_users()) {
             // if concat is reorder's user and concat's axis is 0(Batch) or 1(Feature), conv's output would have padding.
             // This padding might lead not to select the optimized conv kernel("convolution_gpu_bfyx_f16")
             if (user->is_type<concatenation>()) {
@@ -651,16 +651,16 @@ void remove_redundant_reorders::run(program& p) {
             p.add_optimized_primitive_info(node->id());
             p.extract_and_remove(*node);
             return true;
-        } else {
-            input.set_output_layout(old_output_layout_of_input, false);
-            return false;
         }
+        input.set_output_layout(old_output_layout_of_input, false);
+        return false;
+
     };
 
     if (enable_reorder_fusing) {
         itr = p.get_processing_order().begin();
         while (itr != p.get_processing_order().end()) {
-            auto& node = *itr++;
+            const auto& node = *itr++;
             if (!node->is_type<reorder>())
                 continue;
 
@@ -690,7 +690,7 @@ void remove_redundant_reorders::run(program& p) {
     // In addition this pass can completely remove useless reshapes sequence where the output size is equal to input.
     itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto node = *itr++;
+        auto *node = *itr++;
         if (!node->is_type<reshape>())
             continue;
 
@@ -737,7 +737,7 @@ void remove_redundant_reorders::run(program& p) {
     // Remove reorders before shape_of primitive
     itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto& node = *itr++;
+        const auto& node = *itr++;
         if (!node->is_type<reorder>() || node->has_fused_primitives() ||
             !node->is_in_data_flow() || node->get_users().size() != 1 ||
             !node->get_users().front()->is_type<shape_of>())
@@ -752,7 +752,7 @@ void remove_redundant_reorders::run(program& p) {
         p.remove_if_dangling(*node);
     }
 
-    for (auto n : p.get_processing_order()) {
+    for (auto *n : p.get_processing_order()) {
         if (n->is_in_data_flow() && n->is_type<reorder>()) {
             auto preferred_impl = lo.get_preferred_impl_type(*n, n->get_input_layout(0).format);
             n->set_preferred_impl_type(preferred_impl);
@@ -761,7 +761,7 @@ void remove_redundant_reorders::run(program& p) {
 
     // Recalculate processing order if it is not correct
     bool is_correct = true;
-    for (auto node : p.get_processing_order()) {
+    for (auto *node : p.get_processing_order()) {
         if (!p.get_processing_order().is_correct(node)) {
             is_correct = false;
             break;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -44,7 +44,7 @@ std::map<program_node*, format::type> get_preferred_formats(program& p, layout_o
     size_t onednn_impls_counter = 0;
     bool should_update_fmt_map = false;
     // Calculate onednn kernels number and all kernels number inside the network
-    for (auto n : p.get_processing_order()) {
+    for (auto *n : p.get_processing_order()) {
         if (!n->is_in_data_flow())
             continue;
 
@@ -67,7 +67,7 @@ std::map<program_node*, format::type> get_preferred_formats(program& p, layout_o
     if (should_update_fmt_map)
 #endif // ENABLE_ONEDNN_FOR_GPU
     {
-        for (auto n : p.get_processing_order()) {
+        for (auto *n : p.get_processing_order()) {
             if (!n->is_in_data_flow())
                 continue;
 
@@ -259,7 +259,7 @@ void propagate_formats_in_dir(std::map<program_node*, format::type>& fmt_map,
 void propagate_formats(program& p, std::map<program_node*, format::type>& fmt_map, layout_optimizer& lo) {
     auto it = p.get_processing_order().begin();
     while (it != p.get_processing_order().end()) {
-        auto node = *it++;
+        auto *node = *it++;
 
         if (fmt_map.count(node) == 0 || fmt_map.at(node) == format::any)
             continue;
@@ -311,7 +311,7 @@ reorder_cnt count_reorders(const std::map<program_node*, format::type>& fmt_map,
 }
 
 void minimize_local_reorders(program& p, std::map<program_node*, format::type>& fmt_map, layout_optimizer& lo) {
-    for (auto node : p.get_processing_order()) {
+    for (auto *node : p.get_processing_order()) {
         if (!node->is_in_data_flow())
             continue;
         auto preferred_format = lo.get_preferred_format(*node);
@@ -320,7 +320,7 @@ void minimize_local_reorders(program& p, std::map<program_node*, format::type>& 
             if (preferred_format == format::b_fs_yx_fsv4 &&
                 (node->get_output_layout().data_type == data_types::i8 || node->get_output_layout().data_type == data_types::u8)) {
                 std::set<format::type> io_formats;
-                for (auto user : node->get_users()) {
+                for (auto *user : node->get_users()) {
                     io_formats.insert(fmt_map.at(user));
                 }
                 for (const auto& dep : node->get_dependencies()) {
@@ -351,7 +351,7 @@ void minimize_local_reorders(program& p, std::map<program_node*, format::type>& 
 
         std::set<format::type> local_formats;
 
-        for (auto user : node->get_users()) {
+        for (auto *user : node->get_users()) {
             auto user_fmt = get_target_input_format(lo, fmt_map, user, node);
 
             if (user_fmt != format::any &&
@@ -400,8 +400,7 @@ void minimize_local_reorders(program& p, std::map<program_node*, format::type>& 
 const char *dir_msg(direction_e dir) {
     if (dir == direction_e::forwards)
         return "forward";
-    else
-        return "backward";
+    return "backward";
 }
 
 static bool is_weights_dependency(program_node* predecessor, program_node* successor) {
@@ -489,7 +488,7 @@ void insert_reorders_in_dir(program& p, const std::map<program_node*, format::ty
 void insert_reorders(program& p, const std::map<program_node*, format::type>& fmt_map, reorder_factory& rf, layout_optimizer& lo) {
     auto fwd_it = p.get_processing_order().begin();
     while (fwd_it != p.get_processing_order().end()) {
-        auto node = *(fwd_it++);
+        auto *node = *(fwd_it++);
 
         if (fmt_map.count(node) != 1)
             continue;
@@ -503,7 +502,7 @@ void insert_reorders(program& p, const std::map<program_node*, format::type>& fm
 
     auto bwd_it = p.get_processing_order().rbegin();
     while (bwd_it != p.get_processing_order().rend()) {
-        auto node = *(bwd_it++);
+        auto *node = *(bwd_it++);
 
         if (fmt_map.count(node) != 1)
             continue;
@@ -536,7 +535,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
     minimize_local_reorders(p, fmt_map, lo);
 
     GPU_DEBUG_LOG_PASS << "Selected formats:" << std::endl;
-    for (auto node_ptr : p.get_processing_order()) {
+    for (auto *node_ptr : p.get_processing_order()) {
         if (fmt_map.count(node_ptr) == 0)
             continue;
 
@@ -561,7 +560,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
 
         // Count number of reorders that will be fused
         size_t nodes_with_fusing = 0;
-        for (auto node_ptr : p.get_processing_order()) {
+        for (auto *node_ptr : p.get_processing_order()) {
             if (fmt_map.count(node_ptr) == 0 || fmt_map.at(node_ptr) == format::any)
                 continue;
             for (const auto& prev_ptr : travel_direction_wrapper<direction_e::backwards>::next_nodes(node_ptr)) {
@@ -579,7 +578,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
 
     insert_reorders(p, fmt_map, rf, lo);
 
-    for (auto n : p.get_processing_order()) {
+    for (auto *n : p.get_processing_order()) {
         n->recalc_output_layouts(true);
     }
 
@@ -796,7 +795,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
                     auto reorder_back = rf.get_reorder(mvn_node.id(), mvn_output_layout, output_layout);
                     if (reorder_back.first) {
                         const auto& users = mvn_node.get_users();
-                        auto first_user = users.front();
+                        auto *first_user = users.front();
                         p.add_intermediate(reorder_back.first, *first_user, 0, !reorder_back.second, true);
                     }
                 }
@@ -837,7 +836,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
     };
 #endif // ENABLE_ONEDNN_FOR_GPU
 
-    for (auto& prim : p.get_processing_order()) {
+    for (const auto& prim : p.get_processing_order()) {
         program_helpers::do_for_types<detection_output, deconvolution, convolution, fully_connected, pooling, mvn>(
             *prim,
             reorder_input_detection_output,
@@ -854,7 +853,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
 #endif // ENABLE_ONEDNN_FOR_GPU
     }
 
-    for (auto n : p.get_processing_order()) {
+    for (auto *n : p.get_processing_order()) {
         if (n->is_in_data_flow() && fmt_map.count(n) != 0) {
             n->get_output_layout(); // There might be some invalid output layout
             auto preferred_impl = lo.get_preferred_impl_type(*n, fmt_map.at(n));
@@ -863,7 +862,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
     }
 
     // WA for OneDNN PRelu activation fusions: convert activation's slope buffer to expected f32 data type
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         if (node->get_preferred_impl_type() == impl_types::onednn) {
             auto fused_prims = node->get_fused_primitives();
             for (auto& fused_desc : fused_prims) {
@@ -896,7 +895,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
     // If batch dimension of gemm output is not equal to 1, then OneDNN will not be able to broadcast fused op data
     // correctly and we need to do it manually
 #ifdef ENABLE_ONEDNN_FOR_GPU
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         if (node->is_type<gemm>() && node->get_preferred_impl_type() == impl_types::onednn) {
             for (const auto& fused_prim : node->get_fused_primitives()) {
                 if (fused_prim.is_type<eltwise>() &&

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_transfer.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_transfer.cpp
@@ -12,7 +12,7 @@ using namespace cldnn;
 void reorder_transfer::run(program& p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
-        auto& node = *itr++;
+        const auto& node = *itr++;
 
         if (!node->is_type<reorder>())
             continue;
@@ -48,7 +48,7 @@ void reorder_transfer::run(program& p) {
         }
 
         if (new_prev != nullptr) {
-            auto& new_next = new_prev->get_users().front();
+            const auto& new_next = new_prev->get_users().front();
             p.move_node(reorder_node, *new_prev, *new_next);
             reorder_node.recalc_output_layout(false);
         }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
@@ -128,7 +128,7 @@ void select_preferred_formats::run(program& p) {
 
     auto forcing_map = p.get_config().get_force_implementations();
 
-    for (auto n : p.get_processing_order()) {
+    for (auto *n : p.get_processing_order()) {
         n->recalc_output_layout();
         if (n->is_input() || !n->is_in_data_flow()) {
             continue;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/skipped_branch_memory_dependencies.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/skipped_branch_memory_dependencies.cpp
@@ -17,7 +17,7 @@ void skipped_branch_memory_dependencies::run(program& p) {
     auto& processing_order = p.get_processing_order();
     auto itrB = processing_order.begin();
     while (itrB != processing_order.end()) {
-        auto& nodeB = *itrB;
+        const auto& nodeB = *itrB;
         auto itrA = ++itrB;
         if (!nodeB->may_use_mempool())
             continue;
@@ -35,7 +35,7 @@ void skipped_branch_memory_dependencies::run(program& p) {
 
         // mark all nodes in between B and lastUsr of B as forbidden to share buffer with B
         while (itrA != processing_order.get_processing_iterator(**lastUsr) && itrA != processing_order.end()) {
-            auto& nodeA = *itrA;
+            const auto& nodeA = *itrA;
             itrA++;
             add_memory_dependency(nodeA, nodeB);
             add_memory_dependency(nodeB, nodeA);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/trim_to_outputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/trim_to_outputs.cpp
@@ -24,7 +24,7 @@ void trim_to_outputs::run(program& p) {
     queue.push(p.get_outputs());
 
     std::vector<program_node*> special_nodes;
-    for (auto& node : p.get_processing_order()) {   // input layout may become disconnected during prior boxes calculations so
+    for (const auto& node : p.get_processing_order()) {   // input layout may become disconnected during prior boxes calculations so
         if (node->is_type<input_layout>()) {        // it may have not been marked at this place but we don't want to remove it
             special_nodes.push_back(node);          // ToDo: remove this after support for multi-outputs in primitives will
         }                                           // be implemented.
@@ -40,7 +40,7 @@ void trim_to_outputs::run(program& p) {
                 node->mark();
                 if (!node->get_dependencies().empty()) {
                    std::vector<program_node*> deps;
-                    for (auto& dep : node->get_dependencies()) {
+                    for (const auto& dep : node->get_dependencies()) {
                         deps.push_back(dep.first);
                     }
                     queue.push(deps);
@@ -51,13 +51,13 @@ void trim_to_outputs::run(program& p) {
 
     // all not-marked nodes should be removed
     std::vector<program_node*> to_rem;
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         if (!node->is_marked())
             to_rem.push_back(node);
     }
     p.remove_nodes(to_rem);
 
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         node->unmark();
     }
 }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/update_inner_program_io_map.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/update_inner_program_io_map.cpp
@@ -14,7 +14,7 @@
 using namespace cldnn;
 
 void update_inner_program_io_map::run(program& p) {
-    for (auto& node : p.get_processing_order()) {
+    for (const auto& node : p.get_processing_order()) {
         if (node->is_type<loop>()) {
             loop_node& node2 = node->as<loop>();
             for (const auto& info : p.get_optimized()) {

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention.cpp
@@ -124,7 +124,7 @@ public:
     void update_xattn_rt_params(const primitive_inst& instance) {
         const auto& params = *instance.get_impl_params();
         const auto desc = params.typed_desc<paged_attention>();
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
 
         const size_t block_size = get_xattn_block_size(params);
         const uint32_t block_wg_n = XAttentionEstimateGeneratorBase::get_block_wg_n(params);
@@ -246,7 +246,7 @@ public:
 
         const auto& params = *instance.get_impl_params();
         OPENVINO_ASSERT(!params.is_dynamic());
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         const auto& desc = params.typed_desc<paged_attention>();
         rt_params->batch_size_in_sequences = get_batch_size_in_sequences(params.input_layouts);
         rt_params->single_token_selected_count = 0;
@@ -308,7 +308,7 @@ public:
 
     void prepare_multi_token_mapping(primitive_inst& instance) {
         const auto& params = *instance.get_impl_params();
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         OPENVINO_ASSERT(rt_params != nullptr);
         if (rt_params->multi_token_wg_count == 0) {
             return;
@@ -351,7 +351,7 @@ public:
     }
 
     void prepare_single_token_selected_ids(primitive_inst& instance) {
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         OPENVINO_ASSERT(rt_params != nullptr);
         OPENVINO_ASSERT(rt_params->stage == PagedAttentionStage::GENERATE, "prepare_single_token_selected_ids is expected only for generate/decode stage");
         auto& stream = instance.get_network().get_stream();
@@ -372,7 +372,7 @@ public:
 
     void prepare_split_mixed_selected_ids_and_mapping(primitive_inst& instance) {
         const auto& params = *instance.get_impl_params();
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         OPENVINO_ASSERT(rt_params != nullptr);
         OPENVINO_ASSERT(rt_params->stage == PagedAttentionStage::MIXED && m_mixed_route_mode == MixedRouteMode::SPLIT,
                         "prepare_split_mixed_selected_ids_and_mapping must be used only in split mixed mode");
@@ -442,7 +442,7 @@ public:
     }
 
     void prepare_xattn_metadata(primitive_inst& instance) {
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         OPENVINO_ASSERT(rt_params != nullptr);
         if (!rt_params->enable_xattn_estimation || m_xattn_meta.empty())
             return;
@@ -487,7 +487,7 @@ public:
         const auto desc = params.typed_desc<paged_attention>();
 
         update_stages_flags(instance);
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         OPENVINO_ASSERT(rt_params != nullptr);
 
         GPU_DEBUG_TRACE_DETAIL << "ov::intel_gpu::cm::PagedAttentionCmImpl::execute():  stage = " << static_cast<int>(rt_params->stage) << std::endl;
@@ -576,7 +576,7 @@ public:
         std::vector<BufferDescriptor> internal_buffers;
 
         const auto desc = params.typed_desc<paged_attention>();
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         // Assume rt_params are updated, because get_internal_buffer_descs surely occurs after update_rt_params.
         OPENVINO_ASSERT(rt_params != nullptr);
 
@@ -704,7 +704,7 @@ private:
         constexpr int32_t block_size_128 = 128;
         constexpr int32_t block_size_256 = 256;
 
-        const auto rt_params = static_cast<const PagedAttentionRuntimeParams*>(m_rt_params.get());
+        const auto* const rt_params = static_cast<const PagedAttentionRuntimeParams*>(m_rt_params.get());
         OPENVINO_ASSERT(rt_params != nullptr, "PagedAttention runtime params are not initialized");
         OPENVINO_ASSERT(rt_params->enable_xattn_estimation, "XAttention block size must be accessed only when enable_xattn_estimation is true");
 

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -33,12 +33,12 @@ inline size_t get_kv_len(const RuntimeParams& params, const PagedAttentionStage&
         auto key_shape = params.input_layouts[PagedAttentionInputIdx::KEY].get_shape();
         const size_t kv_len = key_shape[key_shape.size() - 2];
         return kv_len;
-    } else {
-        // key_cache shape = [block_num, head_num, block_size(128), head_size]
-        auto key_cache_shape = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE].get_shape();
-        const size_t kv_len = key_cache_shape[0] * key_cache_shape[2];
-        return kv_len;
     }
+    // key_cache shape = [block_num, head_num, block_size(128), head_size]
+    auto key_cache_shape = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE].get_shape();
+    const size_t kv_len = key_cache_shape[0] * key_cache_shape[2];
+    return kv_len;
+
     OPENVINO_ASSERT(false, "Unsupported PagedAttentionStage for get_kv_len");
     return 0;  // Fallback case, should not be reached
 }
@@ -53,9 +53,8 @@ inline bool get_kv_compressed(const RuntimeParams& params) {
     auto key_cache_layout = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE];
     if (data_type_traits::is_i8_u8(key_cache_layout.data_type)) {
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 // max_context_len = max(past_lens + prompt_lens)
@@ -300,7 +299,7 @@ DispatchDataFunc PagedAttentionGeneratorKVCacheUpdate::get_dispatch_data_func() 
             size_t offset = 0;
             const auto& data_padding = layout.data_padding;
             const auto& lower_pads = data_padding._lower_size;
-            for (auto& it : lower_pads) {
+            for (const auto& it : lower_pads) {
                 if (it > 0) {
                     offset = it;
                     break;
@@ -393,7 +392,7 @@ DispatchDataFunc PagedAttentionGeneratorMultiToken::get_dispatch_data_func() con
         auto& wgs = kd.params.workGroups;
         auto& scalars = kd.params.scalars;
         auto desc = params.typed_desc<paged_attention>();
-        auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+        auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
         OPENVINO_ASSERT(rt_params != nullptr);
         const size_t heads_num = desc->heads_num;
 
@@ -479,7 +478,7 @@ DispatchDataFunc PagedAttentionGeneratorSingleToken::get_dispatch_data_func() co
         OPENVINO_ASSERT(!params.is_dynamic());
         auto& wgs = kd.params.workGroups;
         const auto desc = params.typed_desc<paged_attention>();
-        auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+        auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
         OPENVINO_ASSERT(rt_params != nullptr);
 
         const size_t batch = rtp->single_token_selected_count;
@@ -549,7 +548,7 @@ DispatchDataFunc PagedAttentionGeneratorSingleTokenFinalization::get_dispatch_da
         auto& wgs = kd.params.workGroups;
 
         const auto desc = params.typed_desc<paged_attention>();
-        auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+        auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
 
         OPENVINO_ASSERT(rt_params != nullptr);
 
@@ -660,7 +659,7 @@ DispatchDataFunc XAttentionEstimateGEMMQK::get_dispatch_data_func() const {
     return DispatchDataFunc{[&](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* rt_params) {
         OPENVINO_ASSERT(!params.is_dynamic());
         OPENVINO_ASSERT(rt_params != nullptr);
-        auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+        auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
         const auto desc = params.typed_desc<paged_attention>();
 
         auto get_simple_pitch = [](const layout& layout) {
@@ -735,7 +734,7 @@ DispatchDataFunc XAttentionEstimateFindBlock::get_dispatch_data_func() const {
     return DispatchDataFunc{[&](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* rt_params) {
         OPENVINO_ASSERT(!params.is_dynamic());
         OPENVINO_ASSERT(rt_params != nullptr);
-        auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+        auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
         const auto desc = params.typed_desc<paged_attention>();
 
         auto& wgs = kd.params.workGroups;
@@ -785,7 +784,7 @@ DispatchDataFunc XAttentionEstimatePostProc::get_dispatch_data_func() const {
     return DispatchDataFunc{[&](const RuntimeParams& params, KernelData& kd, ImplRuntimeParams* rt_params) {
         OPENVINO_ASSERT(!params.is_dynamic());
         OPENVINO_ASSERT(rt_params != nullptr);
-        auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+        auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
         const auto desc = params.typed_desc<paged_attention>();
 
         auto& wgs = kd.params.workGroups;

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.hpp
@@ -29,7 +29,8 @@ constexpr int32_t PA_CM_REGISTER_FILE_SIZE = 256;
 inline std::pair<size_t, size_t> get_kv_split_size(size_t arch) {
     if (arch == 1) {
         return {8, 32};  // For Xe1
-    } else if (arch == 2) {
+    }
+    if (arch == 2) {
         return {16, 32};  // For Xe2
     }
     OPENVINO_ASSERT(false, "Unsupported architecture for KV split size");
@@ -229,9 +230,8 @@ public:
         // internal testing. We can consider to make it configurable if needed in the future.
         if (!has_xattention && PA_KV_CACHE_BLOCK_SIZE_LEGACY < 128) {
             return 128;
-        } else {
-            return PA_KV_CACHE_BLOCK_SIZE_XATTN;
         }
+        return PA_KV_CACHE_BLOCK_SIZE_XATTN;
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/common/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/condition.cpp
@@ -102,36 +102,36 @@ struct condition_impl : typed_primitive_impl<condition> {
                 instance.set_flag(ExecutionFlags::MEMORY_CHANGED);
             }
             return stream.group_events(output_events);
-        } else {
-            // Set input memory of inner network before its execution
-            for (size_t mem_idx = 0; mem_idx < instance.inputs_memory_count(); mem_idx++) {
-                const primitive_id& input_external_id = instance.dependencies().at(mem_idx).first->id();
-                auto iter = branch.input_map.find(input_external_id);
-                if (iter != branch.input_map.end()) {
-                    const primitive_id& input_internal_id = iter->second;
-                    auto mem_ptr = instance.input_memory_ptr(mem_idx);
-                    auto dep = instance.dependencies()[mem_idx];
-                    auto layout = dep.first->get_impl_params()->get_output_layout(dep.second);
-                    if (mem_ptr) {
-                        GPU_DEBUG_LOG << "Reshape input from " << mem_ptr->get_layout().to_short_string() << " to "
-                                      << layout.to_short_string() << std::endl;
-                        // Preallocation logic may allocate more memory than actually produced on current iteration, so
-                        // we need to adjust input buffers layout
-                        mem_ptr = instance.get_network().get_engine().reinterpret_buffer(*mem_ptr, layout);
-                    } else if (layout.count() == 0) {
-                        // Use dummy memory for empty tensor
-                        mem_ptr = std::make_shared<simple_attached_memory>(layout, nullptr);
-                    }
-                    OPENVINO_ASSERT(mem_ptr != nullptr, "[GPU] Can't assign nullptr memory buffer for condition primitive with id=", instance.id(), " ("
-                                                        "mem_idx=", mem_idx, ", "
-                                                        "external_id=", input_external_id, ", "
-                                                        "internal_id=", input_internal_id, ")");
-                    executed_net->set_input_data(input_internal_id, mem_ptr);
-                    GPU_DEBUG_LOG << "Inner net - Inputs[" << mem_idx << "]: layout=" << mem_ptr->get_layout().to_short_string() << ", "
-                                  << "allocation_type=" << mem_ptr->get_allocation_type() << std::endl;
+        }
+        // Set input memory of inner network before its execution
+        for (size_t mem_idx = 0; mem_idx < instance.inputs_memory_count(); mem_idx++) {
+            const primitive_id& input_external_id = instance.dependencies().at(mem_idx).first->id();
+            auto iter = branch.input_map.find(input_external_id);
+            if (iter != branch.input_map.end()) {
+                const primitive_id& input_internal_id = iter->second;
+                auto mem_ptr = instance.input_memory_ptr(mem_idx);
+                auto dep = instance.dependencies()[mem_idx];
+                auto layout = dep.first->get_impl_params()->get_output_layout(dep.second);
+                if (mem_ptr) {
+                    GPU_DEBUG_LOG << "Reshape input from " << mem_ptr->get_layout().to_short_string() << " to "
+                                  << layout.to_short_string() << std::endl;
+                    // Preallocation logic may allocate more memory than actually produced on current iteration, so
+                    // we need to adjust input buffers layout
+                    mem_ptr = instance.get_network().get_engine().reinterpret_buffer(*mem_ptr, layout);
+                } else if (layout.count() == 0) {
+                    // Use dummy memory for empty tensor
+                    mem_ptr = std::make_shared<simple_attached_memory>(layout, nullptr);
                 }
+                OPENVINO_ASSERT(mem_ptr != nullptr, "[GPU] Can't assign nullptr memory buffer for condition primitive with id=", instance.id(), " ("
+                                                    "mem_idx=", mem_idx, ", "
+                                                    "external_id=", input_external_id, ", "
+                                                    "internal_id=", input_internal_id, ")");
+                executed_net->set_input_data(input_internal_id, mem_ptr);
+                GPU_DEBUG_LOG << "Inner net - Inputs[" << mem_idx << "]: layout=" << mem_ptr->get_layout().to_short_string() << ", "
+                              << "allocation_type=" << mem_ptr->get_allocation_type() << std::endl;
             }
         }
+
 
         auto sub_net_results = executed_net->execute(events);
         // Update output layout of impl_param in condition_inst

--- a/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
@@ -234,7 +234,7 @@ struct loop_impl : typed_primitive_impl<loop> {
             }
 
             // Collect output events for waiting for all iterations finishing
-            for (auto& out : body_network->get_outputs()) {
+            for (const auto& out : body_network->get_outputs()) {
                 auto output_id = out->id();
                 if (body_network->has_event(output_id)) {
                     auto output_event = body_network->get_primitive_event(output_id);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/activation.cpp
@@ -100,7 +100,7 @@ struct activation_impl : public typed_primitive_impl<activation> {
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         std::vector<memory::ptr> input_mem_ptrs;
         for (size_t i = 0; i < instance.dependencies().size(); i++)
@@ -251,7 +251,7 @@ struct activation_impl : public typed_primitive_impl<activation> {
             }
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         switch (params->input_layouts[0].data_type) {
         case data_types::f32:

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/broadcast.cpp
@@ -67,7 +67,7 @@ struct broadcast_impl : public typed_primitive_impl<broadcast> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/concat.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/concat.cpp
@@ -58,7 +58,7 @@ struct concatenation_impl : public typed_primitive_impl<concatenation> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;
@@ -69,7 +69,7 @@ struct concatenation_impl : public typed_primitive_impl<concatenation> {
 
         std::vector<memory::ptr> input_mem_ptrs;
         for (size_t i = 0; i < instance.dependencies().size(); i++) {
-            auto& dep = instance.dependencies().at(i);
+            const auto& dep = instance.dependencies().at(i);
             if (dep.first->get_output_layout().count() > 0) {
                 auto mem_ptr = instance.dep_memory_ptr(i);
                 input_host_tensors.push_back(make_tensor(params->input_layouts[i], mem_ptr->lock(stream, mem_lock_type::read)));

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/crop.cpp
@@ -44,7 +44,7 @@ struct crop_impl : public typed_primitive_impl<crop> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
         auto input_layout = params->input_layouts[0];
         auto input_offset = params->input_offsets[0];
         auto output_layout = params->output_layouts[0];

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/detection_output.cpp
@@ -100,9 +100,9 @@ public:
             float bbox1_size = bbox1.area();
             float bbox2_size = bbox2.area();
             return intersect_size / (bbox1_size + bbox2_size - intersect_size);
-        } else {
-            return 0.0f;
         }
+        return 0.0f;
+
     }
 
     static void decode_bounding_box(const bounding_box& prior_bbox,

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/eltwise.cpp
@@ -88,7 +88,7 @@ struct eltwise_impl : public typed_primitive_impl<eltwise> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/fake_convert.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/fake_convert.cpp
@@ -58,7 +58,7 @@ struct fake_convert_impl : public typed_primitive_impl<fake_convert> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/gather.cpp
@@ -66,7 +66,7 @@ struct gather_impl : public typed_primitive_impl<gather> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/range.cpp
@@ -44,7 +44,7 @@ struct range_impl : public typed_primitive_impl<range> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
@@ -65,7 +65,7 @@ struct read_value_impl : public typed_primitive_impl<read_value> {
                 variable.get_memory()->fill(stream);
             }
             if (!instance.get_user_insts().empty()) {
-                auto user_inst = instance.get_user_insts().front();
+                auto *user_inst = instance.get_user_insts().front();
                 if (!(user_inst->get_node().is_type<assign>() || user_inst->get_node().is_type<kv_cache>()) &&
                     instance.get_network().contains_state(variable_id)) {
                     variable.set();
@@ -78,7 +78,7 @@ struct read_value_impl : public typed_primitive_impl<read_value> {
             std::vector<cldnn::event::ptr> res_events;
             res_events.push_back(instance.output_memory(0).copy_from(stream, *variable.get_memory(), false));
 
-            if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+            if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                 auto scales_state = compressed_cache_variable->get_compression_scale_state();
                 res_events.push_back(instance.output_memory(1).copy_from(stream, *scales_state->get_memory(), false));
 

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/reduce.cpp
@@ -84,7 +84,7 @@ struct reduce_impl : public typed_primitive_impl<reduce> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/reorder.cpp
@@ -44,7 +44,7 @@ struct reorder_impl : public typed_primitive_impl<reorder> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         if (instance.get_impl_params()->input_layouts[0].format != instance.get_impl_params()->input_layouts[0].format)
             OPENVINO_THROW("[GPU] Unsupported reorder case: input and output type are different");

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/scatter_update.cpp
@@ -58,7 +58,7 @@ struct scatter_update_impl : public typed_primitive_impl<scatter_update> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/select.cpp
@@ -57,7 +57,7 @@ struct select_impl : public typed_primitive_impl<select> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
@@ -94,7 +94,7 @@ struct strided_slice_impl : public typed_primitive_impl<strided_slice> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/tile.cpp
@@ -57,7 +57,7 @@ struct tile_impl : public typed_primitive_impl<tile> {
             stream.wait_for_events(events);
         }
 
-        auto params = instance.get_impl_params();
+        const auto *params = instance.get_impl_params();
 
         ov::TensorVector input_host_tensors;
         ov::TensorVector output_host_tensors;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -82,7 +82,7 @@ public:
         argm_params.outputs_num = outputs_num;
         argm_params.argMaxMinAxis = GetArgMaxMinAxis(axis, impl_param.get_output_layout().get_rank());
 
-        auto& constant_mem = impl_param.memory_deps;
+        const auto& constant_mem = impl_param.memory_deps;
         if (constant_mem.count(1) && !argm_params.has_dynamic_outputs()) {
             // The topK could be got by reading impl_param.memory_deps.at(1).
             // However, here we utilize output_layout and axis information to minimize mem_lock.

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -84,7 +84,7 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
                 int next_axis = -1;
                 size_t currentRank = 0;
                 int axe_idx = 0;
-                for (auto& axis : primitive->axes_mapping) {
+                for (const auto& axis : primitive->axes_mapping) {
                     prev_axis = next_axis;
                     next_axis = static_cast<int>(axis);
 
@@ -101,7 +101,7 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
                 // insert 1 to extend dimensions by axes_mapping
                 ov::Shape tmp_shape;
                 size_t idx = 0;
-                for (auto& axis : primitive->axes_mapping) {
+                for (const auto& axis : primitive->axes_mapping) {
                     if (idx == axis) {
                         tmp_shape.insert(tmp_shape.begin() + idx, 1, -1);
                         idx += 1;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -159,7 +159,7 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
     void set_arguments_impl(custom_gpu_primitive_inst& instance) override {
         auto& stream = instance.get_network().get_stream();
         kernel_arguments_data args;
-        for (auto& dep : instance.dependencies()) {
+        for (const auto& dep : instance.dependencies()) {
             args.inputs.push_back(dep.first->output_memory_ptr());
         }
         for (size_t i = 0; i < instance.outputs_memory_count(); i++) {
@@ -175,7 +175,7 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
                             custom_gpu_primitive_inst& instance) override {
         auto& stream = instance.get_network().get_stream();
         kernel_arguments_data args;
-        for (auto& dep : instance.dependencies()) {
+        for (const auto& dep : instance.dependencies()) {
             args.inputs.push_back(dep.first->output_memory_ptr());
         }
         for (size_t i = 0; i < instance.outputs_memory_count(); i++) {
@@ -341,7 +341,7 @@ static std::string get_jit_constant(const custom_gpu_primitive_node& outer,
 }
 
 static std::unique_ptr<primitive_impl> create(const custom_gpu_primitive_node& arg, const kernel_impl_params& impl_param) {
-    const auto primitive = arg.get_primitive().get();
+    const auto *const primitive = arg.get_primitive().get();
 
     const auto& orig_output_layout = impl_param.get_output_layout();
     OPENVINO_ASSERT(orig_output_layout.is_static(), "out layouts should be static for create primitive_impl!");
@@ -385,9 +385,9 @@ static std::unique_ptr<primitive_impl> create(const custom_gpu_primitive_node& a
     }
     if (!size_expr_map.empty()) {
         return std::make_unique<custom_gpu_primitive_impl>(arg, cl_kernel, size_expr_map);
-    } else {
-        return std::make_unique<custom_gpu_primitive_impl>(arg, cl_kernel);
     }
+    return std::make_unique<custom_gpu_primitive_impl>(arg, cl_kernel);
+
 }
 
 namespace detail {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -25,7 +25,7 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto primitive = impl_param.typed_desc<dft>();
         auto params = get_default_params<kernel_selector::dft_params>(impl_param);
-        auto& memory_deps = impl_param.memory_deps;
+        const auto& memory_deps = impl_param.memory_deps;
 
         bool allow_new_shape_infer = impl_param.get_program().is_new_shape_infer();
         if (allow_new_shape_infer && primitive->axes.empty() && primitive->signal_size.empty()) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
@@ -40,9 +40,9 @@ struct dynamic_quantize_impl : typed_primitive_impl_ocl<dynamic_quantize> {
 
         // In Some model, the feature size could be dynamic in input0.
         // It refers to IFM value of weight of fully connected.
-        auto user_node = impl_param.prog->get_node(impl_param.desc->id).get_users().front();
+        const auto *user_node = impl_param.prog->get_node(impl_param.desc->id).get_users().front();
         if (user_node != nullptr && user_node->is_type<fully_connected>()) {
-            auto& fc_node = user_node->as<fully_connected>();
+            const auto& fc_node = user_node->as<fully_connected>();
             params.fc_ifm_size = fc_node.weights().get_output_layout().feature();
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -84,10 +84,10 @@ public:
                     if (broadcast) {
                         params.broadcast = true;
                         break;
-                    } else {
-                        params.layoutBased = true;
-                        break;
                     }
+                    params.layoutBased = true;
+                    break;
+
                 }
             }
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -87,9 +87,9 @@ public:
                     size_t total = std::accumulate(static_shape.begin(), static_shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
                     auto dim = feature.is_static() ? feature.get_length() : static_cast<int64_t>(static_shape[rank - 1]);
                     return ov::PartialShape{ static_cast<int64_t>(total) / dim, dim };
-                } else {
-                    return ov::PartialShape{ ov::Dimension::dynamic(), feature };
                 }
+                return ov::PartialShape{ ov::Dimension::dynamic(), feature };
+
             };
 
             auto input0_layout = input_layouts[0];
@@ -200,7 +200,7 @@ public:
             params.outputs = { params.outputs[0].FlattenFeatureAndSpatials() };
 
         bool is_quantized = true;
-        for (auto& input : impl_param.input_layouts)
+        for (const auto& input : impl_param.input_layouts)
             is_quantized &= data_type_traits::is_quantized(input.data_type);
 
         if (is_quantized) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -14,7 +14,8 @@ namespace ocl {
 static kernel_selector::gather_axis convert_axis(int64_t axis, size_t rank) {
     if (axis == 0) {
         return kernel_selector::gather_axis::BATCH;
-    } else if (axis == 1) {
+    }
+    if (axis == 1) {
         return kernel_selector::gather_axis::FEATURE;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -169,14 +169,14 @@ protected:
                 kernel.skip_execution = true;
             }
             return execute_stage(events, instance, indirect_gemm);
-        } else {
-            if (_kernels_data.size() == 2) {
-                for (auto& kernel : _kernels_data[indirect_gemm].kernels) {
-                    kernel.skip_execution = true;
-                }
-            }
-            return execute_stage(events, instance, default_gemm);
         }
+        if (_kernels_data.size() == 2) {
+            for (auto& kernel : _kernels_data[indirect_gemm].kernels) {
+                kernel.skip_execution = true;
+            }
+        }
+        return execute_stage(events, instance, default_gemm);
+
     }
 
 public:
@@ -215,13 +215,13 @@ public:
                         transposed_pshape[i + rank_diff] = pshape[rank_diff + order[i]];
                     }
                     return transposed_pshape;
-                } else {
-                    auto transposed_pshape = ov::PartialShape::dynamic(pshape.rank());
-                    for (size_t i = 0; i < order.size(); i++) {
-                        transposed_pshape[i] = pshape[order[i]];
-                    }
-                    return transposed_pshape;
                 }
+                auto transposed_pshape = ov::PartialShape::dynamic(pshape.rank());
+                for (size_t i = 0; i < order.size(); i++) {
+                    transposed_pshape[i] = pshape[order[i]];
+                }
+                return transposed_pshape;
+
             };
             size_t max_rank = input0_pshape.size();
             auto default_order = ov::intel_gpu::op::Gemm::default_order(max_rank);
@@ -253,7 +253,7 @@ public:
         }
 
         bool is_quantized = true;
-        for (auto& input : impl_param.input_layouts)
+        for (const auto& input : impl_param.input_layouts)
             is_quantized &= data_type_traits::is_quantized(input.data_type);
 
         if (is_quantized) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -73,7 +73,7 @@ namespace cldnn {
 bool check_cm_jit_support(cldnn::engine& e, const cldnn::ExecutionConfig& config) {
     // Even though CM frontend is a component of Intel GPU driver on Windows, the version
     // may still be incompatible to existing CM kernels.
-    auto device = e.get_device().get();
+    auto *device = e.get_device().get();
 
     static std::mutex m;
     std::lock_guard<std::mutex> lock(m);
@@ -159,7 +159,7 @@ static bool driver_version_supports_microkernels(const std::string& driver_versi
 }
 
 bool query_microkernels_supported(cldnn::engine& e, const cldnn::ExecutionConfig& config) {
-    auto device = e.get_device().get();
+    auto *device = e.get_device().get();
 
     static std::mutex m;
     std::lock_guard<std::mutex> lock(m);
@@ -208,7 +208,7 @@ bool query_microkernels_supported(cldnn::engine& e, const cldnn::ExecutionConfig
 }
 
 bool query_register_file_size_option_supported(cldnn::engine& e, const cldnn::ExecutionConfig& config) {
-    auto device = e.get_device().get();
+    auto *device = e.get_device().get();
     if (device->get_info().arch < gpu_arch::xe3)
         return false;
 
@@ -1002,16 +1002,16 @@ kernel_selector::weights_tensor convert_weights_tensor(const layout& l, bool is_
     if (l.data_padding) {
         auto vec = compute_tensor_dimensions(l, kernel_selector::WeightsTensor::ChannelsCount(ks_layout));
         return kernel_selector::weights_tensor(vec, ks_type, ks_layout);
-    } else {
-        const auto& t = l.get_tensor().sizes(l.format);
-        std::vector<size_t> vec(kernel_selector::WeightsTensor::ChannelsCount(ks_layout));
-        for (size_t i = 0; i < vec.size(); i++) {
-            const size_t tensor_index = t.size() - 1 - i;
-            const auto d = t[tensor_index];
-            vec[i] = static_cast<size_t>(d);
-        }
-        return kernel_selector::weights_tensor(vec, ks_type, ks_layout);
     }
+    const auto& t = l.get_tensor().sizes(l.format);
+    std::vector<size_t> vec(kernel_selector::WeightsTensor::ChannelsCount(ks_layout));
+    for (size_t i = 0; i < vec.size(); i++) {
+        const size_t tensor_index = t.size() - 1 - i;
+        const auto d = t[tensor_index];
+        vec[i] = static_cast<size_t>(d);
+    }
+    return kernel_selector::weights_tensor(vec, ks_type, ks_layout);
+
 }
 
 layout from_weights_tensor(const kernel_selector::weights_tensor& l) {
@@ -1149,7 +1149,8 @@ std::shared_ptr<kernel_selector::fuse_params> convert_fuse_params(std::shared_pt
                                                                      clamp_max,
                                                                      swish_beta,
                                                                      up_add_val);
-    } else if (p->type() == activation::type_id()) {
+    }
+    if (p->type() == activation::type_id()) {
         auto casted = std::dynamic_pointer_cast<ActivationFuseParams>(p);
         auto desc = casted->_desc;
         kernel_selector::base_activation_params p;
@@ -1158,18 +1159,21 @@ std::shared_ptr<kernel_selector::fuse_params> convert_fuse_params(std::shared_pt
         p.n = desc->additional_params.b;
 
         return std::make_shared<kernel_selector::activation_fuse_params>(p);
-    } else if (p->type() == depth_to_space::type_id()) {
+    } if (p->type() == depth_to_space::type_id()) {
         return std::make_shared<kernel_selector::depth_to_space_fuse_params>();
-    } else if (p->type() == reorder::type_id()) {
+    }
+    if (p->type() == reorder::type_id()) {
         auto casted = std::dynamic_pointer_cast<ReorderFuseParams>(p);
         kernel_selector::DataLayout ks_input_layout = convert_data_tensor(casted->_in).GetLayout();
         kernel_selector::DataLayout ks_output_layout = convert_data_tensor(casted->_out).GetLayout();
         return std::make_shared<kernel_selector::reorder_fuse_params>(ks_input_layout, ks_output_layout);
-    } else if (p->type() == eltwise::type_id()) {
+    }
+    if (p->type() == eltwise::type_id()) {
         auto casted = std::dynamic_pointer_cast<EltwiseFuseParams>(p);
         kernel_selector::eltwise_mode mode = convert_to_eltwise_mode(casted->_desc->mode);
         return std::make_shared<kernel_selector::eltwise_fuse_params>(mode, casted->_desc->m_pythondiv);
-    } else if (p->type() == quantize::type_id()) {
+    }
+    if (p->type() == quantize::type_id()) {
         auto casted = std::dynamic_pointer_cast<QuantizeFuseParams>(p);
         return std::make_shared<kernel_selector::quantize_fuse_params>(casted->_scale_shift_opt,
                                                                        casted->_need_post_scale,
@@ -1332,7 +1336,7 @@ void set_default_params(const kernel_impl_params& param_info, kernel_selector::b
     } else {
         std::map<primitive_id, std::pair<size_t, kernel_selector::Datatype>> prim_id_type_map;
         size_t op_id = 0;
-        for (auto& fused_prim : param_info.fused_desc) {
+        for (const auto& fused_prim : param_info.fused_desc) {
             kernel_selector::fused_operation_desc desc;
             desc.op_params = convert_fuse_params(fused_prim.f_param);
 
@@ -1352,7 +1356,7 @@ void set_default_params(const kernel_impl_params& param_info, kernel_selector::b
 
             if (fused_prim.total_num_deps > 0) {
                 desc.dep_data.resize(fused_prim.total_num_deps);
-                for (auto& dep : fused_prim.fused_deps) {
+                for (const auto& dep : fused_prim.fused_deps) {
                     auto iter = prim_id_type_map.find(dep.first);
                     if (iter != prim_id_type_map.end()) {
                         auto& op_data = iter->second;
@@ -1363,7 +1367,7 @@ void set_default_params(const kernel_impl_params& param_info, kernel_selector::b
                 }
 
                 int idx = 0;
-                for (auto& dep : fused_prim.deps) {
+                for (const auto& dep : fused_prim.deps) {
                     desc.dep_data[dep.second].dep_type  = kernel_selector::DepType::EXTERNAL;
                     desc.dep_data[dep.second].op_id     = idx;
                     desc.dep_data[dep.second].data_type = desc.tensors[idx++].GetDType();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
@@ -54,12 +54,12 @@ std::mutex cacheAccessMutex;
 
 std::string join_strings(const std::vector<std::string> &strings) {
     size_t total_size = 0;
-    for (auto &str : strings) {
+    for (const auto &str : strings) {
         total_size += str.size();
     }
     std::string acc_str;
     acc_str.reserve(total_size);
-    for (auto &str : strings) {
+    for (const auto &str : strings) {
         acc_str.append(str);
     }
     return acc_str;
@@ -115,11 +115,11 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
     std::map<std::string, std::tuple<int32_t, std::vector<batch_program>>> program_buckets;
 
     for (const auto& k : kernels_source_code) {
-        auto& code = k.second;
+        const auto& code = k.second;
         bool dump_custom_program = code.dump_custom_program;
 
         for (size_t kernel_part_idx = 0; kernel_part_idx < code.kernel_strings.size(); kernel_part_idx++) {
-            auto& kernel_string = code.kernel_strings[kernel_part_idx];
+            const auto& kernel_string = code.kernel_strings[kernel_part_idx];
             std::string full_code = kernel_string->jit + kernel_string->str + kernel_string->undefs;
             std::string entry_point = kernel_string->entry_point;
             std::string options = kernel_string->options;
@@ -300,7 +300,7 @@ void kernels_cache::build_batch(const batch_program& batch, compiled_kernels& co
     if (dump_sources) {
         dump_file.open(current_dump_file_name);
         if (dump_file.good()) {
-            for (auto& s : batch.source)
+            for (const auto& s : batch.source)
                 dump_file << s;
         }
     }
@@ -354,7 +354,7 @@ void kernels_cache::build_batch(const batch_program& batch, compiled_kernels& co
             auto entry_point = k->get_id();
             const auto& iter = batch.entry_point_to_id.find(entry_point);
             if (iter != batch.entry_point_to_id.end()) {
-                auto& params = iter->second.first;
+                const auto& params = iter->second.first;
                 auto kernel_part_idx = iter->second.second;
                 if (compiled_kernels.find(params) != compiled_kernels.end()) {
                     compiled_kernels[params].push_back(std::make_pair(k, kernel_part_idx));
@@ -390,8 +390,8 @@ std::vector<kernel::ptr> kernels_cache::get_kernels(const kernel_impl_params& pa
     OPENVINO_ASSERT(!res->second.empty(), "Number of kernels should not be zero for " + current_node_id);
 
     std::vector<kernel::ptr> kernels(res->second.size());
-    for (auto& k : res->second) {
-        auto& kernel_ptr = k.first;
+    for (const auto& k : res->second) {
+        const auto& kernel_ptr = k.first;
         auto kernel_part_idx = k.second;
         kernels[kernel_part_idx] = kernel_ptr->clone(_reuse_kernels);
     }
@@ -493,7 +493,7 @@ std::string kernels_cache::get_cached_kernel_id(kernel::ptr kernel) const {
 std::vector<std::string> kernels_cache::get_cached_kernel_ids(const std::vector<kernel::ptr>& kernels) const {
     std::vector<std::string> kernel_ids;
 
-    for (auto& kernel : kernels) {
+    for (const auto& kernel : kernels) {
         auto key = get_cached_kernel_id(kernel);
         kernel_ids.emplace_back(key);
     }
@@ -504,7 +504,7 @@ std::vector<std::string> kernels_cache::get_cached_kernel_ids(const std::vector<
 void kernels_cache::add_to_cached_kernels(const std::vector<kernel::ptr>& kernels) {
     static std::atomic<uint32_t> id_gen{0};
 
-    for (auto& kernel : kernels) {
+    for (const auto& kernel : kernels) {
         auto program_binaries = kernel->get_binary();
 
         std::lock_guard<std::mutex> lock(_mutex);
@@ -533,7 +533,7 @@ void kernels_cache::save(BinaryOutputBuffer& ob) const {
         return magic == ELF_MAGIC;
     };
 
-    for (auto& cached_binary : _cached_binaries) {
+    for (const auto& cached_binary : _cached_binaries) {
         auto is_zebin_binary = is_zebin(cached_binary.first);
 
         ob << cached_binary.second;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -70,7 +70,7 @@ struct stages_helper {
 
     void save(BinaryOutputBuffer& ob) const {
         ob << stages.size();
-        for (auto& stage : stages) {
+        for (const auto& stage : stages) {
             ob << static_cast<uint8_t>(stage);
         }
     }
@@ -350,7 +350,7 @@ struct kv_cache_impl : multi_stage_primitive<kv_cache> {
             (_kernels_data[dq_stage].update_dispatch_data_func)(dq_params, _kernels_data[dq_stage]);
             execute_stage(events, instance, res_events, dq_stage);
 
-            auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
+            auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
             OPENVINO_ASSERT(compressed_cache_variable != nullptr, "compressed_cache_variable should not be null.");
             compressed_cache_variable->get_compression_scale_state()->set();
 
@@ -364,32 +364,32 @@ struct kv_cache_impl : multi_stage_primitive<kv_cache> {
             GPU_DEBUG_TRACE_DETAIL << desc->id  << " : Output is same as variable memory! Skip copying " << std::endl;
             // When primitive is optimized, concat kernel writes directly to variable memory
             return stream.aggregate_events(res_events, res_events.size() > 1);
-        } else {
-            // Otherwise, we need to copy result from out buffer to state memory
-            GPU_DEBUG_TRACE_DETAIL << desc->id  << " : Copying output to variable memory" << std::endl;
-
-            stream.enqueue_barrier();
-
-            std::vector<event::ptr> res_events;
-            auto out = instance.get_network().get_engine().reinterpret_buffer(instance.output_memory(0), variable.get_memory()->get_layout());
-            res_events.push_back(variable.get_memory()->copy_from(stream, *out, false));
-
-            if (desc->compressed) {
-                auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
-                OPENVINO_ASSERT(compressed_cache_variable != nullptr, "compressed_cache_variable is nullptr!!!");
-                auto scale_state = compressed_cache_variable->get_compression_scale_state();
-                auto out_scale_mem = instance.get_network().get_engine().reinterpret_buffer(instance.output_memory(2), scale_state->get_memory()->get_layout());
-                res_events.push_back(scale_state->get_memory()->copy_from(stream, *out_scale_mem, false));
-
-                if (desc->get_compression_zp_inputs_num() > 0) {
-                    auto zp_state = compressed_cache_variable->get_compression_zp_state();
-                    auto out_zp_mem = instance.get_network().get_engine().reinterpret_buffer(instance.output_memory(3), zp_state->get_memory()->get_layout());
-                    res_events.push_back(zp_state->get_memory()->copy_from(stream, *out_zp_mem, false));
-                }
-            }
-
-            return stream.aggregate_events(res_events, res_events.size() > 1);
         }
+        // Otherwise, we need to copy result from out buffer to state memory
+        GPU_DEBUG_TRACE_DETAIL << desc->id  << " : Copying output to variable memory" << std::endl;
+
+        stream.enqueue_barrier();
+
+        std::vector<event::ptr> copy_events;
+        auto out = instance.get_network().get_engine().reinterpret_buffer(instance.output_memory(0), variable.get_memory()->get_layout());
+        copy_events.push_back(variable.get_memory()->copy_from(stream, *out, false));
+
+        if (desc->compressed) {
+            auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
+            OPENVINO_ASSERT(compressed_cache_variable != nullptr, "compressed_cache_variable is nullptr!!!");
+            auto scale_state = compressed_cache_variable->get_compression_scale_state();
+            auto out_scale_mem = instance.get_network().get_engine().reinterpret_buffer(instance.output_memory(2), scale_state->get_memory()->get_layout());
+            copy_events.push_back(scale_state->get_memory()->copy_from(stream, *out_scale_mem, false));
+
+            if (desc->get_compression_zp_inputs_num() > 0) {
+                auto zp_state = compressed_cache_variable->get_compression_zp_state();
+                auto out_zp_mem = instance.get_network().get_engine().reinterpret_buffer(instance.output_memory(3), zp_state->get_memory()->get_layout());
+                copy_events.push_back(zp_state->get_memory()->copy_from(stream, *out_zp_mem, false));
+            }
+        }
+
+        return stream.aggregate_events(copy_events, copy_events.size() > 1);
+
     }
 
     static layout get_beam_table_layout(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
@@ -71,7 +71,7 @@ struct multi_stage_primitive : public typed_primitive_impl<PType> {
     void save(BinaryOutputBuffer& ob) const override {
         primitive_impl::save(ob);
         ob << _kernels_data.size();
-        for (auto& kd : _kernels_data) {
+        for (const auto& kd : _kernels_data) {
             ob << make_data(&kd.internalBufferDataType, sizeof(kernel_selector::Datatype));
             ob << kd.internalBuffers;
             ob << kd.kernels;
@@ -152,7 +152,7 @@ protected:
 
     std::vector<BufferDescriptor> get_internal_buffer_descs(const kernel_impl_params&) const override {
         std::vector<BufferDescriptor> internal_buffers;
-        for (auto& kd : _kernels_data) {
+        for (const auto& kd : _kernels_data) {
             if (kd.internalBuffers.empty())
                 continue;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
@@ -168,22 +168,22 @@ private:
         switch (mem->get_layout().data_type) {
         case data_types::f16: {
             mem_lock<ov::float16, mem_lock_type::read> lock(mem, stream);
-            auto mem_value = static_cast<ov::float16*>(lock.data());
+            auto *mem_value = static_cast<ov::float16*>(lock.data());
             retValue = static_cast<T>(*mem_value);
         } break;
         case data_types::f32: {
             mem_lock<float, mem_lock_type::read> lock(mem, stream);
-            auto mem_value = static_cast<float*>(lock.data());
+            auto *mem_value = static_cast<float*>(lock.data());
             retValue = static_cast<T>(*mem_value);
         } break;
         case data_types::i32: {
             mem_lock<int32_t, mem_lock_type::read> lock(mem, stream);
-            auto mem_value = static_cast<int32_t*>(lock.data());
+            auto *mem_value = static_cast<int32_t*>(lock.data());
             retValue = static_cast<T>(*mem_value);
         } break;
         case data_types::i64: {
             mem_lock<int64_t, mem_lock_type::read> lock(mem, stream);
-            auto mem_value = static_cast<int64_t*>(lock.data());
+            auto *mem_value = static_cast<int64_t*>(lock.data());
             retValue = static_cast<T>(*mem_value);
         } break;
         default:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -38,9 +38,9 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
         if (instance.get_impl_params()->input_layouts[0].count() == 0) {
             // set count of non-zero elements to 0 in case if input tensor is empty to have correct memory alloc for gather_nonzero
             return instance.output_memory(0).fill(instance.get_network().get_stream());
-        } else {
-            return parent::execute_impl(events, instance);
         }
+        return parent::execute_impl(events, instance);
+
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, bool is_shape_agnostic = false) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -38,7 +38,7 @@ protected:
     kernel_arguments_data get_arguments(const reorder_inst& instance) const override {
         kernel_arguments_data args = parent::get_arguments(instance);
         if (instance.has_node() && instance.has_mean()) {
-            auto input = &instance.input_memory();
+            auto *input = &instance.input_memory();
             auto input_layout = input->get_layout();
 
             if (input_layout.format == cldnn::format::nv12) {
@@ -130,9 +130,9 @@ public:
                                   format::is_weights_format(impl_param.get_output_layout().format);
         if (is_reorder_weights) {
             return create_reorder_weights(impl_param);
-        } else {
-            return typed_primitive_impl_ocl<reorder>::create<reorder_impl>(arg, impl_param);
         }
+        return typed_primitive_impl_ocl<reorder>::create<reorder_impl>(arg, impl_param);
+
     }
 
     static std::unique_ptr<primitive_impl> create_reorder_weights(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -198,8 +198,7 @@ public:
                     auto size = out_shape[dim];
                     if (value >= size || value < (size * -1))
                         return true;
-                    else
-                        return false;
+                    return false;
                 };
                 bool should_clamp_begin = check_out_of_bounds(begin);
                 bool should_clamp_end = check_out_of_bounds(end);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/col2im.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/col2im.hpp
@@ -39,12 +39,12 @@ struct Col2Im : public ImplementationManager {
             return false;
         }
 
-        for (auto& input : node.get_input_layouts()) {
+        for (const auto& input : node.get_input_layouts()) {
             if (input.data_padding)
                 return false;
         }
 
-        for (auto& output : node.get_output_layouts()) {
+        for (const auto& output : node.get_output_layouts()) {
             if (output.data_padding)
                 return false;
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gather_matmul/gather_matmul.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gather_matmul/gather_matmul.cpp
@@ -206,7 +206,7 @@ public:
             m_rt_params = std::make_unique<GatherMatmulRuntimeParams>();
         }
         update_stages_flags(instance);
-        auto rtp = static_cast<GatherMatmulRuntimeParams*>(m_rt_params.get());
+        auto* rtp = static_cast<GatherMatmulRuntimeParams*>(m_rt_params.get());
         const auto& input_shape = instance.get_input_layout(gather_matmul::BGMInputIdx::INPUT).get_shape();
         const auto& indices_shape = instance.get_input_layout(gather_matmul::BGMInputIdx::INDICES).get_shape();
         rtp->n_activated_experts = static_cast<int32_t>(input_shape[0]);
@@ -249,12 +249,13 @@ public:
                 auto sort_event = execute_stage(events, instance, batched_sort);
                 auto gather_event = execute_stage({sort_event}, instance, batched_gather);
                 return execute_stage({gather_event}, instance, batched_gemm);
-            } else if (has_stage(regular_micro_multi_tokens)) {
+            }
+            if (has_stage(regular_micro_multi_tokens)) {
                 GPU_DEBUG_TRACE_DETAIL << "GatherMatmul Execute prefill micro_multi_tokens stage (n_tokens=" << rtp->n_tokens << ")" << std::endl;
                 return execute_stage(events, instance, regular_micro_multi_tokens);
-            } else {
-                OPENVINO_THROW("GatherMatmul Prefill stage is not available");
             }
+            OPENVINO_THROW("GatherMatmul Prefill stage is not available");
+
         } else {
             return execute_stage(events, instance, regular_micro_single_token);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
@@ -61,7 +61,7 @@ public:
     [[nodiscard]] JitConstants get_jit_constants(const RuntimeParams& params) const override {
         auto get_max_simd_size = [](const RuntimeParams& params) {
             size_t max_simd_size = fsv;
-            for (auto& simd_size : params.get_device_info().supported_simd_sizes) {
+            for (const auto& simd_size : params.get_device_info().supported_simd_sizes) {
                 max_simd_size = std::max(max_simd_size, simd_size);
             }
             return max_simd_size;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora.cpp
@@ -961,26 +961,24 @@ public:
             size_t feature = extract_channel(ChannelName::FEATURE, lora_input_lo);
 
             return {BufferDescriptor{lora_rank * batch * feature * lora_count, params.get_output_layout().data_type}};
-        } else {
-            const auto& state_a_lo = params.input_layouts[2];
-            size_t input_state = extract_channel(ChannelName::FEATURE, state_a_lo);
-
-            size_t max_workgroup_size = params.get_device_info().max_work_group_size;
-
-            size_t gemma_sgK = max_workgroup_size / (lora_rank * lora_count);
-            size_t gemma_wgs = ceil_div(input_state, LoraOptBase<>::gemm_a_sg_bk * gemma_sgK);
-
-            return {BufferDescriptor{gemma_wgs * lora_count, params.get_output_layout().data_type}};
         }
+        const auto& state_a_lo = params.input_layouts[2];
+        size_t input_state = extract_channel(ChannelName::FEATURE, state_a_lo);
+
+        size_t max_workgroup_size = params.get_device_info().max_work_group_size;
+
+        size_t gemma_sgK = max_workgroup_size / (lora_rank * lora_count);
+        size_t gemma_wgs = ceil_div(input_state, LoraOptBase<>::gemm_a_sg_bk * gemma_sgK);
+
+        return {BufferDescriptor{gemma_wgs * lora_count, params.get_output_layout().data_type}};
     }
 
     std::vector<size_t> get_stages_execution_order(const cldnn::kernel_impl_params& impl_params) const override {
         size_t is_single_lora = LoraRefBase<>::get_lora_count(impl_params) == 1;
         if (is_single_lora) {
             return get_stages_execution_order_single_lora(impl_params);
-        } else {
-            return get_stages_execution_order_hf_lora(impl_params);
         }
+        return get_stages_execution_order_hf_lora(impl_params);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/lru_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/lru_cache.cpp
@@ -53,11 +53,10 @@ std::pair<size_t, bool> LRUCache::get_lru_item(size_t expert) {
         m_map[key] = new_it;
         ++m_total_experts;
         return {to_filled_no, false};
-    } else {
-        move_to_end(it->second);
-        const bool is_hit = m_filled_list[it->second->lru_expert_no];
-        return {it->second->lru_expert_no, is_hit};
     }
+    move_to_end(it->second);
+    const bool is_hit = m_filled_list[it->second->lru_expert_no];
+    return {it->second->lru_expert_no, is_hit};
 }
 
 }  // namespace ov::intel_gpu::ocl::moe

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
@@ -136,7 +136,7 @@ protected:
         jit.make("OUTPUT3_TYPE", "int");  // tokens_lens_per_expert
         jit.make("OUTPUT4_TYPE", "int");  // num_actual_used_experts
 
-        auto& config = desc->_config;
+        const auto& config = desc->_config;
         jit.make("NUM_EXPERTS_PER_TOKEN", config.top_k);
         jit.make("SET_TOKEN_LEN", 1);
         jit.make("OPTIONAL_SHAPE_INFO_ARG", "");
@@ -1652,7 +1652,7 @@ public:
         _hidden_size = static_cast<int>(cur_moe->_config.hidden_size);
         _intermediate_size = static_cast<int>(cur_moe->_config.inter_size);
 
-        auto rtp = static_cast<MoE3GemmRuntimeParams*>(m_rt_params.get());
+        auto* rtp = static_cast<MoE3GemmRuntimeParams*>(m_rt_params.get());
         const size_t subgroup_size = instance.get_impl_params()->get_device_info().arch >= gpu_arch::xe2 ? 32 : 16;
 
         event::ptr ret_event;
@@ -2113,9 +2113,8 @@ public:
             int num_k_groups = K / group_size;
             if (num_k_groups > 1) {
                 return dnnl::memory::desc({E, num_k_groups, N}, dt, dnnl::memory::format_tag::abc);
-            } else {
-                return dnnl::memory::desc({E, N}, dt, dnnl::memory::format_tag::ab);
             }
+            return dnnl::memory::desc({E, N}, dt, dnnl::memory::format_tag::ab);
         };
 
         auto gk = std::make_shared<grouped_onednn_kernel>();
@@ -2582,7 +2581,7 @@ public:
         const bool use_gpu_mask_gen = use_micro_gemm_prefill && use_gpu_mask_gen_prefill;
         if (!use_gpu_mask_gen) {
             // Wait for input events (topk produced upstream by MoERouterFused)
-            for (auto& ev : events) {
+            for (const auto& ev : events) {
                 if (ev) {
                     ev->wait();
                 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -38,9 +38,8 @@ inline bool get_kv_compressed(const RuntimeParams& params) {
     auto key_cache_layout = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE];
     if (data_type_traits::is_i8_u8(key_cache_layout.data_type) || data_type_traits::is_i4_u4(key_cache_layout.data_type)) {
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 inline bool is_v_head_aligned_for_dual_nibble(size_t v_head_size) {
@@ -250,7 +249,7 @@ JitConstants make_uint4_kv_cache_jit_constants(const kernel_impl_params& params)
     ov::intel_gpu::JitConstants jit;
     const auto desc = params.typed_desc<paged_attention>();
     const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
-    auto& kv_dt = params.input_layouts[PagedAttentionInputIdx::KEY].data_type;
+    const auto& kv_dt = params.input_layouts[PagedAttentionInputIdx::KEY].data_type;
 
     if (data_type_traits::is_i4_u4(kv_cache_dt)) {
         const auto scales_zp_size = get_element_size(kv_dt) * 2;  // fp16 scale + fp16 zp = 4 bytes
@@ -314,7 +313,7 @@ public:
 
         const auto is_key_by_channel = desc->is_key_by_channel;
         if (is_kv_compressed) {
-            auto& kv_dt = params.input_layouts[PagedAttentionInputIdx::KEY].data_type;
+            const auto& kv_dt = params.input_layouts[PagedAttentionInputIdx::KEY].data_type;
             auto scales_zp_size = get_element_size(kv_dt) * 2;  // scale + zp
 
             jit.make("SCALE_ZP_SIZE_PER_TOKEN", scales_zp_size);
@@ -490,7 +489,7 @@ public:
             assert(!params.is_dynamic());
             auto& wgs = kd.params.workGroups;
             const auto desc = params.typed_desc<paged_attention>();
-            auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+            auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
 
             const size_t total_tokens = params.input_layouts[0].get_partial_shape()[0].get_length();
             const size_t heads_num = desc->heads_num;
@@ -531,7 +530,7 @@ public:
             assert(!params.is_dynamic());
             auto& wgs = kd.params.workGroups;
             const auto desc = params.typed_desc<paged_attention>();
-            auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+            auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
 
             const size_t total_tokens = params.input_layouts[0].get_partial_shape()[0].get_length();
             const size_t heads_num = desc->heads_num;
@@ -590,7 +589,7 @@ public:
             scalars.resize(1);
 
             const auto desc = params.typed_desc<paged_attention>();
-            auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+            auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
 
             const size_t total_tokens = params.input_layouts[0].get_partial_shape()[0].get_length();
             const size_t heads_num = desc->heads_num;
@@ -759,7 +758,7 @@ public:
             scalars.resize(1);
 
             const auto desc = params.typed_desc<paged_attention>();
-            auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+            auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
 
             const size_t total_tokens = params.input_layouts[0].get_partial_shape()[0].get_length();
             const size_t heads_num = desc->heads_num;
@@ -815,7 +814,7 @@ public:
             assert(!params.is_dynamic());
             auto& wgs = kd.params.workGroups;
             const auto desc = params.typed_desc<paged_attention>();
-            auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+            auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
 
             const auto& past_lens = params.input_layouts[PagedAttentionInputIdx::PAST_LENS];
             const auto subsequences_number = static_cast<size_t>(past_lens.get_partial_shape()[0].get_length());
@@ -1063,7 +1062,7 @@ protected:
             scalars.resize(1);
 
             const auto desc = params.typed_desc<paged_attention>();
-            auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+            auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
 
             const auto is_prefill = rtp->stage == PagedAttentionStage::PREFILL || rtp->stage == PagedAttentionStage::MIXED;
             auto heads_number = desc->kv_heads_num;
@@ -1302,7 +1301,7 @@ public:
             auto& wgs = kd.params.workGroups;
             auto& scalars = kd.params.scalars;
             auto desc = params.typed_desc<paged_attention>();
-            auto rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+            auto* rtp = static_cast<PagedAttentionRuntimeParams*>(rt_params);
             const size_t heads_num = desc->heads_num;
             const size_t head_size = desc->v_head_size;
 
@@ -1379,7 +1378,7 @@ public:
     bool valid_micro_stage(const PagedAttentionStage& stage) const {
         if (stage == PagedAttentionStage::PREFILL)
             return !pa_sdpa_micro->kd.micro_kernels.empty();
-        else if (stage == PagedAttentionStage::MIXED)
+        if (stage == PagedAttentionStage::MIXED)
             return !pa_sdpa_micro_mixed->kd.micro_kernels.empty();
         return false;
     }
@@ -1459,7 +1458,7 @@ public:
         if (use_micro_sdpa) {
             if (stage == PagedAttentionStage::PREFILL)
                 return get_micro_tile_qsize(pa_sdpa_micro->kd);
-            else if (stage == PagedAttentionStage::MIXED)
+            if (stage == PagedAttentionStage::MIXED)
                 return get_micro_tile_qsize(pa_sdpa_micro_mixed->kd);
         }
         return default_block_size;
@@ -1477,7 +1476,7 @@ public:
         if (m_rt_params == nullptr) {
             m_rt_params = std::make_unique<PagedAttentionRuntimeParams>();
         }
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         const auto& desc = params.typed_desc<paged_attention>();
 
         auto stage = get_paged_attention_stage(params);
@@ -1539,7 +1538,7 @@ public:
 
         update_stages_flags(instance);
         kernel_dump_info.clear_entries();
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         assert(rt_params != nullptr);
         prepare_internal_buffers(static_cast<paged_attention_inst&>(instance), rt_params->stage, rt_params->use_micro_sdpa, rt_params->query_block_size);
         std::vector<event::ptr> res_event = events;
@@ -1667,7 +1666,7 @@ public:
         auto stage = PagedAttentionStage::UNKNOWN;
         size_t partition_size = 256;
         size_t num_of_partitions = 1;
-        auto rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
+        auto* rt_params = static_cast<PagedAttentionRuntimeParams*>(m_rt_params.get());
         if (rt_params != nullptr && rt_params->num_of_partitions != 0) {
             stage = rt_params->stage;
             partition_size = rt_params->partition_size;
@@ -1934,7 +1933,7 @@ public:
                             ", micro_sdpa=",
                             use_micro_sdpa);
 
-            auto& sequential_gws_subseq_mapping_mem = intermediates_memories[sequential_gws_subseq_mapping_idx];
+            const auto& sequential_gws_subseq_mapping_mem = intermediates_memories[sequential_gws_subseq_mapping_idx];
             sequential_gws_subseq_mapping_lock.reset(new mem_lock<int32_t, mem_lock_type::write>(sequential_gws_subseq_mapping_mem, stream));
         }
 
@@ -1947,7 +1946,7 @@ public:
                             intermediates_memories.size(),
                             ", mixed_stage_index=",
                             required_mixed_stage_index());
-            auto& memory = intermediates_memories[memory_idx];
+            const auto& memory = intermediates_memories[memory_idx];
             micro_sdpa_block_starts_and_gws_mapping_lock.reset(new mem_lock<int32_t, mem_lock_type::write>(memory, stream));
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -178,19 +178,19 @@ inline ov::Dimension micro_get_seq_length(const kernel_impl_params& params, int3
     }
     if (params.is_type<paged_attention>()) {
         return ov::Dimension(params.input_layouts[qkv_idx].get_partial_shape()[0]);
-    } else {
-        const auto desc = params.typed_desc<scaled_dot_product_attention>();
-        switch (qkv_idx) {
-        case 0:
-            return get_seq_length(params.input_layouts[0], extend_order_in_num_heads_dim(desc->input_q_transpose_order));
-        case 1:
-            return get_seq_length(params.input_layouts[1], extend_order_in_num_heads_dim(desc->input_k_transpose_order));
-        case 2:
-            return get_seq_length(params.input_layouts[2], extend_order_in_num_heads_dim(desc->input_v_transpose_order));
-        default:
-            OPENVINO_THROW("Invalid qkv index for scaled dot product attention");
-        }
     }
+    const auto desc = params.typed_desc<scaled_dot_product_attention>();
+    switch (qkv_idx) {
+    case 0:
+        return get_seq_length(params.input_layouts[0], extend_order_in_num_heads_dim(desc->input_q_transpose_order));
+    case 1:
+        return get_seq_length(params.input_layouts[1], extend_order_in_num_heads_dim(desc->input_k_transpose_order));
+    case 2:
+        return get_seq_length(params.input_layouts[2], extend_order_in_num_heads_dim(desc->input_v_transpose_order));
+    default:
+        OPENVINO_THROW("Invalid qkv index for scaled dot product attention");
+    }
+
     return ov::Dimension();
 }
 
@@ -209,19 +209,19 @@ inline ov::Dimension micro_get_aligned_seq_length(const kernel_impl_params& para
             aligned_seq_len += align_to(prompt_length, target_seq_len_block_size);
         }
         return aligned_seq_len;
-    } else {
-        const auto desc = params.typed_desc<scaled_dot_product_attention>();
-        switch (qkv_idx) {
-        case 0:
-            return get_seq_length(params.input_layouts[0], desc->input_q_transpose_order);
-        case 1:
-            return get_seq_length(params.input_layouts[1], desc->input_k_transpose_order);
-        case 2:
-            return get_seq_length(params.input_layouts[2], desc->input_v_transpose_order);
-        default:
-            OPENVINO_THROW("Invalid qkv index for scaled dot product attention");
-        }
     }
+    const auto desc = params.typed_desc<scaled_dot_product_attention>();
+    switch (qkv_idx) {
+    case 0:
+        return get_seq_length(params.input_layouts[0], desc->input_q_transpose_order);
+    case 1:
+        return get_seq_length(params.input_layouts[1], desc->input_k_transpose_order);
+    case 2:
+        return get_seq_length(params.input_layouts[2], desc->input_v_transpose_order);
+    default:
+        OPENVINO_THROW("Invalid qkv index for scaled dot product attention");
+    }
+
     return ov::Dimension();
 }
 
@@ -239,20 +239,18 @@ inline size_t micro_get_key_cache_id(const kernel_impl_params& params) {
     if (params.is_type<paged_attention>()) {
         const size_t key_cache_id = 3;  // Key cache inputs
         return key_cache_id;
-    } else {
-        auto desc = params.typed_desc<scaled_dot_product_attention>();
-        return get_key_cache_id(*desc);
     }
+    auto desc = params.typed_desc<scaled_dot_product_attention>();
+    return get_key_cache_id(*desc);
 }
 
 inline size_t micro_get_value_cache_id(const kernel_impl_params& params) {
     if (params.is_type<paged_attention>()) {
         const size_t value_cache_id = 4;  // Value cache inputs
         return value_cache_id;
-    } else {
-        auto desc = params.typed_desc<scaled_dot_product_attention>();
-        return get_value_cache_id(*desc);
     }
+    auto desc = params.typed_desc<scaled_dot_product_attention>();
+    return get_value_cache_id(*desc);
 }
 
 struct sdpa_config_t {
@@ -462,7 +460,8 @@ sdpa_config_t* choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
         if (seq <= 256)
             return &xehpg_h32_s256;
         return &xehpg_h32;
-    } else if (head_size <= 64) {
+    }
+    if (head_size <= 64) {
         if (seq <= 0 && is_pa)
             return is_prefill ? &xehpg_h64 : &xehpg_h64_pa;
         if (quantized) {
@@ -472,15 +471,14 @@ sdpa_config_t* choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
                 if (seq <= 128)
                     return &xehpg_q_h64_s128_2nd;
                 return &xehpg_q_h64_2nd;
-            } else {
-                if (seq <= 32)
-                    return &xehpg_q_h64_s32;
-                if (seq <= 64)
-                    return &xehpg_q_h64_s64;
-                if (seq <= 128)
-                    return &xehpg_q_h64_s128;
-                return &xehpg_q_h64;
             }
+            if (seq <= 32)
+                return &xehpg_q_h64_s32;
+            if (seq <= 64)
+                return &xehpg_q_h64_s64;
+            if (seq <= 128)
+                return &xehpg_q_h64_s128;
+            return &xehpg_q_h64;
         }
         if (thin_q)
             return &xehpg_h64_2nd;
@@ -489,7 +487,8 @@ sdpa_config_t* choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
         if (seq <= 128)
             return &xehpg_h64_s128;
         return &xehpg_h64;
-    } else if (head_size <= 128) {
+    }
+    if (head_size <= 128) {
         if (seq <= 0 && is_pa)
             return is_prefill ? &xehpg_h128 : &xehpg_h128_pa;
         if (quantized) {
@@ -514,7 +513,8 @@ sdpa_config_t* choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
         if (seq <= 32)
             return &xehpg_h128_s32;
         return &xehpg_h128;
-    } else if (head_size <= 256) {
+    }
+    if (head_size <= 256) {
         if (seq <= 0 && is_pa)
             return is_prefill ? &xehpg_h256 : &xehpg_h256_pa;
         if (thin_q) {
@@ -541,7 +541,8 @@ sdpa_config_t* choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
         if (seq <= 128)
             return &xehpg_h256_s128;
         return &xehpg_h256;
-    } else if (head_size <= 512) {
+    }
+    if (head_size <= 512) {
         if (seq <= 0 && is_pa)
             return is_prefill ? &xehpg_h512 : &xehpg_h512_pa;
         if (quantized) {
@@ -577,7 +578,8 @@ sdpa_config_t* choose_config_xehpc(int head_size, int seq, bool thin_q, bool qua
         if (seq <= 32)
             return &xehpc_h32_s32;
         return &xehpc_h32;
-    } else if (head_size <= 64) {
+    }
+    if (head_size <= 64) {
         if (seq <= 0 && is_pa)
             return is_prefill ? &xehpc_h64 : (thin_q ? &xehpc_h64_pa_2nd : &xehpc_h64_pa);
         if (thin_q) {
@@ -609,7 +611,8 @@ sdpa_config_t* choose_config_xehpc(int head_size, int seq, bool thin_q, bool qua
         if (seq <= 64)
             return &xehpc_h64_s64;
         return &xehpc_h64;
-    } else if (head_size <= 128) {
+    }
+    if (head_size <= 128) {
         if (seq <= 0 && is_pa)
             return is_prefill ? &xehpc_h128 : &xehpc_h128_pa;
         if (quantized) {
@@ -643,7 +646,8 @@ sdpa_config_t* choose_config_xehpc(int head_size, int seq, bool thin_q, bool qua
         if (seq <= 64)
             return &xehpc_h128_s64;
         return &xehpc_h128;
-    } else if (head_size <= 256) {
+    }
+    if (head_size <= 256) {
         if (seq <= 0 && is_pa)
             return is_prefill ? &xehpc_h256 : &xehpc_h256_pa;
         if (thin_q)
@@ -651,7 +655,8 @@ sdpa_config_t* choose_config_xehpc(int head_size, int seq, bool thin_q, bool qua
         if (seq <= 64)
             return &xehpc_h256_s64;
         return &xehpc_h256;
-    } else if (head_size <= 512) {
+    }
+    if (head_size <= 512) {
         if (seq <= 0 && is_pa)
             return is_prefill ? &xehpc_h512 : &xehpc_h512_pa;
         if (thin_q) {
@@ -1429,7 +1434,7 @@ DispatchDataFunc SDPAMicroGenerator::get_dispatch_data_func() const {
             auto head_num = micro_get_num_heads(params, 0);
 
             if (params.is_type<paged_attention>()) {
-                auto pa_rt_params = static_cast<PagedAttentionRuntimeParams*>(rt_params);
+                auto* pa_rt_params = static_cast<PagedAttentionRuntimeParams*>(rt_params);
                 if (pa_rt_params->stage == PagedAttentionStage::GENERATE)
                     head_num = micro_get_num_heads(params, 1);
             }
@@ -1499,7 +1504,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
     const auto& Q = params.input_layouts[0];
     const auto& K = (is_paged_attention && !is_prefill) ? params.input_layouts[3] : params.input_layouts[1];
     const auto& V = (is_paged_attention && !is_prefill) ? params.input_layouts[4] : params.input_layouts[2];
-    auto& out = params.output_layouts[0];
+    const auto& out = params.output_layouts[0];
     const auto& out_ps = out.get_partial_shape();
     const auto& device_info = params.get_device_info();
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
@@ -109,11 +109,10 @@ inline std::vector<int64_t> extend_order_in_num_heads_dim(const std::vector<int6
 }
 
 inline int64_t get_batch_size(const cldnn::layout& qkv, const std::vector<int64_t>& order) {
-    auto& dim = qkv.get_partial_shape()[order[0]];
+    const auto& dim = qkv.get_partial_shape()[order[0]];
     if (dim.is_dynamic())
         return -1;
-    else
-        return dim.get_length();
+    return dim.get_length();
 }
 
 inline int64_t get_num_heads(const cldnn::layout& qkv, const std::vector<int64_t>& order) {
@@ -122,32 +121,28 @@ inline int64_t get_num_heads(const cldnn::layout& qkv, const std::vector<int64_t
     const auto order_rank = order.size();
     if (order_rank == 3) {
         return 1;
-    } else {
-        auto& dim = qkv.get_partial_shape()[order[order_rank - 3]];
-        if (dim.is_dynamic())
-            return -1;
-        else
-            return dim.get_length();
     }
+    const auto& dim = qkv.get_partial_shape()[order[order_rank - 3]];
+    if (dim.is_dynamic())
+        return -1;
+    return dim.get_length();
 }
 
 inline int64_t get_head_size(const cldnn::layout& qkv, const std::vector<int64_t>& order) {
     const auto order_rank = order.size();
-    auto& dim = qkv.get_partial_shape()[order[order_rank - 1]];
+    const auto& dim = qkv.get_partial_shape()[order[order_rank - 1]];
     if (dim.is_dynamic())
         return -1;
-    else
-        return dim.get_length();
+    return dim.get_length();
 }
 
 inline int64_t get_seq_length(const cldnn::layout& qkv, const std::vector<int64_t>& order) {
     const auto order_rank = order.size();
-    auto& dim = qkv.get_partial_shape()[order[order_rank - 2]];
+    const auto& dim = qkv.get_partial_shape()[order[order_rank - 2]];
     if (dim.is_dynamic()) {
         return -1;
-    } else {
-        return dim.get_length();
     }
+    return dim.get_length();
 }
 
 inline ChannelName get_transposed_channel(ChannelName c, const std::vector<int64_t>& order) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -192,9 +192,11 @@ bool FusedOpsCodeGenerator::can_preload_data(const FusedOpsConfiguration& conf) 
 JitTerm FusedOpsCodeGenerator::get_op_type() const {
     if (desc.is_type<eltwise>()) {
         return JitTerm{"eltwise"};
-    } else if (desc.is_type<quantize>()) {
+    }
+    if (desc.is_type<quantize>()) {
         return JitTerm{"quantize"};
-    } else if (desc.is_type<activation>()) {
+    }
+    if (desc.is_type<activation>()) {
         return JitTerm{"activation"};
     }
     return {};
@@ -1027,7 +1029,7 @@ JitConstants make_activation_jit_constants(const std::string& suffix,
             return concat(lit, type_suffix);
         };
         auto horner = [&](const JitTerm& s, std::initializer_list<JitTerm> coefs) {
-            auto it = coefs.begin();
+            const auto* it = coefs.begin();
             JitTerm r = *it++;
             for (; it != coefs.end(); ++it) {
                 r = r * s + *it;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -82,9 +82,9 @@ public:
             ob << false;
             primitive_impl::save(ob);
             return;
-        } else {
-            ob << true;
         }
+        ob << true;
+
 
         parent::save(ob);
 
@@ -128,7 +128,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const concatenation_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         if (impl_params.can_be_optimized())
             return std::make_unique<concatenation_onednn>(engine, config);
         auto prim = impl_params.typed_desc<concatenation>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -121,20 +121,20 @@ static std::shared_ptr<dnnl::convolution_forward::primitive_desc> get_convolutio
             pad_l,
             pad_r,
             attr);
-    } else {
-        return std::make_shared<dnnl::convolution_forward::primitive_desc>(
-            engine.get_onednn_engine(),
-            dnnl::prop_kind::forward_inference,
-            dnnl::algorithm::convolution_direct,
-            input_md,
-            weights_md,
-            output_md,
-            stride,
-            dilation,
-            pad_l,
-            pad_r,
-            attr);
     }
+    return std::make_shared<dnnl::convolution_forward::primitive_desc>(
+        engine.get_onednn_engine(),
+        dnnl::prop_kind::forward_inference,
+        dnnl::algorithm::convolution_direct,
+        input_md,
+        weights_md,
+        output_md,
+        stride,
+        dilation,
+        pad_l,
+        pad_r,
+        attr);
+
 }
 
 struct convolution_onednn : typed_primitive_onednn_impl<convolution> {
@@ -173,7 +173,7 @@ protected:
             // In the case of dynamic model, if choose_impl was executed in runtime,
             // a_zp could be remained as u8 or i8.
             if (a_zp->get_layout().data_type != data_types::i32) {
-                auto& conv_node = instance.get_node().as<convolution>();
+                const auto& conv_node = instance.get_node().as<convolution>();
                 auto& a_zp_node = conv_node.activations_zero_points().as<data>();
                 a_zp = a_zp_node.get_attached_memory_ptr();
             }
@@ -378,7 +378,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const convolution_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         int zero_point_mask = -1;
         dnnl::memory::data_type wzp_data_type = dnnl::memory::data_type::undef;
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -69,20 +69,20 @@ static std::shared_ptr<dnnl::deconvolution_forward::primitive_desc> get_deconvol
             pad_l,
             pad_r,
             attr);
-    } else {
-        return std::make_shared<dnnl::deconvolution_forward::primitive_desc>(
-            engine.get_onednn_engine(),
-            dnnl::prop_kind::forward_inference,
-            dnnl::algorithm::deconvolution_direct,
-            input_md,
-            weights_md,
-            output_md,
-            stride,
-            dilation,
-            pad_l,
-            pad_r,
-            attr);
     }
+    return std::make_shared<dnnl::deconvolution_forward::primitive_desc>(
+        engine.get_onednn_engine(),
+        dnnl::prop_kind::forward_inference,
+        dnnl::algorithm::deconvolution_direct,
+        input_md,
+        weights_md,
+        output_md,
+        stride,
+        dilation,
+        pad_l,
+        pad_r,
+        attr);
+
 }
 
 struct deconvolution_onednn : typed_primitive_onednn_impl<deconvolution> {
@@ -215,7 +215,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const deconvolution_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
         auto prim_desc = get_deconvolution_primitive_descriptor(impl_params, *attr);
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -198,14 +198,14 @@ protected:
                 bias_md,
                 output_md,
                 attr);
-        } else {
-            return std::make_shared<dnnl::matmul::primitive_desc>(
-                engine.get_onednn_engine(),
-                input_md,
-                weights_md,
-                output_md,
-                attr);
         }
+        return std::make_shared<dnnl::matmul::primitive_desc>(
+            engine.get_onednn_engine(),
+            input_md,
+            weights_md,
+            output_md,
+            attr);
+
     }
 
 public:
@@ -267,7 +267,7 @@ public:
         auto prim = impl_params->typed_desc<fully_connected>();
         auto weights_layout = impl_params->get_input_layout(1);
         auto shift_size = std::max<size_t>(prim->input_size - 2, 0);
-        auto& arg = impl_params->get_program().get_node(impl_params->desc->id).as<fully_connected>();
+        const auto& arg = impl_params->get_program().get_node(impl_params->desc->id).as<fully_connected>();
         int idx = !arg.bias_term() ? 1 : 2;
         int per_oc = PER_OC << shift_size;
         int grouped = (1 << prim->input_size) - 1;
@@ -317,7 +317,7 @@ public:
             auto src_scale_idx = ++idx;
             auto partial_shape = impl_params->get_input_layout(0).get_partial_shape();
             auto innermost_len = partial_shape[partial_shape.size() - 1].get_length();
-            auto& src_scale_shape = impl_params->input_layouts[src_scale_idx].get_partial_shape();
+            const auto& src_scale_shape = impl_params->input_layouts[src_scale_idx].get_partial_shape();
             int64_t src_scale_ngroups = src_scale_shape[src_scale_shape.size() - 1].get_length();
             int64_t src_group_size = innermost_len / src_scale_ngroups;
 
@@ -350,7 +350,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const fully_connected_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
         auto prim = impl_params.typed_desc<fully_connected>();
         int group_size = 0;
@@ -422,9 +422,9 @@ public:
 
             if (is_dyn_quan_input && prim->dynamic_quantized_activation) {
                 auto src_scale_idx = ++idx;
-                auto& partial_shape = impl_params.input_layouts[0].get_partial_shape();
+                const auto& partial_shape = impl_params.input_layouts[0].get_partial_shape();
                 auto innermost_len = partial_shape[partial_shape.size() - 1].get_length();
-                auto& src_scale_shape = impl_params.input_layouts[src_scale_idx].get_partial_shape();
+                const auto& src_scale_shape = impl_params.input_layouts[src_scale_idx].get_partial_shape();
                 int64_t src_scale_ngroups = src_scale_shape[src_scale_shape.size() - 1].get_length();
                 int64_t src_group_size = innermost_len / src_scale_ngroups;
 
@@ -453,12 +453,12 @@ public:
             prim_onednn->_ds_data_type = ds_data_type;
             prim_onednn->_dzp_data_type = dzp_data_type;
             return prim_onednn;
-        } else {
-            auto prim_desc = get_matmul_primitive_descriptor(impl_params, impl_params.prog->get_engine(),
-                                                             prim->input_size, prim->weights_rank, prim->bias.is_valid(), *attr);
-
-            return std::make_unique<fully_connected_onednn>(engine, config, attr, *prim_desc);
         }
+        auto prim_desc = get_matmul_primitive_descriptor(impl_params, impl_params.prog->get_engine(),
+                                                         prim->input_size, prim->weights_rank, prim->bias.is_valid(), *attr);
+
+        return std::make_unique<fully_connected_onednn>(engine, config, attr, *prim_desc);
+
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gated_mlp_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gated_mlp_onednn.cpp
@@ -113,7 +113,7 @@ protected:
     public:
     static std::unique_ptr<primitive_impl> create(const gated_mlp_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
         auto prim = impl_params.typed_desc<gated_mlp>();
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -288,14 +288,14 @@ protected:
                 bias_md,
                 out_md,
                 attr);
-        } else {
-            return std::make_shared<dnnl::matmul::primitive_desc>(
-                engine.get_onednn_engine(),
-                in0_md,
-                in1_md,
-                out_md,
-                attr);
         }
+        return std::make_shared<dnnl::matmul::primitive_desc>(
+            engine.get_onednn_engine(),
+            in0_md,
+            in1_md,
+            out_md,
+            attr);
+
     }
 
 public:
@@ -441,7 +441,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const gemm_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
 
         if (impl_params.get_input_layout(0).count() == 0 ||

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/grouped_gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/grouped_gemm_onednn.cpp
@@ -153,7 +153,7 @@ public:
     static std::unique_ptr<primitive_impl> create(const grouped_matmul_node& arg,
                                                   const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
 
         const auto& prim = impl_params.typed_desc<grouped_matmul>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gru_seq_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gru_seq_onednn.cpp
@@ -248,7 +248,7 @@ void save(BinaryOutputBuffer& ob) const override {
 
     static std::unique_ptr<primitive_impl> create(const gru_seq_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
         auto direction = arg.direction();
         auto prim_desc = get_gru_primitive_descriptor(impl_params, engine, *attr, direction);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/lstm_seq_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/lstm_seq_onednn.cpp
@@ -232,7 +232,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const lstm_seq_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
         auto direction = arg.direction();
         auto prim_desc = get_lstm_primitive_descriptor(impl_params, engine, *attr, direction);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.cpp
@@ -139,14 +139,14 @@ protected:
                 bias_md,
                 output_md,
                 attr);
-        } else {
-            return std::make_shared<dnnl::matmul::primitive_desc>(
-                engine.get_onednn_engine(),
-                input_md,
-                weights_md,
-                output_md,
-                attr);
         }
+        return std::make_shared<dnnl::matmul::primitive_desc>(
+            engine.get_onednn_engine(),
+            input_md,
+            weights_md,
+            output_md,
+            attr);
+
     }
 
 public:
@@ -160,7 +160,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const moe_gemm_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
         auto prim = impl_params.typed_desc<moe_gemm>();
         auto moe_cfg = MoEGemmImplementationManager::get_moe_cfg(impl_params);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.cpp
@@ -165,7 +165,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const pooling_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
         auto prim_desc = get_pooling_primitive_descriptor(impl_params, *attr);
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.cpp
@@ -159,7 +159,7 @@ public:
 
     static std::unique_ptr<primitive_impl> create(const reduce_node& arg, const kernel_impl_params& impl_params) {
         auto& engine = impl_params.prog->get_engine();
-        auto& config = impl_params.prog->get_config();
+        const auto& config = impl_params.prog->get_config();
         auto attr = impl_params.attrs_onednn;
         auto prim_desc = get_reduction_primitive_descriptor(impl_params, *attr);
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
@@ -114,13 +114,13 @@ public:
                                   format::is_weights_format(impl_params.get_output_layout().format);
         if (is_reorder_weights) {
             return create_reorder_weights(impl_params);
-        } else {
-            auto& engine = impl_params.prog->get_engine();
-            auto& config = impl_params.prog->get_config();
-            auto attr = impl_params.attrs_onednn;
-            auto prim_desc = get_reorder_primitive_descriptor(impl_params, *attr);
-            return std::make_unique<reorder_onednn>(engine, config, attr, *prim_desc);
         }
+        auto& engine = impl_params.prog->get_engine();
+        const auto& config = impl_params.prog->get_config();
+        auto attr = impl_params.attrs_onednn;
+        auto prim_desc = get_reorder_primitive_descriptor(impl_params, *attr);
+        return std::make_unique<reorder_onednn>(engine, config, attr, *prim_desc);
+
     }
 
     static std::unique_ptr<primitive_impl> create_reorder_weights(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -49,7 +49,7 @@ std::string memory_desc_to_string(const dnnl::memory::desc& desc) {
 
 template <typename T>
 cldnn::memory::ptr convert_zp_data_to_s32(const memory::ptr zp_memory) {
-    auto engine = zp_memory->get_engine();
+    auto *engine = zp_memory->get_engine();
     auto& stream = engine->get_service_stream();
 
     auto zp_s32_layout = zp_memory->get_layout();
@@ -99,11 +99,10 @@ dnnl::memory::format_tag convert_gemm_data_format(dnnl::memory::dims dims, forma
         auto tag = convert_data_format(target);
         if (tag != dnnl::memory::format_tag::undef) {
             return tag;
-        } else {
-            throw std::invalid_argument("[clDNN] Unsupported conversion from "+ target.to_string() + " to onednn format_tag");
         }
-    } else {
-        switch (dims.size()) {
+        throw std::invalid_argument("[clDNN] Unsupported conversion from "+ target.to_string() + " to onednn format_tag");
+
+    }         switch (dims.size()) {
         case 2: return dnnl::memory::format_tag::ab;
         case 3: return dnnl::memory::format_tag::abc;
         case 4: return dnnl::memory::format_tag::abcd;
@@ -111,7 +110,7 @@ dnnl::memory::format_tag convert_gemm_data_format(dnnl::memory::dims dims, forma
         case 6: return dnnl::memory::format_tag::abcdef;
         default: throw std::invalid_argument("[clDNN] Unsupported conversion from "+ std::to_string(dims.size()) + " to onednn format_tag");
         }
-    }
+
 }
 
 dnnl::memory::dims convert_spatials(cldnn::tensor t, size_t dims) {
@@ -338,12 +337,12 @@ public:
             OPENVINO_ASSERT(!_flatten, "The padded layout cannot be flattened.");
             auto strides = calculate_strides(updated_fmt);
             return dnnl::memory::desc(dims, dt, strides);
-        } else {
-            dnnl::memory::format_tag fmt = updated_fmt == dnnl::memory::format_tag::undef
-                ? convert_data_format(_layout.format) : updated_fmt;
-            dnnl::memory::desc res(dims, dt, fmt);
-            return res;
         }
+        dnnl::memory::format_tag fmt = updated_fmt == dnnl::memory::format_tag::undef
+            ? convert_data_format(_layout.format) : updated_fmt;
+        dnnl::memory::desc res(dims, dt, fmt);
+        return res;
+
     }
 
 private:
@@ -636,11 +635,13 @@ cldnn::format find_data_format(dnnl::memory::desc desc) {
         // Special case for 3D tensors without blocking
         if (compare_orders(order, { {0, 1, 2} })) {
             return static_cast<format::type>(format::bfyx);
-        } else if (compare_orders(order, { {0, 2, 1} })) {
+        }
+        if (compare_orders(order, { {0, 2, 1} })) {
             return static_cast<format::type>(format::byxf);
-        } else if (compare_orders(order, { {1, 0, 2} })) {
+        } if (compare_orders(order, { {1, 0, 2} })) {
             return static_cast<format::type>(format::fbyx);
-        } else if (compare_orders(order, { {1, 2, 0} })) {
+        }
+        if (compare_orders(order, { {1, 2, 0} })) {
             return static_cast<format::type>(format::fybx);
         }
     }
@@ -754,7 +755,7 @@ dnnl::algorithm convert_activation_func(cldnn::activation_func func) {
 template <typename T>
 bool is_per_tensor(cldnn::data_node& node, int32_t& zp_val) {
     auto ptr = node.get_attached_memory_ptr();
-    auto engine = ptr->get_engine();
+    auto *engine = ptr->get_engine();
     auto& stream = engine->get_service_stream();
     auto num_elems = node.get_output_layout().count();
     mem_lock<T, mem_lock_type::read> old_data {ptr, stream};
@@ -889,10 +890,11 @@ bool keep_weights_reorder_shape_consistent(cldnn::layout& layout, const dnnl::me
     layout.set_partial_shape(desc_dims);
     if (layout.get_rank() == desc_dims.size()) {
         return true;
-    } else if (layout.get_rank() == 4 && desc_dims.size() == 3) {
+    }
+    if (layout.get_rank() == 4 && desc_dims.size() == 3) {
         // In the case of a 3D shape, cldnn::layout::get_rank() returns 4.
         return true;
-    } else if (layout.get_rank() == 4 && desc_dims.size() == 5) {
+    } if (layout.get_rank() == 4 && desc_dims.size() == 5) {
         // Since onednn does not support 1D group convolution, a z-axis is added, and format change is required in this case.
         auto is_weights = cldnn::format::is_weights_format(layout.format);
         auto is_grouped = cldnn::format::is_grouped(layout.format);
@@ -901,9 +903,9 @@ bool keep_weights_reorder_shape_consistent(cldnn::layout& layout, const dnnl::me
         if (layout.format == expected_default_format) {
             layout.format = cldnn::format::get_default_format(desc_dims.size(), is_weights, is_grouped);
             return true;
-        } else {
-            OPENVINO_ASSERT(false, "Need default format for axis expansion.");
         }
+        OPENVINO_ASSERT(false, "Need default format for axis expansion.");
+
     } else {
         return false;
     }
@@ -911,7 +913,7 @@ bool keep_weights_reorder_shape_consistent(cldnn::layout& layout, const dnnl::me
 
 size_t get_post_ops_count(const program_node& node) {
     size_t onednn_post_ops_count = 0;
-    for (auto& fo : node.get_fused_primitives()) {
+    for (const auto& fo : node.get_fused_primitives()) {
        onednn_post_ops_count += fo.f_param->ops_count();
     }
 
@@ -923,7 +925,7 @@ bool is_supported_post_ops(const program_node& node) {
         return false;
     }
 
-    for (auto& fo : node.get_fused_primitives()) {
+    for (const auto& fo : node.get_fused_primitives()) {
         if (fo.is_type<activation>()) {
             // Some activations aren't implemented in oneDNN
             auto activation_prim = fo.typed_desc<activation>();
@@ -979,8 +981,7 @@ int get_prelu_mask_from_layouts(const std::function<layout()>& get_output_layout
 
     if (is_scalar)
         return 0;
-    else
-        return (1 << 1);
+    return (1 << 1);
 }
 std::string dnnl_status_to_string(dnnl_status_t status) {
     switch (status) {

--- a/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
@@ -152,9 +152,9 @@ public:
             auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
-        } else {  // all weights are in one buffer
+        }  // all weights are in one buffer
             return dep_memory_ptr(1 + _deform_conv_dep_offset);
-        }
+
     }
 
     memory::ptr bias_memory() const {

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -84,9 +84,9 @@ public:
             auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
-        } else {
-            return dep_memory_ptr(1);
         }
+        return dep_memory_ptr(1);
+
     }
 
     memory::ptr bias_memory() const { return dep_memory_ptr(2); }

--- a/src/plugins/intel_gpu/src/graph/include/dft_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/dft_inst.h
@@ -20,8 +20,7 @@ public:
     std::vector<size_t> get_shape_infer_dependencies() const override {
         if (this->get_dependencies().size() == 3)
             return {1, 2};
-        else
-            return {1};
+        return {1};
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
@@ -58,9 +58,9 @@ public:
             auto weights_mem = _reordered_weights_cache.get(*_impl_params->weights_layout);
             OPENVINO_ASSERT(weights_mem != nullptr, "[GPU] Can't find proper weights memory buffer in cache");
             return weights_mem;
-        } else {
-            return dep_memory_ptr(1);
         }
+        return dep_memory_ptr(1);
+
     }
     memory::ptr bias_memory() const { return dep_memory_ptr(2); }
 

--- a/src/plugins/intel_gpu/src/graph/include/group_normalization_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/group_normalization_inst.h
@@ -31,7 +31,7 @@ public:
 
         if (impl_param.has_fused_primitives()) {
             output_type = impl_param.get_output_element_type();
-            for (auto& desc : impl_param.fused_desc) {
+            for (const auto& desc : impl_param.fused_desc) {
                 if (desc.is_type<reorder>()) {
                     out_format = desc.output_layout.format;
                 }

--- a/src/plugins/intel_gpu/src/graph/include/istft_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/istft_inst.h
@@ -23,8 +23,7 @@ public:
     std::vector<size_t> get_shape_infer_dependencies() const override {
         if (this->get_dependencies().size() == 5)
             return {2, 3, 4};
-        else
-            return {2, 3};
+        return {2, 3};
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -43,10 +43,9 @@ struct reorder_cache_key {
     friend bool operator<(reorder_cache_key const& lhs, reorder_cache_key const& rhs) {
         if (lhs.data_source != rhs.data_source)
             return (lhs.data_source < rhs.data_source);
-        else if (lhs.expected_layout != rhs.expected_layout)
+        if (lhs.expected_layout != rhs.expected_layout)
             return (lhs.expected_layout < rhs.expected_layout);
-        else
-            return lhs.expected_layout.format.traits().block_sizes < rhs.expected_layout.format.traits().block_sizes;
+        return lhs.expected_layout.format.traits().block_sizes < rhs.expected_layout.format.traits().block_sizes;
     }
 };
 
@@ -144,7 +143,7 @@ public:
                 bool enabled = false;
                 ib >> p_id;
                 ib >> enabled;
-                auto ptype_id = prim_map_storage::instance().get_type_id(p_id);
+                auto *ptype_id = prim_map_storage::instance().get_type_id(p_id);
                 onednn_impls[ptype_id] = enabled;
             }
         }

--- a/src/plugins/intel_gpu/src/graph/include/memory_accessor.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/memory_accessor.hpp
@@ -63,11 +63,12 @@ struct MemoryAccessor : public ov::ITensorAccessor {
             return {m_accessed_data->get_layout().data_type,
                     m_accessed_data->get_layout().get_shape(),
                     m_accessed_data->lock(m_stream, mem_lock_type::read)};
-        } else if (m_clbk) {
-            return m_clbk(port);
-        } else {
-            return ov::make_tensor_accessor()(port);
         }
+        if (m_clbk) {
+            return m_clbk(port);
+        }
+        return ov::make_tensor_accessor()(port);
+
     }
 
 private:

--- a/src/plugins/intel_gpu/src/graph/include/permute_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/permute_inst.h
@@ -27,7 +27,7 @@ public:
         // Target transform: Rotate feature dim to back to be taken as inner-most axis
         // ex) 0(b), 2(f), 3(x), 4(y), 1(z)
         // ex) 0(b), 2(f), 3(x), 1(y)
-        auto& order = get_primitive()->permute_order;
+        const auto& order = get_primitive()->permute_order;
         if ((int32_t) order[order.size() - 2] != order.size() - 1) return false;
         if ((int32_t) order[0] != 0) return false;
         for (int32_t i = 2; i < (int32_t) order.size(); ++i) {
@@ -40,7 +40,7 @@ public:
         // Target transform: Rotate feature dim to front to be taken as second outer axis
         // ex) 0(b), 4(f), 1(x), 2(y), 3(z)
         // ex) 0(b), 3(f), 1(x), 2(y)
-        auto& order = get_primitive()->permute_order;
+        const auto& order = get_primitive()->permute_order;
         if ((int32_t) order[order.size() - 2] != 1) return false;
         if ((int32_t) order[0] != 0) return false;
         for (int32_t i = 2; i < (int32_t) order.size(); ++i) {

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -261,7 +261,7 @@ public:
     const std::vector<primitive_inst*>& get_user_insts() const { return _users; }
     void init_users() {
         std::vector<primitive_id> users;
-        for (auto u : get_users()) {
+        for (const auto *u : get_users()) {
             users.push_back(u->id());
         }
         _users = get_network().get_primitives(users);

--- a/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
@@ -167,15 +167,15 @@ struct primitive_type_base : primitive_type {
                 if (forced_impl_type == impl->get_impl_type())
                     return true;
                 continue;
-            } else {
-                if (impl_type == impl_types::onednn && !node.get_program().get_layout_optimizer().contains_onednn_impls_optimization_attribute(&node))
-                    continue;
-
-                if (!impl->validate(node))
-                    continue;
-
-                return true;
             }
+            if (impl_type == impl_types::onednn && !node.get_program().get_layout_optimizer().contains_onednn_impls_optimization_attribute(&node))
+                continue;
+
+            if (!impl->validate(node))
+                continue;
+
+            return true;
+
         }
 
         return false;
@@ -183,7 +183,7 @@ struct primitive_type_base : primitive_type {
 
     cldnn::layout calc_output_layout(const cldnn::program_node& node, const kernel_impl_params& impl_param) const override {
         OPENVINO_ASSERT(node.type() == this, "[GPU] primitive_type_base::calc_output_layout: primitive type mismatch");
-        for (auto& t : impl_param.input_layouts) {
+        for (const auto& t : impl_param.input_layouts) {
             GPU_DEBUG_TRACE_DETAIL << impl_param.desc->id << " input tensor: " << t.to_short_string() << std::endl;
         }
         auto res = typed_primitive_inst<PType>::calc_output_layout(node, impl_param);
@@ -195,7 +195,7 @@ struct primitive_type_base : primitive_type {
     std::vector<cldnn::layout> calc_output_layouts(const cldnn::program_node& node, const kernel_impl_params& impl_param) const override {
         OPENVINO_ASSERT(node.type() == this, "primitive_type_base::calc_output_layouts: primitive type mismatch");
 
-        for (auto& t : impl_param.input_layouts) {
+        for (const auto& t : impl_param.input_layouts) {
             GPU_DEBUG_TRACE_DETAIL << impl_param.desc->id << " input tensor: " << t.to_short_string() << std::endl;
         }
 

--- a/src/plugins/intel_gpu/src/graph/include/program_helpers.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_helpers.h
@@ -236,7 +236,7 @@ template <typename... Opts>
 void run_node_optimizations(program& p, Opts&&... opts) {
     auto it = p.get_processing_order().begin();
     while (it != p.get_processing_order().end()) {
-        auto node = *it++;
+        auto *node = *it++;
         run_node_optimizations(*node, opts...);
     }
 }

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -86,7 +86,7 @@ public:
     bool is_shape_infer_dep() const {
         if (!myprog.is_new_shape_infer())
             return false;
-        for (auto u : users) {
+        for (auto *u : users) {
             for (auto dep_idx : u->get_shape_infer_dependencies()) {
                 if (u->get_dependencies().size() <= dep_idx) {
                     continue;
@@ -105,7 +105,7 @@ public:
     bool is_fused_dep(size_t dep_idx) const;
 
     bool has_fused_dep() const {
-        for (auto& fused : get_fused_primitives()) {
+        for (const auto& fused : get_fused_primitives()) {
             if (fused.has_outer_dep())
                 return true;
         }
@@ -115,7 +115,7 @@ public:
     int32_t get_first_fused_dep_idx() const {
         if (!has_fused_dep())
             return -1;
-        for (auto& fused : get_fused_primitives()) {
+        for (const auto& fused : get_fused_primitives()) {
             if (fused.has_outer_dep())
                 return fused.outer_dep_start_idx;
         }
@@ -427,7 +427,7 @@ public:
 
     size_t get_fused_inputs_count() const {
         size_t count = 0;
-        for (auto& fp : get_fused_primitives()) {
+        for (const auto& fp : get_fused_primitives()) {
             count += fp.deps.size();
         }
         return count;
@@ -479,9 +479,9 @@ public:
         });
         if (iter != deps.end()) {
             return iter->idx;
-        } else {
-            return 0;
         }
+        return 0;
+
     }
 
     bool can_use(impl_types impl_type) const;

--- a/src/plugins/intel_gpu/src/graph/include/resample_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/resample_inst.h
@@ -26,9 +26,9 @@ public:
         // if vector of sizes or scales exists, resample in CreateInterpolateOp generates no dependency for inputs of sizes and scales
         if (!typed_desc()->sizes.empty() && !typed_desc()->scales.empty()) {
             return {};
-        } else {
-            return {1, 2};
         }
+        return {1, 2};
+
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/sliding_window_utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/sliding_window_utils.hpp
@@ -441,14 +441,13 @@ inline padding calc_sliding_window_needed_input_padding(const layout& actual_inp
                         std::max(needed_upad.spatial[2], actual_upad[2]),
                         std::max(needed_upad.spatial[1], actual_upad[3]),
                         std::max(needed_upad.spatial[0], actual_upad[4])});
-    else if (spatial_rank >= 2)
+                        if (spatial_rank >= 2)
         return padding({actual_lpad[0], actual_lpad[1], actual_lpad[2], actual_lpad[3]},
                        {actual_upad[0],
                         actual_upad[1],
                         std::max(needed_upad.spatial[1], actual_upad[2]),
                         std::max(needed_upad.spatial[0], actual_upad[3])});
-    else
-        return padding({actual_lpad[0], actual_lpad[1], actual_lpad[2]},
+    return padding({actual_lpad[0], actual_lpad[1], actual_lpad[2]},
                        {actual_upad[0],
                         actual_upad[1],
                         std::max(needed_upad.spatial[0], actual_upad[2])});

--- a/src/plugins/intel_gpu/src/graph/kernel_impl_params.cpp
+++ b/src/plugins/intel_gpu/src/graph/kernel_impl_params.cpp
@@ -13,15 +13,15 @@ size_t kernel_impl_params::hash() const {
     if (desc != nullptr)
         seed = desc->hash();
     const size_t prime_number = 2654435761; // magic number to reduce hash collision rate.
-    for (auto& in : input_layouts) {
+    for (const auto& in : input_layouts) {
         seed = hash_combine(seed, in.hash() * prime_number);
     }
-    for (auto& out : output_layouts) {
+    for (const auto& out : output_layouts) {
         seed = hash_combine(seed, out.hash() * prime_number);
     }
 
     // hash for fused prims
-    for (auto& fd : fused_desc) {
+    for (const auto& fd : fused_desc) {
         seed = hash_combine(seed, fd.desc->hash());
     }
 

--- a/src/plugins/intel_gpu/src/graph/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/kv_cache.cpp
@@ -160,7 +160,7 @@ void kv_cache_inst::update_shape_info_tensor(const kernel_impl_params& params) {
         allocate_shape_info_memory();
     }
     mem_lock<int32_t> lock(_shape_info_memory, _network.get_stream());
-    auto shape_info_ptr = lock.data();
+    auto *shape_info_ptr = lock.data();
     size_t offset = 0;
 
     size_t i = 0;

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -62,7 +62,7 @@ using namespace cldnn;
 
 static size_t get_post_ops_count(const program_node& node) {
     size_t onednn_post_ops_count = 0;
-    for (auto& fo : node.get_fused_primitives()) {
+    for (const auto& fo : node.get_fused_primitives()) {
        onednn_post_ops_count += fo.f_param->ops_count();
     }
 
@@ -105,14 +105,14 @@ std::pair<std::shared_ptr<primitive>, bool> reorder_factory::get_weights_reorder
     auto itr = _cached_reorders.find(ckey);
     if (itr != _cached_reorders.end()) {
         return std::make_pair(itr->second, true);
-    } else {
-        auto count = _cached_reorders.size();
-        std::string reorder_id = input_id + "_weights_reorder_" + std::to_string(count);
-
-        auto reorder = std::make_shared<cldnn::reorder>(reorder_id, input_id, reorder_params);
-        _cached_reorders[ckey] = reorder;
-        return std::make_pair(reorder, false);
     }
+    auto count = _cached_reorders.size();
+    std::string reorder_id = input_id + "_weights_reorder_" + std::to_string(count);
+
+    auto reorder = std::make_shared<cldnn::reorder>(reorder_id, input_id, reorder_params);
+    _cached_reorders[ckey] = reorder;
+    return std::make_pair(reorder, false);
+
 }
 
 int64_t cldnn::get_convolution_channel_count(const convolution_node& conv_node, const layout& layout, bool is_input) {
@@ -250,7 +250,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
         auto& next_dep = next.get_dependency(0);
         if (!next_dep.is_type<reorder>())
             return false;
-        for (auto& prev_usr : prev.get_users()) {
+        for (const auto& prev_usr : prev.get_users()) {
             if (!prev_usr->is_type<reorder>())
                 continue;
             if (&next_dep == prev_usr && next.get_dependency_index(next_dep) == 0) {
@@ -283,7 +283,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
     }
 
     if (use_onednn_impls) {
-        auto& node = prev.get_users().front();
+        const auto& node = prev.get_users().front();
         if (prev.get_output_layout().format == next.get_preferred_input_fmt() &&
                 node->get_output_layout().data_padding == prev.get_output_layout().data_padding)
             return true;
@@ -443,7 +443,7 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, reorder_node
     if (node.get_users().empty())
         return false;
 
-    auto next = node.get_users().front();
+    auto *next = node.get_users().front();
     auto dt_prev = prev.get_output_layout().data_type;
     auto dt_next = next->get_output_layout().data_type;
     auto use_onednn_impls = contains_onednn_impls_optimization_attribute(&node) && contains_onednn_impls_optimization_attribute(&prev);
@@ -493,27 +493,27 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, reorder_node
                 return true;
 
             return false;
-        } else {
-            if (fmt_prev == format::b_fs_yx_fsv32 && fmt_next == format::byxf)
-                return true;
-
-            auto& permute_order = prev.as<permute>().get_primitive()->permute_order;
-            if ((fmt_prev == format::b_fs_yx_fsv4 || fmt_prev == format::b_fs_yx_fsv32 || fmt_prev == format::b_fs_zyx_fsv32 ||
-            fmt_prev == format::b_fs_yx_fsv16 || fmt_prev == format::b_fs_zyx_fsv16 || fmt_prev == format::bs_fs_yx_bsv16_fsv16)
-            && permute_order.back() != 1
-            && (!prev.as<permute>().is_rotating_except_batch())) {
-                return false;
-            }
-            // permute kernel doesn't support reorder fusion for ranks > 6
-            if (fmt_prev.dimension() > 6 || fmt_next.dimension() > 6)
-                return false;
-
-            // Skip reorder fusing to permute when allow_new_shape_infer is True and input and output rank is different
-            if (allow_new_shape_infer && (fmt_prev.dimension() != fmt_next.dimension()))
-                return false;
-
-            return true;
         }
+        if (fmt_prev == format::b_fs_yx_fsv32 && fmt_next == format::byxf)
+            return true;
+
+        const auto& permute_order = prev.as<permute>().get_primitive()->permute_order;
+        if ((fmt_prev == format::b_fs_yx_fsv4 || fmt_prev == format::b_fs_yx_fsv32 || fmt_prev == format::b_fs_zyx_fsv32 ||
+        fmt_prev == format::b_fs_yx_fsv16 || fmt_prev == format::b_fs_zyx_fsv16 || fmt_prev == format::bs_fs_yx_bsv16_fsv16)
+        && permute_order.back() != 1
+        && (!prev.as<permute>().is_rotating_except_batch())) {
+            return false;
+        }
+        // permute kernel doesn't support reorder fusion for ranks > 6
+        if (fmt_prev.dimension() > 6 || fmt_next.dimension() > 6)
+            return false;
+
+        // Skip reorder fusing to permute when allow_new_shape_infer is True and input and output rank is different
+        if (allow_new_shape_infer && (fmt_prev.dimension() != fmt_next.dimension()))
+            return false;
+
+        return true;
+
     }
 
 
@@ -568,7 +568,7 @@ bool should_use_winograd_2x3_s1(const convolution_node& node,
 
 layout_optimizer::layout_optimizer(bool output_size_handling_enabled)
     : _optimization_attributes(), _output_size_handling_enabled(output_size_handling_enabled), _total_conv(0) {
-    for (auto& format : optimized_formats) {
+    for (const auto& format : optimized_formats) {
         _optimized_conv_count.insert({format, 0});
     }
 }
@@ -668,14 +668,14 @@ bool layout_optimizer::convolution_b_fs_yx_fsv16_opt(const layout& input_layout,
              conv->groups == static_cast<uint32_t>(input_layout.feature())))
             return true;
         // Check for grouped convolution
-        else if (input_layout.format.dimension() == 4 && input_layout.batch() < 16 &&
+        if (input_layout.format.dimension() == 4 && input_layout.batch() < 16 &&
                  out_features_per_group >= 16 &&
                  // Need to extend imad fsv4 kernel to handle e.g. 3 input features per group
                  (in_features_per_group % 4 == 0) &&
                  ((conv->dilation[conv->dilation.size() - 1] + 1) * (ks_x - 1)) <= 16)
                 return true;
         // Check for fsv16 imad kernel
-        else if ((input_layout.format.dimension() == 4) &&
+        if ((input_layout.format.dimension() == 4) &&
                  ((in_features_per_group > 8) || (out_features_per_group >= 4)))
                 return true;
         return false;
@@ -733,9 +733,9 @@ static bool has_reorder_before_mvn(const program_node& node, size_t cur_depth, s
     if (cur_depth > max_depth) return false;
     if (node.is_type<reorder>()) {
         if (node.get_users().size() == 1) {
-            auto reorder_first_user = node.get_users().front();
+            const auto *reorder_first_user = node.get_users().front();
             if (reorder_first_user->is_type<reshape>()) {
-                for (auto& reshape_user : reorder_first_user->get_users()) {
+                for (const auto& reshape_user : reorder_first_user->get_users()) {
                     if (reshape_user->is_type<mvn>() && !node.get_output_layout().is_dynamic() &&
                         node.get_output_layout().get_linear_size() > reorder_size_threshold) {
                         GPU_DEBUG_LOG << node.id() << ": " << node.get_output_layout().to_short_string() << " : heavy reorder" << std::endl;
@@ -916,7 +916,7 @@ bool layout_optimizer::users_for_convolution_byxf_opt(program_node const& node, 
     if (depth == 0)
         return true;
 
-    for (auto& user : node.get_users()) {
+    for (const auto& user : node.get_users()) {
         // primitives that support transitions byxf->other format and other format->byxf are valid for byxf opt
         if ((user->type() == cldnn::eltwise::type_id() && !is_scale_shift(user->as<eltwise>())) || user->type() == cldnn::pooling::type_id()) {
             if (!users_for_convolution_byxf_opt(*user, depth - 1))
@@ -945,7 +945,7 @@ bool layout_optimizer::deps_for_convolution_byxf_opt(program_node const& node, u
     if (depth == 0)
         return true;
 
-    for (auto& dep : node.get_dependencies()) {
+    for (const auto& dep : node.get_dependencies()) {
         // skip data layers
         if (dep.first->is_type<data>())
             continue;
@@ -977,7 +977,8 @@ format layout_optimizer::imad_case(convolution_node const& node) const {
 
     if (dims_count == 5 && is_grouped) {
         return format::bfzyx;
-    } else if (dims_count == 4 && is_grouped && !is_dw) {
+    }
+    if (dims_count == 4 && is_grouped && !is_dw) {
         return format::b_fs_yx_fsv4;
     }
 
@@ -986,9 +987,9 @@ format layout_optimizer::imad_case(convolution_node const& node) const {
     if (asymmetric_quantization && _optimization_attributes.b_fs_zyx_fsv32_network) {
         if (dims_count == 5) {
             return format::b_fs_zyx_fsv32;
-        } else {
-            return format::b_fs_yx_fsv32;
         }
+        return format::b_fs_yx_fsv32;
+
     }
 
     if (dims_count == 5) {
@@ -1296,7 +1297,7 @@ format layout_optimizer::get_expected_format(quantize_node const& node) {
     std::function<bool(const program_node& node)> only_gemm_users = [&](const program_node& node) {
         bool all_users_gemm = (!node.get_users().empty());
 
-        for (auto user : node.get_users()) {
+        for (const auto *user : node.get_users()) {
             if (user->is_type<reorder>() || user->is_type<reshape>())
                 all_users_gemm &= only_gemm_users(*user);
             else if (user->is_type<gemm>())
@@ -1312,9 +1313,9 @@ format layout_optimizer::get_expected_format(quantize_node const& node) {
 
     if (use_onednn_impls) {
         expected = format::any;
-        auto& users = node.get_users();
+        const auto& users = node.get_users();
         if (!users.empty()) {
-            auto& user = users.front();
+            const auto& user = users.front();
             if (user != nullptr && user->get_preferred_input_fmt(user->get_dependency_index(node)) != format::any) {
                 expected = user->get_preferred_input_fmt(user->get_dependency_index(node));
             }
@@ -1373,8 +1374,7 @@ impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format 
 
     if (impl)
         return impl->get_impl_type();
-    else
-        return impl_types::any;
+    return impl_types::any;
 }
 
 format layout_optimizer::get_preferred_format(program_node& node) {
@@ -1388,7 +1388,7 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         // Let reorder_input pass to check input format instead of output_format in forward investigation, vice versa
         auto out_lay_rank = node.get_output_layout(false).get_rank();
         auto has_reshape_user = [&](const program_node& node) -> bool {
-            for (auto& user_node : node.get_users()) {
+            for (const auto& user_node : node.get_users()) {
                 if (user_node->is_type<reshape>())
                     return true;
             }
@@ -1629,7 +1629,7 @@ void layout_optimizer::set_value_onednn(primitive_type_id p_type, bool val) {
 }
 
 bool layout_optimizer::contains_onednn_impls_optimization_attribute(const program_node* node) {
-    auto type_id = node->type();
+    auto *type_id = node->type();
     auto it = _optimization_attributes.onednn_impls.find(type_id);
     if (it == _optimization_attributes.onednn_impls.end()) {
         return false;
@@ -1680,7 +1680,7 @@ bool layout_optimizer::is_format_optimized(const convolution_node& node, const f
 }
 
 void layout_optimizer::update_formats_map(const convolution_node &node) {
-    for (auto& format : optimized_formats) {
+    for (const auto& format : optimized_formats) {
         if (is_format_optimized(node, format.first, format.second)) {
             _optimized_conv_count.at(format)++;
         }

--- a/src/plugins/intel_gpu/src/graph/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/loop.cpp
@@ -76,7 +76,7 @@ static std::vector<layout> get_output_layouts(kernel_impl_params const& impl_par
     std::vector<layout> output_layouts;
 
     const auto& output_primitive_maps = prim->output_primitive_maps;
-    for (auto& output_mapping : output_primitive_maps) {
+    for (const auto& output_mapping : output_primitive_maps) {
         const primitive_id& output_internal_id = output_mapping.internal_id.pid;
         auto target = std::find_if(body_outputs.begin(), body_outputs.end(), [&](const T output) {
             return output->id() == output_internal_id;
@@ -116,7 +116,7 @@ std::vector<layout> loop_inst::calc_output_layouts(loop_node const& /*node*/, ke
         const auto& body_outputs = impl_param.inner_progs.front()->get_outputs();
         output_layouts = get_output_layouts<program_node*>(impl_param, body_outputs, prim->max_num_iterations);
     } else {
-        auto& memory_deps = impl_param.memory_deps;
+        const auto& memory_deps = impl_param.memory_deps;
         const size_t current_iteration_idx = 0;
         OPENVINO_ASSERT(memory_deps.count(current_iteration_idx) > 0, "The count of memory deps(current_iteration) should not be zero");
         cldnn::mem_lock<int64_t, mem_lock_type::read> current_iterations_lock(memory_deps.at(current_iteration_idx), impl_param.get_stream());
@@ -246,7 +246,7 @@ void loop_inst::update_input_mapped_memory() {
 
         auto memory = input_memory_ptr(memory_num);
         for (size_t i = 0; i < input_map_ptrs.size(); ++i) {
-            const auto input_map = input_map_ptrs.at(i);
+            const auto *const input_map = input_map_ptrs.at(i);
             bool is_concatenated_input = (input_map->axis >= 0);
             if (is_concatenated_input) {
                 for (auto& mem_mapping : concatenated_input_mem_mappings) {
@@ -314,12 +314,12 @@ void loop_inst::update_backedge_mapped_memory() {
                         if (backedge_to_prim.get() == backedge_from_prim->dependencies().front().first) {
                             backedge_mapping.initial_mem = initial_mem;
                             continue;
-                        } else {
-                            // generally, shouldn't go this way, but...
-                            auto output_prim = body_network->get_primitive(back_edge.from);
-                            layout output_layout = output_prim->output_memory().get_layout();
-                            backedge_mem = body_network->get_engine().allocate_memory(output_layout, false);
                         }
+                        // generally, shouldn't go this way, but...
+                        auto output_prim = body_network->get_primitive(back_edge.from);
+                        layout output_layout = output_prim->output_memory().get_layout();
+                        backedge_mem = body_network->get_engine().allocate_memory(output_layout, false);
+
                     } else {
                         auto external_id = output_mapping.front()->external_id;
                         backedge_mem = get_external_memory(external_id.pid, external_id.idx);
@@ -469,7 +469,7 @@ void loop_inst::preprocess_input_memory(const int64_t num_iterations) {
 
         auto memory = input_memory_ptr(memory_num);
         for (size_t i = 0; i < input_map_ptrs.size(); ++i) {
-            const auto input_map = input_map_ptrs.at(i);
+            const auto *const input_map = input_map_ptrs.at(i);
             const auto& external_id = input_map->external_id;
             const auto& internal_id = input_map->internal_id;
             GPU_DEBUG_LOG << i << ") input mapping - external " << external_id.to_string() << std::endl;
@@ -585,7 +585,7 @@ void loop_inst::preprocess_backedge_memory() {
                                     << ") from back_edge.from(" << back_edge.from << ")" << std::endl;
                 } else {
                     // Set input and output memory for body_network using external output memory of loop op
-                    auto& out_mapping_ext_id = output_mapping.front()->external_id;
+                    const auto& out_mapping_ext_id = output_mapping.front()->external_id;
                     backedge_mem = get_external_memory(out_mapping_ext_id.pid, out_mapping_ext_id.idx);
                     GPU_DEBUG_LOG << idx << ") Get backedge_mem(" << backedge_mem << ") from output_mapping_external_id.pid("
                                     << out_mapping_ext_id.pid << ")" << std::endl;
@@ -886,7 +886,7 @@ void loop_inst::concatenated_memory_mapping::slice_mem(const int64_t num_iterati
         const size_t part_length = concat_mem_shape.at(axis) / num_iters;
         const size_t inner_axis = axis + 1;
         auto output_shape = concat_mem_shape;
-        auto out_data = pointers_to_data.data();
+        auto *out_data = pointers_to_data.data();
         output_shape[axis] = part_length;
 
         ov::Coordinate lower_bounds(concat_mem_shape.size(), 0);
@@ -906,12 +906,12 @@ void loop_inst::concatenated_memory_mapping::slice_mem(const int64_t num_iterati
             strides[iter] = upper_bounds[iter];
 
         const auto strides_copy_size = elem_size * continuous_size;
-        const auto out_last = std::next(out_data, num_iters);
-        for (auto out_iter = out_data; out_iter != out_last; ++out_iter) {
-            auto dst_mem = *out_iter;
+        auto *const out_last = std::next(out_data, num_iters);
+        for (auto *out_iter = out_data; out_iter != out_last; ++out_iter) {
+            auto *dst_mem = *out_iter;
             auto slice_ranges = ov::coordinates::slice(concat_mem_shape, lower_bounds, upper_bounds, strides);
             for (const auto& range : slice_ranges) {
-                const auto src_mem = concat_data + range.begin_index * elem_size;
+                auto *const src_mem = concat_data + range.begin_index * elem_size;
                 std::memcpy(dst_mem, src_mem, strides_copy_size);
                 std::advance(dst_mem, strides_copy_size);
             }

--- a/src/plugins/intel_gpu/src/graph/lrn.cpp
+++ b/src/plugins/intel_gpu/src/graph/lrn.cpp
@@ -34,7 +34,7 @@ std::string lrn_inst::to_string(lrn_node const& node) {
     auto k = desc->k;
     auto alpha = desc->alpha;
     auto beta = desc->beta;
-    auto norm_region = desc->norm_region == lrn_norm_region::lrn_norm_region_across_channel
+    const auto *norm_region = desc->norm_region == lrn_norm_region::lrn_norm_region_across_channel
                            ? "across channel"
                            : "within channel";
     auto& input = node.input();

--- a/src/plugins/intel_gpu/src/graph/moe_gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/moe_gather.cpp
@@ -34,10 +34,10 @@ std::vector<layout> moe_gather_inst::calc_output_layouts(const moe_gather_node& 
     if (desc->has_batch_dim) {
         const auto& out_shape = ov::PartialShape{ov::Dimension(1), ov::Dimension(num_tokens * num_experts_per_token), ov::Dimension(hidden_size)};
         return {layout{out_shape, in_layout.data_type, in_layout.format}};
-    } else {
-        const auto& out_shape = ov::PartialShape{ov::Dimension(num_tokens * num_experts_per_token), ov::Dimension(1), ov::Dimension(hidden_size)};
-        return {layout{out_shape, in_layout.data_type, in_layout.format}};
     }
+    const auto& out_shape = ov::PartialShape{ov::Dimension(num_tokens * num_experts_per_token), ov::Dimension(1), ov::Dimension(hidden_size)};
+    return {layout{out_shape, in_layout.data_type, in_layout.format}};
+
 }
 
 template std::vector<layout> moe_gather_inst::calc_output_layouts<ov::PartialShape>(moe_gather_node const& node, const kernel_impl_params& impl_param);

--- a/src/plugins/intel_gpu/src/graph/moe_scatter_reduction.cpp
+++ b/src/plugins/intel_gpu/src/graph/moe_scatter_reduction.cpp
@@ -32,11 +32,11 @@ std::vector<layout> moe_scatter_reduction_inst::calc_output_layouts(moe_scatter_
         const auto num_tokens = impl_param.input_layouts[0].get_shape()[1] / num_active_experts_per_token;
         const auto& out_shape = ov::PartialShape{1, ov::Dimension(num_tokens), ov::Dimension(hidden_size)};
         return {layout{out_shape, impl_param.input_layouts[0].data_type, impl_param.input_layouts[0].format}};
-    } else {
-        const auto num_tokens = impl_param.input_layouts[0].get_shape()[0] / num_active_experts_per_token;
-        const auto& out_shape = ov::PartialShape{ov::Dimension(num_tokens), 1, ov::Dimension(hidden_size)};
-        return {layout{out_shape, impl_param.input_layouts[0].data_type, impl_param.input_layouts[0].format}};
     }
+    const auto num_tokens = impl_param.input_layouts[0].get_shape()[0] / num_active_experts_per_token;
+    const auto& out_shape = ov::PartialShape{ov::Dimension(num_tokens), 1, ov::Dimension(hidden_size)};
+    return {layout{out_shape, impl_param.input_layouts[0].data_type, impl_param.input_layouts[0].format}};
+
 }
 
 template std::vector<layout> moe_scatter_reduction_inst::calc_output_layouts<ov::PartialShape>(moe_scatter_reduction_node const& node,

--- a/src/plugins/intel_gpu/src/graph/multinomial.cpp
+++ b/src/plugins/intel_gpu/src/graph/multinomial.cpp
@@ -31,13 +31,13 @@ layout multinomial_inst::calc_output_layout(multinomial_node const& node, kernel
             tensor{std::vector<tensor::value_type>{
                 static_cast<tensor::value_type>(primitive->num_samples)
             }}};
-    } else {
-        return {primitive->output_data_type, input_layout.format,
-            tensor{std::vector<tensor::value_type>{
-                input_layout.batch(),
-                static_cast<tensor::value_type>(primitive->num_samples)
-            }}};
     }
+    return {primitive->output_data_type, input_layout.format,
+        tensor{std::vector<tensor::value_type>{
+            input_layout.batch(),
+            static_cast<tensor::value_type>(primitive->num_samples)
+        }}};
+
 }
 
 multinomial_inst::typed_primitive_inst(network& network, multinomial_node const& node)

--- a/src/plugins/intel_gpu/src/graph/mutable_data.cpp
+++ b/src/plugins/intel_gpu/src/graph/mutable_data.cpp
@@ -76,8 +76,7 @@ event::ptr mutable_data_inst::set_output_memory(memory::ptr mem_new, bool check,
     auto ev = primitive_inst::set_output_memory(mem_new, check);
     if (input_ev == nullptr)
         return ev;
-    else
-        return _network.get_stream().group_events({ev, input_ev});
+    return _network.get_stream().group_events({ev, input_ev});
 }
 
 mutable_data_inst::typed_primitive_inst(network& network, mutable_data_node const& node)

--- a/src/plugins/intel_gpu/src/graph/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/mvn.cpp
@@ -54,8 +54,8 @@ std::string mvn_inst::to_string(mvn_node const& node) {
     auto desc = node.get_primitive();
     auto epsilon = desc->epsilon;
     auto axes = desc->reduction_axes;
-    auto normalize_variance = desc->normalize_variance ? "true" : "false";
-    auto eps_inside_sqrt = desc->eps_inside_sqrt ? "true" : "false";
+    const auto *normalize_variance = desc->normalize_variance ? "true" : "false";
+    const auto *eps_inside_sqrt = desc->eps_inside_sqrt ? "true" : "false";
     auto& input = node.input();
 
     std::stringstream primitive_description;

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -79,18 +79,18 @@ void dump_perf_data_raw(std::string dump_path, bool per_iter_mode, const std::li
     std::ofstream of(dump_path);
     if (of.is_open()) {
         of << perf_raw_csv_header;
-        for (auto& inst : exec_order) {
+        for (const auto& inst : exec_order) {
             auto prim_id = inst->id();
-            auto& perf_data = inst->get_profiling_data();
-            auto& perf_info = inst->get_profiling_info();
+            const auto& perf_data = inst->get_profiling_data();
+            const auto& perf_info = inst->get_profiling_info();
             std::vector<size_t> sorted_entries;
             std::transform(perf_data.begin(), perf_data.end(), std::back_inserter(sorted_entries),
             [](const std::pair<size_t, std::tuple<int64_t, size_t>>& e) {
                 return e.first;
             });
             std::sort(sorted_entries.begin(), sorted_entries.end(), [&](size_t a, size_t b) -> bool {
-                auto& a_info = perf_info.at(a);
-                auto& b_info = perf_info.at(b);
+                const auto& a_info = perf_info.at(a);
+                const auto& b_info = perf_info.at(b);
 
                 if (a_info.stage != b_info.stage) {
                     return static_cast<std::underlying_type<instrumentation::pipeline_stage>::type>(a_info.stage) <
@@ -105,18 +105,18 @@ void dump_perf_data_raw(std::string dump_path, bool per_iter_mode, const std::li
 
                 size_t total_out_size_a = 0;
                 size_t total_out_size_b = 0;
-                for (auto& ol : a_info.output_layouts) {
+                for (const auto& ol : a_info.output_layouts) {
                     total_out_size_a += ol.count();
                 }
-                for (auto& ol : b_info.output_layouts) {
+                for (const auto& ol : b_info.output_layouts) {
                     total_out_size_b += ol.count();
                 }
                 return total_out_size_a < total_out_size_b;
             });
             for (auto& hash : sorted_entries) {
-                auto& key = perf_info.at(hash);
-                auto& entry = perf_data.at(hash);
-                auto& time = std::get<0>(entry);
+                const auto& key = perf_info.at(hash);
+                const auto& entry = perf_data.at(hash);
+                const auto& time = std::get<0>(entry);
                 auto num_iters = per_iter_mode ? key.iteration_num : std::get<1>(entry);
                 int64_t time_avg = per_iter_mode ? time : time / num_iters;
                 std::string net_in_l_str = layouts_to_str(key.network_input_layouts);
@@ -334,7 +334,7 @@ void network::preallocate_shape_info_buffers() {
     const int alignment = 512;
 
     for (auto const& prim : _exec_order) {
-        auto& node = prim->get_node();
+        const auto& node = prim->get_node();
         int64_t shape_elements = align_to(node.get_total_shape_info_size(), alignment);
         sum += shape_elements;
     }
@@ -346,7 +346,7 @@ void network::preallocate_shape_info_buffers() {
     _shape_info_ptr = engine.allocate_memory(layout{{sum}, data_types::i32, format::bfyx}, false);
     size_t offset = 0;
     for (auto const& prim : _exec_order) {
-        auto& node = prim->get_node();
+        const auto& node = prim->get_node();
         const int64_t shape_elements = node.get_total_shape_info_size();
 
         if (shape_elements == 0)
@@ -366,7 +366,7 @@ void network::set_arguments() {
     for (auto const& prim : _exec_order) {
         if (!prim->is_dynamic()) {
             bool can_set_args = true;
-            for (auto& dep : prim->dependencies()) {
+            for (const auto& dep : prim->dependencies()) {
                 // Skip set args for nodes with dynamic & optimized_out dependency
                 // This is needed to handle dynamic -> static cases like
                 // (dynamic) -> reshape -> (static) -> some_op
@@ -459,7 +459,7 @@ void network::calculate_weights_cache_capacity() {
     size_t total_const_size = 0;
     size_t weights_const_size = 0;
     size_t required_mem_size = 0;
-    for (auto node : _program->get_processing_order()) {
+    for (auto *node : _program->get_processing_order()) {
         if (node->is_type<fully_connected>() || node->is_type<convolution>() || node->is_type<deconvolution>())
             weights_const_size += get_buffer_size(*node);
         else if (node->is_type<data>())
@@ -489,18 +489,18 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
     const auto& mem_orig = p_inst->output_memory_ptr();
 
     auto add_mdata_chain = [&](primitive_inst* p_inst) {
-        auto mdata_ptr = dynamic_cast<mutable_data_inst*>(p_inst);
+        auto *mdata_ptr = dynamic_cast<mutable_data_inst*>(p_inst);
         if (!mdata_ptr)
             return;
         // special handling for mutable data, which can share
         // its attached memory with both its inputs and outputs
-        for (auto& dep : p_inst->dependencies()) {
+        for (const auto& dep : p_inst->dependencies()) {
             // check dependencies
             if (dep.first->outputs_allocated() && mem_orig && eng.is_the_same_buffer(*mem_orig, dep.first->output_memory())) {
                 chain.push_back(const_cast<primitive_inst*>(dep.first));
             }
             // then second order dependencies
-            for (auto& second_dep : dep.first->dependencies()) {
+            for (const auto& second_dep : dep.first->dependencies()) {
                 if (second_dep.first->outputs_allocated() && mem_orig && eng.is_the_same_buffer(*mem_orig, second_dep.first->output_memory())) {
                     chain.push_back(const_cast<primitive_inst*>(second_dep.first));
                 }
@@ -510,7 +510,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
         //then users
         const auto& user_ids = mdata_ptr->get_user_ids();
         for (const auto& id : user_ids) {
-            auto usr_prim = get_primitive(id).get();
+            auto *usr_prim = get_primitive(id).get();
             if (usr_prim->outputs_allocated() && mem_orig && eng.is_the_same_buffer(*mem_orig, usr_prim->output_memory())) {
                 chain.push_back(usr_prim);
             }
@@ -526,17 +526,17 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
 
     // find all dependencies that are 'optimized'
     while (!candidates.empty()) {
-        auto cand = candidates.top();
+        const auto *cand = candidates.top();
         candidates.pop();
         // Add cand inst to the chain when cand's output is not allocated yet.
         if (!p_inst->outputs_allocated()
             || (cand->outputs_allocated() && eng.is_the_same_buffer(*mem_orig, cand->output_memory()))) {
-            auto nc_cand = const_cast<primitive_inst*>(cand);
+            auto *nc_cand = const_cast<primitive_inst*>(cand);
             chain.push_back(nc_cand);
             add_mdata_chain(nc_cand);
         }
 
-        for (auto& dep : cand->dependencies()) {
+        for (const auto& dep : cand->dependencies()) {
             if (dep.first->can_be_optimized()) {
                 candidates.push(dep.first);
             } else {
@@ -545,7 +545,7 @@ network::output_chains_map::iterator network::add_output_chain(std::shared_ptr<p
                     // Add dep inst to the chain when dep's output is not allocated yet.
                     if (!p_inst->outputs_allocated()
                         || eng.is_the_same_buffer(*mem_orig, mem_dep)) {
-                        auto nc_dep = const_cast<primitive_inst*>(dep.first);
+                        auto *nc_dep = const_cast<primitive_inst*>(dep.first);
                         chain.push_back(nc_dep);
                         add_mdata_chain(nc_dep);
                     }
@@ -618,9 +618,9 @@ bool network::does_node_need_lockable_output(const primitive_id& id) const {
         }
 
         return false;
-    } else {
-        return prim_inst->get_impl() ? prim_inst->get_impl()->is_cpu() : true;
     }
+    return prim_inst->get_impl() ? prim_inst->get_impl()->is_cpu() : true;
+
 }
 
 std::string network::get_implementation_info(const primitive_id& id) const {
@@ -633,9 +633,9 @@ std::string network::get_implementation_info(const primitive_id& id) const {
                 if (_program != nullptr) {
                     const auto& node = it->second->get_node();
                     return kernel_name + "__" + dt_to_str(_program->get_inference_precision(node));
-                } else {
-                    return kernel_name;
                 }
+                return kernel_name;
+
             }
         }
     } catch (...) { }
@@ -657,7 +657,7 @@ layout network::get_output_layout(const primitive_id& output_id) const {
 void network::allocate_primitives() {
     GPU_DEBUG_DEFINE_MEM_LOGGER("allocate_primitives");
     const auto& ao = _program->get_allocating_order();
-    for (auto& node_id : ao) {
+    for (const auto& node_id : ao) {
         allocate_primitive_instance(_program->get_node(node_id));
     }
 
@@ -691,7 +691,7 @@ void network::configure_primitives_second_output() {
     GPU_DEBUG_DEFINE_MEM_LOGGER("configure_primitives_second_output");
     std::map<cldnn::memory::ptr, std::vector<const cldnn::program_node*>> mutable_datas_ptrs;
     for (auto& inst : _primitives) {
-        auto& node = inst.second->get_node();
+        const auto& node = inst.second->get_node();
 
         if (!node.is_type<mutable_data>())
             continue;
@@ -705,8 +705,8 @@ void network::configure_primitives_second_output() {
 
         auto is_first_node_input_md = [&](const cldnn::program_node* first,
                                           const cldnn::program_node* second) {
-            for (auto user : first->get_users()) {
-                for (auto next_user : user->get_users()) {
+            for (const auto *user : first->get_users()) {
+                for (const auto *next_user : user->get_users()) {
                     if (next_user == second)
                         return true;
                 }
@@ -735,7 +735,7 @@ void network::build_insts_deps() {
 void network::build_exec_order() {
     GPU_DEBUG_DEFINE_MEM_LOGGER("build_exec_order");
     if (!_is_dynamic) {
-        for (auto& node : _program->get_processing_order()) {
+        for (const auto& node : _program->get_processing_order()) {
             if (!node->is_type<data>() && !(node->is_type<mutable_data>() && node->get_dependencies().empty())) {
                 add_to_exec_order(node->id());
             }
@@ -748,11 +748,12 @@ void network::build_exec_order() {
             return (!node->is_type<data>() && !(node->is_type<mutable_data>() && node->get_dependencies().empty()) &&
                     node->get_users().size() == 1 && is_runtime_optimized_concat(node->get_users().front()));
         };
-        for (auto& node : _program->get_processing_order()) {
+        for (const auto& node : _program->get_processing_order()) {
             if (!node->is_type<data>() && !(node->is_type<mutable_data>() && node->get_dependencies().empty())) {
                 if (is_allowed_pred_for_runtime_optimized_concat(node)) {
                     continue;
-                } else if (is_runtime_optimized_concat(node)) {
+                }
+                if (is_runtime_optimized_concat(node)) {
                     // For in-place concat applied at runtime, we need to do update_shape for all other predecessors of the concat user.
                     // i.e., We need to make sure that all the preds of them are already updated too.
                     for (auto dep : node->get_dependencies()) {
@@ -771,8 +772,7 @@ bool network::contains_state(const std::string& variable_id) {
     auto it = _state_initializers.find(variable_id);
     if (it != _state_initializers.end())
         return true;
-    else
-        return false;
+    return false;
 }
 
 memory& network::get_output_remote_memory(const primitive_id& id) const {
@@ -784,8 +784,7 @@ bool network::has_output_remote_memory_ptr(const primitive_id& id) const {
     auto it = _output_remote_mem_ptrs.find(id);
     if (it != _output_remote_mem_ptrs.end())
         return true;
-    else
-        return false;
+    return false;
 }
 
 void network::reset_output_remote_memory_ptrs() {
@@ -1044,10 +1043,10 @@ const program::graph_optimizer_info& network::get_optimizer_passes_info() const 
 
 std::map<primitive_id, primitive_id> network::get_ext_id_mapping() const {
     std::map<primitive_id, primitive_id> result;
-    for (auto& prim : _primitives) {
+    for (const auto& prim : _primitives) {
         result.emplace(prim.first, prim.second->get_node().get_primitive()->origin_op_name);
     }
-    for (auto& opt_id : _program->get_optimized_out()) {
+    for (const auto& opt_id : _program->get_optimized_out()) {
         std::string ext_id = opt_id;
         if (opt_id.find(":") != std::string::npos) {
             ext_id = opt_id.substr(opt_id.find(":") + 1, opt_id.length());
@@ -1094,8 +1093,8 @@ void network::allocate_primitive_instance(program_node const& node) {
     auto inst = node.type()->create_instance(*this, node);
 
     std::function<bool(const program_node&)> is_mutable_input = [&is_mutable_input](const program_node& node) {
-        for (auto& dep : node.get_dependencies()) {
-            const auto dep_node = dep.first;
+        for (const auto& dep : node.get_dependencies()) {
+            auto *const dep_node = dep.first;
             if (dep_node->is_type<input_layout>() || dep_node->is_type<mutable_data>() || (dep_node->is_type<read_value>() && !dep_node->can_be_optimized())) {
                 return true;
             }

--- a/src/plugins/intel_gpu/src/graph/nodes_ordering.cpp
+++ b/src/plugins/intel_gpu/src/graph/nodes_ordering.cpp
@@ -13,7 +13,7 @@ namespace cldnn {
 void program::nodes_ordering::calc_processing_order_visit(program_node* node) {
     if (node->is_marked())
         return;
-    for (auto user : node->users) {
+    for (auto *user : node->users) {
         calc_processing_order_visit(user);
     }
     node->mark();
@@ -25,7 +25,7 @@ void program::nodes_ordering::calc_processing_order_visit(program_node* node) {
 // any topological sort of nodes is required for further optimizations
 void program::nodes_ordering::calc_processing_order(program& p) {
     _processing_order.clear();
-    for (auto input : p.get_inputs()) {
+    for (auto *input : p.get_inputs()) {
         calc_processing_order_visit(input);
     }
     for (auto& node : _processing_order) {
@@ -43,17 +43,17 @@ void program::nodes_ordering::calc_processing_order(program& p) {
 void program::nodes_ordering::calculate_BFS_processing_order() {
     GPU_DEBUG_DEFINE_MEM_LOGGER("calculate_BFS_processing_order");
     std::map<program_node*, int> distances;
-    for (auto itr : _processing_order) {
+    for (auto *itr : _processing_order) {
         distances[itr] = -1;
     }
     int max_distance = 0;
-    for (auto itr : _processing_order) {
+    for (auto *itr : _processing_order) {
         // Init
         if (distances[itr] == -1) {  // this must be an input
             distances[itr] = 0;      // initialize input
         }
         // RELAX
-        for (auto& user : itr->get_users()) {
+        for (const auto& user : itr->get_users()) {
             distances[user] = std::max(distances[user], distances[itr] + 1);
             max_distance = std::max(max_distance, distances[user]);
         }
@@ -62,7 +62,7 @@ void program::nodes_ordering::calculate_BFS_processing_order() {
     // bucket sort nodes based on their max distance from input
     std::vector<std::vector<program_node*>> dist_lists;
     dist_lists.resize(max_distance + 1);
-    for (auto itr : _processing_order) {
+    for (auto *itr : _processing_order) {
         dist_lists[distances[itr]].push_back(itr);
     }
 
@@ -79,7 +79,7 @@ void program::nodes_ordering::calculate_BFS_processing_order() {
 
 // verifies if a given node will be processed before all its dependent nodes
 bool program::nodes_ordering::is_correct(program_node* node) {
-    for (auto& dep : node->get_dependencies()) {
+    for (const auto& dep : node->get_dependencies()) {
         if (get_processing_number(node) < get_processing_number(dep.first)) {
             return false;
         }
@@ -91,7 +91,7 @@ void program::nodes_ordering::save(cldnn::BinaryOutputBuffer& ob) const {
     ob << _processing_order.size();
     auto itr = rbegin();
     while (itr != rend()) {
-        auto& node = *itr;
+        const auto& node = *itr;
         ob << node->id();
         itr++;
     }
@@ -106,7 +106,7 @@ void program::nodes_ordering::load(cldnn::BinaryInputBuffer& ib, program& p) {
         primitive_id node_id;
         ib >> node_id;
 
-        auto node = p.get_node_ptr(node_id).get();
+        auto *node = p.get_node_ptr(node_id).get();
         _processing_order.push_front(node);
         processing_order_iterators[node] = _processing_order.begin();
     }

--- a/src/plugins/intel_gpu/src/graph/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/non_max_suppression.cpp
@@ -102,11 +102,11 @@ std::vector<layout> non_max_suppression_gather_inst::calc_output_layouts(non_max
     auto desc = impl_param.typed_desc<non_max_suppression_gather>();
     std::vector<ShapeType> output_shapes = { ShapeType{}, ShapeType{}, ShapeType{} };
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
     if (memory_deps.count(2)) {
         auto third_output = memory_deps.at(2);
         cldnn::mem_lock<int32_t, mem_lock_type::read> third_output_lock(third_output, impl_param.get_stream());
-        auto third_output_data = third_output_lock.data();
+        auto *third_output_data = third_output_lock.data();
 
         output_shapes[0] = ShapeType{third_output_data[0], 3};
     } else {

--- a/src/plugins/intel_gpu/src/graph/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/non_zero.cpp
@@ -60,9 +60,9 @@ layout gather_nonzero_inst::calc_output_layout(gather_nonzero_node const& node, 
     if (impl_param.memory_deps.count(1)) {
         auto out_size = read_vector<int64_t>(impl_param.memory_deps.at(1), impl_param.get_stream());
         return layout{{rank, out_size[0], 1, 1}, cldnn::data_types::i32, cldnn::format::bfyx};
-    } else {
-        return layout{ov::PartialShape({ov::Dimension(rank), ov::Dimension::dynamic(), 1, 1}), cldnn::data_types::i32, cldnn::format::bfyx};
     }
+    return layout{ov::PartialShape({ov::Dimension(rank), ov::Dimension::dynamic(), 1, 1}), cldnn::data_types::i32, cldnn::format::bfyx};
+
 }
 
 template<typename ShapeType>
@@ -77,9 +77,9 @@ std::vector<layout> gather_nonzero_inst::calc_output_layouts(gather_nonzero_node
         // output shape of nonzero is [input_rank, count_non_zero]
         auto out_layout = layout{{rank, out_size[0]}, cldnn::data_types::i32, cldnn::format::bfyx};
         return {out_layout};
-    } else {
-        return {layout{ov::PartialShape({ov::Dimension(rank), ov::Dimension::dynamic()}), cldnn::data_types::i32, cldnn::format::bfyx}};
     }
+    return {layout{ov::PartialShape({ov::Dimension(rank), ov::Dimension::dynamic()}), cldnn::data_types::i32, cldnn::format::bfyx}};
+
 }
 
 std::string gather_nonzero_inst::to_string(gather_nonzero_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/normalize.cpp
+++ b/src/plugins/intel_gpu/src/graph/normalize.cpp
@@ -30,7 +30,7 @@ std::string normalize_inst::to_string(normalize_node const& node) {
     auto node_info = node.desc_to_json();
     auto desc = node.get_primitive();
     auto epsilon = desc->epsilon;
-    auto norm_region = desc->across_spatial ? "across spatial" : "within spatial";
+    const auto *norm_region = desc->across_spatial ? "across spatial" : "within spatial";
     auto& input = node.input();
     auto& scale_input = node.scale();
 

--- a/src/plugins/intel_gpu/src/graph/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/one_hot.cpp
@@ -66,7 +66,7 @@ std::vector<layout> one_hot_inst::calc_output_layouts(const one_hot_node& /*node
     };
 
     int64_t depth = desc->depth;
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
 
     std::unordered_map<size_t, ov::Tensor> const_data = {};
     if (depth != 0) {
@@ -76,7 +76,7 @@ std::vector<layout> one_hot_inst::calc_output_layouts(const one_hot_node& /*node
         auto depth_mem = memory_deps.at(1);
 
         cldnn::mem_lock<uint8_t, mem_lock_type::read> depth_lock(depth_mem, impl_param.get_stream());
-        auto depth_ptr = depth_lock.data();
+        auto *depth_ptr = depth_lock.data();
 
         // update depth_tensor if depth value comes from memory_deps instead of Constant node
         auto depth_tensor = make_tensor(depth_mem->get_layout(), depth_ptr);

--- a/src/plugins/intel_gpu/src/graph/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/permute.cpp
@@ -60,7 +60,7 @@ std::vector<layout> permute_inst::calc_output_layouts(permute_node const& node, 
 
     if (impl_param.has_fused_primitives()) {
         output_type = impl_param.get_output_element_type();
-        for (auto& desc : impl_param.fused_desc) {
+        for (const auto& desc : impl_param.fused_desc) {
             if (desc.is_type<reorder>()) {
                 output_fmt = desc.output_layout.format;
             }

--- a/src/plugins/intel_gpu/src/graph/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/pooling.cpp
@@ -258,7 +258,7 @@ template std::vector<layout> pooling_inst::calc_output_layouts<ov::PartialShape>
 std::string pooling_inst::to_string(pooling_node const& node) {
     auto desc = node.get_primitive();
     auto strd = desc->stride;
-    auto mode = desc->mode == pooling_mode::max ? "max" : "average";
+    const auto *mode = desc->mode == pooling_mode::max ? "max" : "average";
     auto node_info = node.desc_to_json();
     auto kernel_size = desc->size;
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -134,7 +134,7 @@ bool has_cpu_user_not_shape_of(const program_node* user) {
         }
         return false;
     }
-    if (auto impl = user->get_selected_impl())
+    if (auto *impl = user->get_selected_impl())
         // Use requires_lockable_input() rather than is_cpu() directly. Some impls are
         // registered as CPU but do not actually access their inputs from the host
         // (e.g. assign, which only enqueues USM memcpy).
@@ -349,7 +349,7 @@ void primitive_inst::update_shape() {
         update_state_layout(variable, new_layout, 0);
 
         if (prim->num_outputs > 1) {
-            if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+            if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                 _impl_params->state_layouts.resize(compressed_cache_variable->has_zp_state() ? 3 : 2);
 
                 auto scales_state = compressed_cache_variable->get_compression_scale_state();
@@ -412,7 +412,7 @@ void primitive_inst::update_shape() {
         : _deps[i].first->get_node().get_preferred_impl_type() == impl_types::cpu)) {
             bool can_skip = true;
             const auto& insts = _deps[i].first->_dependant_shape_of_insts;
-            for (auto& inst : insts) {
+            for (const auto& inst : insts) {
                 can_skip &= !inst->get_flag(ExecutionFlags::SHAPE_CHANGED);
             }
             if (can_skip)
@@ -512,7 +512,7 @@ void primitive_inst::update_shape() {
         // Custom output layout update as update_output_layout handles paddings incorrectly for optimized out read_value + kv_cache pattern
         _impl_params->output_layouts[0] = variable.get_layout();
 
-        if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+        if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
             _impl_params->output_layouts[1] = compressed_cache_variable->get_compression_scale_state()->get_layout();
 
             if (compressed_cache_variable->has_zp_state()) {
@@ -629,7 +629,7 @@ bool primitive_inst::need_reset_output_memory() const {
         const bool is_user_onednn_impl = user_inst->get_node().get_preferred_impl_type() == impl_types::onednn;
         const bool is_user_conv = user_inst->get_node().is_type<convolution>();
         if (dependency_idx == 0 && is_user_conv && is_user_onednn_impl) {
-            auto& conv_node = user_inst->get_node().as<convolution>();
+            const auto& conv_node = user_inst->get_node().as<convolution>();
             auto& output_layout = _impl_params->get_output_layout(0);
             auto in_channel_count = get_convolution_channel_count(conv_node, output_layout, true);
             // If the channel count is dynamic, we cannot verify feature alignment,
@@ -639,7 +639,7 @@ bool primitive_inst::need_reset_output_memory() const {
 
             auto get_feature_block_size = [](format fmt) {
                         int feature_block_size = 1;
-                        for (auto &e : fmt.block_sizes()) {
+                        for (const auto &e : fmt.block_sizes()) {
                             if (e.first == 1) {
                                 OPENVINO_ASSERT(feature_block_size == 1, "UNSUPPORTED: multi-blocking for feature axis is not considered");
                                 feature_block_size = e.second;
@@ -720,7 +720,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
 
     const auto& users = get_user_insts();
     if (users.size() == 1 && users.front()->get_node().is_type<concatenation>() && users.front()->get_node().is_runtime_skippable()) {
-        auto concat_inst = users.front();
+        auto *concat_inst = users.front();
         if (concat_inst->can_be_optimized()) {
             if (!concat_inst->_allocation_done_by_other) {
                 concat_inst->realloc_if_needed();
@@ -739,7 +739,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
     OPENVINO_ASSERT(actual_layouts[0].is_static(), "[GPU] Can't realloc mem for dynamic layout");
 
     if (users.size() == 1 && users.front()->get_node().is_type<reorder>() && users.front()->can_be_optimized()) {
-        auto reorder_inst = users.front();
+        auto *reorder_inst = users.front();
         if (reorder_inst->is_output()
             && reorder_inst->output_memory_ptr()
             && get_network().has_output_remote_memory_ptr(reorder_inst->id())
@@ -748,10 +748,10 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                 this->_outputs[0] = reorder_inst->_outputs[0];
                 GPU_DEBUG_TRACE_DETAIL << id() << ": use reorder user's remote tensor memory " << this->_outputs[0]->buffer_ptr() << std::endl;
                 return;
-            } else {
-                GPU_DEBUG_TRACE_DETAIL << reorder_inst->id() << " cannot be optimized for the mismatch between input layout and output layout" << std::endl;
-                reorder_inst->set_can_be_optimized(false);
             }
+            GPU_DEBUG_TRACE_DETAIL << reorder_inst->id() << " cannot be optimized for the mismatch between input layout and output layout" << std::endl;
+            reorder_inst->set_can_be_optimized(false);
+
         }
     }
 
@@ -798,8 +798,8 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
         dt_sizes_in_B.push_back(ov::element::Type(actual_layouts[i].data_type).size());
     }
     // read_value/assign nodes are supposed to always use variable memory
-    if (auto stateful_prim = dynamic_cast<memory_state::variable*>(this)) {
-        auto& variable_id = stateful_prim->variable_id();
+    if (auto *stateful_prim = dynamic_cast<memory_state::variable*>(this)) {
+        const auto& variable_id = stateful_prim->variable_id();
         auto& variable = get_network().get_variable(variable_id);
         if (get_node().is_type<kv_cache>()) {
             // Reuse state memory as output for kv cache if possible
@@ -812,7 +812,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
 
                 _outputs[0] = variable.get_memory();
 
-                if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+                if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                     _outputs[2] = compressed_cache_variable->get_compression_scale_state()->get_memory();
 
                     if (compressed_cache_variable->has_zp_state()) {
@@ -825,7 +825,8 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                     sp.predict_preallocation_shape(id(), _impl_params->output_layouts[j], true, j);
                 GPU_DEBUG_PROFILED_STAGE_MEMALLOC_INFO("can_be_optimized");
                 return;
-            } else if (_outputs[0] && variable.get_memory() && get_network().get_engine().is_the_same_buffer(*_outputs[0], *variable.get_memory())) {
+            }
+            if (_outputs[0] && variable.get_memory() && get_network().get_engine().is_the_same_buffer(*_outputs[0], *variable.get_memory())) {
                 GPU_DEBUG_TRACE_DETAIL << id() << " : realloc_if_needed: Reset output mem" << std::endl;
                 for (size_t j = 0; j < _impl_params->output_layouts.size(); ++j) {
                     _outputs[j] = nullptr;
@@ -840,7 +841,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                     _outputs[0] = variable.get_memory();
                     _max_output_layout_count[0] = variable.get_actual_mem_size() / dt_sizes_in_B[0];
 
-                    if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+                    if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                         _outputs[2] = compressed_cache_variable->get_compression_scale_state()->get_memory();
 
                         if (compressed_cache_variable->has_zp_state()) {
@@ -857,7 +858,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                                    << ", actual_size:" << variable.get_actual_mem_size() << " bytes"
                                    << ", variable layout:" << variable.get_layout().to_short_string() << ")" << std::endl;
 
-            if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+            if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                 compressed_cache_variable->get_compression_scale_state()->set_layout(_impl_params->output_layouts[1]);
 
                 if (compressed_cache_variable->has_zp_state()) {
@@ -870,7 +871,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
         if (can_be_optimized()) {
             _max_output_layout_count[0] = variable.get_actual_mem_size() / dt_sizes_in_B[0];
 
-            if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+            if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                 const size_t scale_idx = get_node().is_type<read_value>() ? 1 : 2; // kv_cache or read_value
                 _max_output_layout_count[scale_idx] = compressed_cache_variable->get_compression_scale_state()->get_actual_mem_size() / dt_sizes_in_B[1];
                 if (compressed_cache_variable->has_zp_state()) {
@@ -887,7 +888,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
     std::vector<cldnn::primitive_inst *> user_insts;
     {
         const auto& user_insts_origin = get_user_insts();
-        for (auto& user : user_insts_origin) {
+        for (const auto& user : user_insts_origin) {
             auto uid = user->id();
             if (user->get_node().is_type<fully_connected>() && user->is_dynamic() && user->_deps[0].first == this
                 && std::find_if(user_insts_origin.begin(), user_insts_origin.end(), [&](cldnn::primitive_inst * uu){
@@ -905,9 +906,9 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
         OPENVINO_ASSERT(user_insts.size() == user_insts_origin.size(), "Should have same size between ",
                         user_insts.size(), " and ", user_insts_origin.size());
     }
-    for (auto user : user_insts) {
+    for (auto *user : user_insts) {
         auto is_fused_prim_of_user = [&](primitive_id id) -> bool {
-            for (auto& p : user->get_node().get_fused_primitives()) {
+            for (const auto& p : user->get_node().get_fused_primitives()) {
                 if (p.has_outer_dep()) {
                     const auto start_idx = p.outer_dep_start_idx;
                     // exclude fused_node from total_num_deps
@@ -972,7 +973,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
     if (!get_node().is_type<concatenation>() && (get_node().is_runtime_skippable() || get_node().is_type<crop>())) {
         std::function<void(cldnn::primitive_inst*, cldnn::memory::ptr)> reset_user_output_memory
                             = [&](cldnn::primitive_inst* curr_inst, cldnn::memory::ptr target_mem_ptr) {
-            for (auto& user_inst : curr_inst->get_user_insts()) {
+            for (const auto& user_inst : curr_inst->get_user_insts()) {
                 auto curr_output_memory_ptr = user_inst->output_memory_ptr(0);
                 if (user_inst->can_be_optimized()
                         && (curr_output_memory_ptr
@@ -995,7 +996,8 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                 reset_user_output_memory(this, dep_memory_ptr(0));
             }
             return;
-        } else if (_outputs[0] && dep_memory_ptr(0) &&
+        }
+        if (_outputs[0] && dep_memory_ptr(0) &&
                    get_network().get_engine().is_the_same_buffer(dep_memory(0), output_memory(0))) {
             if (mem_allocated()) {
                 get_network().get_memory_pool().release_memory(_outputs[0].get(),
@@ -1192,7 +1194,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                                                       sequence_axis,
                                                       "present_layout");
             if (max_pad > 0) {
-                if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+                if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                     auto present_scales_layout = _impl_params->output_layouts[2];
                     const auto sequence_axis = kv_cache_inst::get_scale_zp_sequence_axis();
 
@@ -1234,7 +1236,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                                        << " (is_set  = " << variable.is_set() << ") " << std::endl;
                 variable.set_memory(_outputs[0], present_layout);
 
-                if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+                if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                     auto present_scales_layout = _impl_params->output_layouts[2];
 
                     compressed_cache_variable->get_compression_scale_state()->set_memory(_outputs[2], present_scales_layout);
@@ -1250,7 +1252,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                                    << " (is_set  = " << variable.is_set() << ") " << std::endl;
             variable.set_layout(present_layout);
 
-            if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+            if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                 auto present_scales_layout = _impl_params->output_layouts[2];
 
                 compressed_cache_variable->get_compression_scale_state()->set_layout(present_scales_layout);
@@ -1363,7 +1365,7 @@ void primitive_inst::update_shape_info_tensor(const kernel_impl_params& params) 
     }
 
     mem_lock<int32_t> lock(_shape_info_memory, get_network().get_stream());
-    auto shape_info_ptr = lock.data();
+    auto *shape_info_ptr = lock.data();
     size_t offset = 0;
     for (size_t i = 0; i < get_node().get_dependencies().size(); i++) {
         GPU_DEBUG_TRACE_DETAIL << id() << " : update shape_info for input[" << i << "]" << std::endl;
@@ -1438,7 +1440,7 @@ void primitive_inst::update_paddings() {
             while (inst) {
                 reset_pad(*inst->_impl_params, inst->_node);
                 if (inst == this) {
-                    if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+                    if (auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                         const size_t scale_idx = get_node().is_type<read_value>() ? 1 : 2;
                         reset_pad(*inst->_impl_params, inst->_node, scale_idx);
                         if (compressed_cache_variable->has_zp_state()) {
@@ -1446,7 +1448,7 @@ void primitive_inst::update_paddings() {
                         }
                     }
                 }
-                auto& users = inst->get_node().get_users();
+                const auto& users = inst->get_node().get_users();
                 if (users.size() == 1 && users.front()->get_output_layout(0).data_padding.is_dynamic()) {
                     inst = inst->get_user_insts().front();
                 } else {
@@ -1465,7 +1467,7 @@ void primitive_inst::update_paddings() {
         return;
     }
     // Reset paddings used in the previous iteration for crop before executing do_runtime_in_place_crop
-    for (auto u : get_user_insts()) {
+    for (auto *u : get_user_insts()) {
         if (u->get_node().is_type<crop>() && u->_impl_params->output_layouts[0].data_padding.is_dynamic()) {
             if (u->get_node().can_be_optimized()) {
                 reset_pad(*u->_impl_params, u->_node);
@@ -1486,7 +1488,7 @@ void primitive_inst::do_runtime_skip_reorder() {
         return;
 
     // set successive reorder can_be_optimized if layouts are same
-    for (auto u : get_user_insts()) {
+    for (auto *u : get_user_insts()) {
         if (u->get_node().is_type<reorder>()) {
             if (u->get_node().can_be_optimized() && u->get_node().is_runtime_skippable()) {
                 auto out_port_idx = u->get_node().get_dependency_with_port(0).second;
@@ -1581,7 +1583,7 @@ void primitive_inst::do_runtime_in_place_kv_cache() {
         variable.set_layout(present_layout);
 
         if (desc->compressed) {
-            auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
+            auto *compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
             OPENVINO_ASSERT(compressed_cache_variable != nullptr, "[GPU] compressed_cache_variable is null");
             auto& present_scales_layout = _impl_params->output_layouts[2];
             const auto sequence_axis = kv_cache_inst::get_scale_zp_sequence_axis();
@@ -1804,7 +1806,7 @@ void primitive_inst::do_runtime_in_place_concat() {
     }
     if (get_users().size() != 1) return;
 
-    auto concat_inst = get_user_insts().front();
+    auto *concat_inst = get_user_insts().front();
 
     if (!concat_inst->get_node().is_type<concatenation>() || !(concat_inst->get_node().can_be_optimized() && concat_inst->get_node().is_runtime_skippable()))
         return;
@@ -1821,7 +1823,7 @@ void primitive_inst::do_runtime_in_place_concat() {
 
     GPU_DEBUG_TRACE_DETAIL << "[In place concat] Preparing for runtime buffer fusing" << std::endl;
     // Do shape_infer for all concat's preds and concat
-    for (auto pred : concat_preds) {
+    for (auto *pred : concat_preds) {
         if (!pred->_update_shape_done_by_other) {
             GPU_DEBUG_TRACE_DETAIL << "[In place concat] update shape for " << pred->id() << std::endl;
             pred->update_shape();
@@ -1916,7 +1918,7 @@ void primitive_inst::do_runtime_in_place_crop() {
         return;
     }
 
-    for (auto u : get_user_insts()) {
+    for (auto *u : get_user_insts()) {
         if (u->get_node().is_type<crop>()) {
             if (u->get_node().can_be_optimized()) {
                 GPU_DEBUG_TRACE_DETAIL << "[In place crop] update shape for " << u->id() << std::endl;
@@ -1927,7 +1929,7 @@ void primitive_inst::do_runtime_in_place_crop() {
                 std::pair<const program_node*, layout> user_info;
                 if (crop_users.front()->get_node().is_type<reshape>()) {
                     OPENVINO_ASSERT(crop_users.size() == 1, "[GPU] Expected number of reshape users is 1, but it is ", crop_users.size());
-                    auto reshape_inst = crop_users.front();
+                    auto *reshape_inst = crop_users.front();
                     if (!reshape_inst->_update_shape_done_by_other) {
                         GPU_DEBUG_TRACE_DETAIL << "[In place crop] update shape for " << reshape_inst->id() << std::endl;
                         reshape_inst->update_shape();
@@ -1963,7 +1965,7 @@ void primitive_inst::do_runtime_in_place_crop() {
                         continue;
                     }
                     if (user_info.first) {
-                        auto reshape_inst = crop_users.front();
+                        auto *reshape_inst = crop_users.front();
                         reshape_inst->_impl_params->output_layouts[0] = user_info.second;
                         reshape_inst->set_flag(ExecutionFlags::SHAPE_CHANGED);
                     }
@@ -2171,11 +2173,12 @@ void primitive_inst::prepare_primitive() {
 
     std::function<bool(const cldnn::primitive_inst*)> has_dynamic_dependencies_insts =
         [&has_dynamic_dependencies_insts](const cldnn::primitive_inst* prim_inst) {
-        for (auto& dep : prim_inst->_deps) {
+        for (const auto& dep : prim_inst->_deps) {
             const cldnn::primitive_inst* dep_inst = dep.first;
             if (dep_inst->get_flag(ExecutionFlags::MEMORY_CHANGED)) {
                 return true;
-            } else if (dep_inst->can_be_optimized()) {
+            }
+            if (dep_inst->can_be_optimized()) {
                 if (has_dynamic_dependencies_insts(dep_inst)) {
                     return true;
                 }
@@ -2333,7 +2336,7 @@ void primitive_inst::build_deps() {
 
 void primitive_inst::configure_shape_of_dependencies() {
     if (_dependant_shape_of_insts.empty()) {
-        for (auto shape_of : get_node().get_dependant_shape_of_nodes()) {
+        for (const auto *shape_of : get_node().get_dependant_shape_of_nodes()) {
             _dependant_shape_of_insts.push_back(get_network().get_primitive(shape_of->id()).get());
         }
     }
@@ -2423,7 +2426,7 @@ primitive_inst::primitive_inst(network & network, program_node const& node, bool
             // but kernels always write both outputs to the same memory object which leads to wrong result.
             if (user_count == 1 && mutable_data_count == 1 && !node.is_type<arg_max_min>() &&
                 !node.is_type<experimental_detectron_roi_feature_extractor>()) {
-                for (auto& user : node.get_users())
+                for (const auto& user : node.get_users())
                     if (user->is_type<mutable_data>())
                         _outputs[0] = user->as<mutable_data>().get_attached_memory_ptr();
             } else {
@@ -2579,13 +2582,15 @@ void primitive_inst::update_weights() {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
             GPU_DEBUG_TRACE_DETAIL << id() << ": reuse weights for " << expected_layout.to_short_string() << std::endl;
             return;
-        } else if (original_layout.compatible(expected_layout)) {
+        }
+        if (original_layout.compatible(expected_layout)) {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(true);
             GPU_DEBUG_TRACE_DETAIL << id() << ": reinterpret original weights memory from " << original_layout.to_short_string()
                                            << " to " << expected_layout.to_short_string() << std::endl;
             _reordered_weights_cache.add(expected_layout, engine.reinterpret_buffer(*original_weights_memory, expected_layout));
             return;
-        } else {
+        }
+        {
             GPU_DEBUG_PROFILED_STAGE_CACHE_HIT(false);
             auto& cache = get_network().get_program()->get_implementations_cache();
             auto reorder_inst = std::make_shared<cldnn::reorder_inst>(get_network());
@@ -2640,7 +2645,7 @@ void primitive_inst::update_weights() {
             args.inputs.push_back(original_weights_memory);
             args.outputs.push_back(weights_memory);
 
-            auto reorder_impl = reorder_inst->get_impl();
+            auto *reorder_impl = reorder_inst->get_impl();
             reorder_impl->set_arguments(*reorder_inst, args);
             add_dep_event(reorder_impl->execute({}, *reorder_inst));
 
@@ -2658,10 +2663,11 @@ void primitive_inst::update_weights() {
 }
 
 static bool user_requesting_mem_reuse_false(const program_node& node) {
-    for (auto& user : node.get_users()) {
+    for (const auto& user : node.get_users()) {
         if ((user->get_selected_impl() != nullptr) && (user->get_selected_impl()->can_reuse_memory == false)) {
             return true;
-        } else if (user->get_selected_impl() == nullptr) {
+        }
+        if (user->get_selected_impl() == nullptr) {
             if (user->is_dynamic()) {
                 return true;
             }
@@ -2749,27 +2755,26 @@ memory::ptr primitive_inst::allocate_output(engine& _engine,
                                         memory_dependencies,
                                         reset,
                                         curr_memory);
-        } else {
-            if ((node.is_output() && is_reorder_weights) || (!node.is_output() && node.is_type<input_layout>()))
-                reset = false;
-            GPU_DEBUG_LOG << "[" << node.id() << ": constant]" << std::endl;
-            return _engine.allocate_memory(layout, alloc_type, reset);
         }
-    } else if (!node.can_share_buffer() || impl_params.can_be_optimized() || node.is_output()) {
+        if ((node.is_output() && is_reorder_weights) || (!node.is_output() && node.is_type<input_layout>()))
+            reset = false;
+        GPU_DEBUG_LOG << "[" << node.id() << ": constant]" << std::endl;
+        return _engine.allocate_memory(layout, alloc_type, reset);
+    }
+    if (!node.can_share_buffer() || impl_params.can_be_optimized() || node.is_output()) {
         GPU_DEBUG_LOG << "[" << node.id() << ": output]" << std::endl;
         return _engine.allocate_memory(layout, alloc_type, reset);
-    } else {
-        return get_memory_from_pool(_engine,
-                                    net_id,
-                                    pool,
-                                    node,
-                                    layout,
-                                    alloc_type,
-                                    reusable_across_network,
-                                    memory_dependencies,
-                                    reset,
-                                    curr_memory);
     }
+    return get_memory_from_pool(_engine,
+                                net_id,
+                                pool,
+                                node,
+                                layout,
+                                alloc_type,
+                                reusable_across_network,
+                                memory_dependencies,
+                                reset,
+                                curr_memory);
 }
 
 std::vector<memory::ptr> primitive_inst::allocate_outputs(kernel_impl_params* updated_params, bool reset_mem, bool runtime_alloc) {
@@ -2782,7 +2787,7 @@ std::vector<memory::ptr> primitive_inst::allocate_outputs(kernel_impl_params* up
         if (out_layouts[i].is_dynamic() && !out_layouts[i].has_upper_bound()) {
             outputs.push_back(memory::ptr());
         } else {
-            auto current_memory_ptr = _outputs.size() > i ? output_memory_ptr(i).get() : nullptr;
+            auto *current_memory_ptr = _outputs.size() > i ? output_memory_ptr(i).get() : nullptr;
             auto is_output = is_output_buffer(this, runtime_alloc);
 
             outputs.push_back(allocate_output(get_network().get_engine(),
@@ -2805,7 +2810,7 @@ std::vector<memory::ptr> primitive_inst::allocate_outputs(kernel_impl_params* up
 std::vector<primitive_inst*> primitive_inst::build_exec_deps(std::vector<std::pair<primitive_inst*, int32_t>> const& deps) {
     std::vector<primitive_inst*> exec_deps;
     exec_deps.reserve(deps.size());
-    for (auto& dep : deps)
+    for (const auto& dep : deps)
         if (dep.first->get_impl() != nullptr || dep.first->is_dynamic())
             exec_deps.push_back(dep.first);
 
@@ -2855,7 +2860,7 @@ cldnn::network::ptr primitive_inst::get_unfused_subgraph() {
         //   Name has postfix of port number for multi-port connection case (such as dynamic_quantization)
         auto prim_of_fused_node = _impl_params->desc->clone();
         size_t dep_idx = 0;
-        for (auto& dep : get_node().get_dependencies()) {
+        for (const auto& dep : get_node().get_dependencies()) {
             cldnn::primitive_id dep_id = dep.first->id();
 
             // Update name to have port number as postfix
@@ -2970,7 +2975,7 @@ bool primitive_inst::is_valid_fusion() const {
     if (fuse_descriptors.empty())
         return true;
     std::vector<fused_primitive_desc> fused_eltwise_prims;
-    for (auto& fd : fuse_descriptors) {
+    for (const auto& fd : fuse_descriptors) {
         if (fd.is_type<eltwise>() || fd.is_type<activation>()) {
             fused_eltwise_prims.push_back(fd);
         } else {
@@ -2983,8 +2988,7 @@ bool primitive_inst::is_valid_fusion() const {
                 // TODO : support ref kernel too
                 if (get_node().get_selected_impl()->get_kernel_name().find("fully_connected_gpu_bf_tiled") != std::string::npos)
                     return true;
-                else
-                    LOG_AND_RETURN_FALSE(_node);
+                LOG_AND_RETURN_FALSE(_node);
             }
 
             OPENVINO_THROW("[GPU] Unsupported fused operation in dynamic shape: type=", fd.desc->type_string(), ", id=", fd.desc->id);
@@ -3124,7 +3128,7 @@ std::shared_ptr<primitive_impl> ImplementationsFactory::get_primitive_impl_for_p
         return nullptr;
     };
 
-    const auto node = &inst.get_node();
+    const auto *const node = &inst.get_node();
     auto& prog = *inst.get_network().get_program();
     auto& kernels_cache = prog.get_kernels_cache();
 

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -442,7 +442,7 @@ std::vector<layout> prior_box_inst::calc_output_layouts(prior_box_node const& /*
     std::vector<ShapeType> output_shapes = {ShapeType()};
     std::unordered_map<size_t, ov::Tensor> const_data;
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
 
     if (memory_deps.count(0) && memory_deps.count(1)) {
         auto output_size_mem = memory_deps.at(0);
@@ -453,7 +453,7 @@ std::vector<layout> prior_box_inst::calc_output_layouts(prior_box_node const& /*
 
         const_data.emplace(0, make_tensor(output_size_mem->get_layout(), output_size_lock.data()));
 
-        auto p_param = const_cast<kernel_impl_params*>(&impl_param);
+        auto *p_param = const_cast<kernel_impl_params*>(&impl_param);
         if (output_size_mem->get_layout().data_type == cldnn::data_types::i64) {
             auto output_height = reinterpret_cast<int64_t*>(output_size_lock.data())[0];
             auto output_width = reinterpret_cast<int64_t*>(output_size_lock.data())[1];
@@ -524,9 +524,9 @@ template std::vector<layout> prior_box_inst::calc_output_layouts<ov::PartialShap
 
 std::string prior_box_inst::to_string(prior_box_node const& node) {
     auto desc = node.get_primitive();
-    auto flip = desc->flip ? "true" : "false";
-    auto clip = desc->clip ? "true" : "false";
-    auto scale_all_sizes = desc->scale_all_sizes ? "true" : "false";
+    const auto *flip = desc->flip ? "true" : "false";
+    const auto *clip = desc->clip ? "true" : "false";
+    const auto *scale_all_sizes = desc->scale_all_sizes ? "true" : "false";
     auto node_info = node.desc_to_json();
 
     std::string str_min_sizes = vector_to_string(desc->min_sizes);

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -180,12 +180,13 @@ program::program(engine& engine_ref,
         if (_is_body_program) {
             // To skip empty if (condition) subgraph
             bool can_be_optimized = true;
-            for (auto& node : processing_order) {
+            for (const auto& node : processing_order) {
                 if (node->is_type<input_layout>()) {
                     continue;
-                } else if (node->is_type<data>()) {
+                }
+                if (node->is_type<data>()) {
                     continue;
-                } else if (node->is_output() && node->is_type<reorder>() && !node->has_fused_primitives() &&
+                } if (node->is_output() && node->is_type<reorder>() && !node->has_fused_primitives() &&
                       node->get_input_layout(0).data_type == node->get_output_layouts(false)[0].data_type &&
                       node->get_input_layout(0).format == node->get_output_layouts(false)[0].format &&
                       node->get_input_layout(0).get_partial_shape().size() == node->get_output_layouts(false)[0].get_partial_shape().size()) {
@@ -441,7 +442,7 @@ void program::prepare_nodes(topology const& topology) {
         get_or_create(prim.second);
     }
     for (const auto& node : nodes_map) {
-        auto node_ptr = node.second.get();
+        auto *node_ptr = node.second.get();
         if (node_ptr == nullptr)
             throw std::runtime_error("NULL pointer in nodes_map.");
         add_node_dependencies(node_ptr);
@@ -527,7 +528,7 @@ void program::init_graph() {
     apply_opt_pass<graph_initializations>();
 
     apply_opt_pass<mark_nodes>();
-    for (auto& node : processing_order) {
+    for (const auto& node : processing_order) {
         if (!node->is_type<data>())
             node->get_output_layouts();
     }
@@ -650,7 +651,7 @@ void program::mark_if_constant(program_node& node) {
         return;
     }
     node.constant = true;
-    for (auto& dep : node.get_dependencies()) {
+    for (const auto& dep : node.get_dependencies()) {
         if (!dep.first->is_constant()) {
             node.constant = false;
             return;
@@ -727,7 +728,7 @@ void program::transfer_memory_to_device() {
         // TODO: Do we need finish call here? Maybe call it in network::execute() ?
         get_stream().finish();
     };
-    for (auto& node : processing_order) {
+    for (const auto& node : processing_order) {
         if (node->is_shape_infer_dep()) {
             continue;
         }
@@ -786,7 +787,7 @@ const std::vector<primitive_id>& program::get_allocating_order(bool forced_updat
 
     std::vector<std::shared_ptr<program_node>> nodes_to_allocate{};
     auto& po = get_processing_order();
-    for (auto node : po) {
+    for (auto *node : po) {
         nodes_to_allocate.push_back(get_node_ptr(node->id()));
     }
 
@@ -828,7 +829,7 @@ const std::vector<primitive_id>& program::get_allocating_order(bool forced_updat
 void program::prepare_memory_dependencies() {
     if (!_config.get_enable_memory_pool())
         return;
-    for (auto& node : get_processing_order()) {
+    for (const auto& node : get_processing_order()) {
         node->add_memory_dependency(*node);
     }
     apply_opt_pass<basic_memory_dependencies>();
@@ -840,7 +841,7 @@ std::string program::get_memory_dependencies_string() const {
     std::string mem_dep = "Memory dependencies/restrictions:\n";
     auto itr = processing_order.begin();
     while (itr != processing_order.end()) {
-        auto& node = *itr;
+        const auto& node = *itr;
         itr++;
         mem_dep = mem_dep.append("primitive: ")
                          .append(node->id())
@@ -900,8 +901,7 @@ bool program::contains_state(const std::string& variable_id) {
     auto it = state_initializers.find(variable_id);
     if (it != state_initializers.end())
         return true;
-    else
-        return false;
+    return false;
 }
 
 program_node& program::get_or_create(std::shared_ptr<primitive> prim) {
@@ -943,7 +943,7 @@ void program::add_intermediate(program_node& node,
     if (move_usrs_of_prev_to_node) {
         auto itr = prev.get_users().begin();
         while (itr != prev.get_users().end()) {
-            auto usr = *itr;
+            auto *usr = *itr;
             itr++;
             if (usr->id() != node.id())
                 usr->replace_dependency(prev, node);
@@ -1052,7 +1052,7 @@ void program::replace_all_usages(program_node& old_node, std::pair<program_node*
     const std::list<program_node*> users(old_node.users);
     auto itr = users.begin();
     while (itr != users.end()) {
-        auto user = *(itr++);
+        auto *user = *(itr++);
         user->replace_dependency(old_node, new_node, remove_if_dangling);
     }
 }
@@ -1367,7 +1367,7 @@ data_types program::get_inference_precision(const program_node& node) const {
         return node.get_output_layout().data_type;
     }
     std::vector<data_types> input_dts;
-    for (auto& dep : node.get_dependencies()) {
+    for (const auto& dep : node.get_dependencies()) {
         if (dep.first->is_valid_output_layout())
             input_dts.push_back(dep.first->get_output_layout().data_type);
     }
@@ -1382,25 +1382,27 @@ data_types program::get_inference_precision(const program_node& node) const {
     if (node.is_type<reorder>()) {
         // If reorder has different input/output types - pick the max one as runtime precision
         return data_type_traits::max_type(input_dts[0], output_dt);
-    } else if (node.is_type<quantize>()) {
+    }
+    if (node.is_type<quantize>()) {
         if (data_type_traits::is_quantized(output_dt))
             return output_dt;
         return data_type_traits::max_type(input_dts[0], output_dt);
-    } else if (node.is_type<eltwise>()) {
+    } if (node.is_type<eltwise>()) {
         auto max_dt = input_dts[0];
         for (size_t i = 1; i < input_dts.size(); i++) {
             max_dt = data_type_traits::max_type(max_dt, input_dts[i]);
         }
         return max_dt;
-    } else if (node.is_type<convolution>() || node.is_type<deconvolution>() || node.is_type<fully_connected>() || node.is_type<gemm>()) {
+    }
+    if (node.is_type<convolution>() || node.is_type<deconvolution>() || node.is_type<fully_connected>() || node.is_type<gemm>()) {
         if (input_dts.size() < 2) {
             throw std::runtime_error("[clDNN] Invalid inputs count in node " + node.id() + " during stage info collection. Expected >= 2 inputs");
         }
         if (data_type_traits::is_quantized(input_dts[0]) && data_type_traits::is_quantized(input_dts[1])) {
             return input_dts[0];
-        } else {
-            return data_type_traits::max_type(input_dts[0], input_dts[1]);
         }
+        return data_type_traits::max_type(input_dts[0], input_dts[1]);
+
     }
 
     return input_dts[0];
@@ -1409,7 +1411,7 @@ data_types program::get_inference_precision(const program_node& node) const {
 std::string program::get_implementation_info(const primitive_id& id) const {
     try {
         const auto& node = get_node(id);
-        auto impl = node.get_selected_impl();
+        auto *impl = node.get_selected_impl();
         auto kernel_name = impl ? impl->get_kernel_name() : "";
         return !kernel_name.empty() ? (kernel_name + "__" + dt_to_str(get_inference_precision(node))) : "undef";
     } catch (...) { }
@@ -1422,7 +1424,7 @@ program::primitives_info program::get_current_stage_info() const {
 
     // Get info for actually executed graph nodes
     int exec_id = 0;
-    for (auto& p : get_processing_order()) {
+    for (const auto& p : get_processing_order()) {
         std::vector<primitive_id> users;
         for (auto& user : p->users) {
             users.push_back(user->id());
@@ -1433,8 +1435,8 @@ program::primitives_info program::get_current_stage_info() const {
         }
 
         std::vector<primitive_id> fused;
-        for (auto& op_prim : optimized) {
-            for (auto& fused_to : op_prim.second) {
+        for (const auto& op_prim : optimized) {
+            for (const auto& fused_to : op_prim.second) {
                 if (p->id() == fused_to) {
                     fused.push_back(op_prim.first);
                 }
@@ -1531,7 +1533,7 @@ void program::set_layout_optimizer_attributes(layout_optimizer& lo) {
                                                                               cldnn::reorder::type_id(),
                                                                               cldnn::eltwise::type_id()};
 #endif
-    for (auto& node : get_processing_order()) {
+    for (const auto& node : get_processing_order()) {
         auto &prim = *node;
         if (prim.type() == cldnn::convolution::type_id()) {
             auto &conv = prim.as<convolution>();
@@ -1800,7 +1802,7 @@ std::pair<int64_t, int64_t> program::get_estimated_device_mem_usage() {
     }
 #endif
     std::vector<program_node*> nodes_to_allocate{};
-    for (auto node : processing_order) {
+    for (auto *node : processing_order) {
         nodes_to_allocate.push_back(node);
     }
 
@@ -1874,7 +1876,7 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     std::map<cldnn::memory::ptr, std::vector<const cldnn::program_node*>> mutable_datas_ptrs;
     ob << nodes_map.size();
 
-    for (auto& node : nodes_map) {
+    for (const auto& node : nodes_map) {
         ob.setKernelImplParams(node.second->get_kernel_impl_params().get());
 
         if (node.second->is_type<data>() && node.second->as<data>().get_primitive()->mem == nullptr) {
@@ -1882,9 +1884,9 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
             if (data_node.get_attached_memory_ptr() == nullptr) {
                 ob << false;
                 continue;
-            } else {
-                node.second->as<data>().typed_desc()->mem = data_node.get_attached_memory_ptr();
             }
+            node.second->as<data>().typed_desc()->mem = data_node.get_attached_memory_ptr();
+
         }
 
         ob << true;
@@ -1910,22 +1912,22 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
         ob << shared_mem_pair.second;
     }
 
-    for (auto& node : nodes_map) {
+    for (const auto& node : nodes_map) {
         ob << node.first;
         node.second->save(ob);
         ob << node.second->get_dependant_shape_of_nodes().size();
-        for (auto& dep_node : node.second->get_dependant_shape_of_nodes()) {
+        for (const auto& dep_node : node.second->get_dependant_shape_of_nodes()) {
             ob << dep_node->id();
         }
     }
 
     ob << inputs.size();
-    for (auto& input : inputs) {
+    for (const auto& input : inputs) {
         ob << input->id();
     }
 
     ob << outputs.size();
-    for (auto& output : outputs) {
+    for (const auto& output : outputs) {
         ob << output->id();
     }
 
@@ -1939,7 +1941,7 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     {
         auto& kernels_cache = get_kernels_cache();
         std::vector<primitive_id> impl_ids;
-        for (auto& node : processing_order) {
+        for (const auto& node : processing_order) {
             if (node->get_selected_impl() != nullptr) {
                 impl_ids.emplace_back(node->id());
                 kernels_cache.add_to_cached_kernels(node->get_selected_impl()->get_kernels());
@@ -1958,12 +1960,12 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     }
 
     ob << optimized_out.size();
-    for (auto& opt_prim : optimized_out) {
+    for (const auto& opt_prim : optimized_out) {
         ob << opt_prim;
     }
 
     ob << prim_info.size();
-    for (auto& p_info : prim_info) {
+    for (const auto& p_info : prim_info) {
         ob << p_info.original_id;
         ob << p_info.type_id;
         ob << p_info.c_dependencies;
@@ -1983,11 +1985,11 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     }
 
     ob << state_initializers.size();
-    for (auto& state_initializer : state_initializers) {
+    for (const auto& state_initializer : state_initializers) {
         ob << state_initializer.first;
         ob << state_initializer.second;
     }
-    
+
     const auto& dev_info = get_engine().get_device_info();
     if (!ob.is_encrypted() && get_engine().can_use_host_usm_zero_copy()) {
         if (const auto pad = ov::util::align_padding_size(dev_info.cacheline_size.value_or(0), ob.get_offset()); pad > 0) {
@@ -2059,7 +2061,7 @@ void program::load(cldnn::BinaryInputBuffer& ib,
 
         std::shared_ptr<cldnn::primitive> prim;
         ib >> prim;
-        if (auto data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
+        if (auto *data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
             data_prim->load_weights(ib, weights_memory, host_buffer_base_ptr);
         }
         get_or_create(prim);

--- a/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_dump_graph.cpp
@@ -228,7 +228,7 @@ void dump_graph_init(std::ofstream& graph,
     };
 
     graph << "digraph cldnn_program {\n";
-    for (auto& node : program.get_processing_order()) {
+    for (const auto& node : program.get_processing_order()) {
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpotentially-evaluated-expression"
@@ -284,7 +284,7 @@ void dump_graph_init(std::ofstream& graph,
         // <user_node, user's input port>
         std::set<std::pair<program_node *, int>> marked_connection;
 
-        for (auto& user : node->get_users()) {
+        for (const auto& user : node->get_users()) {
             bool doubled = true;
             auto it = user->get_dependencies().begin();
             while (it != user->get_dependencies().end()) {
@@ -315,7 +315,7 @@ void dump_graph_init(std::ofstream& graph,
             graph << ";\n";
         }
 
-        for (auto& dep : node->get_dependencies()) {
+        for (const auto& dep : node->get_dependencies()) {
             if (std::find(dep.first->get_users().begin(), dep.first->get_users().end(), node) != dep.first->get_users().end()) {
                 continue;
             }
@@ -329,20 +329,20 @@ void dump_graph_init(std::ofstream& graph,
 }
 
 void dump_graph_processing_order(std::ofstream& graph, const program& program) {
-    for (auto node : program.get_processing_order())
+    for (auto *node : program.get_processing_order())
         graph << reinterpret_cast<uintptr_t>(node) << " (" << node->id() << ")\n";
     graph << '\n';
     close_stream(graph);
 }
 
 void dump_graph_optimized(std::ofstream& graph, const program& program) {
-    for (auto& prim_id : program.get_optimized_out()) graph << prim_id << "\n";
+    for (const auto& prim_id : program.get_optimized_out()) graph << prim_id << "\n";
     graph << '\n';
     close_stream(graph);
 }
 
 void dump_graph_info(std::ofstream& graph, const program& program) {
-    for (auto& node : program.get_processing_order()) {
+    for (const auto& node : program.get_processing_order()) {
         dump_full_node(graph, node);
         graph << std::endl << std::endl;
     }

--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -85,7 +85,7 @@ void onednn_add_fusing_helpers::for_eltwise(
     const program_node& node, eltwise_mode mode,
     std::function<void(const program_node& p_node,
                     const fused_primitive_desc& desc)> func) {
-    for (auto& fo : node.get_fused_primitives()) {
+    for (const auto& fo : node.get_fused_primitives()) {
         if (fo.is_type<eltwise>() && fo.typed_desc<eltwise>()->mode == mode) {
             func(node, fo);
         }
@@ -111,7 +111,7 @@ static bool is_direct_ancestor(const program_node& child, const program_node& ta
         return false;
 
     // Limit the iteration depth to 5 for performance reason
-    auto iter = &child;
+    const auto *iter = &child;
     for (int i = 0; i < 5; i++) {
         if (iter == &target)
             return true;
@@ -151,7 +151,8 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
             && !p_node.is_output()
             && !(dep_node.is_type<input_layout>() && dep_node.get_users().size() > 1)) {
             return add_fusing_type::sum;
-        } else if (p_layout.get_tensor() == d_layout.get_tensor()) {
+        }
+        if (p_layout.get_tensor() == d_layout.get_tensor()) {
             return add_fusing_type::binary_per_tensor;
         }
     }
@@ -161,7 +162,7 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
 
 int32_t onednn_add_fusing_helpers::get_reused_eltwmem_idx(const program_node& node) {
     if (node.get_preferred_impl_type() == impl_types::onednn) {
-        for (auto& fused_op : node.get_fused_primitives()) {
+        for (const auto& fused_op : node.get_fused_primitives()) {
             if (fused_op.is_type<eltwise>() && fused_op.deps.size() == 1) {
                 // If it is first sum, reuse the buffer
                 auto fusing_type = get_add_fusing_type(node, fused_op);

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -182,7 +182,7 @@ void program_node::replace_dependency(program_node const& old_dep, program_node&
 
 std::vector<primitive_id> program_node::get_dependencies_ids() const {
     std::vector<primitive_id> dep_ids;
-    for (auto& dependency : dependencies) dep_ids.push_back(dependency.first->get_primitive()->id);
+    for (const auto& dependency : dependencies) dep_ids.push_back(dependency.first->get_primitive()->id);
     return dep_ids;
 }
 
@@ -241,7 +241,7 @@ std::unique_ptr<json_composite> program_node::desc_to_json() const {
 
     json_composite fused_nodes_info;
     size_t index = 0;
-    for (auto& fused_desc : get_fused_primitives()) {
+    for (const auto& fused_desc : get_fused_primitives()) {
         json_composite fused_node_info;
         fused_node_info.add("id", fused_desc.desc->id);
         std::vector<primitive_id> dep_ids;
@@ -260,11 +260,11 @@ std::unique_ptr<json_composite> program_node::desc_to_json() const {
     node_info->add("fused primitives", fused_nodes_info);
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-    auto& onednn_post_ops = get_fused_primitives_onednn();
+    const auto& onednn_post_ops = get_fused_primitives_onednn();
     if (!onednn_post_ops.empty()) {
         size_t post_op_index = 0;
         json_composite post_ops_info;
-        for (auto& fused_prim_desc : onednn_post_ops) {
+        for (const auto& fused_prim_desc : onednn_post_ops) {
             json_composite post_op_info;
             post_op_info.add("post op", onednn_post_op_type_to_str(fused_prim_desc.op_type));
             post_op_info.add("memory dependency", fused_prim_desc.mem_dep);
@@ -334,7 +334,7 @@ std::unique_ptr<json_composite> program_node::desc_to_json() const {
     node_info->add("implementation", impls);
 
     std::vector<std::string> dependant_shape_of_nodes_ids;
-    for (auto shape_of : dependant_shape_of_nodes) {
+    for (const auto *shape_of : dependant_shape_of_nodes) {
         dependant_shape_of_nodes_ids.push_back(shape_of->id());
     }
     node_info->add("dependant_shape_of_nodes_ids", dependant_shape_of_nodes_ids);
@@ -350,11 +350,10 @@ void program_node::remove_dependency(program_node& node) {
 
 size_t program_node::get_user_index(const program_node& node) const {
     size_t idx = 0;
-    for (auto& user : users) {
+    for (const auto& user : users) {
         if (user == &node)
             return idx;
-        else
-            idx++;
+        idx++;
     }
 
     OPENVINO_THROW("[GPU] Search invalid user node" + node.id() + " node");
@@ -499,7 +498,7 @@ bool program_node::is_dynamic() const {
 }
 
 bool program_node::is_dynamic() {
-    for (auto& input : get_dependencies()) {
+    for (const auto& input : get_dependencies()) {
         if (input.first->is_dynamic_output_layout(input.second))
             return true;
     }
@@ -542,7 +541,7 @@ bool program_node::is_fused_dep(size_t dep_idx) const {
 }
 
 std::set<size_t> program_node::get_lockable_input_ids() const {
-    const auto impl = get_selected_impl();
+    auto *const impl = get_selected_impl();
     const bool has_cpu_impl = get_preferred_impl_type() == impl_types::cpu || (impl && impl->is_cpu());
     if (has_cpu_impl && !is_type<shape_of>()) {
         std::set<size_t> dependencies_indexes;
@@ -550,9 +549,9 @@ std::set<size_t> program_node::get_lockable_input_ids() const {
             dependencies_indexes.insert(i);
 
         return dependencies_indexes;
-    } else {
-        return {};
     }
+    return {};
+
 }
 
 std::map<size_t, memory::ptr> program_node::get_const_memory_deps() const {
@@ -577,7 +576,7 @@ std::map<size_t, memory::ptr> program_node::get_const_memory_deps() const {
 }
 
 void program_node::invalidate_users() const {
-    for (auto& user : users) {
+    for (const auto& user : users) {
         for (size_t i = 0; i < user->valid_output_layouts.size(); ++i) {
             if (user->valid_output_layouts[i]) {
                 if (user->get_preferred_output_fmt() != format::any)
@@ -624,7 +623,7 @@ bool program_node::is_padding_supported(int axis, int padding) const {
 }
 
 bool program_node::is_padded_spatial(size_t idx) const {
-    auto& layout = get_output_layout(idx);
+    const auto& layout = get_output_layout(idx);
     const auto& lower_size = layout.data_padding._lower_size;
     const auto& upper_size = layout.data_padding._upper_size;
     return std::any_of(std::begin(lower_size) + 2, std::begin(lower_size) + 2 + layout.get_spatial_rank(),
@@ -639,7 +638,7 @@ void program_node::set_selected_impl(std::unique_ptr<primitive_impl> impl) {
 
 bool program_node::need_lockable_memory() const {
     bool need_lockable_mem = get_users().empty() || std::any_of(get_users().begin(), get_users().end(), [](const program_node* n) {
-        auto impl = n->get_selected_impl();
+        auto *impl = n->get_selected_impl();
         return impl ? impl->is_cpu() : n->get_preferred_impl_type() == impl_types::cpu;
     });
 
@@ -728,7 +727,7 @@ void program_node::save(cldnn::BinaryOutputBuffer& ob) const {
     // fused_prims;
     {
         ob << fused_prims.size();
-        for (auto& f_desc : fused_prims) {
+        for (const auto& f_desc : fused_prims) {
             if (get_program().has_node(f_desc.desc->id)) {
                 ob << true;
                 ob << f_desc.desc->id;
@@ -797,12 +796,12 @@ void program_node::save(cldnn::BinaryOutputBuffer& ob) const {
             }
 
             ob << f_desc.deps.size();
-            for (auto& dep : f_desc.deps) {
+            for (const auto& dep : f_desc.deps) {
                 ob << dep.first;
                 ob << dep.second;
             }
             ob << f_desc.fused_deps.size();
-            for (auto& f_dep : f_desc.fused_deps) {
+            for (const auto& f_dep : f_desc.fused_deps) {
                 ob << f_dep.first;
                 ob << f_dep.second;
             }
@@ -927,7 +926,7 @@ void program_node::load(cldnn::BinaryInputBuffer& ib) {
 
             std::string f_param_type_str;
             ib >> f_param_type_str;
-            auto f_param_type = cldnn::prim_map_storage::instance().get_type_id(f_param_type_str);
+            auto *f_param_type = cldnn::prim_map_storage::instance().get_type_id(f_param_type_str);
             if (f_param_type == activation::type_id()) {
                 ib >> exist_prim;
                 std::shared_ptr<activation> param_desc;
@@ -1543,17 +1542,17 @@ void program_node::create_onednn_primitive_attributes(
     const auto& get_input_layout = [&](int32_t idx) -> cldnn::layout {
         if (impl_params != nullptr) {
             return impl_params->get_input_layout(idx);
-        } else {
-            return get_dependency(idx).get_output_layout();
         }
+        return get_dependency(idx).get_output_layout();
+
     };
 
     const auto& get_output_layout = [&]() -> cldnn::layout {
         if (impl_params != nullptr) {
             return impl_params->get_output_layout();
-        } else {
-            return this->get_output_layout();
         }
+        return this->get_output_layout();
+
     };
 
     // Add information about post-operation into the list, update indices
@@ -1590,7 +1589,7 @@ void program_node::create_onednn_primitive_attributes(
 
     int32_t num_sum_post_ops = 0;
     for (size_t idx = 0; idx < cldnn_post_ops.size(); idx++) {
-        auto& desc = cldnn_post_ops[idx];
+        const auto& desc = cldnn_post_ops[idx];
         if (desc.is_type<activation>()) {
             auto fused_desc = desc.typed_desc<activation>();
             if (fused_desc->activation_function == cldnn::activation_func::relu_negative_slope

--- a/src/plugins/intel_gpu/src/graph/proposal.cpp
+++ b/src/plugins/intel_gpu/src/graph/proposal.cpp
@@ -100,13 +100,13 @@ std::string proposal_inst::to_string(proposal_node const& node) {
 
     std::stringstream primitive_description;
 
-    auto swap_xy = desc->swap_xy ? "true" : "false";
-    auto initial_clip = desc->initial_clip ? "true" : "false";
-    auto round_ratios = desc->round_ratios ? "true" : "false";
-    auto shift_anchors = desc->shift_anchors ? "true" : "false";
-    auto clip_before_nms = desc->clip_before_nms ? "true" : "false";
-    auto clip_after_nms = desc->clip_after_nms ? "true" : "false";
-    auto for_deformable = desc->clip_after_nms ? "true" : "false";
+    const auto *swap_xy = desc->swap_xy ? "true" : "false";
+    const auto *initial_clip = desc->initial_clip ? "true" : "false";
+    const auto *round_ratios = desc->round_ratios ? "true" : "false";
+    const auto *shift_anchors = desc->shift_anchors ? "true" : "false";
+    const auto *clip_before_nms = desc->clip_before_nms ? "true" : "false";
+    const auto *clip_after_nms = desc->clip_after_nms ? "true" : "false";
+    const auto *for_deformable = desc->clip_after_nms ? "true" : "false";
 
     json_composite proposal_info;
     proposal_info.add("cls score", stringify_port(node.cls_score()));

--- a/src/plugins/intel_gpu/src/graph/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/quantize.cpp
@@ -32,7 +32,7 @@ std::string quantize_inst::to_string(quantize_node const& node) {
     auto& input_high = node.input(2);
     auto& output_low = node.input(3);
     auto& output_high = node.input(4);
-    auto scale_shift_opt = node.get_scale_shift_opt() ? "true" : "false";
+    const auto *scale_shift_opt = node.get_scale_shift_opt() ? "true" : "false";
 
     std::stringstream primitive_description;
 

--- a/src/plugins/intel_gpu/src/graph/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/random_uniform.cpp
@@ -32,7 +32,7 @@ std::vector<layout> random_uniform_inst::calc_output_layouts(random_uniform_node
                                             impl_param.get_input_layout(1).get_partial_shape(),
                                             impl_param.get_input_layout(2).get_partial_shape() };
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
     std::unordered_map<size_t, ov::Tensor> const_data;
 
     auto run_shape_infer = [&]() {
@@ -47,9 +47,9 @@ std::vector<layout> random_uniform_inst::calc_output_layouts(random_uniform_node
             const_data.emplace(2, make_tensor(max_val->get_layout(), max_val_lock.data()));
 
             return ov::op::v8::shape_infer(&op, input_shapes, ov::make_tensor_accessor(const_data));
-        } else {
-            return ov::op::v8::shape_infer(&op, input_shapes, ov::make_tensor_accessor(const_data));
         }
+        return ov::op::v8::shape_infer(&op, input_shapes, ov::make_tensor_accessor(const_data));
+
     };
 
     if (memory_deps.count(0) > 0) {

--- a/src/plugins/intel_gpu/src/graph/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/range.cpp
@@ -35,7 +35,7 @@ std::vector<layout> range_inst::calc_output_layouts(range_node const& /*node*/, 
     std::vector<ShapeType> input_shapes = {ov::Shape(), ov::Shape(), ov::Shape()};
 
     std::unordered_map<size_t, ov::Tensor> const_data;
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
 
     if (memory_deps.count(0) > 0 && memory_deps.count(1) > 0 && memory_deps.count(2) > 0) {
         auto start_mem = memory_deps.at(0);

--- a/src/plugins/intel_gpu/src/graph/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/read_value.cpp
@@ -60,7 +60,7 @@ void read_value_inst::update_output_memory() {
     GPU_DEBUG_TRACE_DETAIL << " - actual_size " << variable.get_actual_mem_size() << " bytes" << std::endl;
     set_output_memory(variable.get_memory(), false, 0);
 
-    if (auto compressed_cache_variable = dynamic_cast<const ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+    if (const auto *compressed_cache_variable = dynamic_cast<const ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
         auto scales_state = compressed_cache_variable->get_compression_scale_state();
         set_output_memory(scales_state->get_memory(), false, 1);
 

--- a/src/plugins/intel_gpu/src/graph/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/reduce.cpp
@@ -98,10 +98,9 @@ layout reduce_inst::calc_output_layout(reduce_node const& node, kernel_impl_para
 
     if (format_dim == 6)
         return layout{output_type, input_format, tensor(batch(in_dims[0]), feature(in_dims[1]), spatial(in_dims[2], in_dims[3], in_dims[4], in_dims[5]))};
-    else if (format_dim == 5)
+    if (format_dim == 5)
         return layout{output_type, input_format, tensor(batch(in_dims[0]), feature(in_dims[1]), spatial(in_dims[2], in_dims[3], in_dims[4]))};
-    else
-        return layout{output_type, input_format, tensor(batch(in_dims[0]), feature(in_dims[1]), spatial(in_dims[2], in_dims[3]))};
+    return layout{output_type, input_format, tensor(batch(in_dims[0]), feature(in_dims[1]), spatial(in_dims[2], in_dims[3]))};
 }
 
 template<typename ShapeType>

--- a/src/plugins/intel_gpu/src/graph/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/region_yolo.cpp
@@ -27,15 +27,15 @@ layout region_yolo_inst::calc_output_layout(region_yolo_node const& node, kernel
                    input_layout.feature() * input_layout.spatial(0) * input_layout.spatial(1),
                    1,
                    1));
-    } else {
-        tensor::value_type features = static_cast<tensor::value_type>(desc->mask_size) *
-                                     (static_cast<tensor::value_type>(desc->classes) +
-                                      static_cast<tensor::value_type>(desc->coords) + 1);
-        return cldnn::layout(
-            input_layout.data_type,
-            input_layout.format,
-            tensor(input_layout.batch(), features, input_layout.spatial(0), input_layout.spatial(1)));
     }
+    tensor::value_type features = static_cast<tensor::value_type>(desc->mask_size) *
+                                 (static_cast<tensor::value_type>(desc->classes) +
+                                  static_cast<tensor::value_type>(desc->coords) + 1);
+    return cldnn::layout(
+        input_layout.data_type,
+        input_layout.format,
+        tensor(input_layout.batch(), features, input_layout.spatial(0), input_layout.spatial(1)));
+
 }
 
 template<typename ShapeType>

--- a/src/plugins/intel_gpu/src/graph/registry/detection_output_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/detection_output_impls.cpp
@@ -49,16 +49,7 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<detec
                 auto prim = detection_output_node.get_primitive();
                 if (confidence_layout.is_dynamic()) {
                     return false;
-                } else {
-                    auto batch_size_limitations = (device_info.supports_immad && device_info.execution_units_count >= 256) ?
-                                                    true : confidence_layout.batch() >= 4;
-                    auto can_use_ocl_impl = confidence_layout.batch() <= lws_max &&
-                                            batch_size_limitations &&
-                                            prim->confidence_threshold >= 0.1 &&
-                                            prim->top_k <= 400 && prim->num_classes >= 16 &&
-                                            confidence_layout.feature() > 10000;
-                    return can_use_ocl_impl;
-                }
+                } 
         })
         OV_GPU_GET_INSTANCE_CPU(detection_output, shape_types::static_shape)
         OV_GPU_GET_INSTANCE_CPU(detection_output, shape_types::dynamic_shape)

--- a/src/plugins/intel_gpu/src/graph/registry/implementation_manager.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/implementation_manager.cpp
@@ -9,12 +9,12 @@
 namespace cldnn {
 
 shape_types ImplementationManager::get_shape_type(const kernel_impl_params& impl_params) {
-    for (auto& in_shape : impl_params.input_layouts) {
+    for (const auto& in_shape : impl_params.input_layouts) {
         if (in_shape.is_dynamic()) {
             return shape_types::dynamic_shape;
         }
     }
-    for (auto& out_shape : impl_params.output_layouts) {
+    for (const auto& out_shape : impl_params.output_layouts) {
         if (out_shape.is_dynamic()) {
             return shape_types::dynamic_shape;
         }
@@ -24,12 +24,12 @@ shape_types ImplementationManager::get_shape_type(const kernel_impl_params& impl
 }
 
 shape_types ImplementationManager::get_shape_type(const program_node& node) {
-    for (auto& in_layout : node.get_input_layouts()) {
+    for (const auto& in_layout : node.get_input_layouts()) {
         if (in_layout.is_dynamic()) {
             return shape_types::dynamic_shape;
         }
     }
-    for (auto& out_layout : node.get_output_layouts()) {
+    for (const auto& out_layout : node.get_output_layouts()) {
         if (out_layout.is_dynamic()) {
             return shape_types::dynamic_shape;
         }

--- a/src/plugins/intel_gpu/src/graph/registry/implementation_manager.hpp
+++ b/src/plugins/intel_gpu/src/graph/registry/implementation_manager.hpp
@@ -126,10 +126,10 @@ private:
 
     void add_keys_with_any_layout() {
         std::set<data_types> supported_types;
-        for (auto& key : m_keys) {
+        for (const auto& key : m_keys) {
             supported_types.insert(std::get<0>(key));
         }
-        for (auto& dt : supported_types) {
+        for (const auto& dt : supported_types) {
             m_keys.insert({dt, format::any});
         }
     }

--- a/src/plugins/intel_gpu/src/graph/registry/non_max_suppression_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/non_max_suppression_impls.cpp
@@ -48,23 +48,12 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<non_m
 
                 if (one_of(boxes_layout.format, supported_blocked_fmts)) {
                     return true;
-                } else {
-                    const auto& nms_node = node.as<non_max_suppression>();
-                    if (nms_node.get_primitive()->rotation != non_max_suppression::Rotation::NONE) {
-                        return true;
-                    } else {
-                        if (scores_layout.is_dynamic()) {
-                            return false;
-                        } else {
-                            const size_t kBatchNum = static_cast<size_t>(scores_layout.get_partial_shape()[0].get_length());
-                            const size_t kClassNum = static_cast<size_t>(scores_layout.get_partial_shape()[1].get_length());
-                            const size_t kNStreams =
-                                    static_cast<size_t>(node.get_program().get_config().get_num_streams());
-                            const size_t kKeyValue = kBatchNum * std::min(kClassNum, static_cast<size_t>(8)) * kNStreams;
-                            return kKeyValue > 64;
-                        }
-                    }
                 }
+                const auto& nms_node = node.as<non_max_suppression>();
+                if (nms_node.get_primitive()->rotation != non_max_suppression::Rotation::NONE) {
+                    return true;
+                } 
+
 
                 return true;
         })

--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -106,7 +106,8 @@ layout reorder_inst::calc_output_layout(reorder_node const& node, kernel_impl_pa
                               "input for conversion to winograd_2x3_s1 weights format should have spatial size 3x3");
 
         return layout(odt, ofmt, tensor{input_layout.batch(), input_layout.feature(), 4, 3});
-    } else if (ofmt == format::winograd_6x3_s1_fused_weights) {
+    }
+    if (ofmt == format::winograd_6x3_s1_fused_weights) {
         CLDNN_ERROR_NOT_EQUAL(desc->id,
                               "input_layout.spatial(0)",
                               input_layout.spatial(0),
@@ -166,12 +167,13 @@ layout reorder_inst::calc_output_layout(reorder_node const& node, kernel_impl_pa
         ofmt == format::b_fs_zyx_fsv32 || ifmt == format::b_fs_zyx_fsv32 ||
         ofmt == format::bs_fs_yx_bsv16_fsv16 || ifmt == format::bs_fs_yx_bsv16_fsv16) && input_layout.is_static()) {
         return layout(odt, ofmt, input_layout.get_tensor().transform(ofmt, 1), op);
-    } else if (ofmt != ifmt && (ofmt == format::bfwzyx || ifmt == format::bfwzyx)) {
+    }
+    if (ofmt != ifmt && (ofmt == format::bfwzyx || ifmt == format::bfwzyx)) {
         // TODO Shouldn't transform be called every time ifmt != ofmt?
         return layout(odt, ofmt, input_layout.get_tensor().transform(ofmt, 1), op);
-    } else {
-        return layout(odt, ofmt, input_layout.get_tensor(), op);
     }
+    return layout(odt, ofmt, input_layout.get_tensor(), op);
+
 }
 
 template<typename ShapeType>
@@ -192,9 +194,9 @@ std::vector<layout> reorder_inst::calc_output_layouts(reorder_node const& /*node
         }
 #endif // ENABLE_ONEDNN_FOR_GPU
         return { desc->weights_reorder_params->get_output_layout() };
-    } else {
-        return { layout(input_layout.get<ShapeType>(), desc->output_data_types[0].value(), ofmt, desc->output_paddings[0]) };
     }
+    return { layout(input_layout.get<ShapeType>(), desc->output_data_types[0].value(), ofmt, desc->output_paddings[0]) };
+
 }
 
 std::string reorder_inst::to_string(reorder_node const& node) {
@@ -205,7 +207,7 @@ std::string reorder_inst::to_string(reorder_node const& node) {
 
     std::stringstream primitive_description;
 
-    auto input_mem_type = desc->input_mem_type ==
+    const auto *input_mem_type = desc->input_mem_type ==
         reorder::memory_type::buffer ? "buffer" : "surface";
 
     json_composite reorder_info;

--- a/src/plugins/intel_gpu/src/graph/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/resample.cpp
@@ -90,7 +90,7 @@ static std::vector<layout> calc_output_layouts(resample_node const& /*node*/, co
         tensors.emplace(3, ov::Tensor(ov::element::i64, axes_shape, axes.data()));
     }
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
     const auto ta = MemoryAccessor(&memory_deps, impl_param.get_stream(), ov::make_tensor_accessor(tensors));
 
     auto pads_begin = desc->pads_begin;
@@ -143,7 +143,7 @@ static std::vector<layout> calc_output_layouts(resample_node const& /*node*/, co
         tensors.emplace(2, ov::Tensor(ov::element::i64, axes_shape, axes.data()));
     }
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
     const auto ta = MemoryAccessor(&memory_deps, impl_param.get_stream(), ov::make_tensor_accessor(tensors));
 
     auto pads_begin = desc->pads_begin;
@@ -163,8 +163,7 @@ std::vector<layout> resample_inst::calc_output_layouts(resample_node const& node
     auto desc = impl_param.typed_desc<resample>();
     if (desc->operation_type == Mode::BILINEAR_PILLOW || desc->operation_type == Mode::BICUBIC_PILLOW)
         return v11::calc_output_layouts<ShapeType>(node, impl_param);
-    else
-        return v4::calc_output_layouts<ShapeType>(node, impl_param);
+    return v4::calc_output_layouts<ShapeType>(node, impl_param);
 }
 
 template std::vector<layout> resample_inst::calc_output_layouts<ov::PartialShape>(resample_node const& node, const kernel_impl_params& impl_param);

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -149,7 +149,7 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& node, 
     auto prim = impl_param.typed_desc<reshape>();
     auto input_layout = impl_param.get_input_layout(0);
 
-    auto& memory_deps = impl_param.memory_deps;
+    const auto& memory_deps = impl_param.memory_deps;
 
     // For the cases with pattern being stored in a runtime tensor on program build stage
     // we return output_partial_shape taken from the original model intead of something like PartialShape::dynamic(rank)
@@ -157,10 +157,10 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& node, 
     if ((memory_deps.empty() && prim->output_pattern.empty()) || input_layout.is_dynamic()) {
         if (prim->output_shape.count() != 0) {
             return { layout{input_layout.data_type, input_layout.format, prim->output_shape} };
-        } else {
-            auto fm = format::adjust_to_rank(input_layout.format, prim->output_partial_shape.size());
-            return { layout{prim->output_partial_shape, input_layout.data_type, fm} };
         }
+        auto fm = format::adjust_to_rank(input_layout.format, prim->output_partial_shape.size());
+        return { layout{prim->output_partial_shape, input_layout.data_type, fm} };
+
     }
 
     ShapeType pattern_shape = impl_param.input_layouts.size() == 2 ? impl_param.get_input_layout(1).get<ShapeType>()
@@ -217,7 +217,7 @@ std::vector<layout> reshape_inst::calc_output_layouts(reshape_node const& node, 
 
         cldnn::mem_lock<uint8_t, mem_lock_type::read> pattern_lock(pattern_mem, impl_param.get_stream());
 
-        auto pattern_ptr = pattern_lock.data();
+        auto *pattern_ptr = pattern_lock.data();
         auto pattern_tensor = make_tensor(pattern_mem->get_layout(), pattern_ptr);
 
         const_data.emplace(1, pattern_tensor);

--- a/src/plugins/intel_gpu/src/graph/reverse.cpp
+++ b/src/plugins/intel_gpu/src/graph/reverse.cpp
@@ -23,7 +23,7 @@ std::string reverse_inst::to_string(reverse_node const& node) {
     json_composite info;
     info.add("input id", node.input(0).id());
     info.add("axes id", node.input(1).id());
-    const auto mode = prim->mode == reverse_mode::index ? "index" : "mask";
+    const auto *const mode = prim->mode == reverse_mode::index ? "index" : "mask";
     info.add("mode", mode);
 
     auto node_info = node.desc_to_json();

--- a/src/plugins/intel_gpu/src/graph/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/roi_pooling.cpp
@@ -77,12 +77,12 @@ template std::vector<layout> roi_pooling_inst::calc_output_layouts<ov::PartialSh
 
 std::string roi_pooling_inst::to_string(roi_pooling_node const& node) {
     auto desc = node.get_primitive();
-    auto mode = desc->mode == pooling_mode::max
+    const auto *mode = desc->mode == pooling_mode::max
                     ? "max"
                     : desc->mode == pooling_mode::bilinear
                           ? "bilinear"
                           : desc->mode == pooling_mode::deformable_bilinear ? "deformable_bilinear" : "average";
-    auto is_ps = desc->position_sensitive ? "true" : "false";
+    const auto *is_ps = desc->position_sensitive ? "true" : "false";
     auto node_info = node.desc_to_json();
 
     std::stringstream primitive_description;

--- a/src/plugins/intel_gpu/src/graph/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/select.cpp
@@ -77,7 +77,7 @@ std::string select_inst::to_string(select_node const& node) {
 }
 
 select_inst::typed_primitive_inst(network& network, select_node const& node) : parent(network, node) {
-    auto& deps = node.get_dependencies();
+    const auto& deps = node.get_dependencies();
 
     auto dep0_out_layout = deps[0].first->get_output_layout();
     auto dep1_out_layout = deps[1].first->get_output_layout();

--- a/src/plugins/intel_gpu/src/graph/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/slice.cpp
@@ -101,7 +101,7 @@ void slice_inst::update_shape_info_tensor(const kernel_impl_params& params) {
     }
 
     mem_lock<int32_t> lock(_shape_info_memory, _network.get_stream());
-    auto shape_info_ptr = lock.data();
+    auto *shape_info_ptr = lock.data();
     size_t offset = 0;
     const SliceKernelRefNeededInputs inputs = SliceKernelRefNeededInputs::Create(*_node);
 

--- a/src/plugins/intel_gpu/src/graph/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/graph/space_to_batch.cpp
@@ -77,7 +77,7 @@ std::vector<layout> space_to_batch_inst::calc_output_layouts(space_to_batch_node
     auto input0_size = input0_shape.size();
     auto input0_format = input0_layout.format;
 
-    auto& constant_mem = impl_param.memory_deps;
+    const auto& constant_mem = impl_param.memory_deps;
     auto block_data = desc->block_shape;
     auto begin_data = desc->pads_begin;
     auto end_data = desc->pads_end;
@@ -107,9 +107,9 @@ std::vector<layout> space_to_batch_inst::calc_output_layouts(space_to_batch_node
         auto begin_sizes = tensor_to_vec(begin_data, input0_format);
         auto end_sizes = tensor_to_vec(end_data, input0_format);
 
-        auto block_values = static_cast<void*>(block_sizes.data());
-        auto begin_values = static_cast<void*>(begin_sizes.data());
-        auto end_values = static_cast<void*>(end_sizes.data());
+        auto *block_values = static_cast<void*>(block_sizes.data());
+        auto *begin_values = static_cast<void*>(begin_sizes.data());
+        auto *end_values = static_cast<void*>(end_sizes.data());
 
         auto block_tensor = make_tensor({ block_shape, data_types::i32, input0_format }, block_values);
         auto begin_tensor = make_tensor({ begin_shape, data_types::i32, input0_format }, begin_values);

--- a/src/plugins/intel_gpu/src/graph/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/graph/space_to_depth.cpp
@@ -92,16 +92,16 @@ layout space_to_depth_inst::calc_output_layout(space_to_depth_node const& node, 
             output_type,
             input_format,
             tensor(TensorValue(input_layout.batch()), TensorValue(feature), TensorValue(x), TensorValue(y), TensorValue(z))};
-    } else {
-        const size_t feature = input_layout.feature() * block_size * block_size;
-        const size_t y = input_layout.spatial(1) / block_size;
-        const size_t x = input_layout.spatial(0) / block_size;
-
-        return layout{
-            output_type,
-            input_format,
-            tensor(TensorValue(input_layout.batch()), TensorValue(feature), TensorValue(x), TensorValue(y))};
     }
+    const size_t feature = input_layout.feature() * block_size * block_size;
+    const size_t y = input_layout.spatial(1) / block_size;
+    const size_t x = input_layout.spatial(0) / block_size;
+
+    return layout{
+        output_type,
+        input_format,
+        tensor(TensorValue(input_layout.batch()), TensorValue(feature), TensorValue(x), TensorValue(y))};
+
 }
 
 std::string space_to_depth_inst::to_string(space_to_depth_node const& node) {

--- a/src/plugins/intel_gpu/src/graph/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/strided_slice.cpp
@@ -36,7 +36,7 @@ std::vector<layout> strided_slice_inst::calc_output_layouts(strided_slice_node c
     const auto& input0_layout = impl_param.get_input_layout(0);
     auto input0_shape = input0_layout.get<ShapeType>();
 
-    auto& constant_mem = impl_param.memory_deps;
+    const auto& constant_mem = impl_param.memory_deps;
     const auto& begin_data = desc->begin;
     const auto& end_data = desc->end;
     const auto& strides_data = desc->strides;
@@ -83,7 +83,8 @@ std::vector<layout> strided_slice_inst::calc_output_layouts(strided_slice_node c
                 if (num_of_new_axis_bit && desc->new_axis_mask[i]) {
                     output_shape[output_idx++] = {1};
                     continue;
-                } else if (num_of_shrink_axis_bit && desc->shrink_axis_mask[i]) {
+                }
+                if (num_of_shrink_axis_bit && desc->shrink_axis_mask[i]) {
                     continue;
                 }
 

--- a/src/plugins/intel_gpu/src/graph/swiglu.cpp
+++ b/src/plugins/intel_gpu/src/graph/swiglu.cpp
@@ -38,14 +38,14 @@ std::vector<layout> swiglu_inst::calc_output_layouts(swiglu_node const& /*node*/
         op.set_axis(desc->axis);
         std::vector<ov::PartialShape> output_shapes = shape_infer(&op, input_shapes);
         return {layout(output_shapes[0], output_type, output_format)};
-    } else {
-        ov::op::internal::GLU op;
-        op.set_axis(desc->axis);
-        op.set_split_lengths(desc->glu_stride);
-
-        std::vector<ShapeType> output_shapes = shape_infer(&op, input_shapes);
-        return {layout(output_shapes[0], output_type, output_format)};
     }
+    ov::op::internal::GLU op;
+    op.set_axis(desc->axis);
+    op.set_split_lengths(desc->glu_stride);
+
+    std::vector<ShapeType> output_shapes = shape_infer(&op, input_shapes);
+    return {layout(output_shapes[0], output_type, output_format)};
+
 }
 
 template std::vector<layout> swiglu_inst::calc_output_layouts<ov::PartialShape>(swiglu_node const& node,

--- a/src/plugins/intel_gpu/src/graph/topology.cpp
+++ b/src/plugins/intel_gpu/src/graph/topology.cpp
@@ -39,11 +39,11 @@ void topology::change_input_layout(const primitive_id& id, const layout& new_lay
         new_layout.data_type != data_types::i64)
         throw std::invalid_argument("Unknown data_type of layout.");
 
-    auto& inp_layout = this->at(id);
+    const auto& inp_layout = this->at(id);
     if (inp_layout->type != input_layout::type_id()) {
         throw std::runtime_error("Primitive: " + id + " is not input_layout.");
     }
-    auto inp_lay_prim = static_cast<input_layout*>(inp_layout.get());
+    auto *inp_lay_prim = static_cast<input_layout*>(inp_layout.get());
     inp_lay_prim->change_layout(new_layout);
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -253,7 +253,7 @@ JitDefinitions JitConstants::GetDefinitions() const {
     JitDefinitions definitons;
     definitons.reserve(_constants.size() * 6);  // assuming max 6 pairs per jit_constant
 
-    for (auto& constant : _constants) {
+    for (const auto& constant : _constants) {
         auto def = constant->GetDefinitions();
         definitons.insert(definitons.end(), def.begin(), def.end());
     }
@@ -789,7 +789,7 @@ class WeightTensorJitConstant : public TensorBaseTJitConstant<WeightsType, Weigh
                                  "int o_size",
                                  "int osv_size",
                                  "int isv_size"};
-                const auto body = R"V0G0N( \
+                const auto *const body = R"V0G0N( \
     const uint isv = i % isv_size; \
     const uint osv = o % osv_size; \
     const uint is = i / isv_size; \
@@ -837,7 +837,7 @@ class WeightTensorJitConstant : public TensorBaseTJitConstant<WeightsType, Weigh
                                  "int x_size",
                                  "int osv",
                                  "int isv"};
-                const auto body = R"V0G0N( \
+                const auto *const body = R"V0G0N( \
     uint is_size = (i_size + isv - 1) / isv; \
     uint os_size = (o_size + osv - 1) / osv; \
     uint isv_index = i % isv; \
@@ -881,7 +881,7 @@ class WeightTensorJitConstant : public TensorBaseTJitConstant<WeightsType, Weigh
                 args macroNameArgs = {"prefix", "o", "i", "y", "x"};
                 args funcArgs =
                     {"int o", "int i", "int y", "int x", "int i_size", "int o_size", "int x_size", "int otd"};
-                const auto body = R"V0G0N( \
+                const auto *const body = R"V0G0N( \
     uint out_depth_tile = o / otd; \
     uint od             = o - out_depth_tile * otd; \
     const uint tile = 4; \
@@ -913,7 +913,7 @@ class WeightTensorJitConstant : public TensorBaseTJitConstant<WeightsType, Weigh
         static const std::string FuncCall(std::string name, std::initializer_list<std::string> args) {
             std::string args_str;
             size_t counter = 0;
-            for (auto& arg : args)
+            for (const auto& arg : args)
                 args_str += (++counter == args.size()) ? (arg) : (arg + ", ");
             return "FUNC_CALL(" + name + ")(" + args_str + ")";
         }
@@ -921,7 +921,7 @@ class WeightTensorJitConstant : public TensorBaseTJitConstant<WeightsType, Weigh
         static const std::string MacroName(std::string tensor_name, std::string layout_name, std::initializer_list<std::string> args) {
             std::string args_str;
             size_t counter = 0;
-            for (auto& arg : args)
+            for (const auto& arg : args)
                 args_str += (++counter == args.size()) ? (arg) : (arg + ", ");
             return "GET_" + tensor_name + "_" + layout_name + "_INDEX(" + args_str + ")";
         }
@@ -929,7 +929,7 @@ class WeightTensorJitConstant : public TensorBaseTJitConstant<WeightsType, Weigh
         static const std::string FuncBody(std::string name, std::initializer_list<std::string> args = {}, std::string body = "return 0;") {
             std::string args_str;
             size_t counter = 0;
-            for (auto& arg : args)
+            for (const auto& arg : args)
                 args_str += (++counter == args.size()) ? (arg) : (arg + ", ");
             return "inline uint FUNC(" + name + ")(" + args_str + "){" + body + "}";
         }
@@ -1396,7 +1396,7 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
           auto cf = [&](const char* lit) { return JitTerm{lit + type_suffix}; };
           auto horner = [&](const JitTerm& s,
                             std::initializer_list<JitTerm> coefs) {
-            auto it = coefs.begin();
+            const auto *it = coefs.begin();
             JitTerm r = *it++;
             for (; it != coefs.end(); ++it) {
               r = r * s + *it;
@@ -1817,8 +1817,8 @@ bool FusedOpsCodeGenerator::CanPreloadData(const FusedOpsConfiguration& conf) co
 
     bool can_preload = true;
     // Check that tensor offset doesn't have dependency from the loop dimensions
-    for (auto& d : conf.loop_axes) {
-        for (auto& t : desc.tensors) {
+    for (const auto& d : conf.loop_axes) {
+        for (const auto& t : desc.tensors) {
             auto idx = idx_desc{conf.bfzyx_idx_order, t};
             switch (d) {
                 case Tensor::DataChannelName::BATCH:   can_preload &= idx.b == "0"; break;
@@ -1918,7 +1918,7 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
     bool is_shuffled = false;
     bool floor_integer_div = false;
 
-    auto& dep_data = desc.dep_data;
+    const auto& dep_data = desc.dep_data;
     int first_fused_ops_idx = -1;
     size_t dep_idx = 0;
     for (auto dep : dep_data) {
@@ -1960,7 +1960,7 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
 
     auto get_acc_t = [&]() -> Datatype {
         std::vector<Datatype> input_types = {desc.output_tensor.GetDType()};
-        for (auto& dep : dep_data) {
+        for (const auto& dep : dep_data) {
             input_types.push_back(dep.data_type);
         }
 
@@ -2000,8 +2000,7 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
 
         if (input_type != acc_t)
             return ConvertToType(input_name, acc_t, vec_size);
-        else
-            return input_name;
+        return input_name;
     };
 
     for (size_t i = 0; i < dep_data.size(); i++) {
@@ -2102,49 +2101,49 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
                 // Output conversion with rounding and saturation
                 op_decls += "\\\n\t" + GetOutputType(vec_size) + " " + out_var + " = " + ConvertToOutputTypeSat(tmp_var, vec_size) + ";";
                 break;
-            } else {
-                // Input range
-                auto in_lo = p->per_tensor_input_range ? Broadcast(std::to_string(p->in_lo), tmp_type, vec_size)
-                                                       : ConvertToType(GetInputVarName(p->in_range_lo_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
-                auto in_hi = p->per_tensor_input_range ? Broadcast(std::to_string(p->in_hi), tmp_type, vec_size)
-                                                       : ConvertToType(GetInputVarName(p->in_range_hi_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
-
-                // Input clamp
-                if (p->has_clamp) {
-                    if (p->has_min_clamp && p->has_max_clamp)
-                        op_decls += "\\\n\t" + tmp_type_str + " " + tmp_var + " = clamp(" + in_converted + ", " + in_lo + ", " + in_hi + ");";
-                    else if (p->has_min_clamp)
-                        op_decls += "\\\n\t" + tmp_type_str + " " + tmp_var + " = max(" + in_converted + ", " + in_lo + ");";
-                    else
-                        op_decls += "\\\n\t" + tmp_type_str + " " + tmp_var + " = min(" + in_converted + ", " + in_hi + ");";
-                } else {
-                    op_decls += "\\\n\t" + tmp_type_str + " " + tmp_var + " = " + in_converted + ";";
-                }
-
-                // Input scale
-                op_decls += "\\\n\t" + tmp_var + " = " + tmp_var + " * " + pre_scale + ";";
-
-                // Input shift
-                if (p->has_pre_shift)
-                    op_decls += "\\\n\t" + tmp_var + " = " + tmp_var + " + " + pre_shift + ";";
-
-                // Round operation isn't needed if output type is int8/uint8 and scale coefficient in all output channels is equal to 1.0
-                bool output_type_is_int8 = desc.output_tensor.GetDType() == Datatype::UINT8 || desc.output_tensor.GetDType() == Datatype::INT8;
-                if (((p->has_post_scale || p->has_post_shift) && output_type_is_int8) || !output_type_is_int8)
-                    op_decls += "\\\n\t" + tmp_var + " = round(" + tmp_var + ");";
-
-                // Output scale
-                if (p->has_post_scale)
-                    op_decls += "\\\n\t" + tmp_var + " = (" + tmp_var + " * " + post_scale + ");";
-
-                // Output shift
-                if (p->has_post_shift)
-                    op_decls += "\\\n\t" + tmp_var + " = (" + tmp_var + " + " + post_shift + ");";
-
-                // Output conversion with rounding and saturation
-                op_decls += "\\\n\t" + GetOutputType(vec_size) + " " + out_var + " = " + ConvertToOutputTypeSat(tmp_var, vec_size) + ";";
-                break;
             }
+            // Input range
+            auto in_lo = p->per_tensor_input_range ? Broadcast(std::to_string(p->in_lo), tmp_type, vec_size)
+                                                   : ConvertToType(GetInputVarName(p->in_range_lo_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
+            auto in_hi = p->per_tensor_input_range ? Broadcast(std::to_string(p->in_hi), tmp_type, vec_size)
+                                                   : ConvertToType(GetInputVarName(p->in_range_hi_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
+
+            // Input clamp
+            if (p->has_clamp) {
+                if (p->has_min_clamp && p->has_max_clamp)
+                    op_decls += "\\\n\t" + tmp_type_str + " " + tmp_var + " = clamp(" + in_converted + ", " + in_lo + ", " + in_hi + ");";
+                else if (p->has_min_clamp)
+                    op_decls += "\\\n\t" + tmp_type_str + " " + tmp_var + " = max(" + in_converted + ", " + in_lo + ");";
+                else
+                    op_decls += "\\\n\t" + tmp_type_str + " " + tmp_var + " = min(" + in_converted + ", " + in_hi + ");";
+            } else {
+                op_decls += "\\\n\t" + tmp_type_str + " " + tmp_var + " = " + in_converted + ";";
+            }
+
+            // Input scale
+            op_decls += "\\\n\t" + tmp_var + " = " + tmp_var + " * " + pre_scale + ";";
+
+            // Input shift
+            if (p->has_pre_shift)
+                op_decls += "\\\n\t" + tmp_var + " = " + tmp_var + " + " + pre_shift + ";";
+
+            // Round operation isn't needed if output type is int8/uint8 and scale coefficient in all output channels is equal to 1.0
+            bool output_type_is_int8 = desc.output_tensor.GetDType() == Datatype::UINT8 || desc.output_tensor.GetDType() == Datatype::INT8;
+            if (((p->has_post_scale || p->has_post_shift) && output_type_is_int8) || !output_type_is_int8)
+                op_decls += "\\\n\t" + tmp_var + " = round(" + tmp_var + ");";
+
+            // Output scale
+            if (p->has_post_scale)
+                op_decls += "\\\n\t" + tmp_var + " = (" + tmp_var + " * " + post_scale + ");";
+
+            // Output shift
+            if (p->has_post_shift)
+                op_decls += "\\\n\t" + tmp_var + " = (" + tmp_var + " + " + post_shift + ");";
+
+            // Output conversion with rounding and saturation
+            op_decls += "\\\n\t" + GetOutputType(vec_size) + " " + out_var + " = " + ConvertToOutputTypeSat(tmp_var, vec_size) + ";";
+            break;
+
         }
         case KernelType::ACTIVATION: {
             auto p = desc.GetOpParams<activation_fuse_params>();
@@ -2214,8 +2213,7 @@ std::string FusedOpsCodeGenerator::GetInputTypeName(size_t input_id, size_t vec_
     std::string scalar_type = GetInputTensorName(input_id) + "_TYPE";
     if (vec_size > 1)
         return "MAKE_VECTOR_TYPE(" + scalar_type + "," + toCodeString(vec_size) + ")";
-    else
-        return scalar_type;
+    return scalar_type;
 }
 
 std::string FusedOpsCodeGenerator::GetIdx(size_t input_id, idx_desc idx, bool should_be_safe) const {
@@ -2235,14 +2233,14 @@ std::string FusedOpsCodeGenerator::GetIdx(size_t input_id, idx_desc idx, bool sh
 
     if (should_be_safe) {
         return GetInputTensorName(input_id) + "_GET_INDEX_SAFE(" + idx_order + ")";
-    } else {
-        return GetInputTensorName(input_id) + "_GET_INDEX(" + idx_order + ")";
     }
+    return GetInputTensorName(input_id) + "_GET_INDEX(" + idx_order + ")";
+
 }
 
 std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf, size_t input_id, const DataTensor prim_output,
                                               bool reuse_index, std::string reused_idx) const {
-    auto& input_tensor = desc.tensors[input_id];
+    const auto& input_tensor = desc.tensors[input_id];
     size_t vec_size = 1;
     auto input_dt = input_tensor.GetDType();
 
@@ -2299,9 +2297,9 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
             load_str += "for (uint loop_var = 0; loop_var < " + std::to_string(vec_size)  + "; loop_var++) { ";
             load_str += GetInputVarName(input_id) + "[loop_var] = " + GetInputPtrName(input_id) + "[" + new_index_func_call + "]; }";
             return load_str;
-        } else {
-            return GetInputPtrName(input_id) + "[" + new_index_func_call + "]";
         }
+        return GetInputPtrName(input_id) + "[" + new_index_func_call + "]";
+
     }
 
     std::string index_func_call_vec = reuse_index ? reused_idx : GetIdx(input_id, idx_desc{idx, desc.tensors[input_id]}, safe_load);
@@ -2313,10 +2311,8 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
         if (vec_size > 1)
             return "((const __global " + toCLType(input_dt) + toCodeString(vec_size) + "*)(" +
                    GetInputPtrName(input_id) + " + " + offset + "))[0]";
-        else
-            return GetInputPtrName(input_id) + "[" + offset + "]";
-    } else {
-        // TODO: Need to add smarter vectors handling:
+        return GetInputPtrName(input_id) + "[" + offset + "]";
+    }         // TODO: Need to add smarter vectors handling:
         // 1. Boundary checks for safe load
         // 2. If in given configuration data can't be loaded by a simple UNIT_BLOCK_READx call or load from casted ptr,
         //    we can gather the data to vector
@@ -2356,19 +2352,19 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
             if (input_tensor.LogicalSize() > 1) {
                 // Currently we assume that in such scenario we can safely load sub_group_size elements from the pointer
                 return Broadcast(block_read, input_dt, vec_size);
-            } else {
-                // Input has only one element, so broadcast it for the whole vector size
-                return Broadcast(GetInputPtrName(input_id) + "[" + index_func_call + "]", input_dt, vec_size);
             }
-        } else {
-            if (vec_size > 1) {
-                return "((const __global " + toCLType(input_dt) + toCodeString(vec_size) + "*)(" +
-                       GetInputPtrName(input_id) + " + " + index_func_call_vec + "))[0]";
-            } else {
-                return GetInputPtrName(input_id) + "[" + index_func_call + "]";
-            }
+            // Input has only one element, so broadcast it for the whole vector size
+            return Broadcast(GetInputPtrName(input_id) + "[" + index_func_call + "]", input_dt, vec_size);
+
         }
-    }
+        if (vec_size > 1) {
+            return "((const __global " + toCLType(input_dt) + toCodeString(vec_size) + "*)(" +
+                   GetInputPtrName(input_id) + " + " + index_func_call_vec + "))[0]";
+        }
+        return GetInputPtrName(input_id) + "[" + index_func_call + "]";
+
+
+
 }
 
 std::string FusedOpsCodeGenerator::GetInputPtrName(size_t input_id) const {
@@ -2393,8 +2389,7 @@ std::string FusedOpsCodeGenerator::GetOutputVarName(std::string input_var, size_
 std::string FusedOpsCodeGenerator::GetType(Datatype dt, size_t vec_size) const {
     if (vec_size > 1)
         return toCLType(dt) + toCodeString(vec_size);
-    else
-        return toCLType(dt);
+    return toCLType(dt);
 }
 
 std::string FusedOpsCodeGenerator::GetOutputType(size_t vec_size) const {
@@ -2420,8 +2415,7 @@ std::string FusedOpsCodeGenerator::Broadcast(std::string var, Datatype dt, size_
 std::string FusedOpsCodeGenerator::ConvertToOutputTypeSat(std::string var, size_t vec_size) const {
     if (desc.output_tensor.GetDType() == Datatype::F32 || desc.output_tensor.GetDType() == Datatype::F16)
         return "convert_" + GetOutputType(vec_size) + "(" + var + ")";
-    else
-        return "convert_" + GetOutputType(vec_size) + "_sat_rte(" + var + ")";
+    return "convert_" + GetOutputType(vec_size) + "_sat_rte(" + var + ")";
 }
 
 std::vector<size_t> FusedOpsCodeGenerator::GetRequiredInputs() const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base.cpp
@@ -149,7 +149,7 @@ JitConstants KernelBase::MakeFusedOpsJitConstants(const kernel_selector::base_pa
     }
 
     try {
-        for (auto& c : conf) {
+        for (const auto& c : conf) {
             std::string fused_ops;
             std::string fused_ops_preload;
             std::string fused_ops_calc;
@@ -253,10 +253,10 @@ DeviceFeaturesKey KernelBase::get_common_subgroups_device_features_key(const Par
     const auto& casted_params = static_cast<const base_params&>(params);
 
     std::vector<Datatype> tensor_types;
-    for (auto& t : casted_params.inputs) {
+    for (const auto& t : casted_params.inputs) {
         tensor_types.push_back(t.GetDType());
     }
-    for (auto& t : casted_params.outputs) {
+    for (const auto& t : casted_params.outputs) {
         tensor_types.push_back(t.GetDType());
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.cpp
@@ -146,7 +146,7 @@ KernelsData kernel_selector_base::GetAutoTuneBestKernel(const Params& params, Ke
 }
 
 std::shared_ptr<KernelBase> kernel_selector_base::GetImplementation(std::string& kernel_name) const {
-    for (auto& impl : implementations) {
+    for (const auto& impl : implementations) {
         if (impl->GetName().compare(kernel_name) == 0)
             return impl;
     }
@@ -167,7 +167,7 @@ KernelList kernel_selector_base::GetAllImplementations(const Params& params, Ker
     if (params.GetType() == kType) {
         ParamsKey requireKey = params.GetParamsKey();
         bool forceImplementation = !params.forceImplementation.empty();
-        for (auto& impl : implementations) {
+        for (const auto& impl : implementations) {
             const ParamsKey implKey = impl->GetSupportedKey();
             if (!implKey.Support(requireKey))
                 continue;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
@@ -523,23 +523,23 @@ std::string toString(const DataTensor& tensor) {
     if (tensor.GetLayout() != DataLayout::b_fs_yx_fsv16 &&
         tensor.GetLayout() != DataLayout::b_fs_zyx_fsv16) {
         return toStringTensor(tensor);
-    } else {
-        std::stringstream s;
-        s << toString(tensor.GetDType()) << "_";
-        std::string layoutStr;
-        switch (tensor.GetLayout()) {
-            case DataLayout::b_fs_yx_fsv16: layoutStr = "BFYX_F16"; break;
-            case DataLayout::b_fs_zyx_fsv16: layoutStr = "BFZYX_F16"; break;
-            default: layoutStr = toString(tensor.GetLayout()); break;
-        }
-        s << layoutStr << "_";
-        int i = 0;
-        for (auto dim : tensor.GetDims()) {
-            s << "d" << i << "_" << toString(dim) << "_";
-            i++;
-        }
-        return s.str();
     }
+    std::stringstream s;
+    s << toString(tensor.GetDType()) << "_";
+    std::string layoutStr;
+    switch (tensor.GetLayout()) {
+        case DataLayout::b_fs_yx_fsv16: layoutStr = "BFYX_F16"; break;
+        case DataLayout::b_fs_zyx_fsv16: layoutStr = "BFZYX_F16"; break;
+        default: layoutStr = toString(tensor.GetLayout()); break;
+    }
+    s << layoutStr << "_";
+    int i = 0;
+    for (auto dim : tensor.GetDims()) {
+        s << "d" << i << "_" << toString(dim) << "_";
+        i++;
+    }
+    return s.str();
+
 }
 
 std::string toString(const WeightsTensor& tensor) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.h
@@ -198,7 +198,7 @@ inline std::uint64_t create_hash(const unsigned char* begin, const unsigned char
     constexpr auto mul_factor = static_cast<std::uint64_t>(UINT64_C(1099511628211));
 
     std::uint64_t acc = start_acc;
-    for (auto elem_it = begin; elem_it != end; ++elem_it) {
+    for (const auto *elem_it = begin; elem_it != end; ++elem_it) {
         acc ^= static_cast<std::uint64_t>(*elem_it);
         acc *= mul_factor;
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -554,13 +554,14 @@ struct FusedOpsConfiguration {
         int dims_num = static_cast<int>(bfzyx_idx_order.size());
         if (val == Tensor::DataChannelName::BATCH && dims_num >= 1) {
             return 0;
-        } else if (val == Tensor::DataChannelName::FEATURE && dims_num >= 2) {
-            return 1;
-        } else if (dims_num >= 3 && dims_num - static_cast<int>(val) - 1 >= 0) {
-            return static_cast<int>(bfzyx_idx_order.size()) - static_cast<int>(val) - 1;
-        } else {
-            return -1;
         }
+        if (val == Tensor::DataChannelName::FEATURE && dims_num >= 2) {
+            return 1;
+        }
+        if (dims_num >= 3 && dims_num - static_cast<int>(val) - 1 >= 0) {
+            return static_cast<int>(bfzyx_idx_order.size()) - static_cast<int>(val) - 1;
+        }             return -1;
+
     }
 };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_base.cpp
@@ -72,7 +72,7 @@ bool ActivationKernelBase::Validate(const Params& p) const {
     }
     const activation_params& orgParams = static_cast<const activation_params&>(p);
 
-    for (auto& fused_op : orgParams.fused_ops) {
+    for (const auto& fused_op : orgParams.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_base.cpp
@@ -14,7 +14,7 @@ bool BatchToSpaceKernelBase::Validate(const Params& p) const {
     }
 
     const batch_to_space_params& params = static_cast<const batch_to_space_params&>(p);
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/border/border_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/border/border_kernel_base.cpp
@@ -65,7 +65,7 @@ BorderKernelBase::DispatchData BorderKernelBase::SetDefault(const border_params&
             DispatchDataPair{{  3, 336, 336}, {3, 8, 8}}
         }};
     std::array<size_t, 3> gws = {dispatchData.gws[0], dispatchData.gws[1], dispatchData.gws[2]};
-    auto it = std::find_if(lws_mapping_table.begin(), lws_mapping_table.end(), [&gws](const DispatchDataPair& ddp) { return ddp.first == gws; });
+    const auto *it = std::find_if(lws_mapping_table.begin(), lws_mapping_table.end(), [&gws](const DispatchDataPair& ddp) { return ddp.first == gws; });
     if (it != lws_mapping_table.end()) { dispatchData.lws = {it->second[0], it->second[1], it->second[2]}; }
 
     return dispatchData;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv16.cpp
@@ -11,7 +11,7 @@ namespace kernel_selector {
 namespace {
 
 size_t getTileXY(const concatenation_params& params) {
-    auto& input = params.inputs[0];
+    const auto& input = params.inputs[0];
     size_t tileXY =  1;
     if (params.isAligned) {
         switch (input.GetDType()) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_base.cpp
@@ -43,7 +43,7 @@ bool ConcatenationKernelBase::Validate(const Params& p) const {
 
     const concatenation_params& params = static_cast<const concatenation_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
@@ -56,7 +56,7 @@ bool ConcatenationKernelBase::Validate(const Params& p) const {
 }
 
 JitConstants ConcatenationKernelBase::GetJitConstants(const concatenation_params& params) const {
-    auto& inputs = params.original_input_layouts;
+    const auto& inputs = params.original_input_layouts;
     bool is_dynamic = std::any_of(inputs.begin(), inputs.end(), [](const DataTensor& t) { return t.is_dynamic(); }) ||
                       std::any_of(params.outputs.begin(), params.outputs.end(), [](const DataTensor& t) { return t.is_dynamic(); });
     JitConstants jit = MakeBaseParamsJitConstants(params, !is_dynamic);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_simple_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_simple_ref.cpp
@@ -82,7 +82,8 @@ bool ConcatenationKernel_simple_Ref::Validate(const Params& p) const {
              same_layout == DataLayout::b_fs_zyx_fsv32 || same_layout == DataLayout::bs_fs_zyx_bsv16_fsv16
             || same_layout == DataLayout::bs_fs_yx_bsv32_fsv32)) {
             continue;
-        } else if (cur_layout != same_layout) {
+        }
+        if (cur_layout != same_layout) {
             DO_NOT_USE_THIS_KERNEL(p.layerID);
         }
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16.cpp
@@ -41,18 +41,16 @@ ConvolutionKernel_b_fs_yx_fsv16::AutoTuneOption ConvolutionKernel_b_fs_yx_fsv16:
     if (x * f <= 256) {
         if (x <= 8 || x * f <= 128)
             return { 2, EXE_MODE_DEFAULT };
-        else
-            return { 4, EXE_MODE_DEFAULT };
-    } else if (x * f <= 1536) {
         return { 4, EXE_MODE_DEFAULT };
-    } else {
-        if (x >= 8  && x < 12 && x * f < 2600)
-            return { 4, EXE_MODE_DEFAULT };
-        else if (x < 12 && x * f < 8192)
-            return { 8, EXE_MODE_DEFAULT };
-        else
-            return { 8, EXE_MODE_AGE_BASED };
     }
+    if (x * f <= 1536) {
+        return { 4, EXE_MODE_DEFAULT };
+    }         if (x >= 8  && x < 12 && x * f < 2600)
+            return { 4, EXE_MODE_DEFAULT };
+            if (x < 12 && x * f < 8192)
+            return { 8, EXE_MODE_DEFAULT };
+        return { 8, EXE_MODE_AGE_BASED };
+
 }
 
 float ConvolutionKernel_b_fs_yx_fsv16::EstimateOccupancy(const convolution_params& params,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_1x1.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_1x1.cpp
@@ -28,21 +28,21 @@ ConvolutionKernel_b_fs_yx_fsv16_1x1::AutoTuneOption ConvolutionKernel_b_fs_yx_fs
 
         if (x == 1 && y == 1) {
             return { 1, EXE_MODE_DEFAULT };
-        } else if (x * f <= 256) {
+        }
+        if (x * f <= 256) {
             if (x < 8 || x * f <= 128)
                 return { 2, EXE_MODE_DEFAULT };
-            else
-                return { 4, EXE_MODE_DEFAULT };
-        } else if (x * f <= 1536) {
             return { 4, EXE_MODE_DEFAULT };
-        } else {
-            return { 8, EXE_MODE_DEFAULT };
         }
-    } else {
-        // In shape agnostic kernel, the output shape can not be specified at build time,
-        // So we prepare 4 kernels(blockWith 1, 2, 4, 8) in advance and then use proper kernel at runtime when static shape comes.
-        return { 8, EXE_MODE_DEFAULT };
+        if (x * f <= 1536) {
+            return { 4, EXE_MODE_DEFAULT };
+        }             return { 8, EXE_MODE_DEFAULT };
+
     }
+    // In shape agnostic kernel, the output shape can not be specified at build time,
+    // So we prepare 4 kernels(blockWith 1, 2, 4, 8) in advance and then use proper kernel at runtime when static shape comes.
+    return { 8, EXE_MODE_DEFAULT };
+
 }
 
 float ConvolutionKernel_b_fs_yx_fsv16_1x1::EstimateOccupancy(const convolution_params& params,
@@ -151,15 +151,14 @@ KernelsPriority ConvolutionKernel_b_fs_yx_fsv16_1x1::GetKernelsPriority(const Pa
         if (out.Batch().v == 1) {
             if ((bBlockSizeX || bBlockSizeXY) && !bInputPad) {
                 return FORCE_PRIORITY_1;
-            } else {
-                return FORCE_PRIORITY_3;
             }
-        } else {
-            return FORCE_PRIORITY_7;
+            return FORCE_PRIORITY_3;
+
         }
-    } else {
-        return FORCE_PRIORITY_1;
-    }
+        return FORCE_PRIORITY_7;
+
+    }         return FORCE_PRIORITY_1;
+
 }
 
 bool ConvolutionKernel_b_fs_yx_fsv16_1x1::Validate(const Params& p) const {
@@ -240,8 +239,8 @@ JitConstants ConvolutionKernel_b_fs_yx_fsv16_1x1::GetJitConstants(const convolut
         bool non_unit_fused_op_spatial = false;
 
         // Set padded_output to true when fused inputs have paddings to have correct blocked loads
-        for (auto& fused_op : params.fused_ops) {
-            for (auto& t : fused_op.tensors) {
+        for (const auto& fused_op : params.fused_ops) {
+            for (const auto& t : fused_op.tensors) {
                 if (t.PitchesDifferFromLogicalDims()) {
                     padded_output = true;
                 }
@@ -281,20 +280,20 @@ JitConstants ConvolutionKernel_b_fs_yx_fsv16_1x1::GetJitConstants(const convolut
         // In shape agnostic kernel, the fused shape cannot be specified at build time or run time.
         // Currently simply check whether fused_op is dynmaic. Need to further follow up like static behavior.
         bool non_unit_fused_op_spatial = false;
-        for (auto& fused_op : params.fused_ops) {
-            for (auto& t : fused_op.tensors) {
+        for (const auto& fused_op : params.fused_ops) {
+            for (const auto& t : fused_op.tensors) {
                 if (t.is_dynamic()) {
                     non_unit_fused_op_spatial = true;
                     break;
-                } else {
-                    if ((t.X().v > 1) ||
-                        (t.Y().v > 1) ||
-                        (t.Z().v > 1) ||
-                        (t.W().v > 1)) {
-                        non_unit_fused_op_spatial = true;
-                        break;
-                    }
                 }
+                if ((t.X().v > 1) ||
+                    (t.Y().v > 1) ||
+                    (t.Z().v > 1) ||
+                    (t.W().v > 1)) {
+                    non_unit_fused_op_spatial = true;
+                    break;
+                }
+
             }
         }
         jit.AddConstant(MakeJitConstant("NON_UNIT_FUSED_OP_SPATIAL", non_unit_fused_op_spatial));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_imad_1x1.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_imad_1x1.cpp
@@ -387,7 +387,7 @@ KernelsData Convolution_kernel_b_fs_yx_fsv16_imad_1x1::GetKernelsDataForAutoTune
     if (!Validate(params)) {
         return {};
     }
-    auto& conv_params = static_cast<const convolution_params&>(params);
+    const auto& conv_params = static_cast<const convolution_params&>(params);
 
     KernelsData res = {};
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv4_int8.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv4_int8.cpp
@@ -60,8 +60,7 @@ KernelsPriority ConvolutionKernel_b_fs_yx_fsv4_int8::GetKernelsPriority(const Pa
 
     if (p.outputs[0].X().v > 512 && p.filterSize.x == 5 && p.filterSize.y == 5)
         return FORCE_PRIORITY_2;
-    else
-        return FORCE_PRIORITY_9;
+    return FORCE_PRIORITY_9;
 }
 
 bool ConvolutionKernel_b_fs_yx_fsv4_int8::Validate(const Params& p) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.cpp
@@ -107,8 +107,7 @@ bool ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::Validate(const Params& params)
 WeightsLayout ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::GetPreferredWeightsLayout(const convolution_params& params) const {
     if (params.outputs[0].GetLayout() == DataLayout::b_fs_yx_fsv16)
         return WeightsLayout::gs_oi_yxs_gsv16_yxsv4;
-    else
-        return WeightsLayout::gs_oi_yxs_gsv32_yxsv4;
+    return WeightsLayout::gs_oi_yxs_gsv32_yxsv4;
 }
 
 ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::AutoTuneParams
@@ -117,7 +116,7 @@ ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::GetAutoTuneParams(const convolution
         return all_tune_params[index];
     }
 
-    auto& output = params.outputs[0];
+    const auto& output = params.outputs[0];
 
     size_t fsv = 32;
     if (output.GetLayout() == DataLayout::b_fs_yx_fsv16) {
@@ -266,7 +265,7 @@ bool ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::ValidateAutoTuneParams(const c
 ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::DispatchData
 ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::SetDefault(const convolution_params& params, int autoTuneIndex) const {
     DispatchData dispatchData;
-    auto& out = params.outputs[0];
+    const auto& out = params.outputs[0];
 
     auto tune_params = GetAutoTuneParams(params, autoTuneIndex);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.cpp
@@ -178,8 +178,7 @@ ConvolutionKernelBase::DispatchData ConvolutionKernel_b_fs_zyx_fsv16::SetDefault
         while (ocb > 16) {
             if (f % ocb == 0)
                 break;
-            else
-                ocb /= 2;
+            ocb /= 2;
         }
 
         dispatchData.cldnnStyle.blockWidth = ow_block;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.h
@@ -29,19 +29,18 @@ protected:
         bool is_3d_case = params.inputs[0].GetLayout() != DataLayout::bs_fs_yx_bsv16_fsv16;
         if (params.inputs[0].Feature().v == 3 && params.inputs[0].GetLayout() == DataLayout::bfzyx) {
             return WeightsLayout::os_zyxi_osv16;
-        } else if (use_data_type == Datatype::F32 && params.inputs[0].Batch().v % 16 == 0) {
+        }
+        if (use_data_type == Datatype::F32 && params.inputs[0].Batch().v % 16 == 0) {
             if (is_3d_case)
                 return (params.groups > 1) ? WeightsLayout::g_is_os_zyx_isv16_osv16 : WeightsLayout::is_os_zyx_isv16_osv16;
-            else
-                return (params.groups > 1) ? WeightsLayout::g_is_os_yx_isv16_osv16 : WeightsLayout::is_os_yx_isv16_osv16;
-        } else if (use_data_type == Datatype::F16 && params.inputs[0].Batch().v % 32 == 0) {
+            return (params.groups > 1) ? WeightsLayout::g_is_os_yx_isv16_osv16 : WeightsLayout::is_os_yx_isv16_osv16;
+        }
+        if (use_data_type == Datatype::F16 && params.inputs[0].Batch().v % 32 == 0) {
             if (is_3d_case)
                 return (params.groups > 1) ? WeightsLayout::g_os_is_zyx_isv8_osv16_isv2 : WeightsLayout::os_is_zyx_isv8_osv16_isv2;
-            else
-                return (params.groups > 1) ? WeightsLayout::g_os_is_yx_isv8_osv16_isv2 : WeightsLayout::os_is_yx_isv8_osv16_isv2;
-        } else {
-            return (params.groups > 1) ? WeightsLayout::g_os_is_zyx_isv16_osv16 : WeightsLayout::os_is_zyx_isv16_osv16;
-        }
+            return (params.groups > 1) ? WeightsLayout::g_os_is_yx_isv8_osv16_isv2 : WeightsLayout::os_is_yx_isv8_osv16_isv2;
+        }             return (params.groups > 1) ? WeightsLayout::g_os_is_zyx_isv16_osv16 : WeightsLayout::os_is_zyx_isv16_osv16;
+
     }
     bool Validate(const Params& p) const override;
     DispatchData SetDefault(const convolution_params& arg, int autoTuneIndex = -1) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_imad.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_imad.cpp
@@ -200,7 +200,7 @@ float Convolution_kernel_b_fs_zyx_fsv16_imad::EstimateBlockParamsRatio(const con
     float reg_pressure = EstimateRegPressure(params, block);
 
     // Estimate fb32 usage factor
-    auto& output = params.outputs[0];
+    const auto& output = params.outputs[0];
     float feature_block_32 = static_cast<float>(block.output_block_features == 32);
     float fb32_factor = -5.f;
     if (params.engineInfo.deviceType == dev_type::discrete_gpu && params.engineInfo.supports_imad) {
@@ -497,11 +497,9 @@ KernelsPriority Convolution_kernel_b_fs_zyx_fsv16_imad::GetKernelsPriority(const
     if (!p.is_shape_agnostic) {
         if (static_cast<float>(p.weights.IFM().v) / static_cast<float>(Align(p.weights.IFM().v, fsv)) < 0.5f)
             return FORCE_PRIORITY_4;
-        else
-            return FORCE_PRIORITY_2;
-    } else {
-        return FORCE_PRIORITY_4;
-    }
+        return FORCE_PRIORITY_2;
+    }         return FORCE_PRIORITY_4;
+
 }
 
 bool Convolution_kernel_b_fs_zyx_fsv16_imad::Validate(const Params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
@@ -17,7 +17,7 @@ bool ConvolutionKernelBase::Validate(const Params& p) const {
 
     const convolution_params& params = static_cast<const convolution_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
@@ -399,11 +399,11 @@ JitConstants ConvolutionKernelBase::GetFusedPrimitivesJitConstants(const convolu
 Datatype ConvolutionKernelBase::GetPackedType(Datatype dt, size_t pack_size) const {
     if (dt == Datatype::UINT8) {
         return pack_size == 4 ? Datatype::UINT32 : pack_size == 2 ? Datatype::UINT16 : dt;
-    } else if (dt == Datatype::INT8) {
-        return pack_size == 4 ?  Datatype::INT32 : pack_size == 2 ? Datatype::INT16 : dt;
-    } else {
-        return dt;
     }
+    if (dt == Datatype::INT8) {
+        return pack_size == 4 ?  Datatype::INT32 : pack_size == 2 ? Datatype::INT16 : dt;
+    }         return dt;
+
 }
 
 Datatype ConvolutionKernelBase::GetPackedInputType(const convolution_params& params) const {
@@ -433,7 +433,8 @@ Datatype ConvolutionKernelBase::GetActivationType(const convolution_params& para
         params.outputs[0].GetDType() == Datatype::INT8) {
         if (params.inputs[0].GetDType() == Datatype::F32) {
             return Datatype::F32;
-        } else if (params.inputs[0].GetDType() == Datatype::F16) {
+        }
+        if (params.inputs[0].GetDType() == Datatype::F16) {
             return Datatype::F16;
         }
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1_opt.cpp
@@ -58,11 +58,13 @@ static block_params get_out_block_size(const convolution_params& p) {
             total_threads *= 2;
         }
         return {7, 1, out_depth};
-    } else if (p.outputs[0].X().v == 14) {
+    }
+    if (p.outputs[0].X().v == 14) {
         return {7, 1, 8};
-    } else if (p.outputs[0].X().v == 28) {
+    }
+    if (p.outputs[0].X().v == 28) {
         return {7, 2, 4};
-    } else if (p.outputs[0].X().v == 56) {
+    } if (p.outputs[0].X().v == 56) {
         return {8, 1, 8};
     }
 
@@ -151,8 +153,7 @@ WeightsLayout convolution_kernel_bfyx_1x1_opt::GetPreferredWeightsLayout(const c
         return WeightsLayout::os_iyx_osv32;
     if (block.out_depth == 2)
         return WeightsLayout::os_iyx_osv16;
-    else
-        return WeightsLayout::yxio;
+    return WeightsLayout::yxio;
 }
 
 KernelsData convolution_kernel_bfyx_1x1_opt::GetKernelsData(const Params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_gemm_like.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_gemm_like.cpp
@@ -37,9 +37,9 @@ DeviceFeaturesKey ConvolutionKernel_bfyx_GEMMLike::get_required_device_features_
 std::string ConvolutionKernel_bfyx_GEMMLike::GetKernelName(const convolution_params& params) const {
     if (params.inputs[0].GetDType() == Datatype::F32) {
         return kernelName + "_fp32";
-    } else {
-        return kernelName + "_fp16";
     }
+    return kernelName + "_fp16";
+
 }
 
 JitConstants ConvolutionKernel_bfyx_GEMMLike::GetJitConstants(const convolution_params& params,
@@ -124,9 +124,9 @@ WeightsLayout ConvolutionKernel_bfyx_GEMMLike::GetPreferredWeightsLayout(
         const convolution_params &params) const {
     if (params.inputs[0].GetDType() == Datatype::F16) {
         return (params.groups > 1) ? WeightsLayout::giy_xs_os_xsv2_osv16__ao32 : WeightsLayout::iy_xs_os_xsv2_osv16__ao32;
-    } else {
-        return (params.groups > 1) ? WeightsLayout::giy_xs_os_xsv2_osv8__ao32 : WeightsLayout::iy_xs_os_xsv2_osv8__ao32;
     }
+    return (params.groups > 1) ? WeightsLayout::giy_xs_os_xsv2_osv8__ao32 : WeightsLayout::iy_xs_os_xsv2_osv8__ao32;
+
 }
 
 KernelsData ConvolutionKernel_bfyx_GEMMLike::GetKernelsData(const Params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -43,12 +43,12 @@ protected:
             if (params.outputs[0].Feature().v > 8 || params.outputs[0].Batch().v != 1 || !IsSIMDSizeSupported(params.engineInfo, 8)
                || ((params.outputs[0].GetDType() == Datatype::F16) && params.outputs[0].Feature().v == 8)) {
                 return 16;
-            } else {
-                return 8;
             }
-        } else {
-            return 16;
+            return 8;
+
         }
+        return 16;
+
     }
 
 private:

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad.cpp
@@ -188,7 +188,7 @@ bool ConvolutionKernel_imad::Validate(const Params& params) const {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
 
-    auto& conv_params = static_cast<const convolution_params&>(params);
+    const auto& conv_params = static_cast<const convolution_params&>(params);
     if (conv_params.groups > 1 && conv_params.weights.IFM().v % 4 != 0 &&
         conv_params.inputs[0].GetLayout() != DataLayout::b_fs_yx_fsv16)
         DO_NOT_USE_THIS_KERNEL(params.layerID);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_b_fs_yx_fsv4_1x1.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_b_fs_yx_fsv4_1x1.cpp
@@ -173,7 +173,7 @@ JitConstants ConvolutionKernel_imad_b_fs_yx_fsv4_1x1::GetJitConstants(const conv
 ConvolutionKernelBase::DispatchData ConvolutionKernel_imad_b_fs_yx_fsv4_1x1::SetDefault(const convolution_params& params,
                                                                                         int autoTuneIndex) const {
     DispatchData dispatchData;
-    auto& out = params.outputs[0];
+    const auto& out = params.outputs[0];
 
     auto autoTuneParam = GetAutoTuneParams(params, autoTuneIndex);
     auto lwg_depth = autoTuneParam.lwg_depth;
@@ -211,7 +211,7 @@ KernelsData ConvolutionKernel_imad_b_fs_yx_fsv4_1x1::GetKernelsDataForAutoTune(c
     if (!Validate(params)) {
         return {};
     }
-    auto& conv_params = static_cast<const convolution_params&>(params);
+    const auto& conv_params = static_cast<const convolution_params&>(params);
 
     KernelsData res = {};
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_b_fs_yx_fsv4_dw.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_b_fs_yx_fsv4_dw.cpp
@@ -111,7 +111,7 @@ bool ConvolutionKernel_imad_b_fs_yx_fsv4_dw::Validate(const Params& params) cons
 
 bool ConvolutionKernel_imad_b_fs_yx_fsv4_dw::ValidateAutoTuneParams(const convolution_params& params, const AutoTuneParams& tune_params) const {
     // Checks that tune_params can be used for specified convolution_params
-    auto& weights = params.weights;
+    const auto& weights = params.weights;
 
     if (tune_params.tiled) {
         bool tiled_x_once = tune_params.tiled_simd >= (weights.X().v - 1) * params.dilation.x + 1;
@@ -156,8 +156,8 @@ ConvolutionKernel_imad_b_fs_yx_fsv4_dw::AutoTuneParams ConvolutionKernel_imad_b_
         return all_tune_params[index];
     }
 
-    auto& output = params.outputs[0];
-    auto& weights = params.weights;
+    const auto& output = params.outputs[0];
+    const auto& weights = params.weights;
 
     AutoTuneParams tune_params;
 
@@ -283,7 +283,7 @@ JitConstants ConvolutionKernel_imad_b_fs_yx_fsv4_dw::GetJitConstants(const convo
     }
     mem_consts.AddConstant(MakeJitConstant("FILTER_BLOCKED", filter_blocked));
 
-    auto& work_mode = dispatchData.cldnnStyle.prefetch;
+    const auto& work_mode = dispatchData.cldnnStyle.prefetch;
     bool tiled = (work_mode & mode::tiled) != 0;
     bool preload_input = (work_mode & mode::preload_input) != 0;
     bool preload_weights = (work_mode & mode::preload_weights) != 0;
@@ -341,7 +341,7 @@ JitConstants ConvolutionKernel_imad_b_fs_yx_fsv4_dw::GetJitConstants(const convo
 ConvolutionKernelBase::DispatchData ConvolutionKernel_imad_b_fs_yx_fsv4_dw::SetDefault(const convolution_params& params,
                                                                                        int autoTuneIndex) const {
     DispatchData dispatchData;
-    auto& out = params.outputs[0];
+    const auto& out = params.outputs[0];
 
     auto autoTuneParam = GetAutoTuneParams(params, autoTuneIndex);
 
@@ -397,7 +397,7 @@ KernelsData ConvolutionKernel_imad_b_fs_yx_fsv4_dw::GetKernelsDataForAutoTune(co
     if (!Validate(params)) {
         return {};
     }
-    auto& conv_params = static_cast<const convolution_params&>(params);
+    const auto& conv_params = static_cast<const convolution_params&>(params);
 
     KernelsData res = {};
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_b_fs_yx_fsv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_b_fs_yx_fsv32.cpp
@@ -80,8 +80,8 @@ ConvolutionKernel_mmad_b_fs_yx_fsv32::AutoTuneOption ConvolutionKernel_mmad_b_fs
 
     AutoTuneOption option = {0, 0, 0, EXE_MODE_DEFAULT};
 
-    auto& params = dynamic_cast<const convolution_params&>(p);
-    auto& output = params.outputs[0];
+    const auto& params = dynamic_cast<const convolution_params&>(p);
+    const auto& output = params.outputs[0];
 
     // TODO: Check if other block size can improve performance
     option.blockHeight = 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_b_fs_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_b_fs_yx_fsv32.h
@@ -32,16 +32,16 @@ protected:
          if (IsSIMDSizeSupported(p.engineInfo, 8)) {
             if (DataTensor::ChannelsCount(p.outputs[0].GetLayout()) <= 4) {
                 return WeightsLayout::os_is_yx_osa4_isa8_osv8_isv4_swizzled_by_4;
-            } else {
-                return WeightsLayout::os_is_zyx_osa4_isa8_osv8_isv4_swizzled_by_4;
             }
-        } else {
-            if (DataTensor::ChannelsCount(p.outputs[0].GetLayout()) <= 4) {
-                return WeightsLayout::os_is_yx_osa2_isa8_osv16_isv4_swizzled_by_2;
-            } else {
-                return WeightsLayout::os_is_zyx_osa2_isa8_osv16_isv4_swizzled_by_2;
-            }
+            return WeightsLayout::os_is_zyx_osa4_isa8_osv8_isv4_swizzled_by_4;
+
         }
+        if (DataTensor::ChannelsCount(p.outputs[0].GetLayout()) <= 4) {
+            return WeightsLayout::os_is_yx_osa2_isa8_osv16_isv4_swizzled_by_2;
+        }
+        return WeightsLayout::os_is_zyx_osa2_isa8_osv16_isv4_swizzled_by_2;
+
+
     }
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::ELTWISE,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv32.cpp
@@ -89,8 +89,8 @@ ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv32::AutoTuneOption ConvolutionKernel_m
 
     AutoTuneOption option = {0, 0, 0, EXE_MODE_DEFAULT};
 
-    auto &params = dynamic_cast<const convolution_params &>(p);
-    auto &output = params.outputs[0];
+    const auto &params = dynamic_cast<const convolution_params &>(p);
+    const auto &output = params.outputs[0];
 
     // TODO: Check if other block size can improve performance
     option.blockHeight = 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv32.h
@@ -31,12 +31,12 @@ protected:
             p.outputs[0].GetLayout() == DataLayout::b_fs_yx_fsv16 || p.outputs[0].GetLayout() == DataLayout::b_fs_zyx_fsv16) {
             if (p.outputs[0].Dimentions() == 5) {
                 return WeightsLayout::os_is_zyx_osv32_isv4;
-            } else {
-                return WeightsLayout::os_is_yx_osv32_isv4;
             }
-        } else {
-            return WeightsLayout::os_is_yx_osv32_isv4_swizzled_by_2;
+            return WeightsLayout::os_is_yx_osv32_isv4;
+
         }
+        return WeightsLayout::os_is_yx_osv32_isv4_swizzled_by_2;
+
     }
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::ELTWISE,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv4.cpp
@@ -69,8 +69,8 @@ ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv4::AutoTuneOption ConvolutionKernel_mm
 
     AutoTuneOption option = {0, 0, 0, EXE_MODE_DEFAULT};
 
-    auto &params = dynamic_cast<const convolution_params &>(p);
-    auto &output = params.outputs[0];
+    const auto &params = dynamic_cast<const convolution_params &>(p);
+    const auto &output = params.outputs[0];
 
     // TODO: Check if other block size can improve performance
     option.blockHeight = 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.h
@@ -22,8 +22,7 @@ protected:
     WeightsLayout GetPreferredWeightsLayout(const convolution_params &params) const override {
         if (params.inputs[0].Dimentions() == 4)
             return (params.groups > 1) ? WeightsLayout::goiyx : WeightsLayout::oiyx;
-        else
-            return (params.groups > 1) ? WeightsLayout::goizyx : WeightsLayout::oizyx;
+        return (params.groups > 1) ? WeightsLayout::goizyx : WeightsLayout::oizyx;
     }
     std::vector<FusedOpType> GetSupportedFusedOps() const override {
         // FusedOpType::REORDER should be registered explicitly here

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_6x3_s1_fused.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_6x3_s1_fused.cpp
@@ -84,9 +84,9 @@ WeightsLayout ConvolutionKernel_Winograd_6x3_s1_fused::GetPreferredWeightsLayout
     // check if image weights layout will fit into device memory, if not then try to fallback to buffer
     if (CheckImageSize(params, WeightsLayout::image_2d_weights_winograd_6x3_s1_xfbyb)) {
         return WeightsLayout::image_2d_weights_winograd_6x3_s1_xfbyb;
-    } else {
-        return WeightsLayout::winograd_6x3_s1_fused_weights;
     }
+    return WeightsLayout::winograd_6x3_s1_fused_weights;
+
 }
 
 ConvolutionKernel_Winograd_6x3_s1_fused::Parent::DispatchData ConvolutionKernel_Winograd_6x3_s1_fused::SetDefault(

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b16.cpp
@@ -38,9 +38,9 @@ DeviceFeaturesKey ConvolutionKernel_yxfb_yxio_b16::get_required_device_features_
 std::string ConvolutionKernel_yxfb_yxio_b16::GetKernelName(const convolution_params& params) const {
     if (params.inputs[0].GetDType() == Datatype::F32) {
         return kernelName + "_fp32";
-    } else {
-        return kernelName + "_fp16";
     }
+    return kernelName + "_fp16";
+
 }
 
 namespace {
@@ -52,14 +52,14 @@ size_t GetBatchesPerWorkItem(size_t batch_size, Datatype dataType) {
 
         if (batch_size % (4 * min_batches_per_wi * min_lws) == 0) {
             return 4 * min_batches_per_wi;  // USE_BLOCK_READ_2 + as_half4
-        } else if (batch_size % (2 * min_batches_per_wi * min_lws) == 0) {
-            return 2 * min_batches_per_wi;  // USE_BLOCK_READ_1 + as_half2
-        } else {
-            return min_batches_per_wi;
         }
-    } else {
-        return 2;
-    }
+        if (batch_size % (2 * min_batches_per_wi * min_lws) == 0) {
+            return 2 * min_batches_per_wi;  // USE_BLOCK_READ_1 + as_half2
+        }
+        return min_batches_per_wi;
+
+    }         return 2;
+
 }
 
 size_t GetOfmPerWorkitem(Datatype dataType) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b8.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b8.cpp
@@ -34,9 +34,9 @@ namespace {
 size_t GetOfmPerWorkitem(size_t filterOfmNum, size_t batchSize, size_t local_work_size) {
     if (((filterOfmNum * batchSize) / 16) % local_work_size) {
         return 8;
-    } else {
-        return 16;
     }
+    return 16;
+
 }
 }  // namespace
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/cum_sum/cum_sum_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/cum_sum/cum_sum_kernel_base.cpp
@@ -33,7 +33,7 @@ size_t CumSumKernelBase::GetRealAxisIndex(const cum_sum_params& params) const {
     size_t index = params.outputs[0].Dimentions() - GetCumSumAxisIndex(params) - 1;
     if (params.outputs[0].Dimentions() == 6)
         return index;
-    else if (params.outputs[0].Dimentions() == 5)
+    if (params.outputs[0].Dimentions() == 5)
         return (index > 1) ? index + 1 : index;
     return (index > 1) ? index + 2 : index;
 }
@@ -108,7 +108,7 @@ bool CumSumKernelBase::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    auto& params = static_cast<const cum_sum_params&>(p);
+    const auto& params = static_cast<const cum_sum_params&>(p);
     if (GetCumSumAxisIndex(params) == -1)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/cum_sum/cum_sum_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/cum_sum/cum_sum_kernel_ref.cpp
@@ -53,7 +53,7 @@ JitConstants CumSumKernelRef::GetJitConstants(const cum_sum_params& params, Disp
             }
 
             size_t num_of_dynamic_inputs = 0;
-            for (auto& input : params.inputs) {
+            for (const auto& input : params.inputs) {
                 if (input.is_dynamic()) {
                     num_of_dynamic_inputs += 1;
                 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.cpp
@@ -104,7 +104,7 @@ bool DeconvolutionKernel_b_fs_zyx_fsv16::Validate(const Params& p) const {
     if (!DeconvolutionKernelBase::Validate(p)) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
-    auto& deconv_params = static_cast<const deconvolution_params&>(p);
+    const auto& deconv_params = static_cast<const deconvolution_params&>(p);
 
     if (deconv_params.outputs[0].GetLayout() != deconv_params.inputs[0].GetLayout())
         DO_NOT_USE_THIS_KERNEL(p.layerID);
@@ -250,7 +250,7 @@ JitConstants DeconvolutionKernel_b_fs_zyx_fsv16::GetJitConstants(const deconvolu
             Tensor::DataChannelName::BATCH };
 
         auto load_type = LoadType::LT_ALIGNED_READ;
-        for (auto& fused_op : params.fused_ops) {
+        for (const auto& fused_op : params.fused_ops) {
             if (!fused_op.output_tensor.SameDims(params.outputs[0]) &&
                 (fused_op.output_tensor.X().v > 1 || fused_op.output_tensor.Y().v > 1 || fused_op.output_tensor.Z().v > 1)) {
                 load_type = LoadType::LT_UNALIGNED;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.h
@@ -24,8 +24,7 @@ protected:
     WeightsLayout GetPreferredWeightsLayout(const deconvolution_params& p) const override {
         if (p.outputs[0].Dimentions() == 4)
             return WeightsLayout::is_os_yx_isv16_osv16;
-        else
-            return WeightsLayout::is_os_zyx_isv16_osv16;
+        return WeightsLayout::is_os_zyx_isv16_osv16;
     }
     bool Validate(const Params& p) const override;
     CommonDispatchData SetDefault(const deconvolution_params& arg) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16_dw.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16_dw.h
@@ -22,8 +22,7 @@ protected:
     WeightsLayout GetPreferredWeightsLayout(const deconvolution_params& p) const override {
         if (p.outputs[0].GetLayout() == DataLayout::b_fs_yx_fsv16)
             return WeightsLayout::gs_oiyx_gsv16;
-        else
-            return WeightsLayout::gs_oizyx_gsv16;
+        return WeightsLayout::gs_oizyx_gsv16;
     }
     bool Validate(const Params& p) const override;
     CommonDispatchData SetDefault(const deconvolution_params& arg) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.cpp
@@ -43,7 +43,7 @@ bool DeconvolutionKernelBase::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.h
@@ -57,8 +57,7 @@ protected:
     virtual WeightsLayout GetPreferredWeightsLayout(const deconvolution_params &params) const {
         if (params.inputs[0].Dimentions() == 4)
             return (params.groups > 1) ? WeightsLayout::goiyx : WeightsLayout::oiyx;
-        else
-            return (params.groups > 1) ? WeightsLayout::goizyx : WeightsLayout::oizyx;
+        return (params.groups > 1) ? WeightsLayout::goizyx : WeightsLayout::oizyx;
     }
     bool Validate(const Params& p) const override;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_imad_along_f_tile_bfx.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_imad_along_f_tile_bfx.cpp
@@ -68,7 +68,7 @@ bool DeconvolutionKernel_imad_along_f_tile_bfx::Validate(const Params& p) const 
     if (!Parent::Validate(p))
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
-    auto& params = static_cast<const deconvolution_params&>(p);
+    const auto& params = static_cast<const deconvolution_params&>(p);
     if (params.groups > 1 && params.weights.IFM().v % 4 != 0)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
@@ -128,8 +128,7 @@ KernelsPriority DeconvolutionKernel_imad_along_f_tile_bfx::GetKernelsPriority(co
     // Currently most optimized for fsv16 formats
     if (p.inputs[0].GetLayout() == DataLayout::b_fs_yx_fsv16 || p.inputs[0].GetLayout() == DataLayout::b_fs_zyx_fsv16)
         return FORCE_PRIORITY_7;
-    else
-        return FORCE_PRIORITY_8;
+    return FORCE_PRIORITY_8;
 }
 
 JitConstants DeconvolutionKernel_imad_along_f_tile_bfx::GetJitConstants(const deconvolution_params& params) const {
@@ -145,7 +144,7 @@ JitConstants DeconvolutionKernel_imad_along_f_tile_bfx::GetJitConstants(const de
     jit.AddConstant(MakeJitConstant("TILE_B", tile_b));
     jit.AddConstant(MakeJitConstant("SIMD", simd));
 
-    auto& in = params.inputs[0];
+    const auto& in = params.inputs[0];
     auto in_layout = in.GetLayout();
 
     // Layout specific params

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_base.cpp
@@ -15,7 +15,7 @@ bool DepthToSpaceKernelBase::Validate(const Params& p) const {
     }
 
     const depth_to_space_params& params = static_cast<const depth_to_space_params&>(p);
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dft/dft_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dft/dft_kernel_ref.cpp
@@ -190,7 +190,7 @@ bool DFTKernelRef::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    auto& params = dynamic_cast<const dft_params&>(p);
+    const auto& params = dynamic_cast<const dft_params&>(p);
     if (params.inputs.size() != 1) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -38,10 +38,9 @@ static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params
 static DynQuanMode get_dynamic_quantize_mode(const dynamic_quantize_params& params) {
     if (params.group_sizes.back() <= 64)
         return DynQuanMode::SMALL_GS;
-    else if (params.group_sizes.back() == std::numeric_limits<uint64_t>::max())
+    if (params.group_sizes.back() == std::numeric_limits<uint64_t>::max())
         return DynQuanMode::PER_TOKEN;
-    else
-        return DynQuanMode::LARGE_GS;
+    return DynQuanMode::LARGE_GS;
 }
 
 static size_t get_match_vector_size(const dynamic_quantize_params& params) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/ed_pgg/prior_grid_generator_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/ed_pgg/prior_grid_generator_kernel_ref.cpp
@@ -57,7 +57,7 @@ bool ExperimentalDetectronPriorGridGeneratorKernelRef::Validate(const Params &p)
     if (p.GetType() != KernelType::EXPERIMENTAL_DETECTRON_PRIOR_GRID_GENERATOR)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
-    auto &params = dynamic_cast<const experimental_detectron_prior_grid_generator_params&>(p);
+    const auto &params = dynamic_cast<const experimental_detectron_prior_grid_generator_params&>(p);
     if (params.inputs.size() != 1)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
@@ -103,7 +103,7 @@ Datatype EltwiseKernelBase::GetAccumulatorType(const eltwise_params &params) con
     Datatype types[] = { Datatype::F32, Datatype::F16, Datatype::INT64, Datatype::INT32, Datatype::UINT32};
 
     for (Datatype type : types)
-        for (auto& in : params.inputs)
+        for (const auto& in : params.inputs)
             if (in.GetDType() == type)
                 return type;
 
@@ -121,7 +121,7 @@ bool EltwiseKernelBase::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    auto& operations = params.operations;
+    const auto& operations = params.operations;
 
     if (operations.empty()) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
@@ -143,7 +143,7 @@ bool EltwiseKernelBase::Validate(const Params& p) const {
     }
 
     const eltwise_params& orgParams = static_cast<const eltwise_params&>(p);
-    for (auto& fused_op : orgParams.fused_ops) {
+    for (const auto& fused_op : orgParams.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
@@ -191,7 +191,7 @@ JitConstants EltwiseKernelBase::GetOperationsJitConstants(const eltwise_params& 
         std::string op, cast_type;
         std::string input0_str = cast_type + "INPUT_" + op_num_str + "_0";
         std::string input1_str = cast_type + "INPUT_" + op_num_str + "_1";
-        auto& coefficients = params.coefficients;
+        const auto& coefficients = params.coefficients;
 
         if (useVload8) {
             cast_type = "(MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, 8))";
@@ -238,7 +238,7 @@ JitConstants EltwiseKernelBase::GetOperationsJitConstants(const eltwise_params& 
             case EltwiseMode::MODULU:
             case EltwiseMode::MIN:
             case EltwiseMode::MAX: {
-                auto mode = (ew.mode == EltwiseMode::MODULU ? "mod" : (ew.mode == EltwiseMode::MIN ? "min" : "max"));
+                const auto *mode = (ew.mode == EltwiseMode::MODULU ? "mod" : (ew.mode == EltwiseMode::MIN ? "min" : "max"));
                 auto input_0_type = params.inputs[0].GetDType();
                 auto input_1_type = params.inputs[1].GetDType();
 
@@ -429,7 +429,7 @@ JitConstants EltwiseKernelBase::MakeInputDeclsJitConstants(const eltwise_params&
                                                            bool /*useVload8*/) const {
     JitConstants jit = {};
     std::string inputs_decls;
-    auto& updateInputs = params.updateInputIds;
+    const auto& updateInputs = params.updateInputIds;
     for (size_t i = 0; i < params.inputs.size(); i++) {
         // const should be added only to inputs which will not be updated
         std::string const_str = "const";
@@ -448,7 +448,7 @@ JitConstants EltwiseKernelBase::MakeInputDeclsJitConstants(const eltwise_params&
 JitConstants EltwiseKernelBase::MakeIndexJitConstants(const eltwise_params& params,
                                                       bool useVload8) const {
     JitConstants jit = {};
-    auto& updateInputs = params.updateInputIds;
+    const auto& updateInputs = params.updateInputIds;
 
     auto GetIdxOrderVecForLayout = [&](DataLayout l, bool layoutBased, uSize stride) -> std::vector<std::string> {
         // TODO: Generalize this method
@@ -609,12 +609,12 @@ JitConstants EltwiseKernelBase::GetJitConstantsCommon(const eltwise_params& para
     jit.Merge(GetOperationsJitConstants(params, useVload8));
 
     std::string do_eltwise;
-    auto& operations = params.operations;
+    const auto& operations = params.operations;
     for (size_t op_num = 0; op_num < operations.size(); op_num++) {
         do_eltwise += "\\\n\tOPERATION" + toCodeString(op_num) + ";";
     }
 
-    auto& updateInputs = params.updateInputIds;
+    const auto& updateInputs = params.updateInputIds;
     for (size_t update_input_idx = 0; update_input_idx < updateInputs.size(); update_input_idx++)
         do_eltwise += "\\\n\tinput" + toCodeString(updateInputs[update_input_idx].inputId) + "[GET_INDEX(INPUT, " +
                       toCodeString(updateInputs[update_input_idx].inputId) + ", " +

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
@@ -120,8 +120,8 @@ bool EltwiseKernel_blocked_opt::Validate(const Params& params) const {
 
     auto compareTensors = [](const DataTensor& input0, const DataTensor& input1) -> bool {
         // Check all parameters except DataType
-        auto& input0_dims = input0.GetDims();
-        auto& input1_dims = input1.GetDims();
+        const auto& input0_dims = input0.GetDims();
+        const auto& input1_dims = input1.GetDims();
         bool same = input0.GetLayout() == input1.GetLayout() &&
                     input0.GetPaddedVal() == input1.GetPaddedVal() &&
                     input0.GetViewOffset() == input1.GetViewOffset() &&
@@ -165,7 +165,7 @@ JitConstants EltwiseKernel_blocked_opt::MakeLoadJitConstants(const eltwise_param
 
     auto Padded = [](const DataTensor& tensor) -> bool {
         bool is_padded = false;
-        auto& tensor_dims = tensor.GetDims();
+        const auto& tensor_dims = tensor.GetDims();
         for (size_t i = 0; i < tensor_dims.size(); i++) {
             is_padded |= tensor_dims[i].pad.Total() != 0;
         }
@@ -311,7 +311,7 @@ JitConstants EltwiseKernel_blocked_opt::GetJitConstants(const eltwise_params& pa
     jit.Merge(GetOperationsJitConstants(params, use_vload, vec_size));
 
     std::string do_eltwise;
-    auto& operations = params.operations;
+    const auto& operations = params.operations;
     for (size_t op_num = 0; op_num < operations.size(); op_num++) {
         const auto &ew = operations[op_num];
         for (size_t input_idx = 0; input_idx < ew.inputs.size(); input_idx++) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_mixed_byxf_and_fs_b_yx_fsv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_mixed_byxf_and_fs_b_yx_fsv32.cpp
@@ -149,8 +149,8 @@ KernelsPriority EltwiseKernel_mixed_byxf_and_fs_b_yx_fsv32::GetKernelsPriority(c
         (p.outputs[0].GetLayout() ==
          p.inputs[1].GetLayout())) {  // There is no need for reordering kernel, better use something more optimal
         return FORCE_PRIORITY_9;
-    } else {  // There is need for byxf/fsv32 reordering kernel use this one
+    }  // There is need for byxf/fsv32 reordering kernel use this one
         return FORCE_PRIORITY_2;
-    }
+
 }
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_block_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_block_kernel_base.h
@@ -27,8 +27,7 @@ protected:
         auto out_elements_count_per_batch = params.outputs[0].LogicalSize() / batchSize;
         if (out_elements_count_per_batch % 16 == 0)
             return 2;
-        else
-            return 1;
+        return 1;
     }
 };
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.cpp
@@ -184,7 +184,7 @@ bool FullyConnectedKernelBase::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -46,7 +46,7 @@ namespace kernel_selector {
 
 namespace fc_kernel_bf_tiled_utils {
 std::pair<size_t, size_t> get_input_bf_size(const fully_connected_params& params) {
-    auto& input = params.inputs[0];
+    const auto& input = params.inputs[0];
     size_t input_f = input.Feature().v;
     size_t input_batch = input.Batch().v;
 
@@ -313,10 +313,10 @@ bool FullyConnected_bf_tiled::Validate(const Params& params) const {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
 
-    auto& fc_params = static_cast<const fully_connected_params&>(params);
-    auto& input = fc_params.inputs[0];
-    auto& output = fc_params.outputs[0];
-    auto& weights = fc_params.weights;
+    const auto& fc_params = static_cast<const fully_connected_params&>(params);
+    const auto& input = fc_params.inputs[0];
+    const auto& output = fc_params.outputs[0];
+    const auto& weights = fc_params.weights;
 
     // Block reads must be aligned to 4 bytes, for fp16 we can correct for offset misalignment,
     // but we need to ensure that batch pitch preserves alignment.
@@ -499,33 +499,37 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
             if (is_weight_vertical(params, output_f)) {
                 if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
                     return selector.Default(tune_params(1, 1, 4, 2, 1, 1, 1, EXE_MODE_DEFAULT));
-                } else if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16) {
+                }
+                if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16) {
                     return selector.Default(tune_params(1, 1, 4, 4, 1, 1, 1, EXE_MODE_DEFAULT));
                 }
             } else if (is_weight_small_kn(params, output_f)) {
                 if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
                     if (swiglu_fused)
                         return selector.Default(tune_params(1, 1, 4, 2, 2, 1, 1, EXE_MODE_DEFAULT));
-                    else
-                        return selector.Default(tune_params(1, 1, 4, 2, 1, 1, 1, EXE_MODE_DEFAULT));
-                } else {
+                    return selector.Default(tune_params(1, 1, 4, 2, 1, 1, 1, EXE_MODE_DEFAULT));
+                }
+                {
                     return selector.Default(tune_params(1, 2, 4, 2, 1, 1, 1, EXE_MODE_DEFAULT));
                 }
             } else {
                 if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16) {
                     return selector.Default(tune_params(1, 1, 4, 4, 1, 1, 1, EXE_MODE_DEFAULT));
-                } else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2) {
+                }
+                if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2) {
                     // Here : b1 static
                     if (swiglu_fused) {
                         return selector.Default(tune_params(1, 4, 4, 2, 2, 1, 1, EXE_MODE_DEFAULT));
-                    } else {
+                    }
+                    {
                         selector.Case(tune_params(1, 4, 4, 2, 2, 1, 1, EXE_MODE_DEFAULT))
                                 .Case(tune_params(1, 4, 4, 2, 1, 1, 1, EXE_MODE_DEFAULT));
                     }
                 } else {
                     if (swiglu_fused) {
                         return selector.Default(tune_params(1, 2, 4, 2, 2, 1, 1, EXE_MODE_DEFAULT));
-                    } else {
+                    }
+                    {
                         return selector.Default(tune_params(1, 2, 4, 2, 1, 1, 1, EXE_MODE_DEFAULT));
                     }
                 }
@@ -544,10 +548,9 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
 
             if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16)
                 return selector.Default(tune_params(8, 1, 1, 4, forced_outer_ofm, 1, 1, EXE_MODE_DEFAULT));
-            else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2)
+            if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2)
                 return selector.Default(tune_params(8, 4, 1, 2, forced_outer_ofm, 1, 1, EXE_MODE_DEFAULT));
-            else
-                return selector.Default(tune_params(8, 2, 1, 4, forced_outer_ofm, 1, 1, EXE_MODE_DEFAULT));
+            return selector.Default(tune_params(8, 2, 1, 4, forced_outer_ofm, 1, 1, EXE_MODE_DEFAULT));
         }
     } else if (params.compressed && params.engineInfo.supports_immad) {
         return selector.Default(tune_params(1, 1, 1, 4, 1, 1, 1, EXE_MODE_DEFAULT));
@@ -921,7 +924,7 @@ void FullyConnected_bf_tiled::SetDispatchDataFunc(KernelData& kd, const Dispatch
 
         kd.kernels[execute].skip_execution = KernelData::SkipKernelExecution(prim_params);
 
-        auto& input = prim_params.inputs[0];
+        const auto& input = prim_params.inputs[0];
         if (prim_params.outputs[0].GetLayout() == DataLayout::bfyx)
             OPENVINO_ASSERT(input.X().pad.Total() == 0 && input.Y().pad.Total() == 0,
                             "[GPU] Invalid padding in spatial axes observed in FC bf tiled.");
@@ -1020,7 +1023,7 @@ void FullyConnected_bf_tiled::GetUpdateDispatchDataFunc(KernelData& kd) const {
 
 KernelsData FullyConnected_bf_tiled::GetTunedKernelsDataByIndex(const Params &params,
                                                                 const int autoTuneIndex) const {
-    auto& fc_params = static_cast<const fully_connected_params&>(params);
+    const auto& fc_params = static_cast<const fully_connected_params&>(params);
 
     if (autoTuneIndex >= 0 && autoTuneIndex < static_cast<int>(auto_tune_params.size())
         && !TuneParamsSelector::VerifyTuneParams(fc_params, auto_tune_params[autoTuneIndex]))
@@ -1137,7 +1140,7 @@ KernelsData FullyConnected_bf_tiled::GetKernelsDataForAutoTune(const Params& par
 
 KernelsData FullyConnected_bf_tiled::GetKernelsData(const Params& params) const {
     KernelsData res = {};
-    auto& fc_params = static_cast<const fully_connected_params&>(params);
+    const auto& fc_params = static_cast<const fully_connected_params&>(params);
     auto tparams = GetAutoTuneParams(fc_params);
 
     KernelsData kds = GetTunedKernelsDataByIndex(params, -1);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled_dyn_b.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled_dyn_b.cpp
@@ -65,7 +65,7 @@ size_t FullyConnected_bf_tiled_dyn_b::SelectTileB(size_t batch_size) {
 }
 
 bool FullyConnected_bf_tiled_dyn_b::IsBeneficial(const fully_connected_params& params) {
-    auto& weights = params.weights;
+    const auto& weights = params.weights;
     auto wt = weights.GetDType();
 
     // INT4 compressed, F16 input, shape_agnostic only
@@ -98,10 +98,10 @@ bool FullyConnected_bf_tiled_dyn_b::Validate(const Params& params) const {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
 
-    auto& fc_params = static_cast<const fully_connected_params&>(params);
-    auto& input = fc_params.inputs[0];
-    auto& output = fc_params.outputs[0];
-    auto& weights = fc_params.weights;
+    const auto& fc_params = static_cast<const fully_connected_params&>(params);
+    const auto& input = fc_params.inputs[0];
+    const auto& output = fc_params.outputs[0];
+    const auto& weights = fc_params.weights;
 
     // Only INT4 compressed weights
     auto wt = weights.GetDType();
@@ -178,10 +178,9 @@ FullyConnected_bf_tiled_dyn_b::GetTuneParams(const fully_connected_params& param
     // Same base config as static_b16 (optimized for INT4 on iGPU)
     if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16)
         return tune_params(1, 1, 4, 1, 1, EXE_MODE_DEFAULT);
-    else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2)
+    if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2)
         return tune_params(2, 1, 2, 1, 1, EXE_MODE_DEFAULT);
-    else  // os_is_yx_osv32_isv2 (default)
-        return tune_params(2, 1, 4, 1, 1, EXE_MODE_DEFAULT);
+    return tune_params(2, 1, 4, 1, 1, EXE_MODE_DEFAULT);
 }
 
 FullyConnected_bf_tiled_dyn_b::DispatchData
@@ -345,7 +344,7 @@ JitConstants FullyConnected_bf_tiled_dyn_b::GetJitConstants(const fully_connecte
 }
 
 KernelsData FullyConnected_bf_tiled_dyn_b::GetKernelsData(const Params& params) const {
-    auto& fc_params = static_cast<const fully_connected_params&>(params);
+    const auto& fc_params = static_cast<const fully_connected_params&>(params);
     auto tparams = GetTuneParams(fc_params);
 
     // Determine optimal weight layout

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bfyx_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bfyx_ref.cpp
@@ -96,7 +96,7 @@ JitConstants FullyConnected_bfyx_Ref::GetJitConstants(const fully_connected_para
 }
 
 KernelsData FullyConnected_bfyx_Ref::GetKernelsData(const Params& params) const {
-    auto& fc_params = static_cast<const fully_connected_params&>(params);
+    const auto& fc_params = static_cast<const fully_connected_params&>(params);
     KernelsData res = {};
     for (size_t i = 0; i < autoTuneOptions.size(); i++) {
         KernelsData kd = GetTunedKernelsDataByIndex(

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bs_f_bsv16_b1.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bs_f_bsv16_b1.cpp
@@ -32,7 +32,7 @@ DeviceFeaturesKey FullyConnected_bs_f_bsv16_b1::get_required_device_features_key
 JitConstants FullyConnected_bs_f_bsv16_b1::GetJitConstants(
     const fully_connected_params& params,
     const FullyConnectedKernelBase::DispatchData& dispatchData) const {
-    auto& d = static_cast<const DispatchData&>(dispatchData);
+    const auto& d = static_cast<const DispatchData&>(dispatchData);
     auto cldnn_jit = FullyConnectedKernelBase::GetJitConstants(params, dispatchData);
     cldnn_jit.AddConstants({
         MakeJitConstant("SUB_GROUP_SIZE", dispatchData.lws[0]),

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_gemv.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_gemv.cpp
@@ -79,7 +79,7 @@ bool FullyConnected_GEMV::Validate(const Params& params) const {
     auto wl = weights.GetLayout();
     auto wo = weights.OFM().v;
 
-    auto& fc_input = fc_params.inputs[0];
+    const auto& fc_input = fc_params.inputs[0];
     if (is_swiglu_fused(fc_params)) {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
@@ -197,7 +197,7 @@ JitConstants FullyConnected_GEMV::GetJitConstants(const fully_connected_params& 
 }
 
 KernelsData FullyConnected_GEMV::GetTunedKernelsDataByIndex(const Params& params, const int autoTuneIndex) const {
-    auto& fc_params = static_cast<const fully_connected_params&>(params);
+    const auto& fc_params = static_cast<const fully_connected_params&>(params);
     auto output_f = get_output_aligned_bf_size(fc_params, false).second;
 
     WeightsLayout weights_layout = WeightsLayout::os_iyx_osv16;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_mmad.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_mmad.cpp
@@ -157,9 +157,9 @@ JitConstants FullyConnectedKernelMMAD::GetJitConstants(const fully_connected_par
 
     auto jit = Parent::GetJitConstants(params, runInfo);
 
-    auto& input = params.inputs[0];
-    auto& output = params.outputs[0];
-    auto& weights = params.weights;
+    const auto& input = params.inputs[0];
+    const auto& output = params.outputs[0];
+    const auto& weights = params.weights;
 
     size_t sub_group_pack_size = tuning_data.sub_group_size * tuning_data.pack_size;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_ref.cpp
@@ -108,7 +108,7 @@ static inline std::string GetOrderString(const std::vector<std::string>& order) 
 
 static std::string GetDataIndexOrder(const gather_elements_params& params, size_t axis) {
     auto idx_order = GetDefaultOrder(params.outputs[0].GetDims().size());
-    auto index_macro = "indices_val";
+    const auto *index_macro = "indices_val";
 
     idx_order[axis] = index_macro;
 
@@ -187,7 +187,7 @@ bool GatherElementsKernelRef::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
@@ -80,16 +80,15 @@ static size_t GetNonEmptyDimsNumber(const DataTensor& data_tensor) {
                 break;
         }
         return data_tensor.Dimentions() - one_size_dims;
-    } else {
-        return 1;
     }
+    return 1;
+
 }
 
 static int64_t GetGatherBatchDim(const gather_params& params) {
     if (params.batch_dim < 0)
         return (int64_t)GetNonEmptyDimsNumber(params.inputs[1]) + params.batch_dim;
-    else
-        return params.batch_dim;
+    return params.batch_dim;
 }
 
 static inline Tensor::Dim GetGatherIndexDim(const gather_params& params) {
@@ -157,8 +156,8 @@ static inline std::vector<std::string> GetOrder(size_t size) {
 
 static std::string GetDictionaryIndexOrder(const gather_params& params, size_t axis) {
     auto idx_order = GetOrder(params.outputs[0].GetDims().size());
-    auto input_axis_index_macro = "INPUT_AXIS_INDEX";
-    auto zero_val = "0";
+    const auto *input_axis_index_macro = "INPUT_AXIS_INDEX";
+    const auto *zero_val = "0";
 
     size_t dictionary_dims_num = GetNonEmptyDimsNumber(params.inputs[0]);
     size_t indices_dims_num = GetNonEmptyDimsNumber(params.outputs[0]) - dictionary_dims_num + 1;
@@ -188,7 +187,7 @@ static std::string GetIndicesIdxOrder(const gather_params& params, size_t axis, 
     const size_t indices_dims_num = GetNonEmptyDimsNumber(params.inputs[1]);
 
     idx_order = GetOrder(output_rank);
-    const auto zero_val = "0";
+    const auto *const zero_val = "0";
 
      // Shift indices of Gather indices input related to output dims
     for (size_t i = static_cast<size_t>(batch_dim); i < indices_dims_num; i++) {
@@ -321,7 +320,7 @@ bool GatherKernelRef::Validate(const Params& p) const {
 
     const gather_params& params = static_cast<const gather_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
@@ -337,11 +336,11 @@ bool GatherKernelRef::Validate(const Params& p) const {
             return false;
         };
 
-        for (auto& in : params.inputs) {
+        for (const auto& in : params.inputs) {
             if (!supported_tensor_layout(in))
                 DO_NOT_USE_THIS_KERNEL(p.layerID);
         }
-        for (auto& out : params.outputs) {
+        for (const auto& out : params.outputs) {
             if (!supported_tensor_layout(out))
                 DO_NOT_USE_THIS_KERNEL(p.layerID);
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_ref.cpp
@@ -164,7 +164,7 @@ bool GatherNDKernelRef::Validate(const Params& p) const {
         }
     }
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.cpp
@@ -333,7 +333,7 @@ bool GemmKernelBase::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8.cpp
@@ -98,13 +98,14 @@ inline size_t GemmKernelMMADint8::GetMmadOperationsNumber(const GemmTuningData& 
 bool GemmKernelMMADint8::HasLeftovers(const GemmTuningData& tuning_data, int tile_size) const {
     if (tile_size == 32) {
         return tuning_data.size_m % 32 || tuning_data.size_n % 16 || tuning_data.size_k % 64;
-    } else if (tile_size == 16) {
-        return tuning_data.size_m % 16 || tuning_data.size_n % 16 || tuning_data.size_k % 64;
-    } else if (tile_size == 8) {
-        return tuning_data.size_m % 8 || tuning_data.size_n % 8 || tuning_data.size_k % 32;
-    } else {
-        return true;
     }
+    if (tile_size == 16) {
+        return tuning_data.size_m % 16 || tuning_data.size_n % 16 || tuning_data.size_k % 64;
+    }
+    if (tile_size == 8) {
+        return tuning_data.size_m % 8 || tuning_data.size_n % 8 || tuning_data.size_k % 32;
+    }         return true;
+
 }
 
 GemmKernelMMADint8::GemmTuningData GemmKernelMMADint8::SetTuningParams(const gemm_params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8_slm.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8_slm.cpp
@@ -140,10 +140,9 @@ KernelsPriority GemmKernelMMADslmInt8::GetKernelsPriority(const Params& params) 
 
     if ((mmad_operations_number >= 1024 * 1024 * 1024) || (tuning_data.size_m == 384 && tuning_data.size_k == 384 && tuning_data.size_n == 64))
         return FORCE_PRIORITY_2;
-    else if (mmad_operations_number <= 65536 || tuning_data.size_k <= 64)
+    if (mmad_operations_number <= 65536 || tuning_data.size_k <= 64)
         return DONT_USE_IF_HAVE_SOMETHING_ELSE;
-    else
-        return FORCE_PRIORITY_5;
+    return FORCE_PRIORITY_5;
 }
 
 bool GemmKernelMMADslmInt8::Validate(const Params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -235,15 +235,19 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
 
             if (loc == 0) {
                 return data_tensor.Batch().v;
-            } else if (loc == 1) {
+            }
+            if (loc == 1) {
                 return data_tensor.Feature().v;
-            } else if (loc == (rank - 1) && rank >= 3) {
+            }
+            if (loc == (rank - 1) && rank >= 3) {
                 return data_tensor.X().v;
-            } else if (loc == (rank - 2) && rank >= 4) {
+            } if (loc == (rank - 2) && rank >= 4) {
                 return data_tensor.Y().v;
-            } else if (loc == (rank - 3) && rank >= 5) {
+            }
+            if (loc == (rank - 3) && rank >= 5) {
                 return data_tensor.Z().v;
-            } else if (loc == (rank - 4) && rank >= 6) {
+            }
+            if (loc == (rank - 4) && rank >= 6) {
                 return data_tensor.W().v;
             }
             OPENVINO_THROW("Target dimension is not found.");
@@ -462,7 +466,7 @@ bool GemmKernelTiledOpt::Validate(const Params& params) const {
 
     size_t num_inputs = (gmm_params.indirect_input0 || gmm_params.indirect_input1) ? gmm_params.inputs.size() - 1 : gmm_params.inputs.size();
     for (size_t input_idx = 0; input_idx < num_inputs; ++input_idx) {
-        auto& input = gmm_params.inputs[input_idx];
+        const auto& input = gmm_params.inputs[input_idx];
         if (!Tensor::SimpleLayout(input.GetLayout())) {
             DO_NOT_USE_THIS_KERNEL(params.layerID);
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_opt_bilinear_zeros.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_opt_bilinear_zeros.cpp
@@ -33,7 +33,7 @@ bool GridSampleKernelOpt_BilinearZeros::Validate(const Params& params) const {
 
     auto PaddedSpatial = [](const MultiDataTensor& tensors) -> bool {
         bool is_padded = false;
-        for (auto& tensor : tensors) {
+        for (const auto& tensor : tensors) {
             is_padded |= tensor.X().pad.Total() != 0;
             is_padded |= tensor.Y().pad.Total() != 0;
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_across_channel_multiple_features.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_across_channel_multiple_features.cpp
@@ -42,9 +42,11 @@ static unsigned int GetOfmPerSimd(const lrn_params& params) {
 
     if ((output.Feature().v % 8 == 0) && local_size > 4) {
         return 8;
-    } else if ((output.Feature().v % 4 == 0) && local_size > 2) {
+    }
+    if ((output.Feature().v % 4 == 0) && local_size > 2) {
         return 4;
-    } else if ((output.Feature().v % 2 == 0) && local_size > 1) {
+    }
+    if ((output.Feature().v % 2 == 0) && local_size > 1) {
         return 2;
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_base.cpp
@@ -13,7 +13,7 @@ bool LRNKernelBase::Validate(const Params& p) const {
 
     const lrn_params& params = static_cast<const lrn_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_b_fs_yx_fsv16.cpp
@@ -703,8 +703,7 @@ KernelsData MVNKernel_b_fs_yx_fsv16::GetKernelsData(const Params& params) const 
 
     if (enough_slm && enough_lws && enough_items)
         return GetMultiStageKernelsData(orgParams);
-    else
-        return GetCommonKernelsData(params);
+    return GetCommonKernelsData(params);
 }
 
 KernelsPriority MVNKernel_b_fs_yx_fsv16::GetKernelsPriority(const Params& /*params*/) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_base.cpp
@@ -11,7 +11,7 @@ namespace kernel_selector {
 bool MVNKernelBase::Validate(const Params& params) const {
     const mvn_params& orgParams = static_cast<const mvn_params&>(params);
 
-    for (auto& fused_op : orgParams.fused_ops) {
+    for (const auto& fused_op : orgParams.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(params.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_ref.cpp
@@ -55,8 +55,7 @@ JitConstants MVNKernelRef::GetJitConstants(const mvn_params& params, DispatchDat
 std::string MVNKernelRef::GetKernelName(const mvn_params& params) const {
     if (params.mvnMode == MVNMode::ACROSS_CHANNELS)
         return kernelName + "_across_channels";
-    else
-        return kernelName + "_within_channels";
+    return kernelName + "_within_channels";
 }
 
 KernelsData MVNKernelRef::GetKernelsData(const Params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/non_max_suppression/non_max_suppression_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/non_max_suppression/non_max_suppression_kernel_ref.cpp
@@ -172,7 +172,7 @@ bool NonMaxSuppressionKernelRef::Validate(const Params& p) const {
 
     const non_max_suppression_params& params = static_cast<const non_max_suppression_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_base.cpp
@@ -79,7 +79,7 @@ KernelsData NormalizeKernelBase::GetCommonKernelsData(const Params& params) cons
 bool NormalizeKernelBase::Validate(const Params& params) const {
     const normalize_params& orgParams = static_cast<const normalize_params&>(params);
 
-    for (auto& fused_op : orgParams.fused_ops) {
+    for (const auto& fused_op : orgParams.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(params.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_base.cpp
@@ -12,7 +12,7 @@ bool PermuteKernelBase::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
     const permute_params& params = static_cast<const permute_params&>(p);
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op)) {
             DO_NOT_USE_THIS_KERNEL(p.layerID);
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_bfzyx_to_bfyxz.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_bfzyx_to_bfyxz.cpp
@@ -170,10 +170,11 @@ KernelsPriority PermuteKernel_bfzyx_to_bfyxz::GetKernelsPriority(const Params& p
 
     if (IsMultipleDefaultTileSize(newParams.inputs[0].Z().v) && IsMultipleDefaultTileSize(newParams.inputs[0].X().v)) {
         return FORCE_PRIORITY_1;
-    } else if (IsMultipleDefaultTileSize(newParams.inputs[0].Z().v) || IsMultipleDefaultTileSize(newParams.inputs[0].X().v)) {
-        return FORCE_PRIORITY_2;
-    } else {
-        return FORCE_PRIORITY_3;
     }
+    if (IsMultipleDefaultTileSize(newParams.inputs[0].Z().v) || IsMultipleDefaultTileSize(newParams.inputs[0].X().v)) {
+        return FORCE_PRIORITY_2;
+    }
+    return FORCE_PRIORITY_3;
+
 }
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_ref.cpp
@@ -186,7 +186,7 @@ JitConstants PermuteKernelRef::GetJitConstants(const permute_params& params, con
     }
 
     assert(params.order.size() == in_idx.size());
-    for (auto& o : params.order) {
+    for (const auto& o : params.order) {
         permute_out_idx.push_back(in_idx[o]);
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4.cpp
@@ -314,10 +314,11 @@ KernelsPriority PermuteKernel_tile_8x8_4x4::GetKernelsPriority(const Params& par
 
     if ((newParams.inputs[0].Feature().v >= DEFAULT_TILE_SIZE) && (newParams.inputs[0].X().v >= DEFAULT_TILE_SIZE)) {
         return FORCE_PRIORITY_1;
-    } else if ((newParams.inputs[0].Feature().v >= DEFAULT_TILE_SIZE) || (newParams.inputs[0].X().v >= DEFAULT_TILE_SIZE)) {
-        return FORCE_PRIORITY_2;
-    } else {
-        return FORCE_PRIORITY_3;
     }
+    if ((newParams.inputs[0].Feature().v >= DEFAULT_TILE_SIZE) || (newParams.inputs[0].X().v >= DEFAULT_TILE_SIZE)) {
+        return FORCE_PRIORITY_2;
+    }
+    return FORCE_PRIORITY_3;
+
 }
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4_fsv.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4_fsv.cpp
@@ -358,12 +358,13 @@ KernelsPriority PermuteKernel_tile_8x8_4x4_fsv::GetKernelsPriority(const Params&
 
     if (num_working_groups == 1) {
         return DONT_USE_IF_HAVE_SOMETHING_ELSE;
-    } else if ((rotating_dim >= DEFAULT_TILE_SIZE) && (feature >= DEFAULT_TILE_SIZE)) {
-        return FORCE_PRIORITY_1;
-    } else if ((rotating_dim >= DEFAULT_TILE_SIZE) || (feature >= DEFAULT_TILE_SIZE)) {
-        return FORCE_PRIORITY_2;
-    } else {
-        return FORCE_PRIORITY_3;
     }
+    if ((rotating_dim >= DEFAULT_TILE_SIZE) && (feature >= DEFAULT_TILE_SIZE)) {
+        return FORCE_PRIORITY_1;
+    }
+    if ((rotating_dim >= DEFAULT_TILE_SIZE) || (feature >= DEFAULT_TILE_SIZE)) {
+        return FORCE_PRIORITY_2;
+    }         return FORCE_PRIORITY_3;
+
 }
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_base.cpp
@@ -11,9 +11,9 @@ bool PoolingKernelBase::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    auto& params = dynamic_cast<const pooling_params&>(p);
+    const auto& params = dynamic_cast<const pooling_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
@@ -30,22 +30,21 @@ Datatype PoolingKernelBase::GetAccumulatorType(const pooling_params& params) con
 
     if (pool_type == PoolType::MAX) {
         return input_dt;
-    } else {
-        switch (input_dt) {
-            case Datatype::F32: return Datatype::F32;
-            case Datatype::F16: return Datatype::F32;
-            case Datatype::INT8: return Datatype::INT32;
-            case Datatype::UINT8: return Datatype::INT32;
-            default: return Datatype::F32;
-        }
     }
+    switch (input_dt) {
+        case Datatype::F32: return Datatype::F32;
+        case Datatype::F16: return Datatype::F32;
+        case Datatype::INT8: return Datatype::INT32;
+        case Datatype::UINT8: return Datatype::INT32;
+        default: return Datatype::F32;
+    }
+
 }
 
 Datatype PoolingKernelBase::GetActivationType(const pooling_params& params) const {
     if (params.outputs[0].GetDType() == Datatype::F16)
         return Datatype::F16;
-    else
-        return Datatype::F32;
+    return Datatype::F32;
 }
 
 
@@ -94,9 +93,10 @@ bool PoolingKernelBase::NeedsBoundaryCheck(const pooling_params& pp) const {
 
     if (pp.poolPad.x != 0 || pp.poolPad.y != 0 || pp.poolPad.z != 0) {
         return true;
-    } else if (pp.poolDilation.x > 1 || pp.poolDilation.y > 1 || pp.poolDilation.z > 1) {
+    }
+    if (pp.poolDilation.x > 1 || pp.poolDilation.y > 1 || pp.poolDilation.z > 1) {
         return true;
-    } else if ((((input.X().v - pp.poolSize.x) / pp.poolStride.x) + 1) < output.X().v ||
+    } if ((((input.X().v - pp.poolSize.x) / pp.poolStride.x) + 1) < output.X().v ||
                (((input.Y().v - pp.poolSize.y) / pp.poolStride.y) + 1) < output.Y().v ||
                (((input.Z().v - pp.poolSize.z) / pp.poolStride.z) + 1) < output.Z().v) {
         return true;
@@ -119,7 +119,7 @@ bool PoolingKernelBase::NeedsBoundaryCheck(const pooling_params& pp) const {
 
 bool PoolingKernelBase::EnableRound(const kernel_selector::pooling_params& params) const {
     bool has_fused_quantize_to_int8 = false;
-    for (auto& op : params.fused_ops) {
+    for (const auto& op : params.fused_ops) {
         if (op.GetType() == FusedOpType::QUANTIZE &&
             (op.output_tensor.GetDType() == Datatype::INT8 || op.output_tensor.GetDType() == Datatype::UINT8)) {
             has_fused_quantize_to_int8 = true;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv16.cpp
@@ -39,19 +39,17 @@ DeviceFeaturesKey PoolingKernel_b_fs_yx_fsv16::get_required_device_features_key(
 size_t PoolingKernel_b_fs_yx_fsv16::GetBlockSize(const pooling_params& params) const {
     if (params.outputs[0].X().v > 4)
         return 8;
-    else if (params.outputs[0].X().v > 1)
+    if (params.outputs[0].X().v > 1)
         return 2;
-    else
-        return 1;
+    return 1;
 }
 
 size_t PoolingKernel_b_fs_yx_fsv16::GetSimdSize(const pooling_params& params) const {
-    auto& out = params.outputs[0];
+    const auto& out = params.outputs[0];
     // Use smaller simd size in case of global pooling and small channels count to have more threads
     if (out.X().v == 1 && out.Y().v == 1 && out.Feature().v < 64 && IsSIMDSizeSupported(params.engineInfo, 8))
         return 8;
-    else
-        return 16;
+    return 16;
 }
 
 PoolingKernelBase::DispatchData PoolingKernel_b_fs_yx_fsv16::SetDefault(const pooling_params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_vload8_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_vload8_opt.cpp
@@ -132,9 +132,9 @@ static inline size_t CalculateTotalWorkItemCount(const quantize_params& params) 
             spatial = params.outputs[0].X().v * params.outputs[0].Y().v;
 
         return (feature * batch * spatial);
-    } else {
-        return params.outputs[0].LogicalSize();
     }
+    return params.outputs[0].LogicalSize();
+
 }
 
 static inline int GetInnerBatchBlockSize(const DataTensor& tensor) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/random_uniform/random_uniform_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/random_uniform/random_uniform_kernel_ref.cpp
@@ -115,7 +115,7 @@ bool RandomUniformKernelRef::Validate(const Params &params) const {
 
     // output shape, min value, max value
     constexpr uint32_t number_of_inputs = 3;
-    auto &randomUniformParams = dynamic_cast<const random_uniform_params &>(params);
+    const auto &randomUniformParams = dynamic_cast<const random_uniform_params &>(params);
     if (randomUniformParams.inputs.size() != number_of_inputs) {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/range/range_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/range/range_kernel_ref.cpp
@@ -93,11 +93,11 @@ bool RangeKernelRef::Validate(const Params &p) const {
     if (p.GetType() != KernelType::RANGE)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
-    auto &params = dynamic_cast<const range_params&>(p);
+    const auto &params = dynamic_cast<const range_params&>(p);
     if (params.inputs.size() != 3)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
-    for (auto &input : params.inputs)
+    for (const auto &input : params.inputs)
         if (input.LogicalSize() != 1)
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     return true;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_base.cpp
@@ -11,13 +11,13 @@
 namespace kernel_selector {
 
 bool ReduceKernelBase::Validate(const Params& p) const {
-    auto& params = dynamic_cast<const reduce_params&>(p);
+    const auto& params = dynamic_cast<const reduce_params&>(p);
 
     if (params.GetType() != KernelType::REDUCE) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
@@ -183,15 +183,15 @@ Datatype ReduceKernelBase::GetAccumulatorType(const reduce_params& params) const
 
     if (reduce_mode == ReduceMode::MAX || reduce_mode == ReduceMode::MIN) {
         return input_dt;
-    } else {
-        switch (input_dt) {
-            case Datatype::F32: return Datatype::F32;
-            case Datatype::F16: return Datatype::F32;
-            case Datatype::INT8: return Datatype::INT32;
-            case Datatype::UINT8: return Datatype::INT32;
-            default: return Datatype::F32;
-        }
     }
+    switch (input_dt) {
+        case Datatype::F32: return Datatype::F32;
+        case Datatype::F16: return Datatype::F32;
+        case Datatype::INT8: return Datatype::INT32;
+        case Datatype::UINT8: return Datatype::INT32;
+        default: return Datatype::F32;
+    }
+
 }
 
 Datatype ReduceKernelBase::GetFinalAccumulatorType(const reduce_params& params) const {
@@ -203,16 +203,15 @@ Datatype ReduceKernelBase::GetFinalAccumulatorType(const reduce_params& params) 
         reduce_mode == ReduceMode::L2 ||
         reduce_mode == ReduceMode::L1) {
         return Datatype::F32;
-    } else {
-        return GetAccumulatorType(params);
     }
+    return GetAccumulatorType(params);
+
 }
 
 Datatype ReduceKernelBase::GetActivationType(const reduce_params& params) const {
     if (params.outputs[0].GetDType() == Datatype::F16)
         return Datatype::F16;
-    else
-        return Datatype::F32;
+    return Datatype::F32;
 }
 
 void ReduceKernelBase::GetUpdateDispatchDataFunc(KernelData& kd) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_simple_to_scalar.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_simple_to_scalar.cpp
@@ -81,8 +81,8 @@ bool ReduceKernelSimpleToScalar::Validate(const Params& p) const {
     if (supported_modes.find(params.reduceMode) == supported_modes.end())
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
-    auto& in_dims = params.inputs[0].GetDims();
-    auto& out_dims = params.outputs[0].GetDims();
+    const auto& in_dims = params.inputs[0].GetDims();
+    const auto& out_dims = params.outputs[0].GetDims();
     auto has_padding = std::count_if(in_dims.cbegin(), in_dims.cend(),
         [](Tensor::Dim d) { return d.pad.before > 0 || d.pad.after > 0; }) > 0;
     has_padding |= std::count_if(out_dims.cbegin(), out_dims.cend(),

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_base.cpp
@@ -157,8 +157,8 @@ ReorderKernelBase::DispatchData ReorderKernelBase::SetDefault(const reorder_weig
 ReorderKernelBase::DispatchData ReorderKernelBase::SetDefault(const reorder_params& params) const {
     DispatchData dispatchData;
 
-    auto& input = params.inputs[0];
-    auto& output = params.outputs[0];
+    const auto& input = params.inputs[0];
+    const auto& output = params.outputs[0];
     auto input_l = input.GetLayout();
     auto output_l = output.GetLayout();
     DataTensor input_tensor = input;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.cpp
@@ -102,20 +102,19 @@ static inline std::pair<size_t, size_t> GetSliceSizes(WeightsLayout l) {
         l == WeightsLayout::os_is_yx_osv16_isv16 || l == WeightsLayout::g_os_zyx_is_osv16_isv16 ||
         l == WeightsLayout::g_is_os_yx_isv16_osv16 || l == WeightsLayout::g_is_os_zyx_isv16_osv16)
         return {16, 16};
-    else if (l == WeightsLayout::os_iyx_osv16 || l == WeightsLayout::g_os_iyx_osv16)
+    if (l == WeightsLayout::os_iyx_osv16 || l == WeightsLayout::g_os_iyx_osv16)
         return {1, 16};
-    else if (l == WeightsLayout::os_iyx_osv32 || l == WeightsLayout::g_os_iyx_osv32 || l == WeightsLayout::os_iyx_osv32__ai32)
+    if (l == WeightsLayout::os_iyx_osv32 || l == WeightsLayout::g_os_iyx_osv32 || l == WeightsLayout::os_iyx_osv32__ai32)
         return {1, 32};
-    else if (l == WeightsLayout::os_is_zyx_osv32_isv16 || l == WeightsLayout::g_os_zyx_is_osv32_isv16)
+    if (l == WeightsLayout::os_is_zyx_osv32_isv16 || l == WeightsLayout::g_os_zyx_is_osv32_isv16)
         return {16, 32};
-    else if (l == WeightsLayout::os_is_zyx_osv64_isv16)
+    if (l == WeightsLayout::os_is_zyx_osv64_isv16)
         return {16, 64};
-    else if (l == WeightsLayout::g_os_zyx_is_osv16_isv32)
+    if (l == WeightsLayout::g_os_zyx_is_osv16_isv32)
         return {32, 16};
-    else if (l == WeightsLayout::g_os_zyx_is_osv32_isv32)
+    if (l == WeightsLayout::g_os_zyx_is_osv32_isv32)
         return {32, 32};
-    else
-        return {1, 1};
+    return {1, 1};
 }
 
 static inline bool IsOsvFirst(WeightsLayout l) {
@@ -127,8 +126,7 @@ static inline bool IsOsvFirst(WeightsLayout l) {
         l == WeightsLayout::is_os_zyx_isv16_osv16 || l == WeightsLayout::g_is_os_yx_isv16_osv16 ||
         l == WeightsLayout::g_is_os_zyx_isv16_osv16)
         return true;
-    else
-        return false;
+    return false;
 }
 
 static inline size_t GetOptimalSize(size_t val, std::vector<size_t> optimal_sizes) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.cpp
@@ -97,7 +97,7 @@ bool ResampleKernelBase::Validate(const Params& p) const {
 
     const resample_params& params = static_cast<const resample_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_onnx.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_onnx.cpp
@@ -87,9 +87,9 @@ DeviceFeaturesKey ResampleKernelOnnx::get_required_device_features_key(const Par
 static size_t get_vec_size(const resample_params &params) {
     if (params.inputs[0].GetLayout() == DataLayout::fs_b_yx_fsv32) {
         return 2;
-    } else {
-        return 1;
     }
+    return 1;
+
 }
 
 ResampleKernelBase::DispatchData ResampleKernelOnnx::SetDefault(const kernel_selector::resample_params& arg) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
@@ -84,9 +84,9 @@ DeviceFeaturesKey ResampleKernelOpt::get_required_device_features_key(const Para
 static size_t get_vec_size(const resample_params &params) {
     if (params.inputs[0].GetLayout() == DataLayout::fs_b_yx_fsv32) {
         return 2;
-    } else {
-        return 1;
     }
+    return 1;
+
 }
 
 static int get_feature_slice_size(const resample_params &params) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_pil_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_pil_ref.cpp
@@ -120,7 +120,7 @@ std::size_t GetLastRow(const resample_params& params) {
 }
 
 DataTensor GetIntermediateBufferSize(const resample_params& params) {
-    auto& output = params.outputs[0];
+    const auto& output = params.outputs[0];
     auto layout = output.GetLayout();
     auto ybox_first = GetFirstRow(params);
     auto ybox_last = GetLastRow(params);
@@ -170,7 +170,7 @@ ResampleKernelBase::DispatchData ResampleKernelPilRef::SetDefaultForKernel(Kerne
         return dispatchData;
     }
     case ResampleKernelPilRef::eResampleHorizontal: {
-        auto& output = NeedVerticalPass(arg) ? GetIntermediateBufferSize(arg) : arg.outputs[0];
+        const auto& output = NeedVerticalPass(arg) ? GetIntermediateBufferSize(arg) : arg.outputs[0];
         auto in_layout = arg.inputs[0].GetLayout();
         auto out_layout = arg.outputs[0].GetLayout();
         std::vector<std::vector<Tensor::DataChannelName>> dims_by_gws = {{ Tensor::DataChannelName::X },
@@ -187,7 +187,7 @@ ResampleKernelBase::DispatchData ResampleKernelPilRef::SetDefaultForKernel(Kerne
         return dispatchData;
     }
     case ResampleKernelPilRef::eResampleVertical: {
-        auto& output = arg.outputs[0];
+        const auto& output = arg.outputs[0];
         auto in_layout = arg.inputs[0].GetLayout();
         auto out_layout = arg.outputs[0].GetLayout();
         std::vector<std::vector<Tensor::DataChannelName>> dims_by_gws = {{ Tensor::DataChannelName::X },

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp
@@ -231,7 +231,7 @@ bool ScatterElementsUpdateKernelRef::Validate(const Params& p) const {
 
     const scatter_elements_update_params& params = static_cast<const scatter_elements_update_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -262,7 +262,7 @@ bool ScatterUpdateKernelRef::Validate(const Params& p) const {
 
     const scatter_update_params& params = static_cast<const scatter_update_params&>(p);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_items_class_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_items_class_kernel_base.h
@@ -20,8 +20,7 @@ protected:
     Datatype GetAccumulatorType(const softmax_params& params) const {
         if (params.inputs[0].GetDType() == Datatype::F16)
             return Datatype::F16;
-        else
-            return Datatype::F32;
+        return Datatype::F32;
     }
     std::vector<KernelBase::FusedOpType> GetSupportedFusedOps() const override {
         return { FusedOpType::QUANTIZE };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_base.h
@@ -49,8 +49,7 @@ protected:
     Datatype GetActivationType(const softmax_params& params) const {
         if (params.inputs[0].GetDType() == Datatype::F16)
             return Datatype::F16;
-        else
-            return Datatype::F32;
+        return Datatype::F32;
     }
 };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_items_class_optimized.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_items_class_optimized.cpp
@@ -90,7 +90,7 @@ DeviceFeaturesKey SoftmaxKerneItemsClassOptimized::get_required_device_features_
 SoftmaxKerneItemsClassOptimized::Parent::DispatchData SoftmaxKerneItemsClassOptimized::SetDefault(const softmax_params& params) const {
     auto dispatchData = Parent::SetDefault(params);
 
-    auto& input = params.inputs[0];
+    const auto& input = params.inputs[0];
 
     const auto global = GetSoftmaxDimGlobalSizes(params.dim, params.outputs[0]);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_base.cpp
@@ -14,7 +14,7 @@ bool SpaceToBatchKernelBase::Validate(const Params& p) const {
     }
 
     const space_to_batch_params& params = static_cast<const space_to_batch_params&>(p);
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_depth/space_to_depth_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_depth/space_to_depth_kernel_ref.cpp
@@ -35,7 +35,7 @@ bool SpaceToDepthKernelRef::Validate(const Params& p) const {
     }
 
     const space_to_depth_params& params = static_cast<const space_to_depth_params&>(p);
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/stft/stft_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/stft/stft_kernel_opt.cpp
@@ -35,7 +35,7 @@ JitConstants STFTKernelOpt::GetJitConstants(const STFT_params& params) const {
     jit.AddConstants({MakeJitConstant("FREQ_PER_BLOCK", FREQ_PER_BLOCK)});
     jit.AddConstants({MakeJitConstant("STATIC_MAX_X_I_BUFFER", STATIC_MAX_X_I_BUFFER)});
 
-    const auto xiMaxBuffer = params.is_shape_agnostic ? "STATIC_MAX_X_I_BUFFER" : "INPUT1_SIZE_X";
+    const auto *const xiMaxBuffer = params.is_shape_agnostic ? "STATIC_MAX_X_I_BUFFER" : "INPUT1_SIZE_X";
     jit.AddConstants({MakeJitConstant("SHARED_X_I_BUFFER_SIZE", xiMaxBuffer)});
 
     return jit;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_ref.cpp
@@ -80,7 +80,7 @@ bool StridedSliceKernelRef::Validate(const Params& p) const {
     if (params.outputs[0].Dimentions() > 6 || params.inputs[0].Dimentions() > 6)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
-    for (auto& fused_op : params.fused_ops) {
+    for (const auto& fused_op : params.fused_ops) {
         if (!IsFusedPrimitiveSupported(fused_op))
             DO_NOT_USE_THIS_KERNEL(p.layerID);
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_base.cpp
@@ -98,7 +98,7 @@ Datatype SwiGLUKernelBase::GetAccumulatorType(const swiglu_params& params) const
     Datatype types[] = { Datatype::F32, Datatype::F16, Datatype::INT64, Datatype::INT32, Datatype::UINT32};
 
     for (Datatype type : types)
-        for (auto& in : params.inputs)
+        for (const auto& in : params.inputs)
             if (in.GetDType() == type)
                 return type;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/unique/unique_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/unique/unique_kernel_ref.cpp
@@ -33,13 +33,13 @@ JitConstants MakeAxisJitConstants(size_t rank, int64_t axis, const std::string& 
     }();
     auto& axis_dimension = dimensions.at(axis);
 
-    const auto axis_length_name = "AXIS_LENGTH";
+    const auto *const axis_length_name = "AXIS_LENGTH";
     const auto axis_length_val = "INPUT0" + dimensions_sizes_map.at(axis_dimension);
 
     // Mark axis dimension as 'i' for indexing
     axis_dimension = 'i';
 
-    const auto get_index_name = "GET_INDEX(prefix, i)";
+    const auto *const get_index_name = "GET_INDEX(prefix, i)";
     const auto get_index_val = [&dimensions]() {
         std::string str = "CAT(prefix, _GET_INDEX)";
         str += '(';
@@ -51,7 +51,7 @@ JitConstants MakeAxisJitConstants(size_t rank, int64_t axis, const std::string& 
         return str;
     }();
 
-    const auto iterate_name = "ITERATE(body)";
+    const auto *const iterate_name = "ITERATE(body)";
     const auto iterate_val = [&dimensions, &dimensions_sizes_map, &prefix_for_iterate]() {
         std::stringstream ss;
         for (auto ch : dimensions) {
@@ -76,10 +76,10 @@ JitConstants MakeAxisJitConstants(size_t rank, int64_t axis, const std::string& 
 }
 
 JitConstants MakeFlattenedJitConstants(size_t rank, bool simple_layout) {
-    const auto get_index_name = "GET_INDEX(prefix, i)";
+    const auto *const get_index_name = "GET_INDEX(prefix, i)";
 
     if (simple_layout) {
-        const auto get_index_val = "i";
+        const auto *const get_index_val = "i";
         return {MakeJitConstant("FLATTENED", true), MakeJitConstant(get_index_name, get_index_val)};
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/micro_utils.hpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/micro_utils.hpp
@@ -54,7 +54,7 @@ struct MicroKernelPackage {
     // other struct fields are not initializer properly and can't be used
     void save(cldnn::BinaryOutputBuffer& ob) const {
         ob << p.settings.size();
-        for (auto& s : p.settings) {
+        for (const auto& s : p.settings) {
             ob << s.name;
             ob << s.value;
         }

--- a/src/plugins/intel_gpu/src/plugin/common_utils.cpp
+++ b/src/plugins/intel_gpu/src/plugin/common_utils.cpp
@@ -135,11 +135,11 @@ void convert_and_copy(const void* src_ptr, ov::element::Type src_et, void* dst_p
         if (src_et == s_et && dst_et == d_et) {                                                                                             \
             if (static_cast<bool>(layout.data_padding)) {                                                                                   \
                 return convert_and_copy_padded_source(static_cast<const s_type*>(src_ptr), static_cast<d_type*>(dst_ptr), layout);          \
-            } else if (transpose) {                                                                                                         \
-                return convert_and_copy_transposed(static_cast<const s_type*>(src_ptr), static_cast<d_type*>(dst_ptr), layout.get_shape()); \
-            } else {                                                                                                                        \
-                return convert_and_copy_no_pad(static_cast<const s_type*>(src_ptr), static_cast<d_type*>(dst_ptr), size);                   \
             }                                                                                                                               \
+            if (transpose) {                                                                                                                \
+                return convert_and_copy_transposed(static_cast<const s_type*>(src_ptr), static_cast<d_type*>(dst_ptr), layout.get_shape()); \
+            }                                                                                                                               \
+            return convert_and_copy_no_pad(static_cast<const s_type*>(src_ptr), static_cast<d_type*>(dst_ptr), size);                       \
         }
 
     // For unsupported inputs
@@ -230,7 +230,7 @@ void convert_and_copy(const ov::ITensor* src, cldnn::memory::ptr dst, cldnn::str
     auto dst_et = dst->get_layout().data_type;
 
     if (dst_et == src_et && !transpose) {
-        if (auto remote = dynamic_cast<const ov::intel_gpu::RemoteTensorImpl*>(src)) {
+        if (const auto *remote = dynamic_cast<const ov::intel_gpu::RemoteTensorImpl*>(src)) {
             auto mem = remote->get_original_memory();
             dst->copy_from(stream, *mem, blocking);
         } else {
@@ -257,7 +257,7 @@ void convert_and_copy(const cldnn::memory::ptr src, ov::ITensor* dst, const cldn
     const void* src_ptr = src_lock.data();
     void* dst_ptr = nullptr;
 
-    if (auto remote = dynamic_cast<const ov::intel_gpu::RemoteTensorImpl*>(dst)) {
+    if (const auto *remote = dynamic_cast<const ov::intel_gpu::RemoteTensorImpl*>(dst)) {
         auto mem = remote->get_original_memory();
         dst_lock.reset(new cldnn::mem_lock<uint8_t>(mem, stream));
         dst_ptr = dst_lock->data();
@@ -295,7 +295,7 @@ void convert_and_copy(const ov::ITensor* src, ov::ITensor* dst, const cldnn::str
     std::unique_ptr<cldnn::mem_lock<uint8_t>> dst_lock = nullptr;
     ov::Tensor tmp_tensor;
 
-    if (auto remote = dynamic_cast<const ov::intel_gpu::RemoteTensorImpl*>(src)) {
+    if (const auto *remote = dynamic_cast<const ov::intel_gpu::RemoteTensorImpl*>(src)) {
         auto mem = remote->get_original_memory();
         src_lock.reset(new cldnn::mem_lock<uint8_t, cldnn::mem_lock_type::read>(mem, stream));
         src_ptr = src_lock->data();
@@ -307,11 +307,11 @@ void convert_and_copy(const ov::ITensor* src, ov::ITensor* dst, const cldnn::str
         src_ptr = src->data();
     }
 
-    if (auto remote = dynamic_cast<const ov::intel_gpu::RemoteTensorImpl*>(dst)) {
+    if (const auto *remote = dynamic_cast<const ov::intel_gpu::RemoteTensorImpl*>(dst)) {
         auto mem = remote->get_original_memory();
         dst_lock.reset(new cldnn::mem_lock<uint8_t>(mem, stream));
         dst_ptr = dst_lock->data();
-    } else if (auto remote = dynamic_cast<ov::IRemoteTensor*>(dst)) {
+    } else if (auto *remote = dynamic_cast<ov::IRemoteTensor*>(dst)) {
         tmp_tensor = ov::Tensor(dst_et, src->get_shape());
         ::convert_and_copy(src_ptr,
                            src_et,

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -26,7 +26,8 @@ std::shared_ptr<ov::threading::ITaskExecutor> create_task_executor(const std::sh
         // exclusive_async_requests essentially disables the streams (and hence should be checked first) => aligned with
         // the CPU behavior
         return plugin->get_executor_manager()->get_executor("GPU");
-    } else if (config.get_enable_cpu_pinning() ||
+    }
+    if (config.get_enable_cpu_pinning() ||
                config.get_enable_cpu_reservation()) {
         bool enable_cpu_pinning = config.get_enable_cpu_pinning();
         bool enable_cpu_reservation = config.get_enable_cpu_reservation();
@@ -37,16 +38,16 @@ std::shared_ptr<ov::threading::ITaskExecutor> create_task_executor(const std::sh
                                                     ov::hint::SchedulingCoreType::PCORE_ONLY,
                                                     enable_cpu_reservation,
                                                     enable_cpu_pinning});
-    } else {
-        return std::make_shared<ov::threading::CPUStreamsExecutor>(
-            ov::threading::IStreamsExecutor::Config{"Intel GPU plugin executor",
-                                                    config.get_num_streams(),
-                                                    0,
-                                                    ov::hint::SchedulingCoreType::ANY_CORE,
-                                                    false,
-                                                    false,
-                                                    false});
     }
+    return std::make_shared<ov::threading::CPUStreamsExecutor>(
+        ov::threading::IStreamsExecutor::Config{"Intel GPU plugin executor",
+                                                config.get_num_streams(),
+                                                0,
+                                                ov::hint::SchedulingCoreType::ANY_CORE,
+                                                false,
+                                                false,
+                                                false});
+
 }
 }  // namespace
 
@@ -345,18 +346,22 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
             ov::PropertyName{ov::execution_devices.name(), PropertyMutability::RO},
             ov::PropertyName{ov::runtime_requirements.name(), PropertyMutability::RO},
         };
-    } else if (name == ov::model_name) {
+    }
+    if (name == ov::model_name) {
         return decltype(ov::model_name)::value_type {m_model_name};
-    } else if (name == ov::loaded_from_cache) {
+    }
+    if (name == ov::loaded_from_cache) {
         return decltype(ov::loaded_from_cache)::value_type {m_loaded_from_cache};
-    } else if (name == ov::optimal_number_of_infer_requests) {
+    } if (name == ov::optimal_number_of_infer_requests) {
         unsigned int nr = m_config.get_num_streams();
         if (m_config.get_performance_mode() != ov::hint::PerformanceMode::LATENCY)
             nr *= 2;
         return decltype(ov::optimal_number_of_infer_requests)::value_type {nr};
-    } else if (name == ov::execution_devices) {
+    }
+    if (name == ov::execution_devices) {
         return decltype(ov::execution_devices)::value_type{m_context->get_device_name()};
-    } else if (name == ov::runtime_requirements) {
+    }
+    if (name == ov::runtime_requirements) {
         return decltype(ov::runtime_requirements)::value_type{m_runtime_requirements};
     }
 
@@ -367,7 +372,7 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "CompiledModel::create_sync_infer_request");
     OPENVINO_ASSERT(!m_graphs.empty(), "[GPU] Model not loaded");
 
-    for (auto& graph : m_graphs) {
+    for (const auto& graph : m_graphs) {
         OPENVINO_ASSERT(graph != nullptr, "[GPU] Model not loaded: graph is nullptr");
         OPENVINO_ASSERT(graph->is_loaded(), "[GPU] Model not loaded: invalid graph");
     }

--- a/src/plugins/intel_gpu/src/plugin/custom_layer.cpp
+++ b/src/plugins/intel_gpu/src/plugin/custom_layer.cpp
@@ -227,8 +227,7 @@ cldnn::format CustomLayer::FormatFromString(const std::string & str) {
     auto it = FormatNameToType.find(str);
     if (it != FormatNameToType.end())
         return it->second;
-    else
-        return cldnn::format::format_num;
+    return cldnn::format::format_num;
 }
 
 void CustomLayer::LoadFromFile(const std::string configFile, CustomLayerMap& customLayers, bool can_be_missed) {
@@ -239,9 +238,9 @@ void CustomLayer::LoadFromFile(const std::string configFile, CustomLayerMap& cus
         if (can_be_missed) {
             // config file might not exist - like global config, for example
             return;
-        } else {
-            OPENVINO_THROW("Error loading custom layer configuration file: ", configFile, ", ", res.description(), " at offset ", res.offset);
         }
+        OPENVINO_THROW("Error loading custom layer configuration file: ", configFile, ", ", res.description(), " at offset ", res.offset);
+
     }
 
 #ifdef _WIN32

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -213,7 +213,7 @@ Graph::~Graph() {
 void Graph::build(std::shared_ptr<cldnn::program> program) {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Graph::build");
 
-    auto external_queue = m_context->get_external_queue();
+    auto *external_queue = m_context->get_external_queue();
     if (external_queue) {
         OPENVINO_ASSERT(m_config.get_num_streams() == 1, "[GPU] Throughput streams can't be used with shared queue!");
         const auto &engine = program->get_engine();
@@ -366,10 +366,10 @@ std::shared_ptr<ov::Model> Graph::get_runtime_model(std::vector<cldnn::primitive
     auto get_inputs = [&] (const cldnn::primitive_info& prim_info) {
         ov::OutputVector inputs;
 
-        auto& deps = prim_info.c_dependencies;
+        const auto& deps = prim_info.c_dependencies;
 
         // Decrease expected dependencies count if there is a const input without original id in the IR
-        for (auto& dep : deps) {
+        for (const auto& dep : deps) {
             auto dep_it = std::find_if(primitives_info.begin(), primitives_info.end(), [&](cldnn::primitive_info& entry) {
                 return entry.original_id == dep;
             });
@@ -416,7 +416,7 @@ std::shared_ptr<ov::Model> Graph::get_runtime_model(std::vector<cldnn::primitive
                 results.emplace_back(std::make_shared<ov::op::v0::Result>(return_node->get_default_output()));
             } else {
                 size_t port = 0;
-                for (auto& usr_id : user_ids) {
+                for (const auto& usr_id : user_ids) {
                     auto usr_it = std::find_if(primitives_info.begin(), primitives_info.end(), [&](cldnn::primitive_info& entry) {
                         return entry.original_id == usr_id;
                     });
@@ -443,7 +443,7 @@ std::shared_ptr<ov::Model> Graph::get_runtime_model(std::vector<cldnn::primitive
         info[ov::exec_model_info::RUNTIME_PRECISION] = ov::element::Type(prim_info.runtime_precision).get_type_name();
 
         std::vector<std::string> originalNames{find_origin_layers(prim_info.original_id)};
-        for (auto& fused_id : prim_info.c_fused_ids) {
+        for (const auto& fused_id : prim_info.c_fused_ids) {
             for (auto& origin_id : find_origin_layers(fused_id)) {
                 if (std::find(originalNames.begin(), originalNames.end(), origin_id) == originalNames.end())
                     originalNames.push_back(origin_id);
@@ -461,7 +461,7 @@ std::shared_ptr<ov::Model> Graph::get_runtime_model(std::vector<cldnn::primitive
         info[ov::exec_model_info::PERF_COUNTER] = exec_time;
 
         if (prim_info.type_id == "dynamic_quantize") {
-            auto& node = get_network()->get_primitive(prim_info.original_id)->get_node();
+            const auto& node = get_network()->get_primitive(prim_info.original_id)->get_node();
             auto dyn_quan = node.as<cldnn::dynamic_quantize>().get_primitive();
             info["group_sizes"] = ov::util::join(cldnn::convert_vector<int64_t>(dyn_quan->attrs.group_sizes));
             if (dyn_quan->attrs.precomputed_reduction) {
@@ -740,7 +740,7 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
         if (combinePrimByIRLayers) {
             std::string kernelId;
             long long kernelTime = 0;  // used for finding the most complex computation kernel in sub_graph for perf stat
-            for (auto &id : profilingIDs) {
+            for (const auto &id : profilingIDs) {
                 auto iter = perfMap.find(id);
                 if (iter == perfMap.end())  continue;
 
@@ -765,7 +765,7 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
     };
 
     // Step 1. Get all primitives in execution order which was added by GPU plugin
-    for (auto& primId : profilingIDs) {
+    for (const auto& primId : profilingIDs) {
         getFromProfiling(primId);
     }
 
@@ -838,7 +838,7 @@ std::vector<ov::ProfilingInfo> Graph::get_profiling_info() const {
     }
 
     // Step 3. Checking primitives which has been deleted from execution order but added by GPU plugin
-    for (auto& primId : profilingIDs) {
+    for (const auto& primId : profilingIDs) {
         if (std::find(allIds.begin(), allIds.end(), primId) == allIds.end()) {
             getFromProfiling(primId);
         }

--- a/src/plugins/intel_gpu/src/plugin/multi_tensor_variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/multi_tensor_variable_state.cpp
@@ -24,7 +24,7 @@ namespace ov::intel_gpu {
 MultiTensorState::MultiTensorState(const std::vector<VariableStateInfo>& infos,
                                    std::shared_ptr<RemoteContextImpl> context,
                                    ShapePredictor::Ptr shape_predictor) : ov::intel_gpu::VariableStateBase(infos[0].m_id, context) {
-    for (auto& info : infos) {
+    for (const auto& info : infos) {
         m_hidden_states.push_back(std::make_shared<VariableState>(info, context, shape_predictor));
     }
 }
@@ -129,9 +129,9 @@ ov::SoPtr<ov::ITensor> VariableStateIndirectKVCache::get_state() const {
         convert_and_copy(tmp_mem, tensor._ptr.get(), m_context->get_engine().get_service_stream());
 
         return tensor;
-    } else {
-        return m_hidden_states[0]->get_state();
     }
+    return m_hidden_states[0]->get_state();
+
 }
 
 void VariableStateIndirectKVCache::set_memory(const cldnn::memory::ptr& new_mem, const cldnn::layout& actual_layout) {

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -99,7 +99,7 @@ static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const s
 
     cldnn::primitive_id initialconstPrimID = layer_type_name_ID(op);
     cldnn::primitive_id constPrimID;
-    auto data = op->get_data_ptr<char>();
+    const auto *data = op->get_data_ptr<char>();
 
     const auto cache_key = std::make_tuple(data, const_shape, op->get_output_element_type(0));
 
@@ -132,7 +132,7 @@ static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const s
         if (!partial_upload.enabled) {
             auto& stream = p.get_engine().get_service_stream();
             cldnn::mem_lock<char> lock{mem, stream};
-            auto buf = lock.data();
+            auto *buf = lock.data();
             auto bufSize = constLayout.bytes_count();
             auto upload_count = ov::shape_size(const_shape);
 
@@ -142,13 +142,13 @@ static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const s
                 out_dtype == cldnn::data_types::f32 &&
                 op->get_output_element_type(0) == ov::element::f64) {
                 const auto* f64data = op->get_data_ptr<double>();
-                auto f32buf = reinterpret_cast<float*>(buf);
+                auto *f32buf = reinterpret_cast<float*>(buf);
                 f32buf[0] = static_cast<float>(f64data[0]);
             } else if (out_dtype == cldnn::data_types::f32 &&
                        (op->get_output_element_type(0) == ov::element::u16 ||
                         op->get_output_element_type(0) == ov::element::i16)) {
                 size_t count = upload_count;
-                auto f32buf = reinterpret_cast<float*>(buf);
+                auto *f32buf = reinterpret_cast<float*>(buf);
 
                 if (op->get_output_element_type(0) == ov::element::u16) {
                     const auto* u16data = op->get_data_ptr<uint16_t>();
@@ -190,14 +190,14 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
             ov::op::util::is_binary_elementwise_comparison(op) ||
             is_btiwise(op)) {
             return true;
-        } else {
-            return false;
         }
+        return false;
+
     };
 
     auto is_all_inputs_1d = [&] (ov::Node* op) -> bool {
         for (size_t i = 0; i < op->get_input_size(); i++) {
-            auto& in_shape = op->get_input_partial_shape(i);
+            const auto& in_shape = op->get_input_partial_shape(i);
             if (in_shape.size() > 1)
                 return false;
         }
@@ -233,14 +233,14 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
     // For Concat along batch we go with batch interpretation
     // For Gather input we go with batch interpretation
     // Also check if constant users is a backprop convolution - in that case O and I need to be swapped.
-    for (auto& node : constUsers) {
-        auto outOp = node.get_node();
+    for (const auto& node : constUsers) {
+        auto *outOp = node.get_node();
         bool apply_rank2_matmul_wa = false;
         size_t user_index = node.get_index();
         auto is_convert_matmul_pattern = [&](ov::Node* convert_node, size_t& matmul_input_index_ref) -> bool {
             if (ov::is_type<ov::op::v0::Convert>(convert_node) && !p.use_new_shape_infer()) {
                 auto convert_consumers = convert_node->get_output_target_inputs(0);
-                for (auto& consumer_input : convert_consumers) {
+                for (const auto& consumer_input : convert_consumers) {
                     if (ov::is_type<ov::op::v0::MatMul>(consumer_input.get_node()) && consumer_input.get_index() < 2) {
                         matmul_input_index_ref = consumer_input.get_index();
                         auto* matmul = consumer_input.get_node();
@@ -253,7 +253,7 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
             }
             return false;
         };
-        if (auto castedOp = ov::as_type<ov::op::v0::Concat>(outOp)) {
+        if (auto *castedOp = ov::as_type<ov::op::v0::Concat>(outOp)) {
             if (castedOp->get_axis() == 0) {
                 consts[op].needsBatchInterpretation = constDims.size() == 1;
             }

--- a/src/plugins/intel_gpu/src/plugin/ops/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/detection_output.cpp
@@ -20,9 +20,9 @@ static cldnn::prior_box_code_type PriorBoxCodeFromString(const std::string& str)
     auto it = CodeNameToType.find(str);
     if (it != CodeNameToType.end()) {
         return it->second;
-    } else {
-        OPENVINO_THROW("Unknown Prior-Box code type: ", str);
     }
+    OPENVINO_THROW("Unknown Prior-Box code type: ", str);
+
     return cldnn::prior_box_code_type::corner;
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/experimental_detectron_prior_grid_generator.cpp
@@ -13,9 +13,9 @@ static void CreateExperimentalDetectronPriorGridGeneratorOp(
     ProgramBuilder& p,
     const std::shared_ptr<ov::op::v6::ExperimentalDetectronPriorGridGenerator>& op) {
     validate_inputs_count(op, {3});
-    auto& attrs = op->get_attrs();
-    auto& featmap_shape = op->get_input_shape(1);
-    auto& image_shape = op->get_input_shape(2);
+    const auto& attrs = op->get_attrs();
+    const auto& featmap_shape = op->get_input_shape(1);
+    const auto& image_shape = op->get_input_shape(2);
     auto inputs = p.GetInputInfo(op);
     inputs.resize(1);  // only priors is read
     cldnn::experimental_detectron_prior_grid_generator prim{layer_type_name_ID(op),

--- a/src/plugins/intel_gpu/src/plugin/ops/gated_mlp.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gated_mlp.cpp
@@ -46,29 +46,29 @@ static void CreateGatedMLPOp(ProgramBuilder& p, const std::shared_ptr<ov::intel_
                                         op->get_activation(),
                                         output_tensor,
                                         cldnn::element_type_to_data_type(op->get_output_element_type(0)));
-            } else {
-                return cldnn::gated_mlp(layer_name,
-                                        cldnn::input_info(inputs[0]),
-                                        cldnn::input_info(inputs[1]),
-                                        cldnn::input_info(inputs[2]),
-                                        cldnn::input_info(inputs[3]),
-                                        cldnn::input_info(inputs[4]),
-                                        cldnn::input_info(inputs[5]),
-                                        cldnn::input_info(inputs[6]),
-                                        op->get_activation(),
-                                        output_tensor,
-                                        cldnn::element_type_to_data_type(op->get_output_element_type(0)));
             }
-        } else {
             return cldnn::gated_mlp(layer_name,
                                     cldnn::input_info(inputs[0]),
                                     cldnn::input_info(inputs[1]),
                                     cldnn::input_info(inputs[2]),
                                     cldnn::input_info(inputs[3]),
+                                    cldnn::input_info(inputs[4]),
+                                    cldnn::input_info(inputs[5]),
+                                    cldnn::input_info(inputs[6]),
                                     op->get_activation(),
                                     output_tensor,
                                     cldnn::element_type_to_data_type(op->get_output_element_type(0)));
+
         }
+        return cldnn::gated_mlp(layer_name,
+                                cldnn::input_info(inputs[0]),
+                                cldnn::input_info(inputs[1]),
+                                cldnn::input_info(inputs[2]),
+                                cldnn::input_info(inputs[3]),
+                                op->get_activation(),
+                                output_tensor,
+                                cldnn::element_type_to_data_type(op->get_output_element_type(0)));
+
     }();
 
     if (p.use_new_shape_infer())

--- a/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
@@ -70,7 +70,7 @@ static void SetLoopInputOutputMap(ProgramBuilder& p,
     // set input mapping & back edges
     for (const auto& loop_input_desc : loop_input_descs) {
         auto external_id = inputs.at(loop_input_desc->m_input_index);
-        auto& body_input = body_inputs.at(loop_input_desc->m_body_parameter_index);
+        const auto& body_input = body_inputs.at(loop_input_desc->m_body_parameter_index);
         cldnn::primitive_id internal_id = layer_type_name_ID(body_input);
 
         // set input mapping
@@ -189,7 +189,7 @@ static std::vector<cldnn::primitive_id> GetOutputNames(const cldnn::primitive_id
     }
 
     // setup outputs for backedges
-    for (auto& back_edge : back_edges) {
+    for (const auto& back_edge : back_edges) {
         auto iter = std::find(output_names.begin(), output_names.end(), back_edge.from);
         // Do not add duplicated output name
         if (iter == output_names.end()) {

--- a/src/plugins/intel_gpu/src/plugin/ops/lrn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/lrn.cpp
@@ -15,9 +15,9 @@ namespace ov::intel_gpu {
 static cldnn::lrn_norm_region GetNormRegion(std::vector<int64_t> axis_value) {
     if (axis_value.size() == 1 && axis_value[0] == 1) {
         return cldnn::lrn_norm_region_across_channel;
-    } else {
-        return cldnn::lrn_norm_region_within_channel;
     }
+    return cldnn::lrn_norm_region_within_channel;
+
 }
 
 static void CreateLRNOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::LRN>& op) {

--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -64,8 +64,7 @@ static void CreateMatMulOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::
             // until we have an essential solution, i.e., fixing the gemm_tiled_opt kernel to support unaligned shape.
             if (p.get_engine().get_device_info().dev_type == cldnn::device_type::integrated_gpu)
                 return true;
-            else
-                return false;
+            return false;
         }
         if (shapes[0].size() < 2 || shapes[1].size() < 2)
             return false;

--- a/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/moe.cpp
@@ -116,7 +116,7 @@ static bool prepare_moe_otd_params(ProgramBuilder& p,
 
 static void CreateMOECompressedOp(ProgramBuilder& p, const std::shared_ptr<ov::op::internal::MOECompressed>& op) {
     auto inputs = p.GetInputInfo(op);
-    auto& config = op->get_config();
+    const auto& config = op->get_config();
     std::vector<cldnn::input_info> input_infos;
     for (const auto& input : inputs) {
         input_infos.push_back(cldnn::input_info(input));

--- a/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
@@ -36,7 +36,7 @@ static void CreateNormalizeL2Op(ProgramBuilder& p, const std::shared_ptr<ov::op:
     cldnn::layout constLayout = cldnn::layout(cldnn::element_type_to_data_type(op->get_output_element_type(0)), cldnn::format::bfyx, cldnn::tensor{1});
     auto mem = p.get_engine().allocate_memory(constLayout, false);
     cldnn::mem_lock<int8_t> tmpPointer{mem, p.get_engine().get_service_stream()};
-    auto buf = tmpPointer.data();
+    auto *buf = tmpPointer.data();
     auto bufSize = scale->get_output_tensor(0).size();
 
     if (bufSize != constLayout.bytes_count())

--- a/src/plugins/intel_gpu/src/plugin/ops/pa_kv_reorder.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/pa_kv_reorder.cpp
@@ -70,9 +70,9 @@ static void CreatePA_KV_ReorderOp(ProgramBuilder& p, const std::shared_ptr<ov::o
                     "[GPU] pa_kv_reorder expects 4D value cache, got rank ", value_cache_ps.rank());
 
     const auto& rt_info = op->get_rt_info();
-    const auto k_head_size_id = "k_head_size";
-    const auto v_head_size_id = "v_head_size";
-    const auto num_k_heads_id = "num_k_heads";
+    const auto *const k_head_size_id = "k_head_size";
+    const auto *const v_head_size_id = "v_head_size";
+    const auto *const num_k_heads_id = "num_k_heads";
 
     OPENVINO_ASSERT(rt_info.find(k_head_size_id) != rt_info.end() &&
                     rt_info.find(v_head_size_id) != rt_info.end() &&

--- a/src/plugins/intel_gpu/src/plugin/ops/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/paged_attention.cpp
@@ -25,9 +25,9 @@ static void CreatePagedAttentionExtensionOp(ProgramBuilder& p, const std::shared
     auto prim = cldnn::paged_attention(layer_type_name_ID(op), inputs);
 
     const auto& rt_info = op->get_rt_info();
-    const auto k_head_size_id = "k_head_size";
-    const auto v_head_size_id = "v_head_size";
-    const auto num_k_heads_id = "num_k_heads";
+    const auto *const k_head_size_id = "k_head_size";
+    const auto *const v_head_size_id = "v_head_size";
+    const auto *const num_k_heads_id = "num_k_heads";
     const auto has_rt_params =
         rt_info.find(k_head_size_id) != rt_info.end() && rt_info.find(v_head_size_id) != rt_info.end() && rt_info.find(num_k_heads_id) != rt_info.end();
 

--- a/src/plugins/intel_gpu/src/plugin/ops/proposal.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/proposal.cpp
@@ -139,7 +139,8 @@ static void CreateProposalOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
                                                              shared_memory);
             p.add_primitive(*op, argmax_mutable_prim_r);
             return;
-        } else if (op->get_output_size() == 1) {
+        }
+        if (op->get_output_size() == 1) {
             auto proposalPrim = cldnn::proposal(layerName,
                                                 inputs[0],  // cls_score
                                                 inputs[1],  // bbox_pred

--- a/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/rnn.cpp
@@ -30,8 +30,7 @@ static cldnn::activation_func GetActivationFunc(std::string name) {
     auto itr = name_mapping.find(name);
     if (itr != name_mapping.end())
         return itr->second;
-    else
-        return cldnn::activation_func::none;
+    return cldnn::activation_func::none;
 }
 
 template <typename T>

--- a/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
@@ -16,12 +16,11 @@ namespace ov::intel_gpu {
 static cldnn::pooling_mode GetPoolingMode(std::string method) {
     if (method == "bilinear")
         return cldnn::pooling_mode::bilinear;
-    else if (method == "max")
+    if (method == "max")
         return cldnn::pooling_mode::max;
-    else if (method == "average")
+    if (method == "average")
         return cldnn::pooling_mode::average;
-    else
-        return cldnn::pooling_mode::deformable_bilinear;
+    return cldnn::pooling_mode::deformable_bilinear;
 }
 
 static void CreateDeformablePSROIPoolingOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v1::DeformablePSROIPooling>& op) {

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -222,7 +222,7 @@ std::mutex singleton_default_contexts_mutex;
 std::map<std::string, RemoteContextImpl::Ptr> Plugin::get_default_contexts() const {
     std::call_once(m_default_contexts_once, [this]() {
         std::lock_guard<std::mutex> lock(singleton_default_contexts_mutex);
-        for (auto& device : m_device_map) {
+        for (const auto& device : m_device_map) {
             const auto device_name = get_device_name() + "." + device.first;
 
             // If already initialized, use existing one
@@ -255,7 +255,7 @@ Plugin::Plugin() {
     }
 
     // Set common info for compiled_model_runtime_properties
-    auto& ov_version = ov::get_openvino_version();
+    const auto& ov_version = ov::get_openvino_version();
     m_compiled_model_runtime_properties["OV_VERSION"] = ov_version.buildNumber;
 }
 
@@ -450,7 +450,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model,
             // If some app modifies ov::Model before compile_model(), and
             // the constants are changed, and such modification is not done before import_model(),
             // weightless caching will not produce correct result.
-            if (auto& orig_model = config.get_model(); orig_model != nullptr) {
+            if (const auto& orig_model = config.get_model(); orig_model != nullptr) {
                 if (!is_weightless_cache_attributes_set(orig_model)) {
                     create_weightless_cache_attributes(orig_model, config);
                 }
@@ -498,14 +498,16 @@ ov::Any Plugin::get_property(const std::string& name, const ov::AnyMap& options)
     // earler than querying actual ID to avoid exceptions when no devices are found
     if (name == ov::supported_properties) {
         return decltype(ov::supported_properties)::value_type {get_supported_properties()};
-    } else if (ov::internal::supported_properties == name) {
+    }
+    if (ov::internal::supported_properties == name) {
         return decltype(ov::internal::supported_properties)::value_type{get_supported_internal_properties()};
-    } else if (name == ov::available_devices) {
+    } if (name == ov::available_devices) {
         std::vector<std::string> available_devices = { };
         for (const auto& dev : m_device_map)
             available_devices.push_back(dev.first);
         return decltype(ov::available_devices)::value_type {available_devices};
-    } else if (name == ov::internal::caching_properties) {
+    }
+    if (name == ov::internal::caching_properties) {
         return decltype(ov::internal::caching_properties)::value_type(get_caching_properties());
     }
 
@@ -524,7 +526,8 @@ ov::Any Plugin::get_property(const std::string& name, const ov::AnyMap& options)
         auto model_format = ov::Any(model_runtime_info);
         return decltype(ov::internal::compiled_model_runtime_properties)::value_type(
             std::move(model_format.as<std::string>()));
-    } else if (name == ov::internal::compiled_model_runtime_properties_supported.name()) {
+    }
+    if (name == ov::internal::compiled_model_runtime_properties_supported.name()) {
         ov::Any res = true;
         prepare_actual_runtime_info();
         auto it = options.find(ov::internal::compiled_model_runtime_properties.name());
@@ -534,7 +537,7 @@ ov::Any Plugin::get_property(const std::string& name, const ov::AnyMap& options)
         }
         ov::AnyMap input_map = it->second.as<ov::AnyMap>();
         // Check common info of compiled_model_runtime_properties
-        for (auto& item : m_compiled_model_runtime_properties) {
+        for (const auto& item : m_compiled_model_runtime_properties) {
             auto it = input_map.find(item.first);
             if (it == input_map.end() || it->second.as<std::string>() != item.second.as<std::string>()) {
                 res = false;
@@ -612,19 +615,22 @@ ov::Any Plugin::get_metric(const std::string& name, const ov::AnyMap& options) c
 
     if (name == ov::intel_gpu::device_total_mem_size) {
         return decltype(ov::intel_gpu::device_total_mem_size)::value_type {device_info.max_global_mem_size};
-    } else if (name == ov::intel_gpu::device_max_alloc_mem_size) {
+    }
+    if (name == ov::intel_gpu::device_max_alloc_mem_size) {
         return decltype(ov::intel_gpu::device_max_alloc_mem_size)::value_type {device_info.max_alloc_mem_size};
-    } else if (name == ov::device::type) {
+if (name == ov::device::type) {
         auto dev_type = device_info.dev_type == cldnn::device_type::discrete_gpu ? ov::device::Type::DISCRETE : ov::device::Type::INTEGRATED;
         return decltype(ov::device::type)::value_type {dev_type};
-    } else if (name == ov::device::gops) {
+    }
+    if (name == ov::device::gops) {
         std::map<element::Type, float> gops;
         gops[element::i8] = device->get_gops(cldnn::data_types::i8);
         gops[element::u8] = device->get_gops(cldnn::data_types::u8);
         gops[element::f16] = device->get_gops(cldnn::data_types::f16);
         gops[element::f32] = device->get_gops(cldnn::data_types::f32);
         return decltype(ov::device::gops)::value_type {gops};
-    } else if (name == ov::intel_gpu::cacheline_size) {
+    }
+    if (name == ov::intel_gpu::cacheline_size) {
         return static_cast<decltype(ov::intel_gpu::cacheline_size)::value_type>(device_info.cacheline_size.value_or(0));
     } else if (name == ov::intel_gpu::execution_units_count) {
         return static_cast<decltype(ov::intel_gpu::execution_units_count)::value_type>(device_info.execution_units_count);
@@ -671,9 +677,9 @@ ov::Any Plugin::get_metric(const std::string& name, const ov::AnyMap& options) c
             add_zero_mem_usage(cldnn::allocation_type::usm_shared);
             add_zero_mem_usage(cldnn::allocation_type::usm_device);
             return res;
-        } else {
-            return decltype(ov::intel_gpu::memory_statistics)::value_type {ctx->get_engine().get_memory_statistics()};
         }
+        return decltype(ov::intel_gpu::memory_statistics)::value_type {ctx->get_engine().get_memory_statistics()};
+
     } else if (name == ov::max_batch_size) {
         return decltype(ov::max_batch_size)::value_type {get_max_batch_size(options)};
     } else if (name == ov::intel_gpu::driver_version) {
@@ -715,6 +721,7 @@ ov::Any Plugin::get_metric(const std::string& name, const ov::AnyMap& options) c
         return ov::CompatibilityCheck::NOT_APPLICABLE;
     } else {
         OPENVINO_THROW("Unsupported metric key ", name);
+    }
     }
 }
 
@@ -986,9 +993,9 @@ uint32_t Plugin::get_optimal_batch_size(const ov::AnyMap& options) const {
         // Compare x with the threshold and return the appropriate power of 2
         if (x - lower_value > threshold) {
             return upper_value;  // Return the next power of 2
-        } else {
-            return lower_value;  // Return the current power of 2
         }
+        return lower_value;  // Return the current power of 2
+
     };
 
     auto model_param = options.find(ov::hint::model.name());

--- a/src/plugins/intel_gpu/src/plugin/program_builder.cpp
+++ b/src/plugins/intel_gpu/src/plugin/program_builder.cpp
@@ -240,7 +240,7 @@ std::vector<cldnn::input_info> ProgramBuilder::GetInputInfo(const std::shared_pt
     // So the output index of the dependency is not processed
     std::vector<cldnn::input_info> inputInfo;
     for (size_t i = 0; i < op->get_input_size(); i++) {
-        auto prevOp = op->get_input_node_ptr(i);
+        auto *prevOp = op->get_input_node_ptr(i);
         std::string prevName = layer_type_name_ID(prevOp);
         // Note: Currently Split/Variadic Split are divided to multiple crops
         // LSTMCell contains its own body network, and each output has a unique pid
@@ -293,7 +293,7 @@ void ProgramBuilder::add_primitive(const ov::Node& op, std::shared_ptr<cldnn::pr
     prim->origin_op_type_name = op.get_type_name();
 
     if (this->m_config.get_enable_weightless()) {
-        if (auto data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
+        if (auto *data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
             auto rt_info = op.get_rt_info();
 
             auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -143,9 +143,9 @@ ov::SoPtr<ov::ITensor> RemoteContextImpl::create_host_tensor(const ov::element::
     OPENVINO_ASSERT(m_is_initialized, "[GPU] create_host_tensor() called on uninitialized context. Please initialize the context before use");
     if (m_engine->use_unified_shared_memory()) {
         return { std::make_shared<USMHostTensor>(get_this_shared_ptr(), type, shape), nullptr };
-    } else {
-        return { ov::make_tensor(type, shape), nullptr };
     }
+    return { ov::make_tensor(type, shape), nullptr };
+
 }
 
 ov::SoPtr<ov::IRemoteTensor> RemoteContextImpl::create_tensor(const ov::element::Type& type, const ov::Shape& shape, const ov::AnyMap& params) {
@@ -154,8 +154,7 @@ ov::SoPtr<ov::IRemoteTensor> RemoteContextImpl::create_tensor(const ov::element:
     if (params.empty()) {
         // user wants plugin to allocate tensor by itself and return handle
         return { create_buffer(type, shape), nullptr };
-    } else {
-        // user will supply shared object handle
+    }         // user will supply shared object handle
         auto mem_type = extract_object(params, ov::intel_gpu::shared_mem_type);
 
         bool is_usm = mem_type == ov::intel_gpu::SharedMemType::USM_HOST_BUFFER ||
@@ -168,11 +167,14 @@ ov::SoPtr<ov::IRemoteTensor> RemoteContextImpl::create_tensor(const ov::element:
         if (ov::intel_gpu::SharedMemType::VA_SURFACE == mem_type) {
             check_if_shared();
             return { reuse_surface(type, shape, params), nullptr };
-        } else if (ov::intel_gpu::SharedMemType::USM_HOST_BUFFER == mem_type) {
+        }
+        if (ov::intel_gpu::SharedMemType::USM_HOST_BUFFER == mem_type) {
             return { create_usm(type, shape, TensorType::BT_USM_HOST_INTERNAL), nullptr };
-        } else if (ov::intel_gpu::SharedMemType::USM_DEVICE_BUFFER == mem_type) {
+        }
+        if (ov::intel_gpu::SharedMemType::USM_DEVICE_BUFFER == mem_type) {
             return { create_usm(type, shape, TensorType::BT_USM_DEVICE_INTERNAL), nullptr };
-        } else {
+        }
+        {
             TensorType tensor_type;
             cldnn::shared_handle mem = nullptr;
 
@@ -207,14 +209,14 @@ ov::SoPtr<ov::IRemoteTensor> RemoteContextImpl::create_tensor(const ov::element:
 
             return { reuse_memory(type, shape, mem, tensor_type), nullptr };
         }
-    }
+
 }
 
 // For external contexts we try to match underlying handles with default contexts created by plugin to find device name
 std::string RemoteContextImpl::get_device_name(const std::map<std::string, RemoteContextImpl::Ptr>& known_contexts,
                                                const cldnn::device::ptr current_device) const {
     std::string device_name = "GPU";
-    for (auto& c : known_contexts) {
+    for (const auto& c : known_contexts) {
         if (c.second->m_device->is_same(current_device)) {
             device_name = c.second->get_device_name();
             break;

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -448,7 +448,7 @@ bool RemoteTensorImpl::is_surface() const noexcept {
 }
 
 cldnn::memory::ptr RemoteTensorImpl::get_memory() const {
-    auto engine = m_memory_object->get_engine();
+    auto *engine = m_memory_object->get_engine();
     return engine->reinterpret_buffer(*m_memory_object, m_layout);
 }
 
@@ -461,7 +461,7 @@ void* RemoteTensorImpl::get_original_memory_buf_ptr() const {
 }
 
 void RemoteTensorImpl::set_memory(cldnn::memory::ptr memory, size_t actual_size) {
-    auto engine = m_memory_object->get_engine();
+    auto *engine = m_memory_object->get_engine();
     m_layout = memory->get_layout();
     m_shape = m_layout.get_shape();
 

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -263,10 +263,10 @@ ov::SoPtr<ov::ITensor> SyncInferRequest::get_tensor(const ov::Output<const ov::N
             tensor_ptr = inputs->at(port_index).ptr;
         }
         return { tensor_ptr, nullptr };
-    } else {
-        OPENVINO_ASSERT(m_user_outputs.count(port_index) == 1, "[GPU] Output tensor with index ", port_index, " is not found");
-        return { m_user_outputs.at(port_index).ptr, nullptr };
     }
+    OPENVINO_ASSERT(m_user_outputs.count(port_index) == 1, "[GPU] Output tensor with index ", port_index, " is not found");
+    return { m_user_outputs.at(port_index).ptr, nullptr };
+
 }
 
 void SyncInferRequest::check_tensors() const {
@@ -570,7 +570,7 @@ void SyncInferRequest::wait() {
         // let the user take care of them explicitly
         if (!is_remote_tensor_impl && output_memory) {
             if (!is_generic_remote) {
-                auto dst_ptr = static_cast<uint8_t*>(output_tensor->data());
+                auto *dst_ptr = static_cast<uint8_t*>(output_tensor->data());
                 bool same_mem = same_host_mem(output_memory, dst_ptr);
                 if (!same_mem && output_memory->size()) {
                     GPU_DEBUG_TRACE_DETAIL << internal_name << " with index " << port_idx << " copy from: " << output_memory->buffer_ptr() << " to "
@@ -633,7 +633,7 @@ void SyncInferRequest::wait() {
 // ----------------------------------------------------------------------------------------- //
 void SyncInferRequest::setup_stream_graph() {
     int stream_id = 0;
-    auto& stream_graphs = std::static_pointer_cast<const CompiledModel>(get_compiled_model())->get_graphs();
+    const auto& stream_graphs = std::static_pointer_cast<const CompiledModel>(get_compiled_model())->get_graphs();
     if (nullptr != m_stream_executor) {
         stream_id = m_stream_executor->get_stream_id();
         auto num_graphs = stream_graphs.size();
@@ -702,7 +702,8 @@ TensorWrapper SyncInferRequest::create_or_share_device_tensor(const TensorWrappe
 
     if (usm_host_tensor && can_share && m_context == usm_host_tensor->get_impl()->get_context()) {
         return { usm_host_tensor->get_impl(), user_tensor_wrapper.owner };
-    } else if (usm_host_raw_ptr && can_share) {
+    }
+    if (usm_host_raw_ptr && can_share) {
         return { std::make_shared<RemoteTensorImpl>(m_context,
                                                     user_tensor->get_shape(),
                                                     ::data_type_for_remote_tensor(element_type),
@@ -734,9 +735,9 @@ cldnn::event::ptr SyncInferRequest::copy_output_data(cldnn::memory::ptr src, ov:
     if (is_convert_required(layout.data_type, dst.get_element_type())) {
         convert_and_copy(src, &dst, stream);
         return nullptr;
-    } else {
-        return src->copy_to(stream, dst.data(), false);
     }
+    return src->copy_to(stream, dst.data(), false);
+
 }
 
 void SyncInferRequest::ensure_input_allocated(size_t input_idx) const {
@@ -761,7 +762,7 @@ void SyncInferRequest::allocate_input(size_t input_idx, GuardedMap::map_t& user_
     if (element_type == ov::element::string) {
         // In case the element type is string and input data is an empty string,
         // it produces the segmentation fault unless the each element of tensor.data is initialized.
-        auto data = user_inputs.at(input_idx).ptr->data<std::string>();
+        auto *data = user_inputs.at(input_idx).ptr->data<std::string>();
         std::uninitialized_fill_n(data, user_inputs.at(input_idx).ptr->get_size(), std::string());
     }
     // Base-qualified to avoid re-entering the input lock; use internal_port to match the allocated shape.
@@ -847,7 +848,7 @@ void SyncInferRequest::allocate_outputs() {
 void SyncInferRequest::allocate_states() {
     const auto& network = m_graph->get_network();
     const auto& variables_info = network->get_variables_info();
-    for (auto& vi : variables_info) {
+    for (const auto& vi : variables_info) {
         const auto& state_prims = vi.second.m_primitives;
         bool indirect_kv_cache = false;
         int64_t beam_axis = 0;
@@ -856,14 +857,14 @@ void SyncInferRequest::allocate_states() {
         bool has_zp_state = false;
         auto kv_cache_shape = vi.second.m_layout.get_partial_shape();
         std::vector<cldnn::layout> states_layouts;
-        for (auto& p : state_prims) {
-            if (auto kv_cache_prim = dynamic_cast<const cldnn::kv_cache*>(p)) {
+        for (const auto& p : state_prims) {
+            if (const auto *kv_cache_prim = dynamic_cast<const cldnn::kv_cache*>(p)) {
                 indirect_kv_cache = kv_cache_prim->indirect;
                 beam_axis = ov::util::normalize(kv_cache_prim->gather_axis, kv_cache_shape.size());
                 concat_axis = ov::util::normalize(kv_cache_prim->concat_axis, kv_cache_shape.size());
                 compressed = kv_cache_prim->compressed;
                 has_zp_state = kv_cache_prim->get_compression_zp_inputs_num() > 0;
-            } else if (auto read_value = dynamic_cast<const cldnn::read_value*>(p)) {
+            } else if (const auto *read_value = dynamic_cast<const cldnn::read_value*>(p)) {
                 states_layouts = read_value->output_layouts;
             }
         }
@@ -909,7 +910,7 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_batched_input(size_t in
         std::shared_ptr<ov::ITensor> merged_tensor = nullptr;
         if (is_host) {
             merged_tensor = m_context->create_host_tensor(tmp_et, tmp_shape)._ptr;
-            auto ptr = static_cast<uint8_t*>(merged_tensor->data());
+            auto *ptr = static_cast<uint8_t*>(merged_tensor->data());
             ov::parallel_for(user_tensors.size(), [&](size_t i) {
                 const auto& tensor = user_tensors.at(i);
                 std::memcpy(ptr + i * tensor->get_byte_size(), tensor->data(), tensor->get_byte_size());
@@ -1080,7 +1081,7 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
         }
     } else {
         if (!is_remote_tensor_impl && !is_generic_remote) {
-            auto src_ptr = static_cast<const uint8_t*>(user_tensor->data());
+            const auto *src_ptr = static_cast<const uint8_t*>(user_tensor->data());
             if (!same_host_mem(memory, src_ptr)) {
                 // WA: Set need_lockable_mem as a blocking argument
                 // The current input_layout (wait_for_events) does not provide proper synchronization for subsequent CPU implementations
@@ -1099,8 +1100,7 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
 
     if (ret_event && !ret_event->is_set())
         return { ret_event };
-    else
-        return {};
+    return {};
 }
 
 std::vector<cldnn::event::ptr> SyncInferRequest::prepare_output(size_t output_idx,

--- a/src/plugins/intel_gpu/src/plugin/transformations/binary_conv_to_conv.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/binary_conv_to_conv.cpp
@@ -62,7 +62,7 @@ ConvertBinaryConvolutionToConvolution::ConvertBinaryConvolutionToConvolution() {
         auto fp_element_type = activations.get_element_type();
 
         ov::Tensor new_weights_data(fp_element_type, weights->get_output_shape(0));
-        auto src_ptr = static_cast<const uint8_t*>(weights->get_data_ptr());
+        const auto *src_ptr = static_cast<const uint8_t*>(weights->get_data_ptr());
         auto size = ov::shape_size(weights->get_shape());
         switch (fp_element_type) {
             case ov::element::f16: convert_packed_bin_to_fp(src_ptr, static_cast<ov::float16*>(new_weights_data.data()), size); break;

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_convolution.cpp
@@ -88,11 +88,11 @@ ov::Tensor get_compensation(std::shared_ptr<ov::Node> w, std::shared_ptr<ov::Nod
 
     if (w_const->get_element_type() == ov::element::u8 && azp_const->get_element_type() == ov::element::u8)
         return get_compensation<uint8_t, uint8_t>(&w_tensor, &azp_tensor, wzp_const ? &wzp_tensor : nullptr, groups);
-    else if (w_const->get_element_type() == ov::element::u8 && azp_const->get_element_type() == ov::element::i8)
+    if (w_const->get_element_type() == ov::element::u8 && azp_const->get_element_type() == ov::element::i8)
         return get_compensation<uint8_t, int8_t>(&w_tensor, &azp_tensor, wzp_const ? &wzp_tensor : nullptr, groups);
-    else if (w_const->get_element_type() == ov::element::i8 && azp_const->get_element_type() == ov::element::u8)
+    if (w_const->get_element_type() == ov::element::i8 && azp_const->get_element_type() == ov::element::u8)
         return get_compensation<int8_t, uint8_t>(&w_tensor, &azp_tensor, wzp_const ? &wzp_tensor : nullptr, groups);
-    else if (w_const->get_element_type() == ov::element::i8 && azp_const->get_element_type() == ov::element::i8)
+    if (w_const->get_element_type() == ov::element::i8 && azp_const->get_element_type() == ov::element::i8)
         return get_compensation<int8_t, int8_t>(&w_tensor, &azp_tensor, wzp_const ? &wzp_tensor : nullptr, groups);
 
     OPENVINO_THROW("[GPU] Unsupported element types combination for quantized weights and zero-points");

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
@@ -71,8 +71,7 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
             if (current_shape.size() == 3) {
                 if (is_weight_3d)
                     return constant;
-                else
-                    new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0] * current_shape[1], current_shape[2]}
+                new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0] * current_shape[1], current_shape[2]}
                                                             : ov::Shape{current_shape[0], current_shape[1] * current_shape[2]};
             } else if (current_shape.size() == 4 && is_weight_3d) {
                 new_shape = (has_transpose || !grouped) ? ov::Shape{current_shape[0], current_shape[1] * current_shape[2], current_shape[3]}

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_stridedslices_to_variadicsplit.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_stridedslices_to_variadicsplit.cpp
@@ -58,8 +58,8 @@ ConvertStridedSlicesToVariadicSplit::ConvertStridedSlicesToVariadicSplit() {
                 if (!valid_ps(input_ps) || !valid_ps(output_ps) || input_ps.rank().get_length() != output_ps.rank().get_length())
                     return false;
 
-                auto& total_length = input_ps[input_ps.rank().get_length() - 1];
-                auto& split_length = output_ps[output_ps.rank().get_length() - 1];
+                const auto& total_length = input_ps[input_ps.rank().get_length() - 1];
+                const auto& split_length = output_ps[output_ps.rank().get_length() - 1];
                 if (total_length.get_length() / 3 != split_length.get_length())
                     return false;
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/decompose_reduce_scalar_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/decompose_reduce_scalar_output.cpp
@@ -35,14 +35,15 @@ ov::intel_gpu::DecomposeReduceForScalarOutput::DecomposeReduceForScalarOutput() 
     auto check_reduce_shape = [=](Output<Node> output) -> bool {
         const auto reduce = ov::as_type_ptr<op::util::ArithmeticReductionKeepDims>(output.get_node_shared_ptr());
         OPENVINO_ASSERT(reduce != nullptr, "output is not reduce.");
-        auto& input_shape = reduce->input_value(0).get_partial_shape();
-        auto& reduce_shape = reduce->input_value(1).get_partial_shape();
+        const auto& input_shape = reduce->input_value(0).get_partial_shape();
+        const auto& reduce_shape = reduce->input_value(1).get_partial_shape();
         if (reduce_shape.is_dynamic() || reduce_shape.size() != 1) {
             return false;
-        } else if (reduce_shape.to_shape()[0] <= 1 || reduce_shape.to_shape()[0] != input_shape.size()) {
+        }
+        if (reduce_shape.to_shape()[0] <= 1 || reduce_shape.to_shape()[0] != input_shape.size()) {
             return false;
         }
-        auto& output_shape = reduce->get_output_partial_shape(0);
+        const auto& output_shape = reduce->get_output_partial_shape(0);
         if (output_shape.is_static() && input_shape.is_static()) {
             // Output size decides at most how many EU threads can be used for this node execution,
             // less than 4 EU threads to execute a primitive will lead to poor performance.
@@ -71,8 +72,8 @@ ov::intel_gpu::DecomposeReduceForScalarOutput::DecomposeReduceForScalarOutput() 
         if (!reduce_orig || transformation_callback(reduce_orig))
             return false;
 
-        auto& input_shape = reduce_orig->input_value(0).get_partial_shape();
-        auto& output_shape = reduce_orig->get_output_partial_shape(0);
+        const auto& input_shape = reduce_orig->input_value(0).get_partial_shape();
+        const auto& output_shape = reduce_orig->get_output_partial_shape(0);
         bool dynamic_shape = input_shape.is_dynamic() || output_shape.is_dynamic();
         std::shared_ptr<ov::op::util::ArithmeticReductionKeepDims> reduce_new = nullptr;
         if (!dynamic_shape) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
@@ -349,7 +349,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
                 can_be_merged = false;
                 break;
             }
-            auto target_node = output.get_target_inputs().begin()->get_node();
+            auto *target_node = output.get_target_inputs().begin()->get_node();
             if (!ov::is_type<ov::op::v1::Multiply>(target_node)) {
                 can_be_merged = false;
                 break;
@@ -380,7 +380,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
             ov::NodeVector fused_mul_nodes;
             output_split->input(0).replace_source_output(new_mul);
             for (auto& output : output_split->outputs()) {
-                auto target_node = output.get_target_inputs().begin()->get_node();
+                auto *target_node = output.get_target_inputs().begin()->get_node();
                 fused_mul_nodes.push_back(target_node->shared_from_this());
                 ov::replace_output_update_name(target_node->output(0), output);
             }

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_per_layer_scaling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_per_layer_scaling.cpp
@@ -65,7 +65,7 @@ FullyConnectedPerLayerScaling::FullyConnectedPerLayerScaling(float scale_factor)
         auto scale_up = std::make_shared<ov::op::v1::Multiply>(fc, scale_up_const);
         scale_up->set_friendly_name(fc->get_friendly_name() + "_scale_up");
         ov::copy_runtime_info(fc, scale_up);
-        for (auto& in : target_inputs) {
+        for (const auto& in : target_inputs) {
             in.replace_source_output(scale_up);
         }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -258,7 +258,7 @@ IncreasePositionIdsPrecisionForQwen3VL::IncreasePositionIdsPrecisionForQwen3VL()
             for (auto& output : current->outputs()) {
                 if (!output.get_element_type().is_real())
                     continue;
-                for (auto& target_input : output.get_target_inputs()) {
+                for (const auto& target_input : output.get_target_inputs()) {
                     auto consumer = target_input.get_node()->shared_from_this();
                     if (!visited.insert(consumer.get()).second)
                         continue;

--- a/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
@@ -53,15 +53,15 @@ std::shared_ptr<ov::Node> make_kvcache_indirect(const std::shared_ptr<ov::intel_
                                                             kv_cache_node->get_concat_axis(),
                                                             gather_axis,
                                                             kv_cache_node->get_output_element_type(0));
-    } else {
-        return std::make_shared<ov::intel_gpu::op::KVCache>(gather_input_node,
-                                                            kv_cache_node->input(1).get_source_output(),
-                                                            beam_idx_node,
-                                                            kv_cache_node->get_variable(),
-                                                            kv_cache_node->get_concat_axis(),
-                                                            gather_axis,
-                                                            kv_cache_node->get_output_element_type(0));
     }
+    return std::make_shared<ov::intel_gpu::op::KVCache>(gather_input_node,
+                                                        kv_cache_node->input(1).get_source_output(),
+                                                        beam_idx_node,
+                                                        kv_cache_node->get_variable(),
+                                                        kv_cache_node->get_concat_axis(),
+                                                        gather_axis,
+                                                        kv_cache_node->get_output_element_type(0));
+
 }
 
 }  // namespace

--- a/src/plugins/intel_gpu/src/plugin/transformations/kv_cache_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/kv_cache_fusion.cpp
@@ -103,15 +103,15 @@ KVCacheFusionMatcher::KVCacheFusionMatcher() {
         const auto adjust_axis_to_positive = [&new_read_value_node](auto axis) ->std::optional<uint64_t> {
             if (axis >= 0) {
                 return static_cast<uint64_t>(axis);
-            } else {
-                const auto input_rank = new_read_value_node->get_output_partial_shape(0).rank();
-                if (input_rank.is_static()) {
-                    const auto adjusted_axis = input_rank.get_interval().get_min_val() + axis;
-                    if (adjusted_axis >= 0) {
-                        return static_cast<uint64_t>(adjusted_axis);
-                    }
+            }
+            const auto input_rank = new_read_value_node->get_output_partial_shape(0).rank();
+            if (input_rank.is_static()) {
+                const auto adjusted_axis = input_rank.get_interval().get_min_val() + axis;
+                if (adjusted_axis >= 0) {
+                    return static_cast<uint64_t>(adjusted_axis);
                 }
             }
+
             return std::nullopt;
         };
         std::optional<uint64_t> target_concat_axis = adjust_axis_to_positive(concat_axis);

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/convolution.cpp
@@ -103,21 +103,21 @@ std::shared_ptr<Node> Convolution::clone_with_new_inputs(const ov::OutputVector&
                                              m_groups,
                                              m_auto_pad,
                                              m_output_type);
-    } else {
-        return std::make_shared<Convolution>(new_args.at(0),
-                                             new_args.at(1),
-                                             new_args.at(2),
-                                             new_args.at(3),
-                                             new_args.at(4),
-                                             new_args.at(5),
-                                             m_strides,
-                                             m_pads_begin,
-                                             m_pads_end,
-                                             m_dilations,
-                                             m_groups,
-                                             m_auto_pad,
-                                             m_output_type);
     }
+    return std::make_shared<Convolution>(new_args.at(0),
+                                         new_args.at(1),
+                                         new_args.at(2),
+                                         new_args.at(3),
+                                         new_args.at(4),
+                                         new_args.at(5),
+                                         m_strides,
+                                         m_pads_begin,
+                                         m_pads_end,
+                                         m_dilations,
+                                         m_groups,
+                                         m_auto_pad,
+                                         m_output_type);
+
 }
 
 bool Convolution::has_groups() const {
@@ -143,14 +143,14 @@ std::vector<ov::PartialShape> shape_infer(const Convolution* op,
         tmp_op.set_auto_pad(op->get_auto_pad());
 
         return shape_infer(&tmp_op, input_shapes, pads_begin, pads_end);
-   } else {
-        ov::op::v1::Convolution tmp_op;
-        tmp_op.set_strides(op->get_strides());
-        tmp_op.set_dilations(op->get_dilations());
-        tmp_op.set_auto_pad(op->get_auto_pad());
-
-        return shape_infer(&tmp_op, input_shapes, pads_begin, pads_end);
    }
+    ov::op::v1::Convolution tmp_op;
+    tmp_op.set_strides(op->get_strides());
+    tmp_op.set_dilations(op->get_dilations());
+    tmp_op.set_auto_pad(op->get_auto_pad());
+
+    return shape_infer(&tmp_op, input_shapes, pads_begin, pads_end);
+
 }
 
 }  // namespace ov::intel_gpu::op

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/fully_connected_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/fully_connected_compressed.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<ov::Node> FullyConnectedCompressed::clone_with_new_inputs(const 
                                                           new_args.at(3),
                                                           m_output_type,
                                                           m_transpose_b);
-    else if (new_args.size() == 5)
+                                                          if (new_args.size() == 5)
         return std::make_shared<FullyConnectedCompressed>(new_args.at(0),
                                                           new_args.at(1),
                                                           new_args.at(2),
@@ -67,7 +67,7 @@ std::shared_ptr<ov::Node> FullyConnectedCompressed::clone_with_new_inputs(const 
                                                           new_args.at(4),
                                                           m_output_type,
                                                           m_transpose_b);
-    else if (new_args.size() == 8)
+                                                          if (new_args.size() == 8)
         return std::make_shared<FullyConnectedCompressed>(new_args.at(0),
                                                           new_args.at(1),
                                                           new_args.at(2),
@@ -78,7 +78,6 @@ std::shared_ptr<ov::Node> FullyConnectedCompressed::clone_with_new_inputs(const 
                                                           new_args.at(7),
                                                           m_output_type,
                                                           m_transpose_b);
-    else
-        OPENVINO_THROW("Unexpected inputs count for FullyConnectedCompressed op: ", new_args.size());
+            OPENVINO_THROW("Unexpected inputs count for FullyConnectedCompressed op: ", new_args.size());
 }
 }  // namespace ov::intel_gpu::op

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
@@ -105,9 +105,9 @@ std::vector<ov::PartialShape> shape_infer(const Gemm* op,
 
     if (!order_c.empty()) {
         return { transpose_pshape(out_shapes[0], order_c) };
-    } else {
-        return { out_shapes[0] };
     }
+    return { out_shapes[0] };
+
 }
 
 }  // namespace ov::intel_gpu::op

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/indirect_sdpa.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/indirect_sdpa.cpp
@@ -56,18 +56,18 @@ std::shared_ptr<ov::Node> IndirectSDPA::clone_with_new_inputs(const ov::OutputVe
                                               m_order_v,
                                               m_order_out,
                                               m_output_type);
-    } else {
-        return std::make_shared<IndirectSDPA>(data_inputs,
-                                              new_args.back(),
-                                              m_is_causal,
-                                              m_indirect_axis,
-                                              m_order_q,
-                                              m_order_k,
-                                              m_order_v,
-                                              m_order_out,
-                                              m_quantization_attrs,
-                                              m_output_type);
     }
+    return std::make_shared<IndirectSDPA>(data_inputs,
+                                          new_args.back(),
+                                          m_is_causal,
+                                          m_indirect_axis,
+                                          m_order_q,
+                                          m_order_k,
+                                          m_order_v,
+                                          m_order_out,
+                                          m_quantization_attrs,
+                                          m_output_type);
+
 }
 
 void IndirectSDPA::validate_and_infer_types() {

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/kv_cache.cpp
@@ -128,7 +128,8 @@ std::shared_ptr<Node> KVCache::clone_with_new_inputs(const ov::OutputVector& new
                                          m_concat_axis,
                                          m_output_type);
 
-    } else if (new_args.size() == 3) {
+    }
+    if (new_args.size() == 3) {
         if (m_trim) {
             return std::make_shared<KVCache>(new_args.at(0),
                                              new_args.at(1),
@@ -136,16 +137,17 @@ std::shared_ptr<Node> KVCache::clone_with_new_inputs(const ov::OutputVector& new
                                              m_variable,
                                              m_concat_axis,
                                              m_output_type);
-        } else {
-            return std::make_shared<KVCache>(new_args.at(0),
-                                             new_args.at(1),
-                                             new_args.at(2),
-                                             m_variable,
-                                             m_concat_axis,
-                                             m_gather_axis,
-                                             m_output_type);
         }
-    } else if (new_args.size() == 4) {
+        return std::make_shared<KVCache>(new_args.at(0),
+                                         new_args.at(1),
+                                         new_args.at(2),
+                                         m_variable,
+                                         m_concat_axis,
+                                         m_gather_axis,
+                                         m_output_type);
+
+    }
+    if (new_args.size() == 4) {
         return std::make_shared<KVCache>(new_args.at(0),
                                          new_args.at(1),
                                          new_args.at(2),
@@ -154,7 +156,7 @@ std::shared_ptr<Node> KVCache::clone_with_new_inputs(const ov::OutputVector& new
                                          m_concat_axis,
                                          m_gather_axis,
                                          m_output_type);
-    } else if (new_args.size() == 5) {
+    } if (new_args.size() == 5) {
         return std::make_shared<KVCache>(new_args.at(0),
                                          new_args.at(1),
                                          new_args.at(2),
@@ -163,9 +165,9 @@ std::shared_ptr<Node> KVCache::clone_with_new_inputs(const ov::OutputVector& new
                                          m_variable,
                                          m_concat_axis,
                                          m_output_type);
-    } else {
-        OPENVINO_ASSERT(false);
     }
+    OPENVINO_ASSERT(false);
+
 }
 
 std::vector<ov::PartialShape> shape_infer(const KVCache* op, const std::vector<ov::PartialShape>& input_shapes) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/read_value.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/read_value.cpp
@@ -139,9 +139,9 @@ std::shared_ptr<Node> ReadValues::clone_with_new_inputs(const ov::OutputVector& 
 
     if (!new_args.empty()) {
         return std::make_shared<ReadValues>(new_args, m_variable, m_internal_states_infos);
-    } else {
-        return std::make_shared<ReadValues>(m_variable, m_internal_states_infos);
     }
+    return std::make_shared<ReadValues>(m_variable, m_internal_states_infos);
+
 }
 
 std::vector<ov::op::util::VariableInfo> ReadValues::get_all_internal_states_info() const {

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/sdpa.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/sdpa.cpp
@@ -160,15 +160,15 @@ std::vector<ov::PartialShape> shape_infer(const SDPA* op,
     }
 
     OPENVINO_ASSERT(op != nullptr, "op should not be nullptr for shape_infer.");
-    auto op_v13 = ov::as_type<const ov::op::v13::ScaledDotProductAttention>(op);
+    const auto *op_v13 = ov::as_type<const ov::op::v13::ScaledDotProductAttention>(op);
     OPENVINO_ASSERT(op_v13 != nullptr, "ov::op::v13::ScaledDotProductAttention*>(op) should not be nullptr.");
     auto out_shapes = ov::op::v13::shape_infer(op_v13, transposed_input_shapes);
 
     if (!order_out.empty()) {
         return { transpose_pshape(out_shapes[0], order_out) };
-    } else {
-        return { out_shapes[0] };
     }
+    return { out_shapes[0] };
+
 }
 
 }  // namespace ov::intel_gpu::op

--- a/src/plugins/intel_gpu/src/plugin/transformations/print_model_statistics.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/print_model_statistics.cpp
@@ -13,7 +13,7 @@ namespace {
 size_t collect_stats(const std::shared_ptr<ov::Model>& m, std::map<DiscreteTypeInfo, size_t>& ops_stat) {
     const std::vector<std::shared_ptr<ov::Node>> ops = m->get_ops();
     size_t total = ops.size();
-    for (auto& op : ops) {
+    for (const auto& op : ops) {
         const auto& tinfo = op->get_type_info();
         if (ops_stat.find(tinfo) == ops_stat.end()) {
             ops_stat[tinfo] = 0;

--- a/src/plugins/intel_gpu/src/plugin/transformations/sink_reshape.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/sink_reshape.cpp
@@ -60,7 +60,8 @@ SinkReshape::SinkReshape() {
                     continue;
                 if (supported_conv_eltwise_post_ops_for_fuse(node)) {
                     return is_suitable_parent(input);
-                } else if (supported_conv_act_post_ops_for_fuse(node)) {
+                }
+                if (supported_conv_act_post_ops_for_fuse(node)) {
                     return is_suitable_parent(input);
                 }
                 return false;
@@ -71,8 +72,8 @@ SinkReshape::SinkReshape() {
         auto is_suitable_reshape = [](const std::shared_ptr<ov::Node>& node) -> bool {
             if (node->is_dynamic())
                 return false;
-            auto& in_ps = node->get_input_partial_shape(0);
-            auto& out_ps = node->get_output_partial_shape(0);
+            const auto& in_ps = node->get_input_partial_shape(0);
+            const auto& out_ps = node->get_output_partial_shape(0);
             if (in_ps.size() - out_ps.size() != 1)
                 return false;
             size_t mismatch_count = 0;

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
@@ -42,9 +42,9 @@ bool is_valid_order(const std::vector<size_t>& target_order, bool is_output_tran
     cldnn::format fmt_dummy = cldnn::format::bfyx;
     if (is_output_transpose) {
         return cldnn::typed_primitive_inst<cldnn::gemm>::is_fusable_permute_output_order_onednn(target_order, fmt_dummy);
-    } else {
-        return cldnn::typed_primitive_inst<cldnn::gemm>::is_fusable_permute_input_order_onednn(target_order, fmt_dummy);
     }
+    return cldnn::typed_primitive_inst<cldnn::gemm>::is_fusable_permute_input_order_onednn(target_order, fmt_dummy);
+
 }
 
 bool has_optimized_version(const ov::Output<ov::Node>& output, bool supports_immad, bool is_output_transpose = false) {
@@ -323,7 +323,7 @@ TransposeMatMulMatcher::TransposeMatMulMatcher(bool supports_immad) {
     // Don't convert MatMul -> Gemm if no transpose input found as
     // CreateMatMulOp factory can now insert extra transpose which improves the performance
     auto matmul_predicate = [](const ov::Output<ov::Node>& output) -> bool {
-        auto node = output.get_node();
+        auto *node = output.get_node();
         if (node->is_dynamic())
             return true;
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.cpp
@@ -112,10 +112,10 @@ UnsqueezeBroadcastReshapeSDPAFusion::UnsqueezeBroadcastReshapeSDPAFusion() {
                     if (input_shape[i] != target_shape[i]) ++diff_cnt;
                 }
                 return diff_cnt == 1;
-            } else {
-                // For dynamic output shapes, check the target_shape pattern
-                return std::count_if(target_shape.begin(), target_shape.end(), [](int32_t s) { return s != 1; }) == 1;
             }
+            // For dynamic output shapes, check the target_shape pattern
+            return std::count_if(target_shape.begin(), target_shape.end(), [](int32_t s) { return s != 1; }) == 1;
+
         };
 
         std::vector<int32_t> target_shape_val_b;

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -330,7 +330,8 @@ static bool is_decompression_multiply(const std::shared_ptr<const ov::Node> node
                 const auto& type_info = child_consumer.get_node()->get_type_info();
                 if (cldnn::one_of(type_info, target_consumers)) {
                     return true;
-                } else if (are_converts_from_decompression(child_consumers)) {
+                }
+                if (are_converts_from_decompression(child_consumers)) {
                     return true;
                 }
             }
@@ -722,7 +723,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::pass::KeepConstantsPrecisionAndAddConverts>();
         pass_config->set_callback<ov::pass::KeepConstantsPrecisionAndAddConverts>(
             [](const_node_ptr& node) -> bool {
-                auto next_node = node->get_output_target_inputs(0).begin()->get_node();
+                auto *next_node = node->get_output_target_inputs(0).begin()->get_node();
                 if (is_type<ov::op::v0::Convert>(next_node)) {
                     next_node = next_node->get_output_target_inputs(0).begin()->get_node();
                 }
@@ -1133,11 +1134,13 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         auto isCellPrimitiveSupported = [](const_node_ptr &node) -> bool {
             if (ov::as_type_ptr<const ov::op::v0::RNNCell>(node)) {
                 return false;
-            } else if (ov::as_type_ptr<const ov::op::v3::GRUCell>(node)) {
+            }
+            if (ov::as_type_ptr<const ov::op::v3::GRUCell>(node)) {
                 return false;
-            } else if (const auto &lstm_cell = ov::as_type_ptr<const ov::op::v4::LSTMCell>(node)) {
+            } if (const auto &lstm_cell = ov::as_type_ptr<const ov::op::v4::LSTMCell>(node)) {
                 return false;
-            } else if (const auto &lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
+            }
+            if (const auto &lstm_cell_v1 = ov::as_type_ptr<const ov::op::v0::LSTMCell>(node)) {
                 return lstm_cell_v1->get_clip() == 0.0f && lstm_cell_v1->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"};
             }
             return false;
@@ -1158,7 +1161,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
             if (ov::as_type_ptr<const ov::op::v5::RNNSequence>(node)) {
                 return false;
-            } else if (const auto &gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
+            }
+            if (const auto &gru_seq = ov::as_type_ptr<const ov::op::v5::GRUSequence>(node)) {
                 bool is_batch_one_with_dynamic_seq_len = data_pshape[0] == 1 && !data_pshape[1].is_static();
                 return gru_seq->get_clip() == 0.0f &&
                     gru_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh"} &&
@@ -1167,7 +1171,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                                                         gru_seq->get_input_node_shared_ptr(2)) ||
                     is_batch_one_with_dynamic_seq_len) &&
                     gru_seq->get_linear_before_reset();
-            } else if (const auto &lstm_seq = ov::as_type_ptr<const ov::op::v5::LSTMSequence>(node)) {
+            } if (const auto &lstm_seq = ov::as_type_ptr<const ov::op::v5::LSTMSequence>(node)) {
                 if (!data_pshape[1].is_static())
                     return false;
                 return (lstm_seq->get_clip() == 0.0f &&
@@ -1210,7 +1214,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             [](const_node_ptr &node) -> bool {
                 const auto mvn = ov::as_type_ptr<const ov::op::v6::MVN>(node);
                 if (mvn != nullptr && node->get_input_size() == 2) {
-                    if (auto axes_node = ov::as_type<ov::op::v0::Constant>(mvn->get_input_node_ptr(1))) {
+                    if (auto *axes_node = ov::as_type<ov::op::v0::Constant>(mvn->get_input_node_ptr(1))) {
                         auto mvn_axes = axes_node->cast_vector<int64_t>();
                         auto out_rank = mvn->get_output_partial_shape(0).size();
                         ov::util::try_normalize_axes(mvn_axes, out_rank, *mvn);
@@ -1254,7 +1258,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             const auto isSupportedAxes = [](const std::vector<size_t> &axes, const size_t inputRank) {
                 if (axes.size() == 1 && axes[0] == 1) {
                     return true;
-                } else if (axes.size() == inputRank - 1) {
+                }
+                if (axes.size() == inputRank - 1) {
                     auto sortAxes = axes;
                     std::sort(sortAxes.begin(), sortAxes.end());
                     for (size_t i = 0; i < sortAxes.size(); i++) {
@@ -1423,7 +1428,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         lptPassConfig->set_callback<FuseConvertTransformation>([&](const_node_ptr& node) -> bool {
             if (ov::is_type<ov::opset1::Multiply>(node)) {
                 return ov::is_type<ov::opset1::Multiply>(node) && is_decompression_multiply(node, device_info.supports_immad);
-            } else if (ov::is_type<ov::opset1::Subtract>(node)) {
+            }
+            if (ov::is_type<ov::opset1::Subtract>(node)) {
                 const auto& consumers = node->get_output_target_inputs(0);
                 if (consumers.size() == 1) {
                     const auto consumer = consumers.begin()->get_node()->shared_from_this();
@@ -1713,8 +1719,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     if (dyn_quan_single >= 0) {
                         if (fc_count != dyn_quan_single)
                             return true;
-                        else
-                            GPU_DEBUG_COUT << "Try to apply dyn_quan only to " << root->get_friendly_name() << std::endl;
+                        GPU_DEBUG_COUT << "Try to apply dyn_quan only to " << root->get_friendly_name() << std::endl;
                     }
                 }
 

--- a/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
+++ b/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
@@ -15,9 +15,9 @@ std::ostream& get_verbose_stream() {
         if (!fout.is_open())
             fout.open(ExecutionConfig::get_log_to_file());
         return fout;
-    } else {
-        return std::cout;
     }
+    return std::cout;
+
 #else
     return std::cout;
 #endif

--- a/src/plugins/intel_gpu/src/runtime/device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/device.cpp
@@ -45,7 +45,8 @@ struct DeviceOps {
 
         if (gfx_version_list.size() == 1) {
             return info.gfx_ver == gfx_version_list[0];
-        } else if (gfx_version_list.size() == 2) {
+        }
+        if (gfx_version_list.size() == 2) {
             return info.gfx_ver >= gfx_version_list[0] && info.gfx_ver <= gfx_version_list[1];
         }
         return false;
@@ -73,9 +74,9 @@ struct DeviceOps {
         auto it = ops_mad.find(dt);
         if (it != ops_mad.end()) {
             return it->second;
-        } else {
-            return 0;
         }
+        return 0;
+
     }
 };
 

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -190,7 +190,8 @@ void ExecutionConfig::apply_model_specific_options(const IRemoteContext* context
         if (ov::is_type<ov::op::PagedAttentionExtension>(node)) {
             is_paged_attention_model = true;
             return true;
-        } else if (ov::is_type<ov::intel_gpu::op::KVCache>(node)) {
+        }
+        if (ov::is_type<ov::intel_gpu::op::KVCache>(node)) {
             return true;
         }
 

--- a/src/plugins/intel_gpu/src/runtime/format.cpp
+++ b/src/plugins/intel_gpu/src/runtime/format.cpp
@@ -189,7 +189,8 @@ const format_traits& format::traits() const {
 std::string format::to_string() const {
     if (value == any) {
         return "any";
-    } else if (value == custom) {
+    }
+    if (value == custom) {
         return "custom";
     }
     return traits(value).str;
@@ -266,7 +267,7 @@ format format::adjust_to_rank(format fmt, size_t new_rank) {
         align_order(current_order, current_rank, new_rank);
     }
 
-    for (auto& kv : format_traits_map) {
+    for (const auto& kv : format_traits_map) {
         auto candidate_tag = kv.first;
         auto candidate_traits = kv.second;
         auto candidate_order = candidate_traits._order;
@@ -328,7 +329,7 @@ format format::find_format(const std::vector<uint64_t>& order,
     };
 
     std::vector<format> finded_formats;
-    for (auto& traits : format_traits_map) {
+    for (const auto& traits : format_traits_map) {
         if (is_suitable_traits(traits))
             finded_formats.emplace_back(traits.first);
     }

--- a/src/plugins/intel_gpu/src/runtime/layout.cpp
+++ b/src/plugins/intel_gpu/src/runtime/layout.cpp
@@ -452,8 +452,8 @@ layout layout::with_padding(padding const& padd) const {
 //       this behavior is required to force buffer allocation for smaller buffer which, currently, should always be
 //       performed
 bool layout::compatible(const layout& other) const {
-    auto& l1 = *this;
-    auto& l2 = other;
+    const auto& l1 = *this;
+    const auto& l2 = other;
 
     if (l1.is_dynamic() || l2.is_dynamic())
         return false;

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -82,9 +82,9 @@ void memory_pool::release_memory(memory* mem, const size_t& unique_id, primitive
 
                 //entry found and processed - so return
                 return;
-            } else {
-                ++it;
             }
+            ++it;
+
         }
     }
     {
@@ -119,9 +119,9 @@ void memory_pool::release_memory(memory* mem, const size_t& unique_id, primitive
 
                     //entry found and processed - so return
                     break;
-                } else {
-                    list_itr++;
                 }
+                list_itr++;
+
             }
 
             if (list.empty()) {
@@ -196,9 +196,9 @@ memory::ptr memory_pool::get_from_non_padded_pool(const layout& layout,
             auto ret_mem = _engine->reinterpret_buffer(*it->second._memory, layout);
             ret_mem->from_memory_pool = true;
             return ret_mem;
-        } else {
-            ++it;
         }
+        ++it;
+
     }
     GPU_DEBUG_LOG << "[" << prim_id << "(" << unique_id << "): output]" << std::endl;
     // didn't find anything for you? create new resource
@@ -316,13 +316,14 @@ memory::ptr memory_pool::get_memory(const layout& layout,
         }
 #endif
         return mem;
-    } else if (!layout.data_padding || is_dynamic) {
+    }
+    if (!layout.data_padding || is_dynamic) {
         // non-padded buffers. For dynamic shape, use non-padded pool even if it has padding because we will reset the buffer if it is reused
         return get_from_non_padded_pool(layout, prim_id, unique_id, network_id, restrictions, type, reset, is_dynamic);
-    } else {
-        // padded buffers
-        return get_from_padded_pool(layout, prim_id, unique_id, network_id, restrictions, type);
     }
+    // padded buffers
+    return get_from_padded_pool(layout, prim_id, unique_id, network_id, restrictions, type);
+
 }
 
 void memory_pool::clear_pool_for_network(uint32_t network_id) {
@@ -433,9 +434,9 @@ size_t memory_pool::get_total_mem_pool_size(allocation_type type) {
     const auto total_mem_size = total_mem_size_no_reusable + total_mem_size_non_padded_pool + total_mem_size_padded_pool;
     if (type == allocation_type::usm_host) {
         return host_mem_size;
-    } else {
-        return (total_mem_size - host_mem_size);
     }
+    return (total_mem_size - host_mem_size);
+
 #else
     return 0;
 #endif

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -137,8 +137,7 @@ int driver_dev_id() {
 
     if (result.empty())
         return 0;
-    else
-        return result.back();
+    return result.back();
 }
 
 device_type get_device_type(const cl::Device& device) {
@@ -163,15 +162,15 @@ gfx_version parse_version(cl_uint gmdid) {
     if (gmd_id.architecture > 0 && gmd_id.architecture < 100) {
         // New format
         return { static_cast<uint16_t>(gmd_id.architecture), static_cast<uint8_t>(gmd_id.release), static_cast<uint8_t>(gmd_id.revision)};
-    } else {
-        // Old format
-        cl_uint ver = gmdid;
-        uint16_t major = ver >> 16;
-        uint8_t minor = (ver >> 8) & 0xFF;
-        uint8_t revision = ver & 0xFF;
-
-        return {major, minor, revision};
     }
+    // Old format
+    cl_uint ver = gmdid;
+    uint16_t major = ver >> 16;
+    uint8_t minor = (ver >> 8) & 0xFF;
+    uint8_t revision = ver & 0xFF;
+
+    return {major, minor, revision};
+
 }
 
 bool get_imad_support(const cl::Device& device) {
@@ -454,7 +453,7 @@ ocl_device::ocl_device(const ocl_device::ptr other, bool initialize_ctx)
 }
 
 bool ocl_device::is_same(const device::ptr other) {
-    auto casted = downcast<ocl_device>(other.get());
+    auto *casted = downcast<ocl_device>(other.get());
     if (!casted)
         return false;
 
@@ -483,7 +482,7 @@ void ocl_device::initialize() {
     for (auto& device : device_map) {
         if (this->is_same(device.second)) {
             OPENVINO_ASSERT(!found, "[GPU] Multiple matching devices found for ", this->get_info().dev_name, ". Only one matching device is expected");
-            if (auto casted = downcast<ocl_device>(device.second.get())) {
+            if (auto *casted = downcast<ocl_device>(device.second.get())) {
                 auto& casted_device = casted->get_device();
                 if (casted->get_context().get() == nullptr) {
                     casted->set_context(cl::Context(casted_device));

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -62,7 +62,7 @@ ocl_engine::ocl_engine(const device::ptr dev, runtime_types runtime_type)
     : engine(dev) {
     OPENVINO_ASSERT(runtime_type == runtime_types::ocl, "[GPU] Invalid runtime type specified for OCL engine. Only OCL runtime is supported");
 
-    auto casted = dynamic_cast<ocl_device*>(dev.get());
+    auto *casted = dynamic_cast<ocl_device*>(dev.get());
     OPENVINO_ASSERT(casted, "[GPU] Invalid device type passed to ocl engine");
     casted->get_device().getInfo(CL_DEVICE_EXTENSIONS, &_extensions);
 
@@ -140,7 +140,7 @@ memory::ptr ocl_engine::import_buffer(const layout& layout, ov::intel_gpu::os_ha
     };
 
     cl_int errcode = CL_SUCCESS;
-    auto cl_ctx = static_cast<cl_context>(get_user_context(runtime_types::ocl));
+    auto *cl_ctx = static_cast<cl_context>(get_user_context(runtime_types::ocl));
     OPENVINO_ASSERT(cl_ctx != nullptr, "[GPU] OpenCL context is null while importing external buffer");
     const auto byte_size = layout.bytes_count();
     cl_mem imported = clCreateBufferWithProperties(cl_ctx, props, CL_MEM_READ_WRITE, byte_size, nullptr, &errcode);
@@ -216,8 +216,8 @@ memory::ptr ocl_engine::create_subbuffer(const memory& memory, const layout& new
         if (new_layout.format.is_image_2d()) {
             OPENVINO_NOT_IMPLEMENTED;
         } else if (memory_capabilities::is_usm_type(memory.get_allocation_type())) {
-            auto& new_buf = reinterpret_cast<const ocl::gpu_usm&>(memory);
-            auto ptr = new_buf.get_buffer().get();
+            const auto& new_buf = reinterpret_cast<const ocl::gpu_usm&>(memory);
+            auto *ptr = new_buf.get_buffer().get();
             auto sub_buffer = cl::UsmMemory(get_usm_helper(), ptr, byte_offset);
 
             return std::make_shared<ocl::gpu_usm>(this,
@@ -289,13 +289,14 @@ memory::ptr ocl_engine::reinterpret_handle(const layout& new_layout, shared_mem_
         if (new_layout.format.is_image_2d() && params.mem_type == shared_mem_type::shared_mem_image) {
             cl::Image2D img(static_cast<cl_mem>(params.mem), true);
             return std::make_shared<ocl::gpu_image2d>(this, new_layout, img, nullptr);
-        } else if (new_layout.format.is_image_2d() && params.mem_type == shared_mem_type::shared_mem_vasurface) {
+        }
+        if (new_layout.format.is_image_2d() && params.mem_type == shared_mem_type::shared_mem_vasurface) {
             return std::make_shared<ocl::gpu_media_buffer>(this, new_layout, params);
 #ifdef _WIN32
         } else if (params.mem_type == shared_mem_type::shared_mem_dxbuffer) {
             return std::make_shared<ocl::gpu_dx_buffer>(this, new_layout, params);
 #endif
-        } else if (params.mem_type == shared_mem_type::shared_mem_buffer) {
+        } if (params.mem_type == shared_mem_type::shared_mem_buffer) {
             cl::Buffer buf(static_cast<cl_mem>(params.mem), true);
             auto actual_mem_size = buf.getInfo<CL_MEM_SIZE>();
             auto requested_mem_size = new_layout.bytes_count();
@@ -303,7 +304,8 @@ memory::ptr ocl_engine::reinterpret_handle(const layout& new_layout, shared_mem_
                             "[GPU] shared buffer has smaller size (", actual_mem_size,
                             ") than specified layout (", requested_mem_size, ")");
             return std::make_shared<ocl::gpu_buffer>(this, new_layout, buf, nullptr);
-        } else if (params.mem_type == shared_mem_type::shared_mem_usm) {
+        }
+        if (params.mem_type == shared_mem_type::shared_mem_usm) {
             cl::UsmMemory usm_buffer(get_usm_helper(), params.mem);
             auto actual_mem_size = get_usm_helper().get_usm_allocation_size(usm_buffer.get());
             auto requested_mem_size = new_layout.bytes_count();
@@ -311,9 +313,9 @@ memory::ptr ocl_engine::reinterpret_handle(const layout& new_layout, shared_mem_
                             "[GPU] shared USM buffer has smaller size (", actual_mem_size,
                             ") than specified layout (", requested_mem_size, ")");
             return std::make_shared<ocl::gpu_usm>(this, new_layout, usm_buffer, nullptr);
-        } else {
-            OPENVINO_THROW("[GPU] unknown shared object fromat or type");
         }
+        OPENVINO_THROW("[GPU] unknown shared object fromat or type");
+
     }
     catch (const cl::Error& clErr) {
         switch (clErr.err()) {
@@ -339,8 +341,7 @@ bool ocl_engine::is_the_same_buffer(const memory& mem1, const memory& mem2) {
     if (!memory_capabilities::is_usm_type(mem1.get_allocation_type()))
         return (reinterpret_cast<const ocl::gpu_buffer&>(mem1).get_buffer() ==
                 reinterpret_cast<const ocl::gpu_buffer&>(mem2).get_buffer());
-    else
-        return (reinterpret_cast<const ocl::gpu_usm&>(mem1).get_buffer() ==
+    return (reinterpret_cast<const ocl::gpu_usm&>(mem1).get_buffer() ==
                 reinterpret_cast<const ocl::gpu_usm&>(mem2).get_buffer());
 }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.cpp
@@ -37,7 +37,7 @@ namespace cldnn::ocl::utils {
 std::vector<cl::Event> get_cl_events(const std::vector<event::ptr>& events) {
     std::vector<cl::Event> cl_events;
     for (const auto& ev : events) {
-        if (auto ocl_base_ev = dynamic_cast<ocl_base_event*>(ev.get())) {
+        if (auto *ocl_base_ev = dynamic_cast<ocl_base_event*>(ev.get())) {
             if (ocl_base_ev->get().get() != nullptr) {
                 cl_events.push_back(ocl_base_ev->get());
             }
@@ -103,7 +103,7 @@ bool ocl_event::get_profiling_info_impl(std::list<instrumentation::profiling_int
     if (!is_event_profiled(_event))
         return true;
 
-    for (auto& period : profiling_periods) {
+    for (const auto& period : profiling_periods) {
         cl_ulong start;
         cl_ulong end;
 
@@ -164,7 +164,7 @@ bool ocl_events::get_profiling_info_impl(std::list<instrumentation::profiling_in
         if (!is_event_profiled(be->_event))
             continue;
 
-        for (auto& period : profiling_periods) {
+        for (const auto& period : profiling_periods) {
             cl_ulong ev_start;
             cl_ulong ev_end;
             try {
@@ -187,9 +187,9 @@ bool ocl_events::get_profiling_info_impl(std::list<instrumentation::profiling_in
                         if (!ev_duration_merged) {
                             ev_duration_merged = true;
                             break;
-                        } else {
-                            it = durations.erase(it);
                         }
+                        it = durations.erase(it);
+
                     } else {
                         if (!ev_duration_merged) {
                             duration.first = std::min(duration.first, ev_duration.first);
@@ -218,7 +218,7 @@ bool ocl_events::get_profiling_info_impl(std::list<instrumentation::profiling_in
         }
     }
 
-    for (auto& period : profiling_periods) {
+    for (const auto& period : profiling_periods) {
         auto& durations = all_durations[period.stage];
         if (durations.empty()) {
             auto zero_period = std::make_shared<instrumentation::profiling_period_basic>(std::chrono::nanoseconds(0));

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.hpp
@@ -64,10 +64,10 @@ private:
 
     void process_events(const std::vector<event::ptr>& ev) {
         for (size_t i = 0; i < ev.size(); i++) {
-            auto multiple_events = dynamic_cast<ocl_events*>(ev[i].get());
+            auto *multiple_events = dynamic_cast<ocl_events*>(ev[i].get());
             if (multiple_events) {
                 for (size_t j = 0; j < multiple_events->_events.size(); j++) {
-                    if (auto base_ev = dynamic_cast<ocl_event*>(multiple_events->_events[j].get())) {
+                    if (auto *base_ev = dynamic_cast<ocl_event*>(multiple_events->_events[j].get())) {
                         auto current_ev_queue_stamp = base_ev->get_queue_stamp();
                         if ((_queue_stamp == 0) || (current_ev_queue_stamp > _queue_stamp)) {
                             _queue_stamp = current_ev_queue_stamp;
@@ -77,7 +77,7 @@ private:
                     _events.push_back(multiple_events->_events[j]);
                 }
             } else {
-                if (auto base_ev = dynamic_cast<ocl_event*>(ev[i].get())) {
+                if (auto *base_ev = dynamic_cast<ocl_event*>(ev[i].get())) {
                     auto current_ev_queue_stamp = base_ev->get_queue_stamp();
                     if ((_queue_stamp == 0) || (current_ev_queue_stamp > _queue_stamp)) {
                         _queue_stamp = current_ev_queue_stamp;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
@@ -1026,21 +1026,21 @@ public:
 
     void allocateHost(size_t size, const cl_mem_properties_intel* properties = nullptr) {
         cl_int error = CL_SUCCESS;
-        auto ptr = _usmHelper.allocate_host(properties, size, 0, &error);
+        auto *ptr = _usmHelper.allocate_host(properties, size, 0, &error);
         _check_error(size, ptr, error, "Host");
         _allocate(ptr);
     }
 
     void allocateShared(size_t size, const cl_mem_properties_intel* properties = nullptr) {
         cl_int error = CL_SUCCESS;
-        auto ptr = _usmHelper.allocate_shared(properties, size, 0, &error);
+        auto *ptr = _usmHelper.allocate_shared(properties, size, 0, &error);
         _check_error(size, ptr, error, "Shared");
         _allocate(ptr);
     }
 
     void allocateDevice(size_t size, const cl_mem_properties_intel* properties = nullptr) {
         cl_int error = CL_SUCCESS;
-        auto ptr = _usmHelper.allocate_device(properties, size, 0, &error);
+        auto *ptr = _usmHelper.allocate_device(properties, size, 0, &error);
         _check_error(size, ptr, error, "Device");
         _allocate(ptr);
     }
@@ -1068,8 +1068,7 @@ private:
             sout << "[CL ext] Can not allocate " << size << " bytes for USM " << usm_type << ". ptr: " << ptr << ", error: " << error << std::endl;
             if (ptr == nullptr)
                 throw std::runtime_error(sout.str());
-            else
-                detail::errHandler(error, sout.str().c_str());
+            detail::errHandler(error, sout.str().c_str());
         }
     }
 };

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel.hpp
@@ -34,7 +34,7 @@ public:
         return std::make_shared<ocl_kernel>(get_handle().clone(), _kernel_id);
     }
     bool is_same(const kernel &other) const override {
-        auto other_ptr = dynamic_cast<const ocl_kernel*>(&other);
+        const auto *other_ptr = dynamic_cast<const ocl_kernel*>(&other);
         if (other_ptr == nullptr) {
             return false;
         }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_kernel_builder.hpp
@@ -30,7 +30,7 @@ class ocl_kernel_builder : public kernel_builder{
             KernelFormat src_format,
             const std::string &options,
             std::vector<kernel::ptr> &out) const override {
-            auto context = m_device.get_context().get();
+            auto *context = m_device.get_context().get();
 
             cl_program program_handle;
             cl_int err = CL_INVALID_VALUE;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -65,7 +65,7 @@ gpu_buffer::gpu_buffer(ocl_engine* engine,
     , _buffer(buffer) {}
 
 void* gpu_buffer::lock(const stream& stream, mem_lock_type type) {
-    auto& cl_stream = downcast<const ocl_stream>(stream);
+    const auto& cl_stream = downcast<const ocl_stream>(stream);
     std::lock_guard<std::mutex> locker(_mutex);
     if (0 == _lock_count) {
         try {
@@ -79,7 +79,7 @@ void* gpu_buffer::lock(const stream& stream, mem_lock_type type) {
 }
 
 void gpu_buffer::unlock(const stream& stream) {
-    auto& cl_stream = downcast<const ocl_stream>(stream);
+    const auto& cl_stream = downcast<const ocl_stream>(stream);
     std::lock_guard<std::mutex> locker(_mutex);
     _lock_count--;
     if (0 == _lock_count) {
@@ -124,7 +124,7 @@ event::ptr gpu_buffer::fill(stream& stream, unsigned char pattern, const std::ve
 
 shared_mem_params gpu_buffer::get_internal_params(runtime_types rt_type) const {
     OPENVINO_ASSERT(rt_type == runtime_types::ocl, "[GPU] Can not provide internal params for non-OCL runtime");
-    auto cl_engine = downcast<const ocl_engine>(_engine);
+    const auto *cl_engine = downcast<const ocl_engine>(_engine);
     return {shared_mem_type::shared_mem_buffer, static_cast<shared_handle>(cl_engine->get_cl_context().get()), nullptr,
             static_cast<shared_handle>(_buffer.get()),
 #ifdef _WIN32
@@ -142,9 +142,9 @@ event::ptr gpu_buffer::copy_from(stream& stream, const void* data_ptr, size_t sr
 
     check_boundaries(SIZE_MAX, src_offset, _bytes_count, dst_offset, size, "gpu_buffer::copy_from(void*)");
 
-    auto cl_stream = downcast<ocl_stream>(&stream);
-    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
-    auto src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
+    auto *cl_stream = downcast<ocl_stream>(&stream);
+    auto *cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    const auto *src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
 
     TRY_CATCH_CL_ERROR(cl_stream->get_cl_queue().enqueueWriteBuffer(_buffer, blocking, dst_offset, size, src_ptr, nullptr, cl_event))
 
@@ -164,15 +164,15 @@ event::ptr gpu_buffer::copy_from(stream& stream, const memory& src_mem, size_t s
         case allocation_type::usm_device: {
             // If other is gpu_usm, down cast to gpu_buffer is not possible.
             // But it can read as host ptr if it's allocation type is either usm_host or usm_shared.
-            auto usm_mem = downcast<const gpu_usm>(&src_mem);
+            const auto *usm_mem = downcast<const gpu_usm>(&src_mem);
             return copy_from(stream, usm_mem->buffer_ptr(), src_offset, dst_offset, size, blocking);
         }
         case allocation_type::cl_mem: {
             OPENVINO_ASSERT(!src_mem.get_layout().format.is_image_2d());
 
-            auto cl_stream = downcast<ocl_stream>(&stream);
-            auto cl_mem_buffer = downcast<const gpu_buffer>(&src_mem);
-            auto ev_ocl = &downcast<ocl_event>(result_event.get())->get();
+            auto *cl_stream = downcast<ocl_stream>(&stream);
+            const auto *cl_mem_buffer = downcast<const gpu_buffer>(&src_mem);
+            auto *ev_ocl = &downcast<ocl_event>(result_event.get())->get();
 
             TRY_CATCH_CL_ERROR(
                 cl_stream->get_cl_queue().enqueueCopyBuffer(cl_mem_buffer->get_buffer(), get_buffer(), src_offset, dst_offset, size, nullptr, ev_ocl));
@@ -194,9 +194,9 @@ event::ptr gpu_buffer::copy_to(stream& stream, void* data_ptr, size_t src_offset
 
     check_boundaries(_bytes_count, src_offset, SIZE_MAX, dst_offset, size, "gpu_buffer::copy_to(void*)");
 
-    auto cl_stream = downcast<ocl_stream>(&stream);
-    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
-    auto dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
+    auto *cl_stream = downcast<ocl_stream>(&stream);
+    auto *cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto *dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
 
     TRY_CATCH_CL_ERROR(cl_stream->get_cl_queue().enqueueReadBuffer(_buffer, blocking, src_offset, size, dst_ptr, nullptr, cl_event));
 
@@ -221,7 +221,7 @@ dnnl::memory gpu_buffer::get_onednn_grouped_memory(dnnl::memory::desc desc, cons
 #endif
 
 gpu_buffer_from_handle::~gpu_buffer_from_handle() {
-    auto cl_engine = downcast<const ocl_engine>(_engine);
+    const auto *cl_engine = downcast<const ocl_engine>(_engine);
     cl_engine->release_external_memory(static_cast<cl_mem>(_buffer.get()));
 }
 
@@ -332,7 +332,7 @@ event::ptr gpu_image2d::fill(stream& stream, unsigned char pattern, const std::v
 }
 
 void* gpu_image2d::lock(const stream& stream, mem_lock_type type) {
-    auto& cl_stream = downcast<const ocl_stream>(stream);
+    const auto& cl_stream = downcast<const ocl_stream>(stream);
     std::lock_guard<std::mutex> locker(_mutex);
     if (0 == _lock_count) {
         try {
@@ -353,7 +353,7 @@ void* gpu_image2d::lock(const stream& stream, mem_lock_type type) {
 }
 
 void gpu_image2d::unlock(const stream& stream) {
-    auto& cl_stream = downcast<const ocl_stream>(stream);
+    const auto& cl_stream = downcast<const ocl_stream>(stream);
     std::lock_guard<std::mutex> locker(_mutex);
     _lock_count--;
     if (0 == _lock_count) {
@@ -369,7 +369,7 @@ void gpu_image2d::unlock(const stream& stream) {
 
 shared_mem_params gpu_image2d::get_internal_params(runtime_types rt_type) const {
     OPENVINO_ASSERT(rt_type == runtime_types::ocl, "[GPU] gpu_image2d can not provide internal params for non-OCL runtime");
-    auto cl_engine = downcast<const ocl_engine>(_engine);
+    const auto *cl_engine = downcast<const ocl_engine>(_engine);
     return {shared_mem_type::shared_mem_image, static_cast<shared_handle>(cl_engine->get_cl_context().get()), nullptr,
             static_cast<shared_handle>(_buffer.get()),
 #ifdef _WIN32
@@ -388,9 +388,9 @@ event::ptr gpu_image2d::copy_from(stream& stream, const void* data_ptr, size_t s
     OPENVINO_ASSERT(dst_offset == 0, "[GPU] Unsupported dst_offset value for gpu_image2d::copy_from() function");
     OPENVINO_ASSERT(size == _bytes_count, "[GPU] Unsupported data_size value for gpu_image2d::copy_from() function");
 
-    auto cl_stream = downcast<ocl_stream>(&stream);
-    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
-    auto src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
+    auto *cl_stream = downcast<ocl_stream>(&stream);
+    auto *cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    const auto *src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
 
     TRY_CATCH_CL_ERROR(
         cl_stream->get_cl_queue().enqueueWriteImage(_buffer, blocking, {0, 0, 0}, {_width, _height, 1}, _row_pitch, _slice_pitch, src_ptr, nullptr, cl_event));
@@ -408,9 +408,9 @@ event::ptr gpu_image2d::copy_from(stream& stream, const memory& src_mem, size_t 
     OPENVINO_ASSERT(dst_offset == 0, "[GPU] Unsupported dst_offset value for gpu_image2d::copy_from() function");
     OPENVINO_ASSERT(size == _bytes_count, "[GPU] Unsupported data_size value for gpu_image2d::copy_from() function");
 
-    auto cl_stream = downcast<ocl_stream>(&stream);
-    auto cl_event = &downcast<ocl_event>(result_event.get())->get();
-    auto cl_image_mem = downcast<const gpu_image2d>(&src_mem);
+    auto *cl_stream = downcast<ocl_stream>(&stream);
+    auto *cl_event = &downcast<ocl_event>(result_event.get())->get();
+    const auto *cl_image_mem = downcast<const gpu_image2d>(&src_mem);
 
     TRY_CATCH_CL_ERROR(
         cl_stream->get_cl_queue().enqueueCopyImage(cl_image_mem->get_buffer(), get_buffer(), {0, 0, 0}, {0, 0, 0}, {_width, _height, 1}, nullptr, cl_event));
@@ -429,9 +429,9 @@ event::ptr gpu_image2d::copy_to(stream& stream, void* data_ptr, size_t src_offse
     OPENVINO_ASSERT(src_offset == 0, "[GPU] Unsupported src_offset value for gpu_image2d::copy_from() function");
     OPENVINO_ASSERT(size == _bytes_count, "[GPU] Unsupported data_size value for gpu_image2d::copy_from() function");
 
-    auto cl_stream = downcast<ocl_stream>(&stream);
-    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
-    auto dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
+    auto *cl_stream = downcast<ocl_stream>(&stream);
+    auto *cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto *dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
 
     TRY_CATCH_CL_ERROR(
         cl_stream->get_cl_queue().enqueueReadImage(_buffer, blocking, {0, 0, 0}, {_width, _height, 1}, _row_pitch, _slice_pitch, dst_ptr, nullptr, cl_event));
@@ -449,7 +449,7 @@ gpu_media_buffer::gpu_media_buffer(ocl_engine* engine,
 
 shared_mem_params gpu_media_buffer::get_internal_params(runtime_types rt_type) const {
     OPENVINO_ASSERT(rt_type == runtime_types::ocl, "[GPU] gpu_media_buffer can not provide internal params for non-OCL runtime");
-    auto cl_engine = downcast<const ocl_engine>(_engine);
+    const auto *cl_engine = downcast<const ocl_engine>(_engine);
     return {shared_mem_type::shared_mem_vasurface, static_cast<shared_handle>(cl_engine->get_cl_context().get()), device,
             static_cast<shared_handle>(_buffer.get()), surface, plane };
 }
@@ -519,7 +519,7 @@ gpu_usm::gpu_usm(ocl_engine* engine, const layout& layout, allocation_type type)
 void* gpu_usm::lock(const stream& stream, mem_lock_type type) {
     std::lock_guard<std::mutex> locker(_mutex);
     if (0 == _lock_count) {
-        auto& cl_stream = downcast<const ocl_stream>(stream);
+        const auto& cl_stream = downcast<const ocl_stream>(stream);
         if (get_allocation_type() == allocation_type::usm_device) {
             GPU_DEBUG_LOG << "Copy usm_device buffer to host buffer." << std::endl;
             _host_buffer.allocateHost(_bytes_count);
@@ -552,7 +552,7 @@ void gpu_usm::unlock(const stream& stream) {
     if (0 == _lock_count) {
         if (get_allocation_type() == allocation_type::usm_device) {
             if (_copy_back_to_device) {
-                auto& cl_stream = downcast<const ocl_stream>(stream);
+                const auto& cl_stream = downcast<const ocl_stream>(stream);
                 try {
                     cl_stream.get_usm_helper().enqueue_memcpy(cl_stream.get_cl_queue(), _buffer.get(), _host_buffer.get(), _bytes_count, CL_TRUE);
                 } catch (cl::Error const& err) {
@@ -605,10 +605,10 @@ event::ptr gpu_usm::copy_from(stream& stream, const void* data_ptr, size_t src_o
 
     check_boundaries(SIZE_MAX, src_offset, _bytes_count, dst_offset, size, "gpu_usm::copy_from(void*)");
 
-    auto cl_stream = downcast<ocl_stream>(&stream);
-    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
-    auto src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
-    auto dst_ptr = reinterpret_cast<char*>(buffer_ptr()) + dst_offset;
+    auto *cl_stream = downcast<ocl_stream>(&stream);
+    auto *cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    const auto *src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
+    auto *dst_ptr = reinterpret_cast<char*>(buffer_ptr()) + dst_offset;
 
     TRY_CATCH_CL_ERROR(cl_stream->get_usm_helper().enqueue_memcpy(cl_stream->get_cl_queue(), dst_ptr, src_ptr, size, blocking, nullptr, cl_event));
 
@@ -622,18 +622,19 @@ event::ptr gpu_usm::copy_from(stream& stream, const memory& src_mem, size_t src_
 
     check_boundaries(src_mem.size(), src_offset, _bytes_count, dst_offset, size, "gpu_usm::copy_from(memory&)");
 
-    auto cl_stream = downcast<ocl_stream>(&stream);
-    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto *cl_stream = downcast<ocl_stream>(&stream);
+    auto *cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
 
     if (src_mem.get_allocation_type() == allocation_type::cl_mem) {
-        auto cl_mem_buffer = downcast<const gpu_buffer>(&src_mem);
-        auto dst_ptr = reinterpret_cast<char*>(buffer_ptr());
+        const auto *cl_mem_buffer = downcast<const gpu_buffer>(&src_mem);
+        auto *dst_ptr = reinterpret_cast<char*>(buffer_ptr());
 
         return cl_mem_buffer->copy_to(stream, dst_ptr, src_offset, dst_offset, size, blocking);
-    } else if (memory_capabilities::is_usm_type(src_mem.get_allocation_type())) {
-        auto usm_mem = downcast<const gpu_usm>(&src_mem);
-        auto src_ptr = reinterpret_cast<const char*>(usm_mem->buffer_ptr()) + src_offset;
-        auto dst_ptr = reinterpret_cast<char*>(buffer_ptr()) + dst_offset;
+    }
+    if (memory_capabilities::is_usm_type(src_mem.get_allocation_type())) {
+        const auto *usm_mem = downcast<const gpu_usm>(&src_mem);
+        const auto *src_ptr = reinterpret_cast<const char*>(usm_mem->buffer_ptr()) + src_offset;
+        auto *dst_ptr = reinterpret_cast<char*>(buffer_ptr()) + dst_offset;
 
         TRY_CATCH_CL_ERROR(cl_stream->get_usm_helper().enqueue_memcpy(cl_stream->get_cl_queue(), dst_ptr, src_ptr, size, blocking, nullptr, cl_event));
     } else {
@@ -655,10 +656,10 @@ event::ptr gpu_usm::copy_to(stream& stream, void* data_ptr, size_t src_offset, s
 
     check_boundaries(_bytes_count, src_offset, SIZE_MAX, dst_offset, size, "gpu_usm::copy_to(void*)");
 
-    auto cl_stream = downcast<ocl_stream>(&stream);
-    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
-    auto src_ptr = reinterpret_cast<const char*>(buffer_ptr()) + src_offset;
-    auto dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
+    auto *cl_stream = downcast<ocl_stream>(&stream);
+    auto *cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    const auto *src_ptr = reinterpret_cast<const char*>(buffer_ptr()) + src_offset;
+    auto *dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
 
     TRY_CATCH_CL_ERROR(cl_stream->get_usm_helper().enqueue_memcpy(cl_stream->get_cl_queue(), dst_ptr, src_ptr, size, blocking, nullptr, cl_event));
 
@@ -693,7 +694,7 @@ dnnl::memory gpu_usm::get_onednn_grouped_memory(dnnl::memory::desc desc, const m
 
 shared_mem_params gpu_usm::get_internal_params(runtime_types rt_type) const {
     OPENVINO_ASSERT(rt_type == runtime_types::ocl, "[GPU] gpu_usm can not provide internal params for non-OCL runtime");
-    auto cl_engine = downcast<const ocl_engine>(_engine);
+    const auto *cl_engine = downcast<const ocl_engine>(_engine);
     return {
         shared_mem_type::shared_mem_usm,  // shared_mem_type
         static_cast<shared_handle>(cl_engine->get_cl_context().get()),  // context handle
@@ -748,7 +749,7 @@ ocl_surfaces_lock::ocl_surfaces_lock(std::vector<memory::ptr> mem, const stream&
     , _lock(nullptr) {
     cl_int err = CL_SUCCESS;
 
-    auto& cl_stream = downcast<const ocl_stream>(stream);
+    const auto& cl_stream = downcast<const ocl_stream>(stream);
     auto queue = cl_stream.get_cl_queue();
     _lock.reset(new cl::SharedSurfLock(queue.get(), _handles, &err));
     // TODO: err code for some reason is 32766

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -65,17 +65,18 @@ cl_int set_kernel_arg(ocl_kernel_type& kernel, uint32_t idx, cldnn::memory::cptr
         auto buf = std::dynamic_pointer_cast<const ocl::gpu_image2d>(mem)->get_buffer();
         GPU_DEBUG_TRACE_DETAIL << "kernel: " << kernel.get() << " set arg (image) " << idx << " mem: " << buf.get() << " size: " << mem->size() << std::endl;
         return kernel.setArg(idx, buf);
-    } else if (memory_capabilities::is_usm_type(mem->get_allocation_type())) {
+    }
+    if (memory_capabilities::is_usm_type(mem->get_allocation_type())) {
         auto buf = std::dynamic_pointer_cast<const ocl::gpu_usm>(mem)->get_buffer();
         auto mem_type = std::dynamic_pointer_cast<const ocl::gpu_usm>(mem)->get_allocation_type();
         GPU_DEBUG_TRACE_DETAIL << "kernel: " << kernel.get() << " set arg (" << mem_type << ") " << idx
                                << " mem: " << buf.get() << " size: " << mem->size() << std::endl;
         return kernel.setArgUsm(idx, buf);
-    } else {
-        auto buf = std::dynamic_pointer_cast<const ocl::gpu_buffer>(mem)->get_buffer();
-        GPU_DEBUG_TRACE_DETAIL << "kernel: " << kernel.get() << " set arg (buffer) " << idx << " mem: " << buf.get() << " size: " << mem->size() << std::endl;
-        return kernel.setArg(idx, buf);
     }
+    auto buf = std::dynamic_pointer_cast<const ocl::gpu_buffer>(mem)->get_buffer();
+    GPU_DEBUG_TRACE_DETAIL << "kernel: " << kernel.get() << " set arg (buffer) " << idx << " mem: " << buf.get() << " size: " << mem->size() << std::endl;
+    return kernel.setArg(idx, buf);
+
 
     return CL_INVALID_ARG_VALUE;
 }
@@ -236,7 +237,7 @@ ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config)
 ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config, void *handle)
     : stream(ocl_stream::detect_queue_type(handle), stream::get_expected_sync_method(config))
     , _engine(engine) {
-    auto casted_handle = static_cast<cl_command_queue>(handle);
+    auto *casted_handle = static_cast<cl_command_queue>(handle);
     _command_queue = ocl_queue_type(casted_handle, true);
 #if defined(CL_VERSION_2_1)
     if (config.get_enable_profiling()) {
@@ -354,12 +355,12 @@ event::ptr ocl_stream::enqueue_marker(std::vector<event::ptr> const& deps, bool 
         }
 
         return std::make_shared<ocl_event>(ret_ev, ++_queue_counter);
-    } else if (m_sync_method == SyncMethods::barriers) {
+    }
+    if (m_sync_method == SyncMethods::barriers) {
         sync_events(deps, is_output);
         return std::make_shared<ocl_event>(_last_barrier_ev, _last_barrier);
-    } else {
-        return std::make_shared<ocl_user_event>(_engine.get_cl_context(), true, _profiling_device);
-    }
+    }         return std::make_shared<ocl_user_event>(_engine.get_cl_context(), true, _profiling_device);
+
 }
 
 event::ptr ocl_stream::group_events(std::vector<event::ptr> const& deps) {
@@ -414,11 +415,11 @@ void ocl_stream::wait_for_events(const std::vector<event::ptr>& events) {
 
     bool needs_barrier = false;
     std::vector<cl_event> clevents;
-    for (auto& ev : events) {
+    for (const auto& ev : events) {
         if (!ev)
             continue;
 
-        if (auto ocl_base_ev = downcast<ocl_base_event>(ev.get())) {
+        if (auto *ocl_base_ev = downcast<ocl_base_event>(ev.get())) {
             if (ocl_base_ev->get().get() != nullptr) {
                 clevents.push_back(ocl_base_ev->get().get());
             } else {
@@ -447,7 +448,7 @@ void ocl_stream::wait_for_events(const std::vector<event::ptr>& events) {
 
 void ocl_stream::sync_events(std::vector<event::ptr> const& deps, bool is_output) {
     bool needs_barrier = false;
-    for (auto& dep : deps) {
+    for (const auto& dep : deps) {
         auto* ocl_base_ev = downcast<ocl_base_event>(dep.get());
         if (ocl_base_ev->get_queue_stamp() > _last_barrier) {
             needs_barrier = true;

--- a/src/plugins/intel_gpu/src/runtime/shape_predictor.cpp
+++ b/src/plugins/intel_gpu/src/runtime/shape_predictor.cpp
@@ -156,7 +156,8 @@ std::pair<bool, ov::Shape> ShapePredictor::predict_preallocation_shape(const std
             auto preallocation_shape = diffs[0] * mul_shape;
             auto new_shape = current_shape + preallocation_shape;
             return {true, new_shape};
-        } else if (_settings.buffers_preallocation_ratio > 1.0f) {
+        }
+        if (_settings.buffers_preallocation_ratio > 1.0f) {
             if (format::is_blocked(layout.format))
                 return {false, {}};
             // Apply percentage buffer preallocation


### PR DESCRIPTION
This PR enables two readability checks for the Intel GPU plugin: readability-else-after-return, which flags an `else` (or `else if`) that follows a control-flow interruption such as `return`, `break`, `continue`, or `throw` and lets the branch be flattened to reduce nesting, and readability-qualified-auto, which adds the `*` qualifier to `auto` variables that deduce to a pointer type so pointer semantics are explicit at the declaration. All resulting diagnostics across src/plugins/intel_gpu/{include,src} were fixed by hoisting the code out of redundant `else` branches and adding the pointer qualifier to the affected `auto` declarations, with a few macro-expanded and structural sites (else-if chains, constructor init-lists, and single-statement bodies) corrected by hand; no behavior was changed. Next check in the incremental clang-tidy rollout for the plugin.
