### PR TITLE
[NPUW] Add Flux2CompiledModel for Flux.2-klein image generation

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
@@ -45,6 +45,7 @@ INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_FALLBACK_EXEC, bool, true, ov::intel_npu::npuw, f
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_CHECK, bool, false, ov::intel_npu::npuw::accuracy, check, "NPUW_ACC_CHECK", ROOT, HIDDEN, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_THRESH, double, 0.01, ov::intel_npu::npuw::accuracy, threshold, "NPUW_ACC_THRESH", ROOT, HIDDEN, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_DEVICE, std::string, "", ov::intel_npu::npuw::accuracy, reference_device, "NPUW_ACC_DEVICE", ROOT, HIDDEN, UNCACHED, ALL)
+INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_FLUX2, bool, false, ov::intel_npu::npuw::flux2, enabled, "NPUW_FLUX2", ROOT, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_GQA, bool, false, ov::intel_npu::npuw::gqa, enabled, "NPUW_GQA", ROOT, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_UNQDQ, bool, false, ov::intel_npu::npuw, unqdq, "NPUW_UNQDQ", ROOT, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_DUMP_FULL, bool, false, ov::intel_npu::npuw::dump, full, "NPUW_DUMP_FULL", ROOT, HIDDEN, UNCACHED, DEV)

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -24,6 +24,7 @@
 #include "openvino/runtime/internal_properties.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/util/common_util.hpp"
+#include "partitioning/patterns/fold_const.hpp"
 #include "partitioning/patterns/opt.hpp"
 #include "pipelines/kokoro/kokoro_compiled_model.hpp"
 #include "plugin.hpp"
@@ -364,6 +365,14 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
         // In case we bypass LLMCompiledModel and step directly into CompiledModel we still need to regularize SDPA for
         // the attention isolation to work properly
         ov::npuw::patterns::regularize::RegularizeSDPA(true).run_on_model(model);
+    }
+
+    if (cfg_get<::intel_npu::NPUW_PLAN>(properties).empty()) {
+        // Fold shape-compute chains into Constants before partitioning, but only on the
+        // online path (no NPUW_PLAN). When a plan is loaded, node identities must be left
+        // untouched so they still match the plan XML. Strict no-op unless the model has a
+        // VariadicSplit with a non-constant split_lengths (see the function's definition).
+        ov::npuw::patterns::util::foldShapeComputeChainsForConstAttrs(model);
     }
 
     ::intel_npu::registerNPUWOptions(*m_options_desc);

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -737,8 +737,8 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
             auto forced_dev_it = std::find(m_dev_list.begin(), m_dev_list.end(), forced_device);
             if (forced_dev_it == m_dev_list.end()) {
                 LOG_WARN("Target device for Subgraph[" << id << "] was set to " << forced_device
-                                                       << ", but was not found in the device list: "
-                                                       << "[" << dev_list_str << "] -- ignoring");
+                                                       << ", but was not found in the device list: " << "["
+                                                       << dev_list_str << "] -- ignoring");
             } else {
                 LOG_INFO("Force Subgraph[" << id << "] target device to " << *forced_dev_it);
                 devices.push_back(*forced_dev_it);
@@ -1987,8 +1987,7 @@ void ov::npuw::CompiledModel::dump_subgraph_model(std::size_t id,
     LOG_INFO("Dumping Subgraph[" << id << "]");
     LOG_BLOCK();
     if (real_id != id) {
-        LOG_INFO("NOTE: Dumping Subgraph[" << real_id << "]"
-                                           << " as it is a function body for Subgraph[" << id << "]");
+        LOG_INFO("NOTE: Dumping Subgraph[" << real_id << "]" << " as it is a function body for Subgraph[" << id << "]");
     }
 
     const std::string dump_dir = m_cfg.get<::intel_npu::NPUW_DUMP_SUBS_DIR>();

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -11,6 +11,7 @@
 
 #include "accuracy/comparator.hpp"
 #include "attn/attn_subgraph.hpp"
+#include "flux2_compiled_model.hpp"
 #include "gqa_compiled_model.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 #include "just_sync_infer_request.hpp"
@@ -24,7 +25,6 @@
 #include "openvino/runtime/internal_properties.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/util/common_util.hpp"
-#include "partitioning/patterns/fold_const.hpp"
 #include "partitioning/patterns/opt.hpp"
 #include "pipelines/kokoro/kokoro_compiled_model.hpp"
 #include "plugin.hpp"
@@ -297,6 +297,7 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     LOG_INFO("Choosing which NPUW CompiledModel to create");
     LOG_BLOCK();
     std::shared_ptr<ov::npuw::ICompiledModel> compiled_model;
+    auto use_flux2_key = ov::intel_npu::npuw::flux2::enabled.name();
     auto use_gqa_key = ov::intel_npu::npuw::gqa::enabled.name();
     auto use_llm_key = ov::intel_npu::npuw::llm::enabled.name();
     auto use_kokoro_key = ov::intel_npu::npuw::kokoro::enabled.name();
@@ -307,7 +308,10 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     auto config = properties;
     config.erase(ov::cache_dir.name());
 
-    if (properties.count(use_gqa_key) && properties.at(use_gqa_key).as<bool>() == true) {
+    if (properties.count(use_flux2_key) && properties.at(use_flux2_key).as<bool>() == true) {
+        LOG_INFO("ov::npuw::Flux2CompiledModel will be created.");
+        compiled_model = std::make_shared<ov::npuw::Flux2CompiledModel>(model, plugin, config);
+    } else if (properties.count(use_gqa_key) && properties.at(use_gqa_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::GQACompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::GQACompiledModel>(model, plugin, config);
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
@@ -365,14 +369,6 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
         // In case we bypass LLMCompiledModel and step directly into CompiledModel we still need to regularize SDPA for
         // the attention isolation to work properly
         ov::npuw::patterns::regularize::RegularizeSDPA(true).run_on_model(model);
-    }
-
-    if (cfg_get<::intel_npu::NPUW_PLAN>(properties).empty()) {
-        // Fold shape-compute chains into Constants before partitioning, but only on the
-        // online path (no NPUW_PLAN). When a plan is loaded, node identities must be left
-        // untouched so they still match the plan XML. Strict no-op unless the model has a
-        // VariadicSplit with a non-constant split_lengths (see the function's definition).
-        ov::npuw::patterns::util::foldShapeComputeChainsForConstAttrs(model);
     }
 
     ::intel_npu::registerNPUWOptions(*m_options_desc);

--- a/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
@@ -149,6 +149,10 @@ ov::AnyMap with_flux2_defaults(const std::shared_ptr<ov::Model>& model, const ov
     ov::AnyMap config = {
         {std::string(::intel_npu::NPUW_DEVICES::key()), "NPU"},
         {std::string(::intel_npu::COMPILER_DYNAMIC_QUANTIZATION::key()), "YES"},
+        {std::string(::intel_npu::NPUW_FOLD::key()), "YES"},
+        {std::string(::intel_npu::NPUW_DQ::key()), "NO"},
+        {std::string(::intel_npu::NPUW_DQ_FULL::key()), "NO"},
+        {std::string(::intel_npu::NPUW_UNFOLD_IREQS::key()), "NO"},
     };
     merge_config_with(config, submodel_config(role));
     // User-provided properties take precedence over the defaults above.

--- a/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
@@ -1,0 +1,349 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "flux2_compiled_model.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <utility>
+
+#include "intel_npu/config/npuw.hpp"
+#include "logging.hpp"
+#include "openvino/core/version.hpp"
+#include "openvino/runtime/properties.hpp"
+#include "partitioning/patterns/fold_const.hpp"
+#include "serialization.hpp"
+
+namespace {
+
+template <typename T>
+auto cfg_get(const ov::AnyMap& properties) -> typename T::ValueType {
+    const auto& opt_name = std::string(T::key());
+    if (properties.count(opt_name)) {
+        return properties.at(opt_name).as<typename T::ValueType>();
+    }
+    return T::defaultValue();
+}
+
+void merge_config_with(ov::AnyMap& lhs, const ov::AnyMap& rhs) {
+    for (const auto& [key, value] : rhs) {
+        if (auto it = lhs.find(key); it != lhs.end()) {
+            it->second = value;
+        } else {
+            lhs.emplace(key, value);
+        }
+    }
+}
+
+// Flux.2-klein pipeline submodels. Each is compiled separately (with NPUW_FLUX2:YES)
+// and needs its own NPUW configuration - see submodel_config().
+enum class Flux2Submodel { TEXT_ENCODER, TRANSFORMER, VAE_DECODER, VAE_ENCODER, UNKNOWN };
+
+const char* to_cstr(Flux2Submodel role) {
+    switch (role) {
+    case Flux2Submodel::TEXT_ENCODER:
+        return "text_encoder";
+    case Flux2Submodel::TRANSFORMER:
+        return "transformer";
+    case Flux2Submodel::VAE_DECODER:
+        return "vae_decoder";
+    case Flux2Submodel::VAE_ENCODER:
+        return "vae_encoder";
+    default:
+        return "unknown";
+    }
+}
+
+std::string to_lower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return s;
+}
+
+// Per-submodel NPUW knobs for the Flux.2-klein pipeline. NPUW_F16IC:NO keeps the
+// inter-subgraph interconnect in fp32 (Flux.2-klein exports IO in f32; lowering a
+// consumer's input Parameter to f16 fails at runtime with a ParameterMismatch).
+ov::AnyMap submodel_config(Flux2Submodel role) {
+    switch (role) {
+    case Flux2Submodel::TEXT_ENCODER:
+        return {
+            {std::string(::intel_npu::NPUW_F16IC::key()), "NO"},
+        };
+    case Flux2Submodel::TRANSFORMER:
+        return {
+            {std::string(::intel_npu::COMPILATION_MODE_PARAMS::key()), "compute-layers-with-higher-precision=MVN"},
+        };
+    case Flux2Submodel::VAE_DECODER:
+    case Flux2Submodel::VAE_ENCODER:
+        return {
+            {std::string(::intel_npu::NPUW_ONLINE_PIPELINE::key()), "NONE"},
+        };
+    default:
+        return {};
+    }
+}
+
+Flux2Submodel detect_submodel(const std::shared_ptr<ov::Model>& model) {
+    // 1) Explicit signal from the model's friendly name, if the exporter set it.
+    const auto name = to_lower(model->get_friendly_name());
+    if (name.find("vae_encoder") != std::string::npos) {
+        return Flux2Submodel::VAE_ENCODER;
+    }
+    if (name.find("vae_decoder") != std::string::npos) {
+        return Flux2Submodel::VAE_DECODER;
+    }
+    if (name.find("transformer") != std::string::npos) {
+        return Flux2Submodel::TRANSFORMER;
+    }
+    if (name.find("text_encoder") != std::string::npos) {
+        return Flux2Submodel::TEXT_ENCODER;
+    }
+
+    // 2) Fall back to the input signature.
+    bool has_transformer_sig = false;
+    bool has_input_ids = false;
+    for (const auto& p : model->get_parameters()) {
+        const auto& pname = p->get_friendly_name();
+        if (pname.find("encoder_hidden_states") != std::string::npos ||
+            pname.find("timestep") != std::string::npos || pname.find("txt_ids") != std::string::npos) {
+            has_transformer_sig = true;
+        }
+        if (pname.find("input_ids") != std::string::npos) {
+            has_input_ids = true;
+        }
+    }
+    if (has_transformer_sig) {
+        return Flux2Submodel::TRANSFORMER;
+    }
+    if (has_input_ids) {
+        return Flux2Submodel::TEXT_ENCODER;
+    }
+
+    // 3) VAE: a 4D conv-style tensor. 3 input channels => encoder (RGB image), else decoder.
+    for (const auto& p : model->get_parameters()) {
+        const auto& shape = p->get_partial_shape();
+        if (shape.rank().is_static() && shape.rank().get_length() == 4) {
+            const auto& channels = shape[1];
+            if (channels.is_static() && channels.get_length() == 3) {
+                return Flux2Submodel::VAE_ENCODER;
+            }
+            return Flux2Submodel::VAE_DECODER;
+        }
+    }
+    return Flux2Submodel::UNKNOWN;
+}
+
+// Build the effective config: NPU device base < per-submodel defaults < user properties.
+ov::AnyMap with_flux2_defaults(const std::shared_ptr<ov::Model>& model, const ov::AnyMap& properties) {
+    const auto role = detect_submodel(model);
+    if (role == Flux2Submodel::UNKNOWN) {
+        LOG_WARN("Flux2CompiledModel could not identify the Flux.2-klein submodel; "
+                 "applying only base defaults.");
+    } else {
+        LOG_INFO("Flux2CompiledModel: applying '" << to_cstr(role) << "' submodel config.");
+    }
+
+    ov::AnyMap config = {
+        {std::string(::intel_npu::NPUW_DEVICES::key()), "NPU"},
+        {std::string(::intel_npu::COMPILER_DYNAMIC_QUANTIZATION::key()), "YES"},
+    };
+    merge_config_with(config, submodel_config(role));
+    // User-provided properties take precedence over the defaults above.
+    merge_config_with(config, properties);
+    return config;
+}
+
+}  // namespace
+
+ov::npuw::Flux2CompiledModel::PreparedState ov::npuw::Flux2CompiledModel::prepare(
+    const std::shared_ptr<ov::Model>& model,
+    const ov::AnyMap& properties) {
+    auto prepared_properties = with_flux2_defaults(model, properties);
+    model->set_friendly_name(model->get_friendly_name() + "_flux2");
+
+    if (cfg_get<::intel_npu::NPUW_PLAN>(prepared_properties).empty()) {
+        // Fold shape-compute chains into Constants before partitioning, but only on the
+        // online path (no NPUW_PLAN). When a plan is loaded, node identities must be left
+        // untouched so they still match the plan XML. Strict no-op unless the model has a
+        // VariadicSplit with a non-constant split_lengths (see the function's definition).
+        ov::npuw::patterns::util::foldShapeComputeChainsForConstAttrs(model);
+    }
+
+    return {model, std::move(prepared_properties)};
+}
+
+std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::Flux2CompiledModel::make_compiled_model(
+    const std::shared_ptr<ov::Model>& model,
+    const std::shared_ptr<const ov::IPlugin>& plugin,
+    const ov::AnyMap& properties) {
+    return std::make_shared<ov::npuw::CompiledModel>(model, plugin, properties);
+}
+
+ov::npuw::Flux2CompiledModel::Flux2CompiledModel(const std::shared_ptr<ov::Model>& model,
+                                                 const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                 const ov::AnyMap& properties,
+                                                 CompiledModelFactory factory)
+    : Flux2CompiledModel(prepare(model, properties), plugin, std::move(factory)) {}
+
+ov::npuw::Flux2CompiledModel::Flux2CompiledModel(PreparedState prepared,
+                                                 const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                 CompiledModelFactory factory)
+    : ov::npuw::ICompiledModel(prepared.model, plugin),
+      m_compiled_model(factory(prepared.model, plugin, prepared.properties)) {
+    OPENVINO_ASSERT(m_compiled_model != nullptr, "Flux2CompiledModel requires a valid inner compiled model");
+}
+
+void ov::npuw::Flux2CompiledModel::export_model(std::ostream& stream) const {
+    using namespace ov::npuw::s11n;
+    write(stream, NPUW_SERIALIZATION_INDICATOR);
+    write(stream, NPUW_FLUX2_COMPILED_MODEL_INDICATOR);
+    write(stream, OPENVINO_VERSION_MAJOR);
+    write(stream, OPENVINO_VERSION_MINOR);
+    write(stream, OPENVINO_VERSION_PATCH);
+    write(stream, std::string(NPUW_SERIALIZATION_VERSION));
+    m_compiled_model->export_model(stream);
+}
+
+std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::Flux2CompiledModel::import_model(
+    std::istream& stream,
+    const std::shared_ptr<const ov::IPlugin>& plugin,
+    const ov::AnyMap& properties) {
+    LOG_INFO("Deserializing Flux2CompiledModel...");
+    LOG_BLOCK();
+
+    using namespace ov::npuw::s11n;
+
+    ov::npuw::s11n::IndicatorType serialization_indicator;
+    read(stream, serialization_indicator);
+    NPUW_ASSERT(serialization_indicator == NPUW_SERIALIZATION_INDICATOR);
+
+    ov::npuw::s11n::IndicatorType flux2_indicator;
+    read(stream, flux2_indicator);
+    NPUW_ASSERT(flux2_indicator == NPUW_FLUX2_COMPILED_MODEL_INDICATOR);
+
+    int vmajor, vminor, vpatch;
+    std::string s11n_version;
+    read(stream, vmajor);
+    read(stream, vminor);
+    read(stream, vpatch);
+    read(stream, s11n_version);
+
+    if (vmajor != OPENVINO_VERSION_MAJOR || vminor != OPENVINO_VERSION_MINOR || vpatch != OPENVINO_VERSION_PATCH ||
+        s11n_version != std::string(NPUW_SERIALIZATION_VERSION)) {
+        OPENVINO_THROW("Flux2 blob was serialized with a different OV version (",
+                       vmajor,
+                       '.',
+                       vminor,
+                       '.',
+                       vpatch,
+                       " / NPUW s11n ",
+                       s11n_version,
+                       "); current is ",
+                       OPENVINO_VERSION_MAJOR,
+                       '.',
+                       OPENVINO_VERSION_MINOR,
+                       '.',
+                       OPENVINO_VERSION_PATCH,
+                       " / NPUW s11n ",
+                       NPUW_SERIALIZATION_VERSION);
+    }
+
+    // The rest of the stream is the inner CompiledModel ORC blob.
+    // After import it is fully self-contained; no outer Flux2 wrapper is needed
+    // because the partitioning is already baked in and port mappings are consistent.
+    return ov::npuw::CompiledModel::import_model(stream, plugin, properties);
+}
+
+std::shared_ptr<const ov::Model> ov::npuw::Flux2CompiledModel::get_runtime_model() const {
+    return m_compiled_model->get_runtime_model();
+}
+
+void ov::npuw::Flux2CompiledModel::set_property(const ov::AnyMap& properties) {
+    m_compiled_model->set_property(properties);
+}
+
+ov::Any ov::npuw::Flux2CompiledModel::get_property(const std::string& name) const {
+    return m_compiled_model->get_property(name);
+}
+
+std::shared_ptr<ov::ISyncInferRequest> ov::npuw::Flux2CompiledModel::create_sync_infer_request() const {
+    auto self = std::static_pointer_cast<const Flux2CompiledModel>(shared_from_this());
+    return std::make_shared<ov::npuw::Flux2InferRequest>(std::move(self));
+}
+
+ov::npuw::Flux2InferRequest::Flux2InferRequest(std::shared_ptr<const Flux2CompiledModel> compiled_model)
+    : ov::ISyncInferRequest(compiled_model),
+      m_compiled_model(std::move(compiled_model)) {}
+
+void ov::npuw::Flux2InferRequest::ensure_inner_request_locked() const {
+    if (m_inner_request == nullptr) {
+        m_inner_request = m_compiled_model->m_compiled_model->create_infer_request();
+        OPENVINO_ASSERT(m_inner_request != nullptr, "Flux2 infer request requires a valid inner request");
+    }
+}
+
+const ov::Output<const ov::Node>& ov::npuw::Flux2InferRequest::map_port_locked(
+    const ov::Output<const ov::Node>& port) const {
+    ensure_inner_request_locked();
+
+    const auto& outer_inputs = m_compiled_model->inputs();
+    const auto& inner_inputs = m_inner_request->get_compiled_model()->inputs();
+    for (size_t i = 0; i < outer_inputs.size(); ++i) {
+        if (outer_inputs[i] == port) {
+            OPENVINO_ASSERT(i < inner_inputs.size(), "Input port index is out of range in inner infer request");
+            return inner_inputs[i];
+        }
+    }
+
+    const auto& outer_outputs = m_compiled_model->outputs();
+    const auto& inner_outputs = m_inner_request->get_compiled_model()->outputs();
+    for (size_t i = 0; i < outer_outputs.size(); ++i) {
+        if (outer_outputs[i] == port) {
+            OPENVINO_ASSERT(i < inner_outputs.size(), "Output port index is out of range in inner infer request");
+            return inner_outputs[i];
+        }
+    }
+
+    OPENVINO_THROW("Unknown Flux2 infer request port: ", port.get_any_name());
+}
+
+void ov::npuw::Flux2InferRequest::infer() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ensure_inner_request_locked();
+    m_inner_request->infer();
+}
+
+ov::SoPtr<ov::ITensor> ov::npuw::Flux2InferRequest::get_tensor(const ov::Output<const ov::Node>& port) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ensure_inner_request_locked();
+    return m_inner_request->get_tensor(map_port_locked(port));
+}
+
+void ov::npuw::Flux2InferRequest::set_tensor(const ov::Output<const ov::Node>& port,
+                                             const ov::SoPtr<ov::ITensor>& tensor) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ensure_inner_request_locked();
+    m_inner_request->set_tensor(map_port_locked(port), tensor);
+}
+
+void ov::npuw::Flux2InferRequest::check_tensors() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    // Trigger lazy inner request initialization; the JustInferRequest constructor
+    // allocates all sub-tensors during construction, so nothing more is needed here.
+    ensure_inner_request_locked();
+}
+
+std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::Flux2InferRequest::query_state() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ensure_inner_request_locked();
+    return m_inner_request->query_state();
+}
+
+std::vector<ov::ProfilingInfo> ov::npuw::Flux2InferRequest::get_profiling_info() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ensure_inner_request_locked();
+    return m_inner_request->get_profiling_info();
+}

--- a/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
@@ -107,8 +107,8 @@ Flux2Submodel detect_submodel(const std::shared_ptr<ov::Model>& model) {
     bool has_input_ids = false;
     for (const auto& p : model->get_parameters()) {
         const auto& pname = p->get_friendly_name();
-        if (pname.find("encoder_hidden_states") != std::string::npos ||
-            pname.find("timestep") != std::string::npos || pname.find("txt_ids") != std::string::npos) {
+        if (pname.find("encoder_hidden_states") != std::string::npos || pname.find("timestep") != std::string::npos ||
+            pname.find("txt_ids") != std::string::npos) {
             has_transformer_sig = true;
         }
         if (pname.find("input_ids") != std::string::npos) {

--- a/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.hpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <mutex>
 
-#include "npuw/compiled_model.hpp"
+#include "compiled_model.hpp"
 
 namespace ov::npuw {
 

--- a/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.hpp
@@ -1,0 +1,85 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+
+#include "npuw/compiled_model.hpp"
+
+namespace ov::npuw {
+
+class Flux2CompiledModel;
+
+class Flux2InferRequest final : public ov::ISyncInferRequest {
+public:
+    explicit Flux2InferRequest(std::shared_ptr<const Flux2CompiledModel> compiled_model);
+
+    void infer() override;
+
+    ov::SoPtr<ov::ITensor> get_tensor(const ov::Output<const ov::Node>& port) const override;
+    void set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) override;
+    void check_tensors() const override;
+
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override;
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override;
+
+private:
+    void ensure_inner_request_locked() const;
+    const ov::Output<const ov::Node>& map_port_locked(const ov::Output<const ov::Node>& port) const;
+
+    std::shared_ptr<const Flux2CompiledModel> m_compiled_model;
+    mutable std::mutex m_mutex;
+    mutable std::shared_ptr<ov::IAsyncInferRequest> m_inner_request;
+};
+
+class Flux2CompiledModel final : public ov::npuw::ICompiledModel {
+public:
+    using CompiledModelFactory =
+        std::function<std::shared_ptr<ov::npuw::ICompiledModel>(const std::shared_ptr<ov::Model>&,
+                                                                const std::shared_ptr<const ov::IPlugin>&,
+                                                                const ov::AnyMap&)>;
+
+    static std::shared_ptr<ov::npuw::ICompiledModel> make_compiled_model(
+        const std::shared_ptr<ov::Model>& model,
+        const std::shared_ptr<const ov::IPlugin>& plugin,
+        const ov::AnyMap& properties);
+
+    Flux2CompiledModel(const std::shared_ptr<ov::Model>& model,
+                       const std::shared_ptr<const ov::IPlugin>& plugin,
+                       const ov::AnyMap& properties,
+                       CompiledModelFactory factory = make_compiled_model);
+
+    static std::shared_ptr<ov::npuw::ICompiledModel> import_model(std::istream& stream,
+                                                                  const std::shared_ptr<const ov::IPlugin>& plugin,
+                                                                  const ov::AnyMap& properties);
+
+    void export_model(std::ostream& stream) const override;
+    std::shared_ptr<const ov::Model> get_runtime_model() const override;
+
+    void set_property(const ov::AnyMap& properties) override;
+    ov::Any get_property(const std::string& name) const override;
+
+private:
+    struct PreparedState {
+        std::shared_ptr<ov::Model> model;
+        ov::AnyMap properties;
+    };
+
+    static PreparedState prepare(const std::shared_ptr<ov::Model>& model, const ov::AnyMap& properties);
+
+    Flux2CompiledModel(PreparedState prepared,
+                       const std::shared_ptr<const ov::IPlugin>& plugin,
+                       CompiledModelFactory factory);
+
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
+
+    friend class Flux2InferRequest;
+
+    std::shared_ptr<ov::npuw::ICompiledModel> m_compiled_model;
+};
+
+}  // namespace ov::npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/fold_const.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/fold_const.cpp
@@ -4,12 +4,19 @@
 
 #include "fold_const.hpp"
 
+#include "../../logging.hpp"
 #include "openvino/core/graph_util.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/divide.hpp"
 #include "openvino/op/gather.hpp"
+#include "openvino/op/multiply.hpp"
 #include "openvino/op/shape_of.hpp"
+#include "openvino/op/subtract.hpp"
 #include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 
@@ -21,6 +28,20 @@ namespace patterns {
 namespace util {
 
 namespace {
+// Guard used ONLY by FoldEltwiseOfConsts. Shape-compute arithmetic (e.g. a split
+// size expressed as `total - other`) operates on individual dimension sizes,
+// i.e. scalar integer values, which are later Unsqueeze'd and Concat'ed into the
+// split_lengths vector. Restricting the folder to scalar integer operands means
+// it can never touch a (multi-element) weight quantization/decompression
+// constant - so no size heuristic is needed and weightless caching / DCOFF stay
+// intact.
+bool is_scalar_integer_const(const ov::Output<ov::Node>& in) {
+    if (!in.get_element_type().is_integral())
+        return false;
+    const auto& pshape = in.get_partial_shape();
+    return pshape.is_static() && ov::shape_size(pshape.to_shape()) == 1;
+}
+
 // If every input to `node` is an ov::op::v0::Constant and every output shape
 // is statically known, evaluate the node and return one folded Constant per
 // output port.  Returns true on success; `replacements` is populated.
@@ -111,6 +132,26 @@ FoldConcatOfConsts::FoldConcatOfConsts() {
     });
 }
 
+FoldEltwiseOfConsts::FoldEltwiseOfConsts() {
+    auto const_lhs = opp::wrap_type<ov::op::v0::Constant>();
+    auto const_rhs = opp::wrap_type<ov::op::v0::Constant>();
+    auto eltwise = opp::wrap_type<ov::op::v1::Subtract, ov::op::v1::Add, ov::op::v1::Multiply, ov::op::v1::Divide>(
+        {const_lhs, const_rhs});
+
+    register_matcher(std::make_shared<opp::Matcher>(eltwise, "FoldEltwiseOfConsts"), [](opp::Matcher& m) {
+        auto node = m.get_match_root();
+        // Self-contained weight-safety guard (not shared with the other folders):
+        // only fold when both operands are scalar integer constants.
+        if (!is_scalar_integer_const(node->input_value(0)) || !is_scalar_integer_const(node->input_value(1)))
+            return false;
+        ov::OutputVector replacements;
+        if (!fold_if_all_const(node, replacements))
+            return false;
+        ov::replace_node(node, replacements);
+        return true;
+    });
+}
+
 bool FoldShapeComputeChain::run_on_model(const std::shared_ptr<ov::Model>& model) {
     ov::pass::GraphRewrite rewr;
     rewr.add_matcher<FoldShapeOf>();
@@ -118,6 +159,37 @@ bool FoldShapeComputeChain::run_on_model(const std::shared_ptr<ov::Model>& model
     rewr.add_matcher<FoldUnsqueezeOfConst>();
     rewr.add_matcher<FoldConcatOfConsts>();
     return rewr.run_on_model(model);
+}
+
+void foldShapeComputeChainsForConstAttrs(const std::shared_ptr<ov::Model>& model) {
+    const bool needs_shape_fold = [&] {
+        for (const auto& node : model->get_ordered_ops()) {
+            if (!ov::is_type<ov::op::v1::VariadicSplit>(node)) {
+                continue;
+            }
+            if (!ov::is_type<ov::op::v0::Constant>(node->input_value(2).get_node_shared_ptr())) {
+                return true;
+            }
+        }
+        return false;
+    }();
+    if (!needs_shape_fold) {
+        return;
+    }
+    LOG_INFO("Found VariadicSplit with non-constant split_lengths; folding shape-compute "
+             "chains before online partitioning.");
+    // Local rewrite (NOT the shared FoldShapeComputeChain, which the MoE path in
+    // llm_compiled_model.cpp also uses): the shape-compute-chain matchers plus the
+    // opt-in FoldEltwiseOfConsts so a Subtract/Add step (split size = total - other)
+    // also collapses. Scoping it here keeps every other constant-folding caller
+    // untouched.
+    ov::pass::GraphRewrite rewr;
+    rewr.add_matcher<FoldShapeOf>();
+    rewr.add_matcher<FoldGatherOfConst>();
+    rewr.add_matcher<FoldUnsqueezeOfConst>();
+    rewr.add_matcher<FoldEltwiseOfConsts>();
+    rewr.add_matcher<FoldConcatOfConsts>();
+    rewr.run_on_model(model);
 }
 
 }  // namespace util

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/fold_const.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/fold_const.hpp
@@ -17,6 +17,10 @@
 //   Gather(C,C,C)   --[FoldGatherOfConst]--> Const
 //   Unsqueeze(C,C)  --[FoldUnsqueezeOfConst]--> Const
 //   Concat(C...)    --[FoldConcatOfConsts]--> Const
+//
+// FoldEltwiseOfConsts (Sub/Add/Mul/Div of two Constants) is a separate opt-in
+// matcher, NOT part of FoldShapeComputeChain, so existing chain callers are
+// unaffected; add it explicitly where an arithmetic step must also collapse.
 
 namespace ov {
 namespace npuw {
@@ -54,6 +58,18 @@ public:
     FoldConcatOfConsts();
 };
 
+// Fold a binary element-wise op (Add/Subtract/Multiply/Divide) whose both
+// inputs are scalar integer Constants → Constant. Shape-compute chains frequently
+// derive one split size as (total - other) etc.; without folding the arithmetic
+// the downstream Concat never becomes all-constant. Not included in
+// FoldShapeComputeChain by default (add it explicitly where needed); the
+// scalar-integer-operand guard means it can never fold a weight-sized constant.
+class FoldEltwiseOfConsts : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("npuw::patterns::util::FoldEltwiseOfConsts");
+    FoldEltwiseOfConsts();
+};
+
 // Runs the full shape-compute-chain folding pipeline in a single pass:
 // FoldShapeOf → FoldGatherOfConst → FoldUnsqueezeOfConst → FoldConcatOfConsts.
 class FoldShapeComputeChain : public ov::pass::ModelPass {
@@ -61,6 +77,23 @@ public:
     OPENVINO_RTTI("npuw::patterns::util::FoldShapeComputeChain");
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 };
+
+// Fold shape-compute chains (ShapeOf -> Gather -> Sub/Add -> Concat, ...) into
+// Constants before online partitioning creates subgraph boundaries. Otherwise a
+// partition boundary can cut such a chain and lift the (statically known) value
+// into a runtime input Parameter; ops that require a Constant attribute (e.g.
+// VariadicSplit's split_lengths from aten::split_with_sizes) then fail to compile
+// on backends like VPUX. Folding only the ShapeOf root is NOT enough: the
+// boundary can still cut the chain further down (e.g. at the Gather), leaving
+// that op's input as a runtime Parameter. The whole chain is therefore collapsed
+// to a single Constant here. FoldShapeOf is bound-based, so the fold is a no-op
+// on genuinely dynamic shapes where no bound is resolvable.
+//
+// Unlike FoldShapeComputeChain, this also runs the opt-in FoldEltwiseOfConsts so a
+// Subtract/Add step (split size = total - other) collapses too, and it only runs
+// when a VariadicSplit with a non-constant split_lengths is actually present -
+// staying a strict no-op (zero graph changes) for every model without the problem.
+void foldShapeComputeChainsForConstAttrs(const std::shared_ptr<ov::Model>& model);
 
 }  // namespace util
 }  // namespace patterns

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -48,6 +48,10 @@ const constexpr ov::npuw::s11n::IndicatorType NPUW_LLM_COMPILED_MODEL_INDICATOR 
 const constexpr ov::npuw::s11n::IndicatorType NPUW_GQA_COMPILED_MODEL_INDICATOR =
     {char{0x47}, char{0x51}, char{0x41}, char{0x43}, char{0x4d}, char{0x4f}};
 
+// FL2 = 0x46,0x4c,0x32 + CMO = 0x43,0x4d,0x4f
+const constexpr ov::npuw::s11n::IndicatorType NPUW_FLUX2_COMPILED_MODEL_INDICATOR =
+    {char{0x46}, char{0x4c}, char{0x32}, char{0x43}, char{0x4d}, char{0x4f}};
+
 const constexpr char* NPUW_SERIALIZATION_VERSION = "0.29";
 
 // Forward declaration

--- a/src/plugins/intel_npu/src/plugin/sources.cmake
+++ b/src/plugins/intel_npu/src/plugin/sources.cmake
@@ -51,6 +51,8 @@ set(NPUW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/embedding/redirect_new_kv_to_output.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/embedding/remove_empty_kv_inputs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/embedding/remove_empty_kv_inputs.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/flux2_compiled_model.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/flux2_compiled_model.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/host_flash_attention.cpp

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -18,6 +18,7 @@
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/utils/utils.hpp"
 #include "npuw/compiled_model.hpp"
+#include "npuw/flux2_compiled_model.hpp"
 #include "npuw/gqa_compiled_model.hpp"
 #include "npuw/llm_compiled_model.hpp"
 #include "npuw/orc/schema_npuw.hpp"
@@ -81,7 +82,9 @@ std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,
             stream.clear();
             stream.seekg(stream_start_pos);
 
-            if (compiled_model_indicator == NPUW_GQA_COMPILED_MODEL_INDICATOR) {
+            if (compiled_model_indicator == NPUW_FLUX2_COMPILED_MODEL_INDICATOR) {
+                return ov::npuw::Flux2CompiledModel::import_model(stream, pluginSO, properties);
+            } else if (compiled_model_indicator == NPUW_GQA_COMPILED_MODEL_INDICATOR) {
                 return ov::npuw::GQACompiledModel::import_model(stream, pluginSO, properties);
             } else if (compiled_model_indicator == NPUW_LLM_COMPILED_MODEL_INDICATOR) {
                 // Properties are required for ov::weights_path

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -153,6 +153,7 @@ install(TARGETS ${TARGET_NAME}
 target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/executor_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_compiled_model_graph_options_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/flux2_compiled_model_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_continuation_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/stored_tokens_state_test.cpp

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -47,6 +47,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/src/blob_format_importers.cpp
             # npuw core
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/gqa_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model_utils.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/flux2_compiled_model_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/flux2_compiled_model_test.cpp
@@ -1,0 +1,349 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "flux2_compiled_model.hpp"
+#include "llm_test_helpers.hpp"
+#include "openvino/core/version.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/runtime/properties.hpp"
+#include "serialization.hpp"
+
+namespace {
+
+using ov::test::npuw::MockSubCompiledModel;
+using ov::test::npuw::NullPlugin;
+
+// Key strings the inner compile call is expected to carry. Kept as literals so the
+// test breaks loudly if an option's public name ever changes.
+constexpr const char* kDevices = "NPUW_DEVICES";
+constexpr const char* kDynQuant = "NPU_COMPILER_DYNAMIC_QUANTIZATION";
+constexpr const char* kF16IC = "NPUW_F16IC";
+constexpr const char* kCompileParams = "NPU_COMPILATION_MODE_PARAMS";
+constexpr const char* kOnlinePipeline = "NPUW_ONLINE_PIPELINE";
+
+std::shared_ptr<ov::Model> make_model(const std::string& model_name,
+                                      const ov::element::Type& type,
+                                      const ov::PartialShape& shape,
+                                      const std::string& param_name) {
+    auto param = std::make_shared<ov::op::v0::Parameter>(type, shape);
+    param->set_friendly_name(param_name);
+    auto result = std::make_shared<ov::op::v0::Result>(param);
+    return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{param}, model_name);
+}
+
+bool ends_with(const std::string& value, const std::string& suffix) {
+    return value.size() >= suffix.size() &&
+           value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+struct CompileCall {
+    ov::AnyMap props;
+    std::shared_ptr<ov::Model> model;
+};
+
+class RecordingFactory {
+public:
+    ov::npuw::Flux2CompiledModel::CompiledModelFactory make_factory() {
+        return [this](const std::shared_ptr<ov::Model>& model,
+                      const std::shared_ptr<const ov::IPlugin>& plugin,
+                      const ov::AnyMap& props) -> std::shared_ptr<ov::npuw::ICompiledModel> {
+            m_calls.push_back({props, model});
+            return std::make_shared<MockSubCompiledModel>(model, plugin, props);
+        };
+    }
+
+    const CompileCall& only_call() const {
+        OPENVINO_ASSERT(m_calls.size() == 1u, "Expected a single compile call");
+        return m_calls.front();
+    }
+
+private:
+    std::vector<CompileCall> m_calls;
+};
+
+// Build a header matching Flux2CompiledModel::export_model so import_model's validation
+// can be exercised without a real inner ORC blob.
+std::string make_flux2_header(const ov::npuw::s11n::IndicatorType& serialization_indicator,
+                              const ov::npuw::s11n::IndicatorType& model_indicator,
+                              int vmajor,
+                              int vminor,
+                              int vpatch,
+                              const std::string& s11n_version) {
+    std::ostringstream stream;
+    ov::npuw::s11n::write(stream, serialization_indicator);
+    ov::npuw::s11n::write(stream, model_indicator);
+    ov::npuw::s11n::write(stream, vmajor);
+    ov::npuw::s11n::write(stream, vminor);
+    ov::npuw::s11n::write(stream, vpatch);
+    ov::npuw::s11n::write(stream, s11n_version);
+    return stream.str();
+}
+
+class Flux2CompiledModelTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        m_plugin = std::make_shared<NullPlugin>();
+    }
+
+    static ov::AnyMap base_props() {
+        return {{"NPUW_FLUX2", "YES"}};
+    }
+
+    static void merge_props(ov::AnyMap& dst, const ov::AnyMap& src) {
+        for (const auto& [key, value] : src) {
+            dst[key] = value;
+        }
+    }
+
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> create_compiled_model(const std::shared_ptr<ov::Model>& model,
+                                                                        const ov::AnyMap& extra_props,
+                                                                        RecordingFactory& recorder) const {
+        auto props = base_props();
+        merge_props(props, extra_props);
+        return std::make_unique<ov::npuw::Flux2CompiledModel>(model, m_plugin, props, recorder.make_factory());
+    }
+
+    static void expect_base_defaults(const ov::AnyMap& props) {
+        EXPECT_EQ(props.at(kDevices).as<std::string>(), "NPU");
+        EXPECT_EQ(props.at(kDynQuant).as<std::string>(), "YES");
+    }
+
+    std::shared_ptr<ov::IPlugin> m_plugin;
+};
+
+// --- Submodel detection via friendly name -----------------------------------
+
+TEST_F(Flux2CompiledModelTest, TextEncoderByNameDisablesF16IC) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("flux_text_encoder", ov::element::f32, ov::PartialShape{1, 16}, "hidden"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& call = recorder.only_call();
+    expect_base_defaults(call.props);
+    EXPECT_EQ(call.props.at(kF16IC).as<std::string>(), "NO");
+    EXPECT_EQ(call.props.count(kCompileParams), 0u);
+    EXPECT_EQ(call.props.count(kOnlinePipeline), 0u);
+}
+
+TEST_F(Flux2CompiledModelTest, TransformerByNameSetsHigherPrecisionMVN) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("flux_transformer", ov::element::f32, ov::PartialShape{1, 16}, "hidden"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& call = recorder.only_call();
+    expect_base_defaults(call.props);
+    EXPECT_EQ(call.props.at(kCompileParams).as<std::string>(), "compute-layers-with-higher-precision=MVN");
+    EXPECT_EQ(call.props.count(kF16IC), 0u);
+    EXPECT_EQ(call.props.count(kOnlinePipeline), 0u);
+}
+
+TEST_F(Flux2CompiledModelTest, VaeEncoderByNameDisablesOnlinePipeline) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("flux_vae_encoder", ov::element::f32, ov::PartialShape{1, 16}, "sample"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& call = recorder.only_call();
+    expect_base_defaults(call.props);
+    EXPECT_EQ(call.props.at(kOnlinePipeline).as<std::string>(), "NONE");
+}
+
+TEST_F(Flux2CompiledModelTest, VaeDecoderByNameDisablesOnlinePipeline) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("flux_vae_decoder", ov::element::f32, ov::PartialShape{1, 16}, "latent"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& call = recorder.only_call();
+    expect_base_defaults(call.props);
+    EXPECT_EQ(call.props.at(kOnlinePipeline).as<std::string>(), "NONE");
+}
+
+// --- Submodel detection via input signature ---------------------------------
+
+TEST_F(Flux2CompiledModelTest, TransformerDetectedFromEncoderHiddenStatesInput) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("submodel", ov::element::f32, ov::PartialShape{1, 16}, "encoder_hidden_states"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_EQ(recorder.only_call().props.at(kCompileParams).as<std::string>(),
+              "compute-layers-with-higher-precision=MVN");
+}
+
+TEST_F(Flux2CompiledModelTest, TextEncoderDetectedFromInputIdsInput) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("submodel", ov::element::i64, ov::PartialShape{1, 16}, "input_ids"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_EQ(recorder.only_call().props.at(kF16IC).as<std::string>(), "NO");
+}
+
+TEST_F(Flux2CompiledModelTest, VaeEncoderDetectedFromThreeChannelInput) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("submodel", ov::element::f32, ov::PartialShape{1, 3, 32, 32}, "sample"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_EQ(recorder.only_call().props.at(kOnlinePipeline).as<std::string>(), "NONE");
+}
+
+TEST_F(Flux2CompiledModelTest, VaeDecoderDetectedFromLatentChannelInput) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("submodel", ov::element::f32, ov::PartialShape{1, 4, 32, 32}, "latent"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_EQ(recorder.only_call().props.at(kOnlinePipeline).as<std::string>(), "NONE");
+}
+
+// --- Unknown submodel and precedence ----------------------------------------
+
+TEST_F(Flux2CompiledModelTest, UnknownModelGetsOnlyBaseDefaults) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("submodel", ov::element::f32, ov::PartialShape{1, 16}, "sample"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& call = recorder.only_call();
+    expect_base_defaults(call.props);
+    EXPECT_EQ(call.props.count(kF16IC), 0u);
+    EXPECT_EQ(call.props.count(kCompileParams), 0u);
+    EXPECT_EQ(call.props.count(kOnlinePipeline), 0u);
+}
+
+TEST_F(Flux2CompiledModelTest, UserPropertiesOverrideSubmodelAndBaseDefaults) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    // text_encoder would default NPUW_F16IC=NO and base NPU_COMPILER_DYNAMIC_QUANTIZATION=YES;
+    // both must yield to the user-provided values.
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("flux_text_encoder", ov::element::f32, ov::PartialShape{1, 16}, "hidden"),
+                        {{kF16IC, "YES"}, {kDynQuant, "NO"}, {kDevices, "CPU"}},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    const auto& call = recorder.only_call();
+    EXPECT_EQ(call.props.at(kF16IC).as<std::string>(), "YES");
+    EXPECT_EQ(call.props.at(kDynQuant).as<std::string>(), "NO");
+    EXPECT_EQ(call.props.at(kDevices).as<std::string>(), "CPU");
+}
+
+TEST_F(Flux2CompiledModelTest, AppendsFlux2SuffixToInnerModelName) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+                        make_model("flux_transformer", ov::element::f32, ov::PartialShape{1, 16}, "hidden"),
+                        {},
+                        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_TRUE(ends_with(recorder.only_call().model->get_friendly_name(), "_flux2"));
+}
+
+// --- Serialization ----------------------------------------------------------
+
+TEST_F(Flux2CompiledModelTest, ExportWritesFlux2Indicators) {
+    RecordingFactory recorder;
+    auto compiled = create_compiled_model(
+        make_model("flux_transformer", ov::element::f32, ov::PartialShape{1, 16}, "hidden"),
+        {},
+        recorder);
+    ASSERT_NE(compiled, nullptr);
+
+    std::ostringstream out;
+    ASSERT_NO_THROW(compiled->export_model(out));
+
+    std::istringstream in(out.str());
+    ov::npuw::s11n::IndicatorType serialization_indicator{};
+    ov::npuw::s11n::IndicatorType model_indicator{};
+    ov::npuw::s11n::read(in, serialization_indicator);
+    ov::npuw::s11n::read(in, model_indicator);
+    EXPECT_EQ(serialization_indicator, NPUW_SERIALIZATION_INDICATOR);
+    EXPECT_EQ(model_indicator, NPUW_FLUX2_COMPILED_MODEL_INDICATOR);
+}
+
+TEST_F(Flux2CompiledModelTest, ImportRejectsWrongSerializationIndicator) {
+    const auto header = make_flux2_header(NPUW_FLUX2_COMPILED_MODEL_INDICATOR,
+                                          NPUW_FLUX2_COMPILED_MODEL_INDICATOR,
+                                          OPENVINO_VERSION_MAJOR,
+                                          OPENVINO_VERSION_MINOR,
+                                          OPENVINO_VERSION_PATCH,
+                                          std::string(NPUW_SERIALIZATION_VERSION));
+    std::istringstream stream(header);
+    EXPECT_THROW(ov::npuw::Flux2CompiledModel::import_model(stream, m_plugin, {}), ov::Exception);
+}
+
+TEST_F(Flux2CompiledModelTest, ImportRejectsWrongModelIndicator) {
+    const auto header = make_flux2_header(NPUW_SERIALIZATION_INDICATOR,
+                                          NPUW_GQA_COMPILED_MODEL_INDICATOR,
+                                          OPENVINO_VERSION_MAJOR,
+                                          OPENVINO_VERSION_MINOR,
+                                          OPENVINO_VERSION_PATCH,
+                                          std::string(NPUW_SERIALIZATION_VERSION));
+    std::istringstream stream(header);
+    EXPECT_THROW(ov::npuw::Flux2CompiledModel::import_model(stream, m_plugin, {}), ov::Exception);
+}
+
+TEST_F(Flux2CompiledModelTest, ImportRejectsVersionMismatch) {
+    const auto header = make_flux2_header(NPUW_SERIALIZATION_INDICATOR,
+                                          NPUW_FLUX2_COMPILED_MODEL_INDICATOR,
+                                          OPENVINO_VERSION_MAJOR + 1,
+                                          OPENVINO_VERSION_MINOR,
+                                          OPENVINO_VERSION_PATCH,
+                                          std::string(NPUW_SERIALIZATION_VERSION));
+    std::istringstream stream(header);
+    EXPECT_THROW(ov::npuw::Flux2CompiledModel::import_model(stream, m_plugin, {}), ov::Exception);
+}
+
+}  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/flux2_compiled_model_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/flux2_compiled_model_test.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "flux2_compiled_model.hpp"
+
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -9,7 +11,6 @@
 #include <string>
 #include <vector>
 
-#include "flux2_compiled_model.hpp"
 #include "llm_test_helpers.hpp"
 #include "openvino/core/version.hpp"
 #include "openvino/op/parameter.hpp"
@@ -41,8 +42,7 @@ std::shared_ptr<ov::Model> make_model(const std::string& model_name,
 }
 
 bool ends_with(const std::string& value, const std::string& suffix) {
-    return value.size() >= suffix.size() &&
-           value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+    return value.size() >= suffix.size() && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
 struct CompileCall {
@@ -206,10 +206,10 @@ TEST_F(Flux2CompiledModelTest, TextEncoderDetectedFromInputIdsInput) {
     RecordingFactory recorder;
     std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
 
-    ASSERT_NO_THROW(compiled = create_compiled_model(
-                        make_model("submodel", ov::element::i64, ov::PartialShape{1, 16}, "input_ids"),
-                        {},
-                        recorder));
+    ASSERT_NO_THROW(
+        compiled = create_compiled_model(make_model("submodel", ov::element::i64, ov::PartialShape{1, 16}, "input_ids"),
+                                         {},
+                                         recorder));
     ASSERT_NE(compiled, nullptr);
 
     EXPECT_EQ(recorder.only_call().props.at(kF16IC).as<std::string>(), "NO");
@@ -247,10 +247,10 @@ TEST_F(Flux2CompiledModelTest, UnknownModelGetsOnlyBaseDefaults) {
     RecordingFactory recorder;
     std::unique_ptr<ov::npuw::Flux2CompiledModel> compiled;
 
-    ASSERT_NO_THROW(compiled = create_compiled_model(
-                        make_model("submodel", ov::element::f32, ov::PartialShape{1, 16}, "sample"),
-                        {},
-                        recorder));
+    ASSERT_NO_THROW(
+        compiled = create_compiled_model(make_model("submodel", ov::element::f32, ov::PartialShape{1, 16}, "sample"),
+                                         {},
+                                         recorder));
     ASSERT_NE(compiled, nullptr);
 
     const auto& call = recorder.only_call();
@@ -295,10 +295,10 @@ TEST_F(Flux2CompiledModelTest, AppendsFlux2SuffixToInnerModelName) {
 
 TEST_F(Flux2CompiledModelTest, ExportWritesFlux2Indicators) {
     RecordingFactory recorder;
-    auto compiled = create_compiled_model(
-        make_model("flux_transformer", ov::element::f32, ov::PartialShape{1, 16}, "hidden"),
-        {},
-        recorder);
+    auto compiled =
+        create_compiled_model(make_model("flux_transformer", ov::element::f32, ov::PartialShape{1, 16}, "hidden"),
+                              {},
+                              recorder);
     ASSERT_NE(compiled, nullptr);
 
     std::ostringstream out;

--- a/src/plugins/intel_npu/tests/unit/npuw/fold_const_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/fold_const_test.cpp
@@ -220,4 +220,133 @@ TEST(FoldConstTest, RouterSliceStopInputFoldedToConst) {
     EXPECT_TRUE(found_slice) << "Slice node not found in model";
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests for ov::npuw::patterns::util::FoldEltwiseOfConsts.
+//
+// FoldEltwiseOfConsts folds a binary element-wise op (Add/Subtract/Multiply/
+// Divide) of two scalar integer Constants into a single Constant. It is the
+// opt-in matcher used pre-partitioning to collapse a VariadicSplit split size
+// expressed as (total - other): shape-compute arithmetic works on individual
+// dimension sizes (scalars) which are later Unsqueeze'd and Concat'ed into the
+// split_lengths vector. The scalar-integer-operand guard means it can never fold
+// a (multi-element) weight/decompression constant.
+//
+// The tests below cover:
+//   1. the expected fold (scalar Subtract) with value check,
+//   2. Add/Multiply/Divide also fold on scalars,
+//   3. the guard rejects non-integral (weight/float) operands,
+//   4. the guard rejects non-scalar (vector) operands.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Run FoldEltwiseOfConsts (a MatcherPass) over the whole model.
+static void run_fold_eltwise(const std::shared_ptr<ov::Model>& model) {
+    ov::pass::GraphRewrite rewr;
+    rewr.add_matcher<ov::npuw::patterns::util::FoldEltwiseOfConsts>();
+    rewr.run_on_model(model);
+}
+
+// Build a model whose single Result consumes `eltwise`, so the folded node stays
+// reachable and can be inspected after the pass runs.
+static std::shared_ptr<ov::Model> make_single_eltwise_model(const std::shared_ptr<ov::Node>& eltwise) {
+    auto result = std::make_shared<op::v0::Result>(eltwise);
+    return std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{}, "fold_eltwise_test");
+}
+
+// Make a scalar i64 Constant.
+static std::shared_ptr<op::v0::Constant> scalar_i64(int64_t v) {
+    return op::v0::Constant::create(element::i64, Shape{}, std::vector<int64_t>{v});
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Subtract of two scalar i64 constants (split size = total - other) folds to a
+// scalar Constant carrying the correct difference.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(FoldConstTest, EltwiseSubtractOfScalarIntConstsFolded) {
+    auto lhs = scalar_i64(30);
+    auto rhs = scalar_i64(3);
+    auto sub = std::make_shared<op::v1::Subtract>(lhs, rhs);
+    sub->set_friendly_name("split_lengths/Subtract");
+    auto model = make_single_eltwise_model(sub);
+
+    ASSERT_EQ(count_ops_of_type<op::v1::Subtract>(model), 1u);
+
+    run_fold_eltwise(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Subtract>(model), 0u) << "Subtract of two scalar Constants must be folded";
+
+    auto folded = model->get_results().front()->input_value(0).get_node_shared_ptr();
+    auto c = ov::as_type_ptr<op::v0::Constant>(folded);
+    ASSERT_NE(c, nullptr) << "Result input must be a Constant after folding";
+    auto vals = c->cast_vector<int64_t>();
+    ASSERT_EQ(vals.size(), 1u);
+    EXPECT_EQ(vals[0], 27);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Add / Multiply / Divide of two scalar i64 constants also fold (matcher covers
+// all four arithmetic ops), with correct results.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(FoldConstTest, EltwiseAddMulDivOfScalarIntConstsFolded) {
+    {
+        auto add = std::make_shared<op::v1::Add>(scalar_i64(12), scalar_i64(4));
+        auto model = make_single_eltwise_model(add);
+        run_fold_eltwise(model);
+        EXPECT_EQ(count_ops_of_type<op::v1::Add>(model), 0u) << "Add of two scalar Constants must be folded";
+        auto c = ov::as_type_ptr<op::v0::Constant>(model->get_results().front()->input_value(0).get_node_shared_ptr());
+        ASSERT_NE(c, nullptr);
+        EXPECT_EQ(c->cast_vector<int64_t>(), (std::vector<int64_t>{16}));
+    }
+    {
+        auto mul = std::make_shared<op::v1::Multiply>(scalar_i64(12), scalar_i64(4));
+        auto model = make_single_eltwise_model(mul);
+        run_fold_eltwise(model);
+        EXPECT_EQ(count_ops_of_type<op::v1::Multiply>(model), 0u) << "Multiply of two scalar Constants must be folded";
+        auto c = ov::as_type_ptr<op::v0::Constant>(model->get_results().front()->input_value(0).get_node_shared_ptr());
+        ASSERT_NE(c, nullptr);
+        EXPECT_EQ(c->cast_vector<int64_t>(), (std::vector<int64_t>{48}));
+    }
+    {
+        auto div = std::make_shared<op::v1::Divide>(scalar_i64(20), scalar_i64(5));
+        auto model = make_single_eltwise_model(div);
+        run_fold_eltwise(model);
+        EXPECT_EQ(count_ops_of_type<op::v1::Divide>(model), 0u) << "Divide of two scalar Constants must be folded";
+        auto c = ov::as_type_ptr<op::v0::Constant>(model->get_results().front()->input_value(0).get_node_shared_ptr());
+        ASSERT_NE(c, nullptr);
+        EXPECT_EQ(c->cast_vector<int64_t>(), (std::vector<int64_t>{4}));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Guard: a scalar float (weight-like) Subtract must NOT be folded, so the matcher
+// can never materialise a constant out of a dequantization subgraph.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(FoldConstTest, EltwiseScalarFloatConstsNotFolded) {
+    auto lhs = op::v0::Constant::create(element::f32, Shape{}, std::vector<float>{30.f});
+    auto rhs = op::v0::Constant::create(element::f32, Shape{}, std::vector<float>{3.f});
+    auto sub = std::make_shared<op::v1::Subtract>(lhs, rhs);
+    auto model = make_single_eltwise_model(sub);
+
+    run_fold_eltwise(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Subtract>(model), 1u)
+        << "Non-integral (float) operands must NOT be folded by FoldEltwiseOfConsts";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Guard: a non-scalar (vector) integer Subtract must NOT be folded - only scalar
+// shape-compute values are eligible, so a multi-element integer tensor (which
+// could be a weight) is never materialised.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(FoldConstTest, EltwiseVectorIntConstsNotFolded) {
+    auto lhs = op::v0::Constant::create(element::i64, Shape{3}, std::vector<int64_t>{10, 20, 30});
+    auto rhs = op::v0::Constant::create(element::i64, Shape{3}, std::vector<int64_t>{1, 2, 3});
+    auto sub = std::make_shared<op::v1::Subtract>(lhs, rhs);
+    auto model = make_single_eltwise_model(sub);
+
+    run_fold_eltwise(model);
+
+    EXPECT_EQ(count_ops_of_type<op::v1::Subtract>(model), 1u)
+        << "Non-scalar (vector) operands must NOT be folded by FoldEltwiseOfConsts";
+}
+
 }  // namespace


### PR DESCRIPTION
### Details:

- Introduces a dedicated ov::npuw::Flux2CompiledModel that wraps the base NPUW CompiledModel and applies Flux.2-klein–specific NPUW configuration per pipeline submodel (text encoder, transformer, VAE encoder/decoder). The model is selected via the new NPUW_FLUX2 property and round-trips through NPUW's export_model/import_model with its own serialization indicator.
The Flux.2-klein image-generation pipeline is exported as several submodels, each of which needs different NPUW knobs to compile and run correctly on NPU. Rather than requiring callers to hand-tune per-submodel properties, Flux2CompiledModel auto-detects the submodel role and injects sensible defaults, while still letting user-supplied properties win.

-  Integrated FoldShapeComputeChain in the new added  ov::npuw::Flux2CompiledModel. Added foldShapeComputeChainsForConstAttrs(model) - a scoped, opt-in wrapper that first checks whether any VariadicSplit has a non-constant split_lengths; if none, it's a strict no-op. When triggered, it runs the same matchers plus FoldEltwiseOfConsts, keeping every other constant-folding caller unaffected.
This was needed for transform model from Flux2Klein which contain the following pattern around VariadicSplit. 
<img width="530" height="723" alt="image" src="https://github.com/user-attachments/assets/323679d0-a7e0-48eb-9e83-dbf65f74b174" />

### Tickets:
 - *[CVS-192196](https://jira.devtools.intel.com/browse/CVS-192196)*

### AI Assistance:
 - *AI assistance used:  yes*
 - *AI was instructed to extend the FoldShapeComputeChain pass with a rewriter for Eltiwse that has scalar constant inputs and to add new tests*
