### PR TITLE
[NPU][IE-MDK] Cleanup in Skip Config xml

### DIFF
--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -46,6 +46,25 @@ Example:
         </filters>
     </skip_config>
 
+    <skip_config>
+        <message>Data types not supported by NPU3720 PV Driver.</message>
+        <enable_rules>
+            <device>3720</device>
+            <driver_version>1688</driver_version>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=boolean.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i4.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u4.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i16.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u16.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=bf16.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i64.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u64.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=f64.*</filter>
+        </filters>
+    </skip_config>
+
     <!-- C#128116 -->
     <skip_config>
         <message>Unicode paths for ov::cache_dir are not correctly handled on Windows</message>
@@ -187,7 +206,7 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- EISW-162037 -->
+    <!-- E#162037 -->
     <skip_config>
         <message>compiled_blob test use `CACHE_MODE` which is not supported on NPU</message>
         <filters>
@@ -213,6 +232,14 @@ Example:
             <filter>.*smoke_Hetero_BehaviorTests/OVCompiledModelBaseTest.compile_from_weightless_blob/.*</filter>
             <filter>.*smoke_Hetero_BehaviorTests/OVCompiledModelBaseTest.compile_from_weightless_blob_but_no_weights/.*</filter>
             <filter>.*smoke_Hetero_BehaviorTests/OVCompiledModelBaseTest.compile_from_cached_weightless_blob_no_hint/.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- C#191862 -->
+    <skip_config>
+        <message>Non "developer build" CiDs don't support weights separation yet</message>
+        <filters>
+            <filter>.*WeightsSeparationIterativeTests.*DRIVER.*</filter>
         </filters>
     </skip_config>
 
@@ -249,6 +276,28 @@ Example:
             <filter>.*OVCheckSetSupportedRWMetricsPropsTests.*LOG_INFO.*</filter>
             <filter>.*OVCheckSetSupportedRWMetricsPropsTests.*LOG_DEBUG.*</filter>
             <filter>.*OVCheckSetSupportedRWMetricsPropsTests.*LOG_TRACE.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- C#191861 -->
+    <skip_config>
+        <message>Blobs for OVBlobCompatibilityNPU need to be updated for NPU5010</message>
+        <enable_rules>
+            <device>5010</device>
+        </enable_rules>
+        <filters>
+            <filter>.*OVBlobCompatibilityNPU.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>PV driver cannot create infer request for models with boolean inputs</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <driver_version>1688</driver_version>
+        </enable_rules>
+        <filters>
+            <filter>.*BooleanPrecisionInferRequestRunTests.*</filter>
         </filters>
     </skip_config>
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -19,167 +19,11 @@ Example:
 -->
 <skip_configs>
 
-    <skip_config>
-        <!-- E#70764 -->
-        <message>Disabled for when backend is empty (i.e., no device)</message>
-        <enable_rules>
-            <backend></backend> <!-- special case for empty backend -->
-        </enable_rules>
-        <filters>
-            <!-- Cannot run InferRequest tests without a device to infer to -->
-            <filter>.*InferRequest.*</filter>
-            <filter>.*OVInferRequest.*</filter>
-            <filter>.*OVInferenceChaining.*</filter>
-            <filter>.*ExecutableNetworkBaseTest.*</filter>
-            <filter>.*OVExecutableNetworkBaseTest.*</filter>
-            <filter>.*ExecNetSetPrecision.*</filter>
-            <filter>.*SetBlobTest.*</filter>
-            <filter>.*InferRequestCallbackTests.*</filter>
-            <filter>.*PreprocessingPrecisionConvertTest.*</filter>
-            <filter>.*SetPreProcessToInputInfo.*</filter>
-            <filter>.*InferRequestPreprocess.*</filter>
-            <filter>.*HoldersTestOnImportedNetwork.*</filter>
-            <filter>.*HoldersTest.Orders.*</filter>
-            <filter>.*HoldersTestImportNetwork.Orders.*</filter>
-            <!-- Cannot compile network without explicit specifying of the device in case of no devices -->
-            <filter>.*OVExecGraphImportExportTest.*</filter>
-            <filter>.*OVHoldersTest.*</filter>
-            <filter>.*OVClassExecutableNetworkGetMetricTest.*</filter>
-            <filter>.*OVClassExecutableNetworkGetConfigTest.*</filter>
-            <filter>.*OVClassNetworkTestP.*SetAffinityWithConstantBranches.*</filter>
-            <filter>.*OVClassNetworkTestP.*SetAffinityWithKSO.*</filter>
-            <filter>.*OVClassNetworkTestP.*LoadNetwork.*</filter>
-            <filter>.*FailGracefullyTest.*</filter>
-            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
-            <!-- Exception in case of network compilation without devices in system -->
-            <!-- [Track number: E#30824] -->
-            <filter>.*OVClassImportExportTestP.*</filter>
-            <filter>.*OVClassLoadNetworkTestNPU.*LoadNetwork.*</filter>
-            <!-- [Track number: E#84621] -->
-            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
-            <filter>.*QueryNetworkTestSuite.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>Tests break due to starting infer on IA side</message>
-        <filters>
-            <filter>.*CorrectConfigAPITests.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>ARM CPU Plugin is not available on Yocto</message>
-        <filters>
-            <filter>.*IEClassLoadNetworkTest.*HETERO.*</filter>
-            <filter>.*IEClassLoadNetworkTest.*MULTI.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#30810 -->
-    <skip_config>
-        <message>Hetero plugin doesn't throw an exception in case of big device ID</message>
-        <filters>
-            <filter>.*OVClassLoadNetworkTestNPU.*LoadNetworkHETEROWithBigDeviceIDThrows.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#30815 -->
-    <skip_config>
-        <message>NPU Plugin doesn't handle DEVICE_ID in QueryNetwork implementation</message>
-        <filters>
-            <filter>.*OVClassQueryNetworkTest.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#12774 -->
-    <skip_config>
-        <message>Cannot detect npu platform when it's not passed; Skip tests on Yocto which passes device without platform</message>
-        <filters>
-            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithDeviceIDNoThrow.*</filter>
-            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithBigDeviceIDThrows.*</filter>
-            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithInvalidDeviceIDThrows.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#28335 -->
-    <skip_config>
-        <message>Disabled test E#28335</message>
-        <filters>
-            <filter>.*smoke_LoadNetworkToDefaultDeviceNoThrow.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#32241 -->
-    <skip_config>
-        <message>Disabled test E#28335</message>
-        <filters>
-            <filter>.*LoadNetwork.*CheckDeviceInBlob.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#27343 -->
-    <skip_config>
-        <message>double free detected</message>
-        <filters>
-            <filter>.*InferConfigInTests\\.CanInferWithConfig.*</filter>
-        </filters>
-    </skip_config>
-
     <!-- E###### -->
     <skip_config>
         <message>GetExecGraphInfo function is not implemented for NPU plugin</message>
         <filters>
-            <filter>.*checkGetExecGraphInfoIsNotNullptr.*</filter>
-            <filter>.*CanCreateTwoExeNetworksAndCheckFunction.*</filter>
-            <filter>.*CanCreateTwoCompiledModelsAndCheckRuntimeModel.*</filter>
             <filter>.*CheckExecGraphInfo.*</filter>
-            <filter>.*canLoadCorrectNetworkToGetExecutable.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#28335 -->
-    <skip_config>
-        <message>Disabled test E#28335</message>
-        <filters>
-            <filter>.*checkInferTime.*</filter>
-            <filter>.*OVExecGraphImportExportTest.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#31074 -->
-    <skip_config>
-        <message>Test uses legacy OpenVINO 1.0 API, no need to support it</message>
-        <filters>
-            <filter>.*ExecutableNetworkBaseTest.checkGetMetric.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#31074 -->
-    <skip_config>
-        <message>SetConfig function is not implemented for ExecutableNetwork interface (implemented only for npu plugin)</message>
-        <filters>
-            <filter>.*ExecutableNetworkBaseTest.canSetConfigToExecNet.*</filter>
-            <filter>.*ExecutableNetworkBaseTest.canSetConfigToExecNetAndCheckConfigAndCheck.*</filter>
-            <filter>.*CanSetConfigToExecNet.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#30822 -->
-    <skip_config>
-        <message>Exception 'Not implemented</message>
-        <filters>
-            <filter>.*OVClassNetworkTestP.*LoadNetworkCreateDefaultExecGraphResult.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>This is openvino specific test</message>
-        <filters>
-            <filter>.*ExecutableNetworkBaseTest.canExport.*</filter>
         </filters>
     </skip_config>
 
@@ -187,7 +31,6 @@ Example:
     <skip_config>
         <message>TensorIterator layer is not supported</message>
         <filters>
-            <filter>.*OVInferRequestDynamicTests.*</filter>
             <filter>.*OVInferenceChaining.*</filter>
         </filters>
     </skip_config>
@@ -200,322 +43,6 @@ Example:
             <filter>.*InferRequestCheckTensorPrecision.*type=boolean.*device=AUTO.*</filter>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=boolean.*device=MULTI.*</filter>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=boolean.*device=AUTO.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>Data types not supported by NPU3720 PV Driver.</message>
-        <enable_rules>
-            <device>3720</device>
-        </enable_rules>
-        <filters>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=boolean.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i4.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u4.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i16.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u16.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=bf16.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i64.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u64.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=f64.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#32075 -->
-    <skip_config>
-        <message>Exception during loading to the device</message>
-        <filters>
-            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkHETEROwithMULTINoThrow.*</filter>
-            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkMULTIwithHETERONoThrow.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>compiler: Unsupported arch kind: NPUX311X</message>
-        <filters>
-            <filter>.*CompilationForSpecificPlatform.*(3800|3900).*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#67749 -->
-    <skip_config>
-        <message>Can't loadNetwork without cache for ReadConcatSplitAssign with precision f32</message>
-        <filters>
-            <filter>.*CachingSupportCase_NPU.*CompileModelCacheTestBase.*CompareWithRefImpl.*ReadConcatSplitAssign.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#99817 -->
-    <skip_config>
-        <message>NPU Plugin currently fails to get a valid output in these test cases</message>
-        <filters>
-            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
-            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
-            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=(NPU3720_|NPU4000_).*</filter>
-            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=(NPU3720_|NPU4000_)configItem=MULTI_DEVICE_PRIORITIES_NPU_.*</filter>
-            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=(NPU3720_|NPU4000_).*</filter>
-            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=(NPU3720_|NPU4000_)configItem=MULTI_DEVICE_PRIORITIES_NPU_.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#68774 -->
-    <skip_config>
-        <message>OV requires the plugin to throw when value of DEVICE_ID is unrecognized, but plugin does not throw</message>
-        <filters>
-            <filter>smoke_BehaviorTests.*IncorrectConfigTests.SetConfigWithIncorrectKey.*(SOME_DEVICE_ID|DEVICE_UNKNOWN).*</filter>
-            <filter>smoke_BehaviorTests.*IncorrectConfigTests.SetConfigWithNoExistingKey.*SOME_DEVICE_ID.*</filter>
-            <filter>smoke_BehaviorTests.*IncorrectConfigAPITests.SetConfigWithNoExistingKey.*(SOME_DEVICE_ID|DEVICE_UNKNOWN).*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#77755 -->
-    <skip_config>
-        <message>OV requires the plugin to throw on network load when config file is incorrect, but plugin does not throw</message>
-        <filters>
-            <filter>.*smoke_Auto_BehaviorTests.*IncorrectConfigTests.CanNotLoadNetworkWithIncorrectConfig.*AUTO_config.*unknown_file_MULTI_DEVICE_PRIORITIES=(NPU_|NPU,CPU_).*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#77756 -->
-    <skip_config>
-        <message>OV expects the plugin to not throw any exception on network load, but it actually throws</message>
-        <filters>
-            <filter>.*(smoke_Multi_Behavior|smoke_Auto_Behavior).*SetPropLoadNetWorkGetPropTests.*SetPropLoadNetWorkGetProperty.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#68776 -->
-    <skip_config>
-        <message>Plugin can not perform SetConfig for value like: device=NPU config key=LOG_LEVEL value=0</message>
-        <filters>
-            <filter>smoke_BehaviorTests/DefaultValuesConfigTests.CanSetDefaultValueBackToPlugin.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#48480 -->
-    <skip_config>
-        <message>Disabled with ticket number 48480</message>
-        <filters>
-            <filter>.*OVExecutableNetworkBaseTest.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#63708 -->
-    <skip_config>
-        <message>Disabled with ticket number 63708</message>
-        <filters>
-            <filter>.*smoke_BehaviorTests.*InferStaticNetworkSetInputTensor.*</filter>
-            <filter>.*smoke_Multi_BehaviorTests.*InferStaticNetworkSetInputTensor.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#64490 -->
-    <skip_config>
-        <message>Disabled with ticket number 64490</message>
-        <filters>
-            <filter>.*OVClassNetworkTestP.*SetAffinityWithConstantBranches.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#86380 -->
-    <skip_config>
-        <message>The output tensor gets freed when the inference request structure's destructor is called. The issue is unrelated to the caching feature.</message>
-        <filters>
-            <filter>.*CacheTestBase.CompareWithRefImpl.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>Expected: SetConfig(configuration, target_device) throws an exception of type InferenceEngine::Exception. Throws nothing.</message>
-        <filters>
-            <!-- E#89274 -->
-            <filter>.*AutoBatch.*Behavior.*IncorrectConfigAPITests.SetConfigWithNoExistingKey.*AUTO_BATCH_TIMEOUT.*</filter>
-            <!-- E#89084 -->
-            <filter>.*AutoBatch.*Behavior.*IncorrectConfigTests.SetConfigWithIncorrectKey.*AUTO_BATCH_TIMEOUT.*</filter>
-            <filter>.*AutoBatch.*Behavior.*IncorrectConfigTests.CanNotLoadNetworkWithIncorrectConfig.*AUTO_BATCH_TIMEOUT.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>Dynamic I/O shapes are being used when running the tests. This feature is not yet supported by the NPU plugin.</message>
-        <filters>
-            <filter>.*SetPreProcessTo.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>This scenario became invalid upon refactoring the implementation as to use the 2.0 OV API.</message>
-        <filters>
-            <filter>.*smoke_BehaviorTests/VersionTest.pluginCurrentVersionIsCorrect.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#102428 -->
-    <skip_config>
-        <message>Tests throw errors as expected but drivers post-v.1657 will fail to catch them</message>
-        <filters>
-            <filter>.*FailGracefullyTest.*</filter>
-            <filter>.*QueryNetworkTestSuite3NPU.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>Tests are disabled for all devices except NPU3720</message>
-        <enable_rules>
-            <device>!3720</device>
-        </enable_rules>
-        <filters>
-            <!-- E#49620 -->
-            <filter>.*NPU3720.*</filter>
-            <!-- E#84621 -->
-            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
-            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#111510 -->
-    <skip_config>
-        <message>Failing test for NPU device</message>
-        <filters>
-            <filter>.*OVClassImportExportTestP.*OVClassCompiledModelImportExportTestP.*ImportNetworkThrowWithDeviceName.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>These tests runs only on LevelZero backend</message>
-        <enable_rules>
-            <backend>!LEVEL0</backend>
-        </enable_rules>
-        <filters>
-            <filter>.*InferRequestRunTests.*</filter>
-            <filter>.*OVClassGetMetricAndPrintNoThrow.*</filter>
-            <filter>.*IEClassGetMetricAndPrintNoThrow.*</filter>
-            <filter>.*CompileModelLoadFromFileTestBase.*</filter>
-            <filter>.*CorrectConfigTests.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>Other devices than NPU doesn't allow to set NPU properties with OV1.0 and CACHE_DIR + PLUGIN is not supported</message>
-        <filters>
-            <filter>.*smoke_AutoBatch_BehaviorTests/CorrectConfigTests.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#103391 -->
-    <skip_config>
-        <message>IfTest segfaults npuFuncTest on Ubuntu</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <device>3720</device>
-            <operating_system>linux</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*smoke_IfTest.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#111369 -->
-    <skip_config>
-        <message>Tests fail with: ZE_RESULT_ERROR_DEVICE_LOST, code 0x70000001</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <device>3720</device>
-            <operating_system>linux</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*OVInferRequestMultithreadingTests.canRun3SyncRequestsConsistently.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#83423 -->
-    <skip_config>
-        <message>Tests enabled only for L0 NPU3720</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <device>!3720</device>
-        </enable_rules>
-        <filters>
-            <filter>.*smoke_VariableStateBasic.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#83708 -->
-    <skip_config>
-        <message>MemoryLSTMCellTest failing with NOT_IMPLEMENTED</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-        </enable_rules>
-        <filters>
-            <filter>.*smoke_MemoryLSTMCellTest.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#83423 -->
-    <skip_config>
-        <message>QueryNetwork is only supported by 3720 platform</message>
-        <enable_rules>
-            <backend>!LEVEL0</backend>
-            <device>!3720</device>
-        </enable_rules>
-        <filters>
-            <filter>.*QueryNetworkTestSuite.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>Some NPU Plugin metrics require single device to work in auto mode or set particular device</message>
-        <filters>
-            <filter>.*OVClassGetConfigTest.*GetConfigNoThrow.*</filter>
-            <filter>.*OVClassGetConfigTest.*GetConfigHeteroNoThrow.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#99817 -->
-    <skip_config>
-        <message>Disabled tests for NPU3720 and NPU4000</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <device>3720</device>
-            <device>4000</device>
-        </enable_rules>
-        <filters>
-            <filter>.*InferRequestVariableStateTest.inferreq_smoke_VariableState_2infers.*</filter>
-            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#114903 -->
-    <skip_config>
-        <message>Tests fail when using latest OV commit from ww09</message>
-        <enable_rules>
-            <device>3720</device>
-        </enable_rules>
-        <filters>
-            <filter>.*smoke_RandomUniform/RandomLayerTest_NPU3720.SW.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>GetExecGraphInfo function is not implemented for NPU plugin</message>
-        <filters>
-            <filter>.*CanCreateTwoCompiledModelsAndCheckRuntimeModel.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>Fails with CID</message>
-        <filters>
-            <filter>.*smoke_BehaviorTests_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
         </filters>
     </skip_config>
 
@@ -538,36 +65,6 @@ Example:
         </enable_rules>
         <filters>
             <filter>.*OVCheckMetricsPropsTests_ModelDependceProps.*</filter>
-            <filter>.*OVClassCompileModelAndCheckSecondaryPropertiesTest.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>Failing properties tests</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-        </enable_rules>
-        <filters>
-            <!-- E#108600 -->
-            <filter>.*OVSpecificDeviceSetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
-            <!-- E#133153 -->
-            <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#109040 -->
-    <skip_config>
-        <message>Disabled all tests CompileForDifferentPlatformsTests with config NPU_COMPILER_TYPE_DRIVER</message>
-        <filters>
-            <filter>.*smoke_BehaviorTest/CompileForDifferentPlatformsTests.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>Fails with CID</message>
-        <filters>
-            <filter>.*smoke_BehaviorTests_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
         </filters>
     </skip_config>
 
@@ -578,7 +75,6 @@ Example:
             <device>!3720</device>
         </enable_rules>
         <filters>
-            <filter>.*smoke_BehaviorTests_OVClassSetDefaultDeviceIDPropTest/OVClassSetDefaultDeviceIDPropTest.SetDefaultDeviceIDNoThrow.*</filter>
             <filter>.*smoke_BehaviorTests_OVClassSpecificDeviceTest/OVSpecificDeviceGetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
             <filter>.*smoke_BehaviorTests_OVClassSpecificDeviceTest/OVSpecificDeviceTestSetConfig.SetConfigSpecificDeviceNoThrow.*</filter>
         </filters>
@@ -591,17 +87,6 @@ Example:
             <filter>.*smoke.*OVInferRequestCheckTensorPrecision.*type=u4.*</filter>
             <filter>.*smoke.*OVInferRequestIOTensorSetPrecisionTestNPU.*type=i4.*</filter>
             <filter>.*smoke.*OVInferRequestIOTensorSetPrecisionTestNPU.*type=u4.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#109040 -->
-    <skip_config>
-        <message>Disabled tests for NPU3720</message>
-        <enable_rules>
-            <device>3720</device>
-        </enable_rules>
-        <filters>
-            <filter>.*smoke_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.*</filter>
         </filters>
     </skip_config>
 
@@ -626,19 +111,17 @@ Example:
             <operating_system>windows</operating_system>
         </enable_rules>
         <filters>
-            <filter>.*CoreThreadingTest.smoke_QueryModel/.*</filter>
+            <filter>.*CoreThreadingTest.smoke_QueryModel.*</filter>
         </filters>
     </skip_config>
 
+    <!-- E#133153 -->
     <skip_config>
         <message>Failing properties tests</message>
         <enable_rules>
             <backend>LEVEL0</backend>
         </enable_rules>
         <filters>
-            <!-- E#108600 -->
-            <filter>.*OVSpecificDeviceSetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
-            <!-- E#133153 -->
             <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
         </filters>
     </skip_config>
@@ -651,24 +134,6 @@ Example:
         </enable_rules>
         <filters>
             <filter>.*OVCompiledModelPropertiesDefaultSupportedTests.CanCompileWithDefaultValueFromPlugin.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>NPU plugin doesn't support infer dynamic</message>
-        <filters>
-            <filter>.*OVInferRequestBatchedTests.SetInputTensors_Can_Infer_Dynamic.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#118381 -->
-    <skip_config>
-        <message>Comparation is failed, SLT need to be updated.</message>
-        <filters>
-            <filter>.*smoke.*GridSample_Tiling/GridSampleLayerTest.*align_corners=0.*Mode=nearest_padding_mode=zeros.*</filter>
-            <filter>.*smoke.*GridSample_Tiling/GridSampleLayerTest.*align_corners=0.*Mode=nearest_padding_mode=border.*</filter>
-            <filter>.*smoke.*GridSample_Tiling/GridSampleLayerTest.*align_corners=0.*Mode=nearest_padding_mode=reflection.*</filter>
         </filters>
     </skip_config>
 
@@ -693,37 +158,6 @@ Example:
         <message>A property with the name of the tensors must be set to support ROI Tensors</message>
         <filters>
             <filter>.*OVInferRequestInferenceTests.Inference_ROI_Tensor/roi_nchw.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#116761 -->
-    <skip_config>
-        <message>OVClassQueryModel tests do not work with COMPILER_TYPE=DRIVER and PV driver</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <driver_version>1688</driver_version>
-            <operating_system>windows</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*OVClassQueryModelTest.QueryModelWithBigDeviceIDThrows.*</filter>
-            <filter>.*OVClassQueryModelTest.QueryModelWithInvalidDeviceIDThrows.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#109040 -->
-    <skip_config>
-        <message>CheckWrongGraphExtAndThrow tests do not work with COMPILER_TYPE=DRIVER</message>
-        <filters>
-            <filter>.*DriverCompilerAdapterExpectedThrowNPU.CheckWrongGraphExtAndThrow.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#109040 -->
-    <skip_config>
-        <message>Skip tests that can not wrong when DRIVER is default compiler type</message>
-        <filters>
-            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
-            <filter>.*MatMulTransposeConcatTest.*</filter>
         </filters>
     </skip_config>
 
@@ -782,13 +216,6 @@ Example:
         </filters>
     </skip_config>
 
-    <skip_config>
-        <message>Non "developer build" CiDs don't support weights separation yet</message>
-        <filters>
-            <filter>.*WeightsSeparationIterativeTests.*DRIVER.*</filter>
-        </filters>
-    </skip_config>
-
     <!-- E#170977 -->
     <skip_config>
         <message>Data type u1/u2 not supported by NPU3720.</message>
@@ -822,49 +249,6 @@ Example:
             <filter>.*OVCheckSetSupportedRWMetricsPropsTests.*LOG_INFO.*</filter>
             <filter>.*OVCheckSetSupportedRWMetricsPropsTests.*LOG_DEBUG.*</filter>
             <filter>.*OVCheckSetSupportedRWMetricsPropsTests.*LOG_TRACE.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>Blobs for OVBlobCompatibilityNPU need to be updated for NPU5010</message>
-        <enable_rules>
-            <device>5010</device>
-        </enable_rules>
-        <filters>
-            <filter>.*OVBlobCompatibilityNPU.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>Set of caching properties that are not suported by PV driver</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <driver_version>1688</driver_version>
-            <operating_system>windows</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*CompileModelLoadFromCacheTest.*EXECUTION_MODE_HINT.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*INFERENCE_PRECISION_HINT.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_BATCH_COMPILER_MODE_SETTINGS.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_BATCH_MODE.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_COMPILER_DYNAMIC_QUANTIZATION.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_DYNAMIC_SHAPE_TO_STATIC.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_MAX_TILES.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_TILES.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_TURBO.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_QDQ_OPTIMIZATION.*</filter>
-            <filter>.*CompileModelLoadFromCacheTest.*NPU_QDQ_OPTIMIZATION_AGGRESSIVE.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>PV driver cannot create infer request for models with boolean inputs</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <driver_version>1688</driver_version>
-        </enable_rules>
-        <filters>
-            <filter>.*BooleanPrecisionInferRequestRunTests.*</filter>
         </filters>
     </skip_config>
 
@@ -907,6 +291,22 @@ Example:
     </skip_config>
 
     <skip_config>
+        <message>UD12 driver does not support CACHE_ENCRYPTION_CALLBACKS on MTL</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>3720</device>
+            <driver_version>2020568</driver_version>
+        </enable_rules>
+        <filters>
+            <filter>.*OVClassCompiledModelPropertiesTests.CanUseCache.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
+            <filter>.*OVClassCompileModelWithCorrectPropertiesTest.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
+            <filter>.*OVClassCompiledModelGetPropertyTest.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
+            <filter>.*OVCompileModelGetExecutionDeviceTests.CanGetExecutionDeviceInfo.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
+            <filter>.*CompileModelWithCacheEncryptionTest.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
         <message>UD12 driver does not support secure compilation</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -916,24 +316,6 @@ Example:
             <filter>.*WeightlessCacheAccuracy.ReadConcatSplitAssign.*do_encryption=True.*(config=_|NPU_COMPILER_TYPE\[DRIVER\]).*</filter>
             <filter>.*WeightlessCacheAccuracy.SingleConcatWithConstant.*do_encryption=True.*(config=_|NPU_COMPILER_TYPE\[DRIVER\]).*</filter>
             <filter>.*WeightlessCacheAccuracy.TiWithLstmCell.*do_encryption=True.*config=_.*</filter>
-            <filter>.*OVClassCompiledModelPropertiesTests.CanUseCache.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
-            <filter>.*OVClassCompileModelWithCorrectPropertiesTest.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
-            <filter>.*OVClassCompiledModelGetPropertyTest.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
-            <filter>.*OVCompileModelGetExecutionDeviceTests.CanGetExecutionDeviceInfo.*CACHE_ENCRYPTION_CALLBACKS.*</filter>
-            <filter>.*CompileModelWithCacheEncryptionTest.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#210236-->
-    <skip_config>
-        <message>Test fails sporadically on NPU Windows drivers older than 07 2026</message>
-        <enable_rules>
-            <operating_system>windows</operating_system>
-            <driver_version>1688</driver_version>
-            <driver_version>2020568</driver_version>
-        </enable_rules>
-        <filters>
-            <filter>.*samePlatformProduceTheSameBlobCacheEnabled.*</filter>
         </filters>
     </skip_config>
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -18,6 +18,7 @@ Example:
     </skip_config>
 -->
 <skip_configs>
+
     <skip_config>
         <!-- E#70764 -->
         <message>Disabled for when backend is empty (i.e., no device)</message>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -125,7 +125,7 @@ Example:
     <skip_config>
         <message>Failing Windows PV Driver core threading tests</message>
         <enable_rules>
-            <backend>LEVEL0</backend>
+            <device>3720</device>
             <driver_version>1688</driver_version>
             <operating_system>windows</operating_system>
         </enable_rules>
@@ -293,7 +293,7 @@ Example:
     <skip_config>
         <message>PV driver cannot create infer request for models with boolean inputs</message>
         <enable_rules>
-            <backend>LEVEL0</backend>
+            <device>3720</device>
             <driver_version>1688</driver_version>
         </enable_rules>
         <filters>
@@ -371,7 +371,7 @@ Example:
     <skip_config>
         <message>PV driver cannot compile models securely</message>
         <enable_rules>
-            <backend>LEVEL0</backend>
+            <device>3720</device>
             <driver_version>1688</driver_version>
         </enable_rules>
         <filters>


### PR DESCRIPTION
### Details:
- Removed redundant and/or outdated test skips
- Worked backwards from an empty skip_config.xml, failing tests were compared to the original skips and added back. In the end it was observed that many skips were obsolete, redundant or were blocking tests that have since been fixed.
- Unskiped tests were fixed either through driver version updates or through compiler/plugin fixes

### Tickets:
 - E 213064

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
