### PR TITLE
[NPUW] Continuous prefill: reuse chat-history KV across turns

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
@@ -68,6 +68,7 @@ INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_OPTIMIZE_FP8, bool, false, ov::intel_npu::npu
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_ENABLE_PREFIX_CACHING, bool, false, ov::intel_npu::npuw::llm, enable_prefix_caching, "NPUW_LLM_ENABLE_PREFIX_CACHING", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_PREFIX_CACHING_BLOCK_SIZE, uint64_t, 256, ov::intel_npu::npuw::llm, prefix_caching_block_size, "NPUW_LLM_PREFIX_CACHING_BLOCK_SIZE", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_PREFIX_CACHING_MAX_NUM_BLOCKS, uint64_t, 128, ov::intel_npu::npuw::llm, prefix_caching_max_num_blocks, "NPUW_LLM_PREFIX_CACHING_MAX_NUM_BLOCKS", LLM, EXPOSED, CACHED, ALL)
+INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_ENABLE_CONTINUOUS_PREFILL, bool, false, ov::intel_npu::npuw::llm, enable_continuous_prefill, "NPUW_LLM_ENABLE_CONTINUOUS_PREFILL", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_CACHE_ROPE, bool, true, ov::intel_npu::npuw::llm, cache_rope, "NPUW_LLM_CACHE_ROPE", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE, bool, false, ov::intel_npu::npuw::llm, enable_block_based_kv_cache, "NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE", LLM, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_STRING_ENUM_OPT(NPUW_LLM_PREFILL_MOE_HINT, ::intel_npu::npuw::llm::MoEHint, MoEHintOptionTraits, ov::intel_npu::npuw::llm, prefill_moe_hint, "NPUW_LLM_PREFILL_MOE_HINT", LLM, EXPOSED, CACHED, ALL)

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
@@ -178,6 +178,36 @@ void KVCacheBlockManager::clear_all() {
     release(0);
 }
 
+void KVCacheBlockManager::truncate_allocated(uint32_t keep_count) {
+    const auto allocated = get_allocated_blocks();
+    OPENVINO_ASSERT(keep_count <= allocated.size(),
+                    "KVCacheBlockManager: cannot truncate to ",
+                    keep_count,
+                    " blocks, only ",
+                    allocated.size(),
+                    " are allocated");
+
+    // Deallocate the suffix, keeping device tensors warm for quick reuse.
+    for (size_t i = keep_count; i < allocated.size(); ++i) {
+        auto& block = blocks_[allocated[i]];
+        block.is_allocated = false;
+        block.num_tokens = 0;
+    }
+
+    // Rebuild the free stack so the smallest free ID is allocated first. This keeps
+    // logical append order intact when the freed suffix IDs are reacquired.
+    std::stack<uint32_t> empty;
+    free_block_ids_.swap(empty);
+    for (uint32_t i = max_blocks_; i > 0; --i) {
+        if (!blocks_[i - 1].is_allocated) {
+            free_block_ids_.push(i - 1);
+        }
+    }
+
+    LOG_DEBUG("KVCacheBlockManager: truncated to " << keep_count << " blocks, " << (allocated.size() - keep_count)
+                                                   << " suffix block(s) freed");
+}
+
 void KVCacheBlockManager::validate_block_id(uint32_t block_id) const {
     if (block_id >= max_blocks_) {
         OPENVINO_THROW("KVCacheBlockManager: Invalid block ID ", block_id, " (valid range: 0-", max_blocks_ - 1, ")");

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
@@ -128,6 +128,20 @@ public:
     void clear_all();
 
     /**
+     * @brief Truncate the allocated block list to its first keep_count blocks.
+     *
+     * Used by continuous prefill to discard the suffix of a previous turn while
+     * retaining the shared prefix. Retained blocks keep their IDs, order, token
+     * counts and tensors. Suffix blocks are deallocated with token counts zeroed
+     * and their device tensors kept warm, and subsequent allocations return the
+     * freed IDs in ascending order so logical append order is preserved.
+     *
+     * @param keep_count Number of leading allocated blocks to retain. Must not
+     *                   exceed the current allocated count.
+     */
+    void truncate_allocated(uint32_t keep_count);
+
+    /**
      * @brief Get block size (tokens per block)
      */
     uint32_t get_block_size() const {

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.cpp
@@ -483,6 +483,106 @@ void LLMBlockKVCacheStrategy::on_generate_step_done(uint32_t input_tokens_len) {
     update_generate_bindings(tokens_before, tokens_after, m_req.m_kvcache_request);
 }
 
+namespace {
+
+// Plan for continuing a prefill on the block pool. Only records the retained block
+// count, since validation happens in the plan phase and blocks need no KV movement.
+struct BlockContinuationPlan final : ContinuedPrefillPlan {
+    uint32_t keep_blocks = 0u;
+};
+
+}  // anonymous namespace
+
+std::unique_ptr<ContinuedPrefillPlan> LLMBlockKVCacheStrategy::plan_continued_prefill(uint32_t keep,
+                                                                                      uint32_t delta_len) {
+    OPENVINO_ASSERT(!m_kv_cache_block_managers.empty(), "Continued prefill: block managers are not initialized.");
+    OPENVINO_ASSERT(m_block_size > 0u && keep % m_block_size == 0u,
+                    "Continued prefill: keep (",
+                    keep,
+                    ") must be a multiple of the block size (",
+                    m_block_size,
+                    ").");
+    const auto& kvcache_desc = m_req.m_npuw_llm_compiled_model->m_kvcache_desc;
+    OPENVINO_ASSERT(keep + delta_len <= kvcache_desc.max_prompt_size,
+                    "Continued prefill: keep plus delta exceeds the maximum prompt size.");
+
+    const uint32_t keep_blocks = keep / m_block_size;
+
+    // Validate every manager in every layer before changing any of them. Each retained
+    // block must exist and be completely full, since a partially filled block would
+    // make the continuation prefix incoherent.
+    for (const auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        auto validate = [&](KVCacheBlockManager* manager, const char* kv_type) {
+            if (!manager) {
+                return;
+            }
+            const auto allocated = manager->get_allocated_blocks();
+            OPENVINO_ASSERT(allocated.size() >= keep_blocks,
+                            "Continued prefill: layer ",
+                            layer_idx,
+                            " ",
+                            kv_type,
+                            " has only ",
+                            allocated.size(),
+                            " allocated blocks, ",
+                            keep_blocks,
+                            " are required.");
+            for (uint32_t i = 0; i < keep_blocks; ++i) {
+                OPENVINO_ASSERT(manager->get_block_tokens(allocated[i]) == m_block_size,
+                                "Continued prefill: retained block ",
+                                i,
+                                " of layer ",
+                                layer_idx,
+                                " ",
+                                kv_type,
+                                " is not full.");
+            }
+        };
+        validate(layer_managers.key_manager.get(), "key");
+        validate(layer_managers.value_manager.get(), "value");
+    }
+
+    auto plan = std::make_unique<BlockContinuationPlan>();
+    plan->keep_blocks = keep_blocks;
+    return plan;
+}
+
+void LLMBlockKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan& base_plan) {
+    auto& plan = static_cast<BlockContinuationPlan&>(base_plan);
+    LOG_DEBUG("Continued prefill: truncating block pool to " << plan.keep_blocks << " blocks per layer.");
+
+    // Drop prefill output redirections left over from a previous zero-copy chunk so
+    // the model does not write into a block we are about to release.
+    if (m_zero_copy_last_chunk) {
+        restore_prefill_output_buffers(m_req.m_prefill_request, m_req.m_prefill_out_ports);
+        m_zero_copy_last_chunk = false;
+    }
+
+    // Release every input binding that may reference a suffix block. Retained blocks
+    // are rebound by load_past_kv_blocks_to_prefill() at the next chunk begin, and by
+    // on_generate_kv_init() for the generate phase. Dummies go to all variants because
+    // any of them may have been bound during earlier turns.
+    set_dummy_tensors_to_request(m_req.m_prefill_request, m_prefill_classified_in_ports, m_dummy_tensors);
+    for (const auto& generate_request : m_req.m_generate_requests) {
+        set_dummy_tensors_to_request(generate_request, m_gen_classified_in_ports.at(generate_request), m_dummy_tensors);
+    }
+    for (const auto& base_req : m_req.m_generate_base_requests) {
+        base_req->propagate_params_to_subrequests();
+    }
+
+    // Truncate the managers. Stale bytes beyond the retained prefix are inert once no
+    // metadata or binding exposes them, and on_reset() must not run here because it
+    // would release the retained block tensors back to the allocator.
+    for (auto& [layer_idx, layer_managers] : m_kv_cache_block_managers) {
+        if (layer_managers.key_manager) {
+            layer_managers.key_manager->truncate_allocated(plan.keep_blocks);
+        }
+        if (layer_managers.value_manager) {
+            layer_managers.value_manager->truncate_allocated(plan.keep_blocks);
+        }
+    }
+}
+
 // ============================================================================
 // Private: prefill path primitives
 // ============================================================================

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.hpp
@@ -120,6 +120,12 @@ public:
                                     const PortsMap& new_in_ports) override;
     void on_generate_step_done(uint32_t input_tokens_len) override;
 
+    // Continuous prefill. Blocks need no KV movement, so the plan validates that the
+    // retained prefix is fully covered by allocated blocks and the apply truncates the
+    // block pool to it, releasing all suffix bindings.
+    std::unique_ptr<ContinuedPrefillPlan> plan_continued_prefill(uint32_t keep, uint32_t delta_len) override;
+    void apply_continued_prefill(ContinuedPrefillPlan& plan) override;
+
 private:
     // -------------------------------------------------------------------------
     // Private helper structs (used only during initialize())

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -7,6 +7,7 @@
 #include "embedding/prepare_embedding_model.hpp"
 #include "embedding/redirect_new_kv_to_output.hpp"
 #include "embedding/remove_empty_kv_inputs.hpp"
+#include "infer_request_utils.hpp"
 #include "llm_compiled_model_utils.hpp"
 #include "llm_infer_request.hpp"
 #include "logging.hpp"
@@ -801,6 +802,21 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
         }
     }
 
+    // Continuous prefill is opt-in and mutually exclusive with the hash prefix cache.
+    // The prefix cache restore step unconditionally overwrites num_stored_tokens and
+    // its helper hashes absolute token positions of a full prompt. Neither holds under
+    // the delta-input contract, so the combination fails compilation instead of
+    // silently misbehaving, mirroring the block-KV and prefix-caching exclusion.
+    m_enable_continuous_prefill = m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_CONTINUOUS_PREFILL>();
+    if (m_enable_continuous_prefill) {
+        OPENVINO_ASSERT(!m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_PREFIX_CACHING>(),
+                        "NPUW_LLM_ENABLE_CONTINUOUS_PREFILL and NPUW_LLM_ENABLE_PREFIX_CACHING "
+                        "cannot be enabled simultaneously. Continuous prefill receives delta-only "
+                        "inputs which the hash prefix cache cannot process. "
+                        "Please disable one of the two options.");
+        LOG_INFO("Continuous prefill is enabled");
+    }
+
     LOG_VERB("Enabled prefill chunking: " << m_use_chunk_prefill);
     LOG_VERB("Prefill chunk size: " << m_prefill_chunk_size);
     LOG_VERB("Maximum prompt length: " << max_prompt_len);
@@ -1547,6 +1563,8 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
         // Deserialize config
         stream & compiled->m_cfg;
         compiled->implement_properties();
+        // Not serialized. Recomputed from the deserialized config so older blobs stay loadable.
+        compiled->m_enable_continuous_prefill = compiled->m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_CONTINUOUS_PREFILL>();
 
         // Deserialize KV cache model variants
         stream & compiled->m_kvcache_sizes;
@@ -1604,11 +1622,58 @@ void ov::npuw::LLMCompiledModel::set_property(const ov::AnyMap& properties) {
     OPENVINO_NOT_IMPLEMENTED;
 }
 
+bool ov::npuw::LLMCompiledModel::compute_continuous_prefill_supported() const {
+    // Static exclusions for continuous prefill. Every condition here is knowable at
+    // compile or import time. Per-turn limits like capacity, alignment and the
+    // watermark are applied dynamically by the propose/grant channel instead.
+    if (!m_enable_continuous_prefill) {
+        return false;  // opt-in feature
+    }
+    if (!m_use_chunk_prefill) {
+        return false;  // whole (STATIC) prefill has no continuation path
+    }
+    if (m_is_whisper || m_is_embedding || m_is_eagle) {
+        return false;  // out of scope pipelines
+    }
+    if (m_longrope_context_limit > 0u) {
+        return false;  // LongRoPE threshold can be crossed mid-generation
+    }
+    if (!m_prefill_compiled) {
+        return false;  // capability requires a compiled prefill model
+    }
+    const auto& prefill_inputs = m_prefill_compiled->inputs();
+    for (const auto& input : prefill_inputs) {
+        const auto& name = input.get_any_name();
+        if (ov::npuw::util::starts_with_past_lincache(name)) {
+            return false;  // linear/hybrid state has no generate->prefill path
+        }
+        if (ov::npuw::util::matchLoRAMatMulAString(name) || ov::npuw::util::matchLoRAMatMulBString(name) ||
+            ov::npuw::util::matchLoRAMatMulAlphaString(name)) {
+            return false;  // adapter change is only detected after the caller sliced
+        }
+        if (name == ov::npuw::LLMInferRequest::layer_names::inputs_embeds) {
+            return false;  // VLM is out of scope in v1
+        }
+    }
+    // Position ids must form a single linear sequence: 3-D M-RoPE cannot be validated
+    // as a contiguous continuation and is excluded statically.
+    const auto position_ids_port =
+        ov::npuw::util::find_port_by_name(prefill_inputs, ov::npuw::LLMInferRequest::layer_names::position_ids);
+    if (!position_ids_port.has_value() || position_ids_port.value().get_partial_shape().size() >= 3u) {
+        return false;
+    }
+    return true;
+}
+
 ov::Any ov::npuw::LLMCompiledModel::get_property(const std::string& name) const {
     OPENVINO_SUPPRESS_DEPRECATED_START
     if (name == ov::intel_npu::npuw::llm::prefill_config.name() ||
         name == ov::intel_npu::npuw::llm::generate_config.name()) {
         OPENVINO_THROW(name, " is write-only option!");
+    }
+
+    if (name == continuous_prefill_supported_name) {
+        return compute_continuous_prefill_supported();
     }
 
     auto&& configIterator = m_prop_to_opt.find(name);
@@ -1665,6 +1730,7 @@ void ov::npuw::LLMCompiledModel::implement_properties() {
                           BIND(npuw::llm::optimize_fp8, NPUW_LLM_OPTIMIZE_FP8, get),
                           BIND(npuw::llm::cache_rope, NPUW_LLM_CACHE_ROPE, get),
                           BIND(npuw::llm::enable_block_based_kv_cache, NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE, get),
+                          BIND(npuw::llm::enable_continuous_prefill, NPUW_LLM_ENABLE_CONTINUOUS_PREFILL, get),
                           BIND(npuw::llm::prefill_moe_hint, NPUW_LLM_PREFILL_MOE_HINT, get),
                           BIND(npuw::llm::generate_moe_hint, NPUW_LLM_GENERATE_MOE_HINT, get),
                           BIND(npuw::llm::generate_pyramid, NPUW_LLM_GENERATE_PYRAMID, get),

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -32,6 +32,11 @@ class LLMCompiledModel : public ov::npuw::ICompiledModel {
 public:
     static constexpr const char* output_embeds = "npuw_output_embed";
 
+    // Read-only compiled-model property advertising continuous-prefill support.
+    // GenAI probes this by name; it must NOT be inferred from the presence of
+    // npuw_stored_tokens_state in query_state(), which every plugin build publishes.
+    static constexpr const char* continuous_prefill_supported_name = "NPUW_LLM_CONTINUOUS_PREFILL_SUPPORTED";
+
     static constexpr uint32_t whisper_batch_dim = 0u;
     static constexpr uint32_t whisper_seq_len_dim = 2u;
     static constexpr uint32_t whisper_max_prompt_size = 4u;
@@ -133,6 +138,13 @@ private:
     uint64_t m_prefix_caching_block_size = 0;
     uint64_t m_prefix_caching_max_num_blocks = 0;
     uint64_t m_longrope_context_limit = 0;
+
+    // Continuous prefill support. Opted in via NPUW_LLM_ENABLE_CONTINUOUS_PREFILL and
+    // mutually exclusive with hash prefix caching, which fails compilation.
+    bool m_enable_continuous_prefill = false;
+    // Computes the NPUW_LLM_CONTINUOUS_PREFILL_SUPPORTED read-only property from
+    // compiled model state. Not serialized, recomputed identically after import.
+    bool compute_continuous_prefill_supported() const;
 
     // Friend declarations for PrefixCachingHelper to access protected members
     friend class PrefixCachingHelper;

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_continuation.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_continuation.hpp
@@ -1,0 +1,236 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+
+#include "logging.hpp"
+#include "openvino/core/except.hpp"
+
+namespace ov {
+namespace npuw {
+
+/**
+ * @brief Transaction coordinator for continuous prefill.
+ *
+ * Owns the propose/grant negotiation and the request-level transaction state
+ * machine. The caller proposes a common token prefix through the
+ * npuw_stored_tokens_state variable state, the coordinator clamps it by every
+ * limit the plugin owns and grants an effective keep K. A granted keep is a
+ * command, so the next inference must be the matching delta-only prefill.
+ *
+ * While IDLE the state reports the committed live token count and accepts one
+ * proposal, a reset, or ordinary inference. A positive grant moves to PENDING,
+ * a zero grant or an explicit reset moves to RESET_PENDING. ACTIVE covers the
+ * accepted inference itself. Any failure after mutation started poisons the
+ * request as RESET_REQUIRED, where only reset() is accepted.
+ *
+ * The keep rule is K = C * floor(min(K_common, K_max, W) / C), where C is the
+ * prefill chunk size, K_max is how many past tokens the chunked prefill can
+ * represent, and W is the prefill-produced watermark. The rule is evaluated
+ * here at propose time and nowhere else.
+ *
+ * Note for callers of the variable state: a write is not idempotent. You write
+ * X and read back Y <= X, and must always slice at the granted value.
+ */
+class ContinuationCoordinator {
+public:
+    enum class Stage : uint8_t {
+        IDLE,
+        PENDING,
+        RESET_PENDING,
+        ACTIVE,
+        RESET_REQUIRED,
+    };
+
+    struct Command {
+        enum class Kind : uint8_t { NONE, KEEP, RESET };
+        Kind kind = Kind::NONE;
+        uint32_t keep_value = 0u;
+
+        bool is_keep() const {
+            return kind == Kind::KEEP;
+        }
+        bool is_reset() const {
+            return kind == Kind::RESET;
+        }
+    };
+
+    ContinuationCoordinator() = default;
+
+    void enable(uint32_t chunk_size, uint32_t max_prompt_len) {
+        OPENVINO_ASSERT(chunk_size > 0u && max_prompt_len > chunk_size,
+                        "Continuous prefill requires 0 < chunk_size < max_prompt_len, got chunk_size=",
+                        chunk_size,
+                        " max_prompt_len=",
+                        max_prompt_len);
+        m_enabled = true;
+        m_chunk_size = chunk_size;
+        m_k_max = max_prompt_len - chunk_size;
+    }
+
+    bool enabled() const {
+        return m_enabled;
+    }
+
+    Stage stage() const {
+        return m_stage;
+    }
+
+    // Variable-state side, driven by StoredTokensState.
+
+    // A proposal from set_state(N). Validates, applies the keep rule, stores the
+    // result as the pending command, and returns the granted keep.
+    uint32_t propose(int64_t k_common) {
+        OPENVINO_ASSERT(m_enabled, "Continuous prefill is not enabled for this request.");
+        OPENVINO_ASSERT(m_stage == Stage::IDLE,
+                        "npuw_stored_tokens_state: a proposal is accepted only while the request is idle; "
+                        "current state does not accept a new proposal. Complete or reset() the pending "
+                        "operation first.");
+        OPENVINO_ASSERT(k_common >= 0, "npuw_stored_tokens_state: proposed prefix must be non-negative.");
+        // Growth is an error. Validating against total KV capacity instead would let
+        // a caller present uninitialised memory as a valid prefix.
+        OPENVINO_ASSERT(static_cast<uint64_t>(k_common) <= m_live_tokens,
+                        "npuw_stored_tokens_state: proposed prefix (",
+                        k_common,
+                        ") exceeds the live token count (",
+                        m_live_tokens,
+                        "). Growth is an error.");
+
+        const uint32_t clamped = std::min({static_cast<uint32_t>(k_common), m_k_max, m_watermark});
+        const uint32_t granted = m_chunk_size * (clamped / m_chunk_size);
+
+        if (granted > 0u) {
+            m_pending = Command{Command::Kind::KEEP, granted};
+            m_stage = Stage::PENDING;
+        } else {
+            // Preserving zero tokens is a full reset, not a continuation with an
+            // empty prefix.
+            m_pending = Command{Command::Kind::RESET, 0u};
+            m_stage = Stage::RESET_PENDING;
+        }
+        LOG_DEBUG("Continuous prefill: proposed " << k_common << ", granted " << granted << " (K_max=" << m_k_max
+                                                  << ", W=" << m_watermark << ", C=" << m_chunk_size << ")");
+        return granted;
+    }
+
+    // The grant returned by get_state(), meaning the prefix the plugin will honour.
+    int64_t query() const {
+        switch (m_stage) {
+        case Stage::IDLE:
+            return static_cast<int64_t>(m_live_tokens);
+        case Stage::PENDING:
+            return static_cast<int64_t>(m_pending ? m_pending->keep_value : 0u);
+        case Stage::ACTIVE:
+            // Not concurrently observable by design; report the value the accepted
+            // operation is honouring.
+            return static_cast<int64_t>(m_pending && m_pending->is_keep() ? m_pending->keep_value : 0u);
+        case Stage::RESET_PENDING:
+        case Stage::RESET_REQUIRED:
+            return 0;
+        }
+        return 0;
+    }
+
+    // reset() is a control operation rather than a proposal. It discards any pending
+    // keep and enters RESET_PENDING, idempotently. The physical reset happens on the
+    // next validated full prefill.
+    void request_reset() {
+        OPENVINO_ASSERT(m_stage != Stage::ACTIVE,
+                        "npuw_stored_tokens_state: reset() must not be called while an inference is executing.");
+        m_pending = Command{Command::Kind::RESET, 0u};
+        m_stage = Stage::RESET_PENDING;
+    }
+
+    // Infer-request side.
+
+    // What the next inference must be. Throws if the request is poisoned.
+    Command command() const {
+        if (!m_enabled) {
+            return Command{};
+        }
+        OPENVINO_ASSERT(m_stage != Stage::RESET_REQUIRED,
+                        "Continuous prefill: the request is poisoned by a previous failure. "
+                        "Call reset() on npuw_stored_tokens_state and re-send the full history.");
+        switch (m_stage) {
+        case Stage::PENDING:
+        case Stage::RESET_PENDING:
+            return *m_pending;
+        default:
+            return Command{};
+        }
+    }
+
+    // Preflight failed before any mutation. Consume the command and return to IDLE
+    // with the last committed counters intact.
+    void abort_preflight() {
+        m_pending.reset();
+        m_stage = Stage::IDLE;
+    }
+
+    // Preflight passed and live state mutation begins. Any exception from this
+    // point must go through fail_active().
+    void begin_active() {
+        OPENVINO_ASSERT(m_stage == Stage::PENDING || m_stage == Stage::RESET_PENDING,
+                        "Continuous prefill: begin_active() without a pending command.");
+        m_stage = Stage::ACTIVE;
+    }
+
+    // An exception after begin_active() poisons the request. No new count is
+    // published and only reset() can start recovery.
+    void fail_active() {
+        m_pending.reset();
+        m_stage = Stage::RESET_REQUIRED;
+    }
+
+    // Publish a committed prefill, full or continued. The new live count is also
+    // the new prefill-produced watermark.
+    void commit_prefill(uint32_t live_tokens) {
+        m_live_tokens = live_tokens;
+        m_watermark = live_tokens;
+        m_pending.reset();
+        m_stage = Stage::IDLE;
+    }
+
+    // Publish the result of an ordinary generate step. Generate-produced KV must
+    // not advance the watermark; a speculative-decoding trim may even lower the
+    // live count below it, in which case the watermark is clamped down.
+    void publish_generate(uint32_t live_tokens) {
+        m_live_tokens = live_tokens;
+        m_watermark = std::min(m_watermark, live_tokens);
+    }
+
+    uint32_t live_tokens() const {
+        return m_live_tokens;
+    }
+
+    uint32_t watermark() const {
+        return m_watermark;
+    }
+
+    uint32_t chunk_size() const {
+        return m_chunk_size;
+    }
+
+    uint32_t k_max() const {
+        return m_k_max;
+    }
+
+private:
+    bool m_enabled = false;
+    Stage m_stage = Stage::IDLE;
+    // The optional keeps "no command" and "a command to keep 0" distinct, so
+    // publishing a live count never re-arms a pending command.
+    std::optional<Command> m_pending;
+    uint32_t m_live_tokens = 0u;
+    uint32_t m_watermark = 0u;
+    uint32_t m_chunk_size = 0u;
+    uint32_t m_k_max = 0u;
+};
+
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
@@ -4,8 +4,12 @@
 
 #include "llm_continuous_kvcache_strategy.hpp"
 
+#include <regex>
+#include <unordered_map>
+
 #include "infer_request_utils.hpp"
 #include "llm_infer_request.hpp"
+#include "logging.hpp"
 #include "util.hpp"
 
 namespace ov {
@@ -146,6 +150,161 @@ void LLMContinuousKVCacheStrategy::on_generate_step_done(uint32_t input_tokens_l
                              m_req.m_kvcache_out_ports,
                              input_tokens_len,
                              v_transposed);
+}
+
+namespace {
+
+// Plan for continuing a prefill on the contiguous buffer. The live KV prefix can sit
+// in two places. If generation ran, the generate model's past inputs hold the whole
+// history in the generate layout and must be repacked into the prefill layout. If the
+// request finished straight from the prompt logits, the decode loop never executed,
+// so the prefix is split between the prefill past inputs and the last chunk still
+// sitting in the prefill present outputs.
+struct ContinuousContinuationPlan final : ContinuedPrefillPlan {
+    uint32_t keep = 0u;
+    bool source_is_generate = false;
+    // Used when the source is the prefill request itself.
+    uint32_t past_tokens = 0u;
+    uint32_t present_tokens = 0u;
+    // Staging buffers for the alias-safe repack, one per KV input that needs it.
+    std::unordered_map<std::string, ov::SoPtr<ov::ITensor>> temps;
+};
+
+}  // anonymous namespace
+
+std::unique_ptr<ContinuedPrefillPlan> LLMContinuousKVCacheStrategy::plan_continued_prefill(uint32_t keep,
+                                                                                           uint32_t delta_len) {
+    namespace uu = ov::npuw::util;
+    const auto& compiled = m_req.m_npuw_llm_compiled_model;
+    const auto& kvcache_desc = compiled->m_kvcache_desc;
+
+    OPENVINO_ASSERT(compiled->m_use_chunk_prefill, "Continued prefill requires chunked prefill.");
+    OPENVINO_ASSERT(keep > 0u && keep + delta_len <= kvcache_desc.max_prompt_size,
+                    "Continued prefill: keep (",
+                    keep,
+                    ") plus delta (",
+                    delta_len,
+                    ") must fit into the maximum prompt size (",
+                    kvcache_desc.max_prompt_size,
+                    ").");
+    OPENVINO_ASSERT(keep <= kvcache_desc.max_prompt_size - compiled->m_prefill_chunk_size,
+                    "Continued prefill: keep exceeds the prefill past KV view capacity.");
+
+    auto plan = std::make_unique<ContinuousContinuationPlan>();
+    plan->keep = keep;
+    plan->source_is_generate = m_req.m_generate_initialized;
+
+    if (plan->source_is_generate) {
+        // Validate every layer before touching any of them and pre-allocate the staging
+        // buffers where the generate and prefill views share backing memory.
+        for (const auto& name : m_req.m_kvcache_past_names) {
+            OPENVINO_ASSERT(m_req.m_kvcache_in_ports.count(name) && m_req.m_prefill_in_ports.count(name),
+                            "Continued prefill: KV input ",
+                            name,
+                            " is missing from the generate or prefill port map.");
+            auto src = m_req.m_kvcache_request->get_tensor(m_req.m_kvcache_in_ports.at(name));
+            auto dst = m_req.m_prefill_request->get_tensor(m_req.m_prefill_in_ports.at(name));
+            OPENVINO_ASSERT(src->get_element_type() == dst->get_element_type(),
+                            "Continued prefill: element type mismatch for ",
+                            name);
+
+            const auto present_name =
+                std::regex_replace(name, std::regex(LLMInferRequest::layer_names::past_key_values), "present");
+            const bool is_value = present_name.find("value") != std::string::npos;
+            const uint32_t src_dim = (is_value && kvcache_desc.v_tensors_transposed_gen) ? 3u : kvcache_desc.dim;
+            const uint32_t dst_dim = (is_value && kvcache_desc.v_tensors_transposed_pre) ? 3u : kvcache_desc.dim;
+            OPENVINO_ASSERT(src->get_shape()[src_dim] >= keep && dst->get_shape()[dst_dim] >= keep,
+                            "Continued prefill: KV extent of ",
+                            name,
+                            " cannot cover the granted keep.");
+
+            // Shared backing memory is an aliasing hazard, not layout compatibility.
+            // Identical bytes are addressed with different per-head strides whenever the
+            // sequence extents differ, so the repack must stage through a temporary.
+            const bool aliased = src->data() == dst->data();
+            const bool same_layout = aliased && src->get_shape() == dst->get_shape() && src_dim == dst_dim;
+            if (aliased && !same_layout) {
+                auto src_slice = uu::make_tensor_slice(src, src_dim, 0u, keep);
+                plan->temps[name] = uu::allocMem(src->get_element_type(), src_slice->get_shape(), "CPU", nullptr);
+            }
+        }
+    } else {
+        // The prompt-phase finish case. The prefill past inputs hold everything except
+        // the last chunk, which is still in the present outputs.
+        const uint32_t live = kvcache_desc.num_stored_tokens;
+        plan->present_tokens = static_cast<uint32_t>(m_req.m_tokens_in_present_chunk);
+        OPENVINO_ASSERT(live >= plan->present_tokens, "Continued prefill: inconsistent stored token accounting.");
+        plan->past_tokens = live - plan->present_tokens;
+        OPENVINO_ASSERT(keep <= live, "Continued prefill: keep exceeds the live token count.");
+        for (const auto& name : m_req.m_kvcache_past_names) {
+            const auto present_name =
+                std::regex_replace(name, std::regex(LLMInferRequest::layer_names::past_key_values), "present");
+            OPENVINO_ASSERT(m_req.m_prefill_in_ports.count(name) && m_req.m_prefill_out_ports.count(present_name),
+                            "Continued prefill: prefill ports are missing for ",
+                            name);
+        }
+    }
+    return plan;
+}
+
+void LLMContinuousKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan& base_plan) {
+    namespace uu = ov::npuw::util;
+    auto& plan = static_cast<ContinuousContinuationPlan&>(base_plan);
+    const auto& kvcache_desc = m_req.m_npuw_llm_compiled_model->m_kvcache_desc;
+    const uint32_t keep = plan.keep;
+
+    if (plan.source_is_generate) {
+        LOG_DEBUG("Continued prefill: repacking " << keep << " tokens from generate past KV into prefill layout.");
+        for (const auto& name : m_req.m_kvcache_past_names) {
+            auto src = m_req.m_kvcache_request->get_tensor(m_req.m_kvcache_in_ports.at(name));
+            auto dst = m_req.m_prefill_request->get_tensor(m_req.m_prefill_in_ports.at(name));
+
+            const auto present_name =
+                std::regex_replace(name, std::regex(LLMInferRequest::layer_names::past_key_values), "present");
+            const bool is_value = present_name.find("value") != std::string::npos;
+            const uint32_t src_dim = (is_value && kvcache_desc.v_tensors_transposed_gen) ? 3u : kvcache_desc.dim;
+            const uint32_t dst_dim = (is_value && kvcache_desc.v_tensors_transposed_pre) ? 3u : kvcache_desc.dim;
+
+            const bool aliased = src->data() == dst->data();
+            const bool same_layout = aliased && src->get_shape() == dst->get_shape() && src_dim == dst_dim;
+            if (same_layout) {
+                // The bytes already sit where the prefill will read them.
+                continue;
+            }
+
+            auto src_slice = uu::make_tensor_slice(src, src_dim, 0u, keep);
+            auto dst_slice = uu::make_tensor_slice(dst, dst_dim, 0u, keep);
+            auto temp_it = plan.temps.find(name);
+            if (temp_it != plan.temps.end()) {
+                src_slice->copy_to(temp_it->second._ptr);
+                uu::copy_tensor_by_dim(temp_it->second, dst_slice, src_dim, dst_dim);
+            } else {
+                uu::copy_tensor_by_dim(src_slice, dst_slice, src_dim, dst_dim);
+            }
+        }
+    } else if (keep > plan.past_tokens) {
+        // Persist the final present chunk into the past inputs before the next prefill
+        // overwrites it. Repacking from the generate request here would copy stale data
+        // over a valid prefix.
+        LOG_DEBUG("Continued prefill: persisting " << plan.present_tokens
+                                                   << " present-chunk tokens into prefill past KV.");
+        const auto chunk = static_cast<uint32_t>(m_req.m_npuw_llm_compiled_model->m_prefill_chunk_size);
+        for (const auto& name : m_req.m_kvcache_past_names) {
+            const auto present_name =
+                std::regex_replace(name, std::regex(LLMInferRequest::layer_names::past_key_values), "present");
+            const bool is_value = present_name.find("value") != std::string::npos;
+            const uint32_t kv_dim = (is_value && kvcache_desc.v_tensors_transposed_pre) ? 3u : kvcache_desc.dim;
+
+            auto present = m_req.m_prefill_request->get_tensor(m_req.m_prefill_out_ports.at(present_name));
+            auto past = m_req.m_prefill_request->get_tensor(m_req.m_prefill_in_ports.at(name));
+
+            auto src_slice = uu::make_tensor_slice(present, kv_dim, chunk - plan.present_tokens, chunk);
+            auto dst_slice =
+                uu::make_tensor_slice(past, kv_dim, plan.past_tokens, plan.past_tokens + plan.present_tokens);
+            uu::copy_tensor_by_dim(src_slice, dst_slice, kv_dim, kv_dim);
+        }
+    }
+    // Otherwise the prefill past inputs already hold the whole preserved prefix.
 }
 
 }  // namespace npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
@@ -4,6 +4,8 @@
 
 #include "llm_continuous_kvcache_strategy.hpp"
 
+#include <atomic>
+#include <chrono>
 #include <regex>
 #include <unordered_map>
 
@@ -228,6 +230,14 @@ std::unique_ptr<ContinuedPrefillPlan> LLMContinuousKVCacheStrategy::plan_continu
                 auto src_slice = uu::make_tensor_slice(src, src_dim, 0u, keep);
                 plan->temps[name] = uu::allocMem(src->get_element_type(), src_slice->get_shape(), "CPU", nullptr);
             }
+            if (name == m_req.m_kvcache_past_names.front()) {
+                // One line of layout diagnosis per continuation so slow copy paths can be
+                // identified from the log alone.
+                LOG_INFO("Continued prefill layout: src "
+                         << src->get_shape() << " dim " << src_dim << ", dst " << dst->get_shape() << " dim " << dst_dim
+                         << ", aliased " << aliased << ", same_layout " << same_layout << ", v_trans gen/pre "
+                         << kvcache_desc.v_tensors_transposed_gen << "/" << kvcache_desc.v_tensors_transposed_pre);
+            }
         }
     } else {
         // The prompt-phase finish case. The prefill past inputs hold everything except
@@ -256,6 +266,9 @@ void LLMContinuousKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan&
 
     if (plan.source_is_generate) {
         LOG_DEBUG("Continued prefill: repacking " << keep << " tokens from generate past KV into prefill layout.");
+        const auto t_start = std::chrono::steady_clock::now();
+        std::atomic<uint64_t> bytes_total{0u};
+        std::atomic<uint32_t> n_skipped{0u}, n_staged{0u}, n_permuted{0u}, n_direct{0u};
         // Every tensor is independent, so repack them in parallel like copy_kvcache does.
         // The plan's temp map is only read here.
         ov::parallel_for(m_req.m_kvcache_past_names.size(), [&](size_t idx) {
@@ -273,19 +286,34 @@ void LLMContinuousKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan&
             const bool same_layout = aliased && src->get_shape() == dst->get_shape() && src_dim == dst_dim;
             if (same_layout) {
                 // The bytes already sit where the prefill will read them.
+                n_skipped.fetch_add(1u, std::memory_order_relaxed);
                 return;
             }
 
             auto src_slice = uu::make_tensor_slice(src, src_dim, 0u, keep);
             auto dst_slice = uu::make_tensor_slice(dst, dst_dim, 0u, keep);
+            bytes_total.fetch_add(src_slice->get_byte_size(), std::memory_order_relaxed);
+            if (src_dim != dst_dim) {
+                n_permuted.fetch_add(1u, std::memory_order_relaxed);
+            } else {
+                n_direct.fetch_add(1u, std::memory_order_relaxed);
+            }
             auto temp_it = plan.temps.find(name);
             if (temp_it != plan.temps.end()) {
+                n_staged.fetch_add(1u, std::memory_order_relaxed);
                 src_slice->copy_to(temp_it->second._ptr);
                 uu::copy_tensor_by_dim(temp_it->second, dst_slice, src_dim, dst_dim);
             } else {
                 uu::copy_tensor_by_dim(src_slice, dst_slice, src_dim, dst_dim);
             }
         });
+        const auto t_ms =
+            std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t_start).count() /
+            1000.0;
+        LOG_INFO("Continued prefill repack: " << keep << " tokens, " << (bytes_total.load() / 1024) << " KiB in "
+                                              << t_ms << " ms (tensors: " << n_direct.load() << " direct, "
+                                              << n_permuted.load() << " permuted, " << n_staged.load() << " staged, "
+                                              << n_skipped.load() << " skipped)");
     } else if (keep > plan.past_tokens) {
         // Persist the final present chunk into the past inputs before the next prefill
         // overwrites it. Repacking from the generate request here would copy stale data

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
@@ -10,6 +10,7 @@
 #include "infer_request_utils.hpp"
 #include "llm_infer_request.hpp"
 #include "logging.hpp"
+#include "openvino/core/parallel.hpp"
 #include "util.hpp"
 
 namespace ov {
@@ -255,7 +256,10 @@ void LLMContinuousKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan&
 
     if (plan.source_is_generate) {
         LOG_DEBUG("Continued prefill: repacking " << keep << " tokens from generate past KV into prefill layout.");
-        for (const auto& name : m_req.m_kvcache_past_names) {
+        // Every tensor is independent, so repack them in parallel like copy_kvcache does.
+        // The plan's temp map is only read here.
+        ov::parallel_for(m_req.m_kvcache_past_names.size(), [&](size_t idx) {
+            const auto& name = m_req.m_kvcache_past_names[idx];
             auto src = m_req.m_kvcache_request->get_tensor(m_req.m_kvcache_in_ports.at(name));
             auto dst = m_req.m_prefill_request->get_tensor(m_req.m_prefill_in_ports.at(name));
 
@@ -269,7 +273,7 @@ void LLMContinuousKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan&
             const bool same_layout = aliased && src->get_shape() == dst->get_shape() && src_dim == dst_dim;
             if (same_layout) {
                 // The bytes already sit where the prefill will read them.
-                continue;
+                return;
             }
 
             auto src_slice = uu::make_tensor_slice(src, src_dim, 0u, keep);
@@ -281,7 +285,7 @@ void LLMContinuousKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan&
             } else {
                 uu::copy_tensor_by_dim(src_slice, dst_slice, src_dim, dst_dim);
             }
-        }
+        });
     } else if (keep > plan.past_tokens) {
         // Persist the final present chunk into the past inputs before the next prefill
         // overwrites it. Repacking from the generate request here would copy stale data
@@ -289,7 +293,8 @@ void LLMContinuousKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan&
         LOG_DEBUG("Continued prefill: persisting " << plan.present_tokens
                                                    << " present-chunk tokens into prefill past KV.");
         const auto chunk = static_cast<uint32_t>(m_req.m_npuw_llm_compiled_model->m_prefill_chunk_size);
-        for (const auto& name : m_req.m_kvcache_past_names) {
+        ov::parallel_for(m_req.m_kvcache_past_names.size(), [&](size_t idx) {
+            const auto& name = m_req.m_kvcache_past_names[idx];
             const auto present_name =
                 std::regex_replace(name, std::regex(LLMInferRequest::layer_names::past_key_values), "present");
             const bool is_value = present_name.find("value") != std::string::npos;
@@ -302,7 +307,7 @@ void LLMContinuousKVCacheStrategy::apply_continued_prefill(ContinuedPrefillPlan&
             auto dst_slice =
                 uu::make_tensor_slice(past, kv_dim, plan.past_tokens, plan.past_tokens + plan.present_tokens);
             uu::copy_tensor_by_dim(src_slice, dst_slice, kv_dim, kv_dim);
-        }
+        });
     }
     // Otherwise the prefill past inputs already hold the whole preserved prefix.
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.hpp
@@ -35,6 +35,11 @@ public:
                                     const std::shared_ptr<ov::IAsyncInferRequest>& new_req,
                                     const PortsMap& new_in_ports) override;
     void on_generate_step_done(uint32_t input_tokens_len) override;
+
+    // Continuous prefill. Repack the preserved KV prefix [0, keep) into the prefill
+    // model's past KV layout so the chunked prefill can resume from `keep`.
+    std::unique_ptr<ContinuedPrefillPlan> plan_continued_prefill(uint32_t keep, uint32_t delta_len) override;
+    void apply_continued_prefill(ContinuedPrefillPlan& plan) override;
 };
 
 }  // namespace npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -307,6 +307,16 @@ ov::npuw::LLMInferRequest::LLMInferRequest(const std::shared_ptr<ov::npuw::LLMCo
     m_stored_tokens_state = std::make_shared<ov::npuw::StoredTokensState>();
     init_lora_states();
 
+    // Wire the continuous prefill negotiation channel when the compiled model
+    // reports the capability. Without it the stored tokens state keeps its
+    // legacy contract untouched.
+    if (compiled_model->compute_continuous_prefill_supported()) {
+        m_continuation.enable(static_cast<uint32_t>(compiled_model->m_prefill_chunk_size),
+                              compiled_model->m_kvcache_desc.max_prompt_size);
+        m_stored_tokens_state->attach_continuation(&m_continuation);
+        LOG_INFO("Continuous prefill is active for this infer request.");
+    }
+
     m_eagle3_ext.initialize(m_npuw_llm_compiled_model->m_is_eagle, m_prefill_in_ports, m_prefill_out_ports);
 
     // Instantiate the KV cache strategy and run one-time initialization.
@@ -941,8 +951,11 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
                         current_prompts_len,
                         attn_mask_in_tensor->data<int64_t>() + attn_mask_in_tensor->get_size() - current_prompts_len);
 
+            // Caller tensors hold only the delta during a continued prefill, so they are
+            // indexed relative to the absolute base the continuation started at. The
+            // base is zero for an ordinary prefill, keeping this the absolute position.
             auto current_prefill_bytes = current_prompts_len * input_ids_elem_size;
-            auto prefilled_bytes = kvcache_desc.num_stored_tokens * input_ids_elem_size;
+            auto prefilled_bytes = (kvcache_desc.num_stored_tokens - m_continued_prefill_base) * input_ids_elem_size;
             if (is_input_embeds) {
                 current_prefill_bytes *= input_ids->get_shape().back();
                 prefilled_bytes *= input_ids->get_shape().back();
@@ -957,12 +970,14 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             // NB: Regular LLM uses 2D position_ids [BATCH, SEQ_LEN], Qwen2.5 VL/Omni, Qwen3.5 VL use 3D position_ids
             // [3, BATCH, SEQ_LEN]
             // Copy postion ids with considering the 3D position_ids
+            // The caller tensor is delta-relative during a continued prefill.
             auto last_dim = position_ids->get_shape().size() - 1;
-            auto actual_position_ids_slice = ov::npuw::util::make_tensor_slice(
-                position_ids,
-                static_cast<uint32_t>(last_dim),
-                kvcache_desc.num_stored_tokens,
-                kvcache_desc.num_stored_tokens + static_cast<uint32_t>(current_prompts_len));
+            const uint32_t pos_src_offset = kvcache_desc.num_stored_tokens - m_continued_prefill_base;
+            auto actual_position_ids_slice =
+                ov::npuw::util::make_tensor_slice(position_ids,
+                                                  static_cast<uint32_t>(last_dim),
+                                                  pos_src_offset,
+                                                  pos_src_offset + static_cast<uint32_t>(current_prompts_len));
 
             auto pos_ids_slice =
                 ov::npuw::util::make_tensor_slice(pos_ids_in_tensor,
@@ -1006,10 +1021,11 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             // Dest shape:   [1, chunk_prompt_len, num_layers, proj_dim] (static)
             if (per_layer_inputs) {
                 auto dst = m_prefill_request->get_tensor(m_prefill_in_ports.at(layer_names::per_layer_inputs));
-                ov::npuw::util::copy_per_layer_inputs_chunk_to_right(per_layer_inputs,
-                                                                     dst,
-                                                                     kvcache_desc.num_stored_tokens,
-                                                                     static_cast<uint32_t>(current_prompts_len));
+                ov::npuw::util::copy_per_layer_inputs_chunk_to_right(
+                    per_layer_inputs,
+                    dst,
+                    kvcache_desc.num_stored_tokens - m_continued_prefill_base,
+                    static_cast<uint32_t>(current_prompts_len));
             }
 
             // Prepare KV blocks or bind memory for this chunk via strategy.
@@ -1203,6 +1219,140 @@ void ov::npuw::LLMInferRequest::infer_prefill(ov::SoPtr<ov::ITensor> input_ids,
     });
 
     m_generate_initialized = false;
+
+    LOG_DEBUG("Done");
+}
+
+void ov::npuw::LLMInferRequest::validate_continued_position_ids(const ov::SoPtr<ov::ITensor>& position_ids,
+                                                                uint32_t keep) const {
+    // A continued prefill is validated from the whole position id sequence, never from
+    // a single scalar equality, which would become a second routing heuristic.
+    OPENVINO_ASSERT(position_ids->get_shape().size() == 2u,
+                    "Continued prefill: 3-D position ids cannot be validated as a linear sequence.");
+    OPENVINO_ASSERT(!m_first_run,
+                    "Continued prefill: no position baseline is latched yet. A full prefill "
+                    "must run before a continuation.");
+    const auto* data = position_ids->data<int64_t>();
+    const size_t count = position_ids->get_size();
+    OPENVINO_ASSERT(count >= 1u, "Continued prefill: position ids must not be empty.");
+    const int64_t expected_start = m_first_position_id + static_cast<int64_t>(keep);
+    OPENVINO_ASSERT(data[0] == expected_start,
+                    "Continued prefill: position ids must start at the granted keep. Expected ",
+                    expected_start,
+                    ", got ",
+                    data[0],
+                    ".");
+    for (size_t i = 1; i < count; ++i) {
+        OPENVINO_ASSERT(data[i] == expected_start + static_cast<int64_t>(i),
+                        "Continued prefill: position ids must be contiguous and strictly increasing.");
+    }
+}
+
+void ov::npuw::LLMInferRequest::prepare_for_continued_prefill(uint32_t keep,
+                                                              int64_t total_prompt_length,
+                                                              ov::SoPtr<ov::ITensor> attention_mask) {
+    namespace uu = ov::npuw::util;
+
+    // Zero only the prefill staging tensors. The KV state, the strategy and the
+    // lincache are deliberately left alone, unlike prepare_for_new_conversation.
+    uu::fill_tensor_bytes(m_prefill_request->get_tensor(m_prefill_in_ports.at(m_input_ids_name)), 0u);
+    uu::fill_tensor<int64_t>(m_prefill_request->get_tensor(m_prefill_in_ports.at(layer_names::attention_mask)), 0);
+    uu::fill_tensor<int64_t>(m_prefill_request->get_tensor(m_prefill_in_ports.at(layer_names::position_ids)), 0);
+    if (auto per_layer_port = m_prefill_in_ports.find(layer_names::per_layer_inputs);
+        per_layer_port != m_prefill_in_ports.end()) {
+        uu::fill_tensor_bytes(m_prefill_request->get_tensor(per_layer_port->second), 0u);
+    }
+
+    // Restore the preserved prefix attention mask. Nothing else populates the first
+    // keep positions before the first continued chunk, and without them the new tokens
+    // could not attend to the preserved conversation at all.
+    auto attn_mask_in_tensor = m_prefill_request->get_tensor(m_prefill_in_ports.at(layer_names::attention_mask));
+    std::copy_n(attention_mask->data<int64_t>(), keep, attn_mask_in_tensor->data<int64_t>());
+
+    m_npuw_llm_compiled_model->m_kvcache_desc.num_stored_tokens = keep;
+
+    // Select the generate variant for the full logical prompt, matching what a fresh
+    // full-history run of the same conversation would have chosen.
+    m_kvcache_request = select_generate_request(total_prompt_length);
+    m_kvcache_in_ports = m_generate_variant_in_ports.at(m_kvcache_request);
+    m_kvcache_out_ports = m_generate_variant_out_ports.at(m_kvcache_request);
+    const auto& reqs = m_generate_requests;
+    m_kvcache_variant_idx =
+        static_cast<size_t>(std::distance(reqs.begin(), std::find(reqs.begin(), reqs.end(), m_kvcache_request)));
+}
+
+void ov::npuw::LLMInferRequest::infer_continued_prefill(ov::SoPtr<ov::ITensor> input_ids,
+                                                        ov::SoPtr<ov::ITensor> attention_mask,
+                                                        ov::SoPtr<ov::ITensor> position_ids,
+                                                        ov::SoPtr<ov::ITensor> per_layer_inputs,
+                                                        uint32_t keep) {
+    LOG_DEBUG("Calling continued prefill, keep=" << keep);
+    LOG_BLOCK();
+
+    auto& kvcache_desc = m_npuw_llm_compiled_model->m_kvcache_desc;
+    const uint32_t delta_len = static_cast<uint32_t>(input_ids->get_shape()[layer_ids::INPUT_IDS_SEQ_LEN_DIM]);
+
+    // Preflight. Nothing below may touch live tensors, bindings or counters, so a
+    // failure consumes the command and leaves the cache exactly as it was.
+    std::unique_ptr<ContinuedPrefillPlan> plan;
+    try {
+        OPENVINO_ASSERT(m_npuw_llm_compiled_model->m_use_chunk_prefill, "Continued prefill requires chunked prefill.");
+        OPENVINO_ASSERT(delta_len >= 1u, "Continued prefill: the delta must not be empty.");
+        const uint64_t total = static_cast<uint64_t>(keep) + delta_len;
+        OPENVINO_ASSERT(total <= kvcache_desc.max_prompt_size,
+                        "Continued prefill: keep (",
+                        keep,
+                        ") plus delta (",
+                        delta_len,
+                        ") exceeds NPUW_LLM_MAX_PROMPT_LEN (",
+                        kvcache_desc.max_prompt_size,
+                        ").");
+        OPENVINO_ASSERT(attention_mask->get_size() == total,
+                        "Continued prefill: attention mask must cover the whole history. Expected ",
+                        total,
+                        " entries, got ",
+                        attention_mask->get_size(),
+                        ".");
+        validate_continued_position_ids(position_ids, keep);
+        plan = m_kvcache_strategy->plan_continued_prefill(keep, delta_len);
+    } catch (...) {
+        m_continuation.abort_preflight();
+        throw;
+    }
+
+    // The command is accepted and mutation starts. Failing closed from here on is
+    // mandatory. The caller sent only the delta, so falling back to a normal reset
+    // would prefill the delta as if it were the whole conversation and produce
+    // fluent but wrong output.
+    m_continuation.begin_active();
+    try {
+        m_kvcache_strategy->apply_continued_prefill(*plan);
+        prepare_for_continued_prefill(keep, static_cast<int64_t>(keep + delta_len), attention_mask);
+
+        m_continued_prefill_base = keep;
+        infer_chunked_prefill(input_ids,
+                              attention_mask,
+                              position_ids,
+                              per_layer_inputs,
+                              ov::npuw::util::TensorPtr(),
+                              ov::npuw::util::TensorPtr());
+        m_continued_prefill_base = 0u;
+
+        if (m_lm_head_request) {
+            m_lm_head_request->infer();
+            m_logits = m_lm_head_request->get_tensor(m_lm_head_logits_port);
+        } else {
+            m_logits = m_prefill_request->get_tensor(m_prefill_out_ports.at(layer_names::logits));
+        }
+
+        m_generate_initialized = false;
+        m_continuation.commit_prefill(kvcache_desc.num_stored_tokens);
+        m_stored_tokens_state->set_num_stored_tokens(kvcache_desc.num_stored_tokens);
+    } catch (...) {
+        m_continued_prefill_base = 0u;
+        m_continuation.fail_active();
+        throw;
+    }
 
     LOG_DEBUG("Done");
 }
@@ -1448,6 +1598,54 @@ void ov::npuw::LLMInferRequest::infer() {
         m_first_run = false;
     }
 
+    // Continuous prefill routing comes first. A granted keep is an explicit command, so
+    // it must never be re-derived from position ids. A delta continuation starts at
+    // exactly the cache end, which the legacy heuristic below would misroute to the
+    // generate path with a speculative-decoding trim.
+    const auto continuation_cmd = m_continuation.command();
+    if (continuation_cmd.is_keep()) {
+        infer_continued_prefill(input_ids, attention_mask, position_ids, per_layer_inputs, continuation_cmd.keep_value);
+        return;
+    }
+    if (continuation_cmd.is_reset()) {
+        // A pending reset accepts only a complete prompt at cache position zero. A
+        // mismatch raises and stays in the reset pending state, so no ordinary
+        // inference can run until the caller supplies the required full prompt.
+        const auto prompt_len = input_ids->get_shape()[layer_ids::INPUT_IDS_SEQ_LEN_DIM];
+        OPENVINO_ASSERT(attention_mask->get_size() == prompt_len,
+                        "Continuous prefill reset: the attention mask must cover exactly the full "
+                        "prompt. Expected ",
+                        prompt_len,
+                        " entries, got ",
+                        attention_mask->get_size(),
+                        ".");
+        OPENVINO_ASSERT(position_ids->data<int64_t>()[0] == m_first_position_id,
+                        "Continuous prefill reset: position ids must start at the request's "
+                        "first-position baseline (",
+                        m_first_position_id,
+                        "), got ",
+                        position_ids->data<int64_t>()[0],
+                        ".");
+        m_continuation.begin_active();
+        try {
+            // infer_prefill performs the complete physical reset through
+            // prepare_for_new_conversation before prefilling from position zero.
+            infer_prefill(input_ids,
+                          attention_mask,
+                          position_ids,
+                          token_type_ids,
+                          per_layer_inputs,
+                          visual_pos_masks,
+                          deepstack_visual_embeds);
+            m_continuation.commit_prefill(m_npuw_llm_compiled_model->m_kvcache_desc.num_stored_tokens);
+            m_stored_tokens_state->set_num_stored_tokens(m_npuw_llm_compiled_model->m_kvcache_desc.num_stored_tokens);
+        } catch (...) {
+            m_continuation.fail_active();
+            throw;
+        }
+        return;
+    }
+
     // NB: Check the sequence length provided for input_ids
     //     and start position idx in order to distinguish prefill
     //     and generate stages.
@@ -1479,6 +1677,12 @@ void ov::npuw::LLMInferRequest::infer() {
                       per_layer_inputs,
                       visual_pos_masks,
                       deepstack_visual_embeds);
+        if (m_continuation.enabled()) {
+            // An ordinary full prefill from idle is a legal conversation start. Publish
+            // it so the next proposal negotiates against the fresh history.
+            m_continuation.commit_prefill(m_npuw_llm_compiled_model->m_kvcache_desc.num_stored_tokens);
+            m_stored_tokens_state->set_num_stored_tokens(m_npuw_llm_compiled_model->m_kvcache_desc.num_stored_tokens);
+        }
     } else {
         // FIXME: Need to make the solution smarter.
         // Qwen2.5VL uses 3D position_ids but current `trim_kvcache_for_speculative_decoding`
@@ -1488,6 +1692,11 @@ void ov::npuw::LLMInferRequest::infer() {
             trim_kvcache_for_speculative_decoding(position_ids);
         }
         infer_generate(input_ids, attention_mask, position_ids, token_type_ids, per_layer_inputs);
+        if (m_continuation.enabled()) {
+            // Generate-produced KV never advances the prefill watermark.
+            m_continuation.publish_generate(m_npuw_llm_compiled_model->m_kvcache_desc.num_stored_tokens);
+            m_stored_tokens_state->set_num_stored_tokens(m_npuw_llm_compiled_model->m_kvcache_desc.num_stored_tokens);
+        }
     }
 
     if (!position_ids_opt.has_value()) {

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -935,6 +935,17 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
         // The last chunk may not be completely filled if the actual length of the prompts is not evenly divisible by
         // the chunk size
         auto current_prompts_len = std::min(remaining_prompts, chunk_prompt_len);
+        const auto t_chunk = std::chrono::steady_clock::now();
+        const auto chunk_start_pos = kvcache_desc.num_stored_tokens;
+        std::chrono::steady_clock::time_point t_mark;
+        double prep_ms = 0.0, infer_ms = 0.0;
+        const auto lap = [&t_mark]() {
+            const auto now = std::chrono::steady_clock::now();
+            const auto ms = std::chrono::duration_cast<std::chrono::microseconds>(now - t_mark).count() / 1000.0;
+            t_mark = now;
+            return ms;
+        };
+        t_mark = t_chunk;
 
         m_llm_profile["1/prefill:3a.prepare_chunk"].record([&]() {
             // Handle first chunk with prefix caching: populate attention mask for restored cache
@@ -1040,9 +1051,11 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             m_kvcache_strategy->on_prefill_chunk_begin(static_cast<uint32_t>(current_prompts_len));
         });
 
+        prep_ms = lap();
         m_llm_profile["1/prefill:3b.infer"].record([&]() {
             m_prefill_request->infer();
         });
+        infer_ms = lap();
 
         m_llm_profile["1/prefill:3c.post_chunk"].record([&]() {
             // Accumulate Eagle3 last_hidden_state from this chunk
@@ -1078,6 +1091,11 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
                     attn_mask_in_tensor->data<int64_t>() + kvcache_desc.num_stored_tokens - current_prompts_len);
             }
         });
+
+        const auto post_ms = lap();
+        LOG_INFO("Prefill chunk @" << chunk_start_pos << " len " << current_prompts_len << ": prepare " << prep_ms
+                                   << " ms, infer " << infer_ms << " ms, post+kv " << post_ms << " ms"
+                                   << (m_continued_prefill_base > 0u ? " (continued)" : ""));
 
         if (is_last_chunk) {
             LOG_DEBUG("All prompts have been prefilled in chunks");

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -5,6 +5,7 @@
 #include "llm_infer_request.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <regex>
 
@@ -624,6 +625,9 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
     namespace uu = ov::npuw::util;
     LOG_DEBUG("Copying kv-cache from prefill to generate model.");
     LOG_BLOCK();
+    // Timed as the mirror operation of the continued prefill repack, so the two copy
+    // directions can be compared in the log.
+    const auto t_start = std::chrono::steady_clock::now();
     auto& kvcache_desc = m_npuw_llm_compiled_model->m_kvcache_desc;
     // FIXME: Find only matching by names outputs and copy them, having previously checked that such inputs exist
     ov::parallel_for(m_kvcache_past_names.size(), [&](size_t out_idx) {
@@ -713,6 +717,10 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
             uu::copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, pre_kv_dim, gen_kv_dim);
         }
     });
+    const auto t_ms =
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t_start).count() /
+        1000.0;
+    LOG_INFO("copy_kvcache: " << kvcache_desc.num_stored_tokens << " tokens, prefill to generate, " << t_ms << " ms");
     LOG_DEBUG("Done.");
 }
 
@@ -1326,9 +1334,20 @@ void ov::npuw::LLMInferRequest::infer_continued_prefill(ov::SoPtr<ov::ITensor> i
     // fluent but wrong output.
     m_continuation.begin_active();
     try {
+        const auto ms_since = [](std::chrono::steady_clock::time_point from) {
+            return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - from)
+                       .count() /
+                   1000.0;
+        };
+        const auto t_apply = std::chrono::steady_clock::now();
         m_kvcache_strategy->apply_continued_prefill(*plan);
-        prepare_for_continued_prefill(keep, static_cast<int64_t>(keep + delta_len), attention_mask);
+        const auto apply_ms = ms_since(t_apply);
 
+        const auto t_prepare = std::chrono::steady_clock::now();
+        prepare_for_continued_prefill(keep, static_cast<int64_t>(keep + delta_len), attention_mask);
+        const auto prepare_ms = ms_since(t_prepare);
+
+        const auto t_chunks = std::chrono::steady_clock::now();
         m_continued_prefill_base = keep;
         infer_chunked_prefill(input_ids,
                               attention_mask,
@@ -1337,13 +1356,20 @@ void ov::npuw::LLMInferRequest::infer_continued_prefill(ov::SoPtr<ov::ITensor> i
                               ov::npuw::util::TensorPtr(),
                               ov::npuw::util::TensorPtr());
         m_continued_prefill_base = 0u;
+        const auto chunks_ms = ms_since(t_chunks);
 
+        const auto t_head = std::chrono::steady_clock::now();
         if (m_lm_head_request) {
             m_lm_head_request->infer();
             m_logits = m_lm_head_request->get_tensor(m_lm_head_logits_port);
         } else {
             m_logits = m_prefill_request->get_tensor(m_prefill_out_ports.at(layer_names::logits));
         }
+        const auto head_ms = ms_since(t_head);
+
+        LOG_INFO("Continued prefill timing (keep=" << keep << ", delta=" << delta_len << "): apply " << apply_ms
+                                                   << " ms, staging " << prepare_ms << " ms, chunked prefill "
+                                                   << chunks_ms << " ms, lm_head " << head_ms << " ms");
 
         m_generate_initialized = false;
         m_continuation.commit_prefill(kvcache_desc.num_stored_tokens);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.hpp
@@ -8,6 +8,7 @@
 
 #include "base_sync_infer_request.hpp"
 #include "llm_compiled_model.hpp"
+#include "llm_continuation.hpp"
 #include "llm_eagle3_extension.hpp"
 #include "llm_infer_base_request.hpp"
 #include "llm_kvcache_strategy.hpp"
@@ -102,6 +103,22 @@ protected:
                         ov::SoPtr<ov::ITensor> token_type_ids,
                         ov::SoPtr<ov::ITensor> per_layer_inputs);
 
+    // Continuous prefill. Runs the granted keep transaction, prefilling only the
+    // delta on top of the preserved KV prefix.
+    void infer_continued_prefill(ov::SoPtr<ov::ITensor> input_ids,
+                                 ov::SoPtr<ov::ITensor> attention_mask,
+                                 ov::SoPtr<ov::ITensor> position_ids,
+                                 ov::SoPtr<ov::ITensor> per_layer_inputs,
+                                 uint32_t keep);
+    // Staging preparation for a continued prefill. Zeroes the prefill staging tensors,
+    // restores the preserved prefix attention mask and selects the generate variant,
+    // without touching KV or resetting the strategy.
+    void prepare_for_continued_prefill(uint32_t keep,
+                                       int64_t total_prompt_length,
+                                       ov::SoPtr<ov::ITensor> attention_mask);
+    // Validates the delta position ids as a sequence against the latched baseline.
+    void validate_continued_position_ids(const ov::SoPtr<ov::ITensor>& position_ids, uint32_t keep) const;
+
     // Multiple generate inference request variants, each with a different KV cache size
     std::vector<std::shared_ptr<ov::IAsyncInferRequest>> m_generate_requests;
 
@@ -159,6 +176,14 @@ protected:
 
     // Support reset of stored tokens to 0 from external pipeline
     ov::SoPtr<ov::npuw::StoredTokensState> m_stored_tokens_state;
+
+    // Continuous prefill transaction coordinator, disabled unless the compiled model
+    // reports the capability.
+    ContinuationCoordinator m_continuation;
+    // Absolute KV position the current chunked prefill started at. Non-zero only while
+    // a continued prefill is running, where the caller tensors hold just the delta and
+    // must be indexed relative to this base.
+    uint32_t m_continued_prefill_base = 0u;
 
     // Support LoRA
     std::vector<ov::SoPtr<ov::IVariableState>> m_variableStates;

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_kvcache_strategy.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_kvcache_strategy.hpp
@@ -16,6 +16,17 @@ namespace npuw {
 class LLMInferRequest;  // forward declaration — strategy always outlived by its owning request
 
 /**
+ * @brief Opaque, strategy-owned plan for a continued prefill.
+ *
+ * Produced by the non-mutating plan_continued_prefill() preflight and consumed
+ * by apply_continued_prefill(). Destroying an unapplied plan releases any
+ * staging resources without changing the live cache.
+ */
+struct ContinuedPrefillPlan {
+    virtual ~ContinuedPrefillPlan() = default;
+};
+
+/**
  * @brief Abstract strategy interface for LLM KV cache management.
  *
  * Decouples `LLMInferRequest` from the two concrete KV cache implementations:
@@ -86,6 +97,26 @@ public:
 
     // Called after each generate step's infer(): persist new token KV and update bindings
     virtual void on_generate_step_done(uint32_t input_tokens_len) = 0;
+
+    // Continuous prefill support.
+
+    /// Validate every dynamic precondition of a continued prefill that keeps the first
+    /// `keep` tokens and prefills `delta_len` new ones, and reserve all staging
+    /// resources. Must not change live KV, bindings, block metadata, counters or
+    /// phase flags. A failure here leaves the cache exactly as it was.
+    virtual std::unique_ptr<ContinuedPrefillPlan> plan_continued_prefill(uint32_t keep, uint32_t delta_len) {
+        (void)keep;
+        (void)delta_len;
+        OPENVINO_THROW("Continuous prefill is not supported by this KV cache strategy.");
+    }
+
+    /// Apply an already validated plan. The request is active, so any exception from
+    /// this point poisons the request and must not be converted into a fallback that
+    /// continues inference.
+    virtual void apply_continued_prefill(ContinuedPrefillPlan& plan) {
+        (void)plan;
+        OPENVINO_THROW("Continuous prefill is not supported by this KV cache strategy.");
+    }
 
 protected:
     LLMInferRequest& m_req;

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_stored_tokens_state.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_stored_tokens_state.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "llm_continuation.hpp"
 #include "openvino/runtime/itensor.hpp"
 #include "openvino/runtime/ivariable_state.hpp"
 #include "openvino/runtime/make_tensor.hpp"
@@ -11,34 +12,73 @@
 namespace ov {
 namespace npuw {
 
+class LLMInferRequest;
+
 // Special VariableState for already processed/stored tokens in LLM.
 // Allows external pipelines to call reset on that state where needed.
+//
+// When continuous prefill is enabled for the owning request, this state also
+// becomes the propose/grant negotiation channel. A set_state(N) call is a
+// proposal that the first N tokens are unchanged. The plugin clamps N by every
+// limit it owns and stores the result as a pending command. A get_state() call
+// returns the grant, which is the prefix the plugin will honour. reset() is a
+// control operation that discards any pending keep and requires the next
+// inference to be a full prefill at cache position zero.
+//
+// A write is not idempotent. The caller writes X and reads back Y <= X, and
+// must slice its input at Y, never at X.
+//
+// Without continuous prefill the legacy contract is unchanged. get_state()
+// returns the stored token count, reset() zeroes it and set_state() throws.
 class StoredTokensState : public ov::IVariableState {
 public:
     friend class ov::npuw::LLMInferRequest;
     StoredTokensState() : ov::IVariableState("npuw_stored_tokens_state") {
         auto tensor = ov::Tensor(ov::element::i64, ov::Shape{1});
         m_state = ov::get_tensor_impl(tensor);
-        reset();
-    }
-
-    void reset() override {
         m_state->data<int64_t>()[0] = 0;
     }
 
-    void set_state(const ov::SoPtr<ov::ITensor>&) override {
-        OPENVINO_THROW("StoredTokensState::set_state() should not be called!");
+    void reset() override {
+        if (has_continuation()) {
+            m_coordinator->request_reset();
+        }
+        m_state->data<int64_t>()[0] = 0;
+    }
+
+    void set_state(const ov::SoPtr<ov::ITensor>& new_state) override {
+        if (!has_continuation()) {
+            OPENVINO_THROW("StoredTokensState::set_state() should not be called!");
+        }
+        OPENVINO_ASSERT(new_state, "npuw_stored_tokens_state: set_state() received a null tensor.");
+        OPENVINO_ASSERT(new_state->get_element_type() == ov::element::i64,
+                        "npuw_stored_tokens_state: proposal tensor must be i64, got ",
+                        new_state->get_element_type());
+        OPENVINO_ASSERT(new_state->get_size() == 1u,
+                        "npuw_stored_tokens_state: proposal tensor must be a scalar (one element), got ",
+                        new_state->get_size(),
+                        " elements.");
+        m_coordinator->propose(new_state->data<int64_t>()[0]);
     }
 
     // Returns a copy of state to prevent external modfication.
     ov::SoPtr<ov::ITensor> get_state() const override {
-        const auto* state_data = m_state->data<int64_t>();
         auto result = ov::Tensor(ov::element::i64, ov::Shape{1});
-        result.data<int64_t>()[0] = state_data[0];
+        result.data<int64_t>()[0] = has_continuation() ? m_coordinator->query() : m_state->data<int64_t>()[0];
         return ov::get_tensor_impl(result);
     }
 
 private:
+    // Wire the negotiation channel. The coordinator is owned by LLMInferRequest,
+    // which also owns (and outlives) this state.
+    void attach_continuation(ContinuationCoordinator* coordinator) {
+        m_coordinator = coordinator;
+    }
+
+    bool has_continuation() const {
+        return m_coordinator != nullptr && m_coordinator->enabled();
+    }
+
     int64_t get_num_stored_tokens() const {
         return m_state->data<int64_t>()[0];
     }
@@ -46,6 +86,8 @@ private:
     void set_num_stored_tokens(int64_t num_tokens) {
         m_state->data<int64_t>()[0] = num_tokens;
     }
+
+    ContinuationCoordinator* m_coordinator = nullptr;
 };
 
 }  // namespace npuw

--- a/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
@@ -248,6 +248,57 @@ TEST_F(KVCacheBlockManagerTest, InvalidBlockID) {
         << "Updating invalid block ID should throw";
 }
 
+// Truncation for continuous prefill keeps the leading blocks and frees the suffix.
+TEST_F(KVCacheBlockManagerTest, TruncateAllocatedKeepsPrefix) {
+    std::vector<uint32_t> ids;
+    for (int i = 0; i < 5; ++i) {
+        auto id = manager->allocate_block();
+        ASSERT_TRUE(id.has_value());
+        manager->update_block_tokens(id.value(), block_size);
+        ids.push_back(id.value());
+    }
+
+    manager->truncate_allocated(2);
+
+    auto allocated = manager->get_allocated_blocks();
+    ASSERT_EQ(allocated.size(), 2u);
+    EXPECT_EQ(allocated[0], ids[0]);
+    EXPECT_EQ(allocated[1], ids[1]);
+    // Retained blocks keep their token counts and tensors.
+    EXPECT_EQ(manager->get_block_tokens(ids[0]), block_size);
+    EXPECT_EQ(manager->get_block_tokens(ids[1]), block_size);
+    EXPECT_NE(manager->get_block_tensor(ids[0]), nullptr);
+    EXPECT_EQ(manager->num_free_blocks(), max_blocks - 2);
+}
+
+TEST_F(KVCacheBlockManagerTest, TruncateAllocatedPreservesAppendOrder) {
+    std::vector<uint32_t> ids;
+    for (int i = 0; i < 4; ++i) {
+        auto id = manager->allocate_block();
+        ASSERT_TRUE(id.has_value());
+        ids.push_back(id.value());
+    }
+
+    manager->truncate_allocated(1);
+
+    // Freed suffix IDs come back in ascending order so logical append order holds.
+    auto first = manager->allocate_block();
+    auto second = manager->allocate_block();
+    ASSERT_TRUE(first.has_value() && second.has_value());
+    EXPECT_EQ(first.value(), ids[1]);
+    EXPECT_EQ(second.value(), ids[2]);
+    // Reacquired blocks start empty.
+    EXPECT_EQ(manager->get_block_tokens(first.value()), 0u);
+}
+
+TEST_F(KVCacheBlockManagerTest, TruncateAllocatedRejectsOverKeep) {
+    ASSERT_TRUE(manager->allocate_block().has_value());
+    EXPECT_THROW(manager->truncate_allocated(2), ov::Exception);
+    // Truncating to the full allocated count is a no-op.
+    manager->truncate_allocated(1);
+    EXPECT_EQ(manager->get_allocated_blocks().size(), 1u);
+}
+
 // Test 11: Get Tensor After Clear (memory kept, state reset)
 TEST_F(KVCacheBlockManagerTest, GetTensorAfterClear) {
     auto block_id = manager->allocate_block();

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_continuation_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_continuation_test.cpp
@@ -1,0 +1,235 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "llm_continuation.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "llm_stored_tokens_state.hpp"
+#include "openvino/runtime/make_tensor.hpp"
+
+namespace {
+
+using ov::npuw::ContinuationCoordinator;
+using Stage = ov::npuw::ContinuationCoordinator::Stage;
+
+constexpr uint32_t CHUNK = 1024u;
+constexpr uint32_t MAX_PROMPT = 4096u;
+
+ContinuationCoordinator make_enabled() {
+    ContinuationCoordinator c;
+    c.enable(CHUNK, MAX_PROMPT);
+    return c;
+}
+
+// Brings the coordinator to an idle state with the given committed prefill history.
+ContinuationCoordinator make_after_prefill(uint32_t prefill_tokens, uint32_t generated_tokens = 0u) {
+    auto c = make_enabled();
+    c.commit_prefill(prefill_tokens);
+    if (generated_tokens > 0u) {
+        c.publish_generate(prefill_tokens + generated_tokens);
+    }
+    return c;
+}
+
+ov::SoPtr<ov::ITensor> scalar_i64(int64_t value) {
+    auto tensor = ov::Tensor(ov::element::i64, ov::Shape{1});
+    tensor.data<int64_t>()[0] = value;
+    return ov::get_tensor_impl(tensor);
+}
+
+int64_t read_scalar(const ov::SoPtr<ov::ITensor>& tensor) {
+    return tensor->data<int64_t>()[0];
+}
+
+// The keep rule. K = C * floor(min(K_common, K_max, W) / C).
+
+TEST(NPUWContinuation, KeepRuleGrantsAlignedValue) {
+    auto c = make_after_prefill(3000u, 50u);
+    // W = 3000, K_max = 3072, propose the full live history.
+    EXPECT_EQ(c.propose(3050), 2048u);
+    EXPECT_EQ(c.stage(), Stage::PENDING);
+}
+
+TEST(NPUWContinuation, KeepRuleClampsToWatermark) {
+    auto c = make_after_prefill(2048u, 500u);
+    // 2548 live tokens but only 2048 were produced by prefill.
+    EXPECT_EQ(c.propose(2548), 2048u);
+}
+
+TEST(NPUWContinuation, KeepRuleClampsToCapacity) {
+    ContinuationCoordinator c;
+    c.enable(1024u, 4096u);
+    c.commit_prefill(4000u);
+    // K_max = 4096 - 1024 = 3072, rounded stays 3072.
+    EXPECT_EQ(c.propose(4000), 3072u);
+}
+
+TEST(NPUWContinuation, KeepRuleRoundsDownToChunk) {
+    auto c = make_after_prefill(1500u);
+    EXPECT_EQ(c.propose(1500), 1024u);
+}
+
+TEST(NPUWContinuation, SubChunkHistoryGrantsZeroAndArmsReset) {
+    auto c = make_after_prefill(1000u);
+    EXPECT_EQ(c.propose(1000), 0u);
+    // A zero keep is a full reset, not a continuation with an empty prefix.
+    EXPECT_EQ(c.stage(), Stage::RESET_PENDING);
+    EXPECT_EQ(c.query(), 0);
+}
+
+TEST(NPUWContinuation, GrowthIsRejected) {
+    auto c = make_after_prefill(2048u);
+    EXPECT_THROW(c.propose(2049), ov::Exception);
+    // A rejected proposal leaves the request idle with the committed count readable.
+    EXPECT_EQ(c.stage(), Stage::IDLE);
+    EXPECT_EQ(c.query(), 2048);
+}
+
+TEST(NPUWContinuation, NegativeProposalIsRejected) {
+    auto c = make_after_prefill(2048u);
+    EXPECT_THROW(c.propose(-1), ov::Exception);
+}
+
+TEST(NPUWContinuation, SecondProposalWhilePendingIsRejected) {
+    auto c = make_after_prefill(3072u);
+    EXPECT_EQ(c.propose(3072), 3072u);
+    EXPECT_THROW(c.propose(2048), ov::Exception);
+}
+
+TEST(NPUWContinuation, ProposalWhileResetPendingIsRejected) {
+    auto c = make_after_prefill(2048u);
+    c.request_reset();
+    EXPECT_THROW(c.propose(2048), ov::Exception);
+}
+
+// The grant readback.
+
+TEST(NPUWContinuation, QueryReturnsLiveTokensWhileIdle) {
+    auto c = make_after_prefill(2048u, 10u);
+    EXPECT_EQ(c.query(), 2058);
+}
+
+TEST(NPUWContinuation, QueryReturnsGrantWhilePending) {
+    auto c = make_after_prefill(3000u);
+    c.propose(3000);
+    EXPECT_EQ(c.query(), 2048);
+}
+
+TEST(NPUWContinuation, PublishingLiveCountDoesNotReArmCommand) {
+    auto c = make_after_prefill(2048u);
+    c.propose(2048);
+    c.begin_active();
+    c.commit_prefill(2500u);
+    // After the commit there is no pending command, only the published count.
+    EXPECT_EQ(c.stage(), Stage::IDLE);
+    EXPECT_FALSE(c.command().is_keep());
+    EXPECT_FALSE(c.command().is_reset());
+    EXPECT_EQ(c.query(), 2500);
+}
+
+// The transaction state machine.
+
+TEST(NPUWContinuation, PreflightAbortConsumesCommandAndKeepsCounters) {
+    auto c = make_after_prefill(3000u, 20u);
+    c.propose(3000);
+    c.abort_preflight();
+    EXPECT_EQ(c.stage(), Stage::IDLE);
+    EXPECT_EQ(c.query(), 3020);
+    EXPECT_FALSE(c.command().is_keep());
+}
+
+TEST(NPUWContinuation, FailureAfterActivePoisonsTheRequest) {
+    auto c = make_after_prefill(3000u);
+    c.propose(3000);
+    c.begin_active();
+    c.fail_active();
+    EXPECT_EQ(c.stage(), Stage::RESET_REQUIRED);
+    EXPECT_EQ(c.query(), 0);
+    // Poisoned requests reject inference until reset() is called.
+    EXPECT_THROW(c.command(), ov::Exception);
+}
+
+TEST(NPUWContinuation, ResetRecoversAPoisonedRequest) {
+    auto c = make_after_prefill(3000u);
+    c.propose(3000);
+    c.begin_active();
+    c.fail_active();
+    c.request_reset();
+    EXPECT_EQ(c.stage(), Stage::RESET_PENDING);
+    EXPECT_TRUE(c.command().is_reset());
+    // Idempotent while already pending.
+    c.request_reset();
+    EXPECT_EQ(c.stage(), Stage::RESET_PENDING);
+}
+
+TEST(NPUWContinuation, ResetDiscardsAPendingKeep) {
+    auto c = make_after_prefill(3000u);
+    c.propose(3000);
+    c.request_reset();
+    EXPECT_TRUE(c.command().is_reset());
+    EXPECT_EQ(c.query(), 0);
+}
+
+TEST(NPUWContinuation, CommitAfterResetPrefillReturnsToIdle) {
+    auto c = make_after_prefill(2048u);
+    c.request_reset();
+    c.begin_active();
+    c.commit_prefill(500u);
+    EXPECT_EQ(c.stage(), Stage::IDLE);
+    EXPECT_EQ(c.query(), 500);
+    EXPECT_EQ(c.watermark(), 500u);
+}
+
+TEST(NPUWContinuation, BeginActiveWithoutCommandThrows) {
+    auto c = make_after_prefill(2048u);
+    EXPECT_THROW(c.begin_active(), ov::Exception);
+}
+
+// Watermark accounting.
+
+TEST(NPUWContinuation, WatermarkFollowsPrefillOnly) {
+    auto c = make_enabled();
+    c.commit_prefill(2048u);
+    EXPECT_EQ(c.watermark(), 2048u);
+    c.publish_generate(2148u);
+    EXPECT_EQ(c.watermark(), 2048u);
+    EXPECT_EQ(c.live_tokens(), 2148u);
+}
+
+TEST(NPUWContinuation, SpeculativeTrimClampsWatermarkDown) {
+    auto c = make_enabled();
+    c.commit_prefill(2048u);
+    // A trim below the watermark must lower it, or a later grant could point at
+    // tokens that no longer exist.
+    c.publish_generate(1500u);
+    EXPECT_EQ(c.watermark(), 1500u);
+    EXPECT_THROW(c.propose(2048), ov::Exception);
+    EXPECT_EQ(c.propose(1500), 1024u);
+}
+
+TEST(NPUWContinuation, DisabledCoordinatorReportsNoCommand) {
+    ContinuationCoordinator c;
+    EXPECT_FALSE(c.enabled());
+    EXPECT_FALSE(c.command().is_keep());
+    EXPECT_FALSE(c.command().is_reset());
+    EXPECT_THROW(c.propose(0), ov::Exception);
+}
+
+// The variable-state channel keeps its legacy contract without a coordinator.
+
+TEST(NPUWStoredTokensState, LegacySetStateThrows) {
+    auto state = std::make_shared<ov::npuw::StoredTokensState>();
+    EXPECT_THROW(state->set_state(scalar_i64(1)), ov::Exception);
+}
+
+TEST(NPUWStoredTokensState, LegacyResetZeroes) {
+    auto state = std::make_shared<ov::npuw::StoredTokensState>();
+    state->reset();
+    EXPECT_EQ(read_scalar(state->get_state()), 0);
+}
+
+}  // anonymous namespace


### PR DESCRIPTION
### Details
- Adds an opt-in propose/grant protocol (`NPUW_LLM_ENABLE_CONTINUOUS_PREFILL`, default off) so GenAI can continue a prefill on top of the KV cache left from the previous chat turn instead of re-prefilling the whole conversation.
- `npuw_stored_tokens_state` becomes a bidirectional negotiation channel: the caller proposes its common token prefix, the plugin clamps by capacity, chunk alignment and the prefill-produced watermark, and grants `K = C * floor(min(K_common, K_max, W) / C)`. A granted keep is an explicit command routed ahead of the legacy position-id heuristic and executed as a fail-closed transaction (idle / pending / reset pending / active / reset required).
- Chunked prefill separates delta coordinates from absolute KV positions, restores the preserved-prefix attention mask, and validates position ids as a contiguous sequence against the latched baseline.
- Both KV strategies implement plan/apply continuation: contiguous repacks the prefix from the generate layout (alias-safe, including the prompt-only-finish split-KV case), block truncates the pool to the retained prefix via the new `KVCacheBlockManager::truncate_allocated()`.
- Capability advertised via read-only `NPUW_LLM_CONTINUOUS_PREFILL_SUPPORTED`; statically false for static prefill, LongRoPE, linear/hybrid state, LoRA, 3-D M-RoPE, VLM, whisper, embedding and eagle. Mutually exclusive with hash prefix caching (compilation fails). Behaviour is unchanged while the option is off.

Companion GenAI PR: openvinotoolkit/openvino.genai#4237 (StatefulLLMPipeline negotiation).

### Measured performance

8-turn chat, Llama-3.2-1B int4 on NPU via llm_bench `text_gen_chat`. Per-turn TTFT with the full re-prefill baseline; outputs are token-identical on all 8 turns.

![Relative TTFT per turn, continuous prefill vs full re-prefill](https://raw.githubusercontent.com/dylanneve1/openvino/7eaa8edeb2226aab49d740ca6188bccd2c760df8/cp_ttft_relative.png)

### Validation
- 26 new unit tests (`llm_continuation_test.cpp`, keep rule + state machine + channel contract) and 3 new `truncate_allocated` tests; 157 neighbouring npuw unit tests still pass.
- End-to-end 3-turn greedy chat on qwen3 with `NPUW_DEVICES=CPU`, chunk 256: transcripts token-identical with the feature on and off; logs confirm turns 2 and 3 prefill only the delta at the granted keep (`proposed 564, granted 512 (K_max=1792, W=547, C=256)`).

### Tickets
- EISW-227938