### PR TITLE
[GPU][CLANG-TIDY] Enable readability-implicit-bool-conversion and readability-simplify-boolean-expr

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -14,7 +14,9 @@ Checks: >
   modernize-use-using
   modernize-redundant-void-arg
   readability-container-size-empty
-  readability-redundant-string-cstr
+  readability-redundant-string-cstr,
+  readability-implicit-bool-conversion,
+  readability-simplify-boolean-expr
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'
@@ -23,5 +25,17 @@ FormatStyle: file
 HeaderFilterRegex: "src/plugins/intel_gpu/(include|src)/.*\\.(h|hpp)$"
 CheckOptions:
   - key: modernize-use-override.AllowOverrideAndFinal
+    value: true
+  - key: readability-implicit-bool-conversion.AllowIntegerConditions
+    value: true
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: true
+  - key: readability-simplify-boolean-expr.ChainedConditionalReturn
+    value: true
+  - key: readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value: true
+  - key: readability-simplify-boolean-expr.SimplifyDeMorgan
+    value: true
+  - key: readability-simplify-boolean-expr.SimplifyDeMorganRelaxed
     value: true
 ---

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/custom_gpu_primitive.hpp
@@ -191,10 +191,7 @@ struct custom_gpu_primitive : public primitive_base<custom_gpu_primitive> {
         if (gws != rhs_casted.gws)
             return false;
 
-        if (lws != rhs_casted.lws)
-            return false;
-
-        return true;
+        return lws == rhs_casted.lws;
     }
 
     void save(BinaryOutputBuffer& ob) const override {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_mask_gen.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/moe_mask_gen.hpp
@@ -119,9 +119,7 @@ struct moe_mask_gen_reshape : public primitive_base<moe_mask_gen_reshape> {
     }
 
     bool operator==(const primitive& rhs) const override {
-        if (!compare_common_params(rhs))
-            return false;
-        return true;
+        return compare_common_params(rhs);
     }
 
     void save(BinaryOutputBuffer& ob) const override {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/mvn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/mvn.hpp
@@ -81,11 +81,7 @@ struct mvn : public primitive_base<mvn> {
 
     bool across_channels() const {
         int64_t channel_axis = 1;
-        if (std::find(reduction_axes.begin(), reduction_axes.end(), channel_axis) != reduction_axes.end()) {
-            return true;
-        } else {
-            return false;
-        }
+        return std::find(reduction_axes.begin(), reduction_axes.end(), channel_axis) != reduction_axes.end();
     }
 
     bool requires_alignment(const ov::PartialShape& shape) const {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
@@ -184,11 +184,7 @@ struct non_max_suppression_gather : primitive_base<non_max_suppression_gather> {
     }
 
     bool operator==(const primitive& rhs) const override {
-        if (!compare_common_params(rhs)) {
-            return false;
-        }
-
-        return true;
+        return compare_common_params(rhs);
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_align.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roi_align.hpp
@@ -64,7 +64,7 @@ struct roi_align : public primitive_base<roi_align> {
     int sampling_ratio = 0;
     /// @brief multiplicative spatial scale factor to translate ROI coordinates
     /// from their input spatial scale to the scale used when pooling.
-    float spatial_scale = false;
+    float spatial_scale = 0.0f;
     /// @brief Method to perform pooling to produce output feature map elements.
     PoolingMode pooling_mode = PoolingMode::max;
     /// @brief Method to coordinate alignment.

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
@@ -183,10 +183,7 @@ struct device_info {
         if (ip_version != other.ip_version || device_id != other.device_id)
             return false;
 
-        if (execution_units_count != other.execution_units_count || max_global_mem_size != other.max_global_mem_size)
-            return false;
-
-        return true;
+        return execution_units_count == other.execution_units_count && max_global_mem_size == other.max_global_mem_size;
     }
 };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
@@ -192,8 +192,7 @@ struct padding {
         // Compare only actual padding size not _dynamic_dims_mask
         if (lhs._lower_size < rhs._lower_size) return true;
         else if (lhs._lower_size > rhs._lower_size) return false;
-        if (lhs._upper_size < rhs._upper_size) return true;
-        return false;
+        return lhs._upper_size < rhs._upper_size;
     }
 
     static padding max(padding const& lhs, padding const& rhs, float filling_value = 0.0f) {

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -82,11 +82,7 @@ struct memory {
             return true;
         }
 
-        if (_bytes_count == l.bytes_count()) {
-            return false;
-        }
-
-        return true;
+        return _bytes_count != l.bytes_count();
     }
 
     // Device <== Host

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_caps.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_caps.hpp
@@ -48,11 +48,9 @@ public:
     bool support_allocation_type(allocation_type type) const { return find_in_caps(type); }
 
     static bool is_usm_type(allocation_type type) {
-        if (type == allocation_type::usm_host ||
+        return type == allocation_type::usm_host ||
             type == allocation_type::usm_shared ||
-            type == allocation_type::usm_device)
-            return true;
-        return false;
+            type == allocation_type::usm_device;
     }
 
     void remove_usm_caps() {

--- a/src/plugins/intel_gpu/src/graph/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/border.cpp
@@ -107,7 +107,7 @@ std::string border_inst::to_string(border_node const& node) {
     border_info.add("pads_end", desc->pads_end);
     border_info.add("pad mode", desc->pad_mode);
     border_info.add("pad value", std::to_string(desc->pad_value));
-    border_info.add("negative_pad", std::to_string(desc->allow_negative_pad));
+    border_info.add("negative_pad", std::to_string(static_cast<int>(desc->allow_negative_pad)));
 
     node_info->add("border info", border_info);
 

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -316,10 +316,7 @@ bool is_target_iteration(int64_t iteration, const std::set<int64_t> dump_iterati
     if (dump_iteration.empty())
         return true;
 
-    if (dump_iteration.find(iteration) == std::end(dump_iteration))
-        return false;
-
-    return true;
+    return dump_iteration.find(iteration) != std::end(dump_iteration);
 }
 
 std::string get_matched_from_filelist(const std::vector<std::string>& file_names, std::string pattern) {

--- a/src/plugins/intel_gpu/src/graph/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/eltwise.cpp
@@ -481,10 +481,7 @@ bool eltwise_node::need_align_for_numpy_broadcast(const layout& input) const {
     auto pshape_a_rank = get_input_pshape(0).size();
     auto pshape_b_rank = get_input_pshape(1).size();
     auto small_pshape_rank = (pshape_a_rank > pshape_b_rank) ? pshape_b_rank : pshape_a_rank;
-    if (pshape_a_rank != pshape_b_rank && small_pshape_rank > 0 &&
-        input.get_partial_shape().rank() == small_pshape_rank)
-        return true;
-
-    return false;
+    return pshape_a_rank != pshape_b_rank && small_pshape_rank > 0 &&
+        input.get_partial_shape().rank() == small_pshape_rank;
 }
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -231,21 +231,21 @@ std::vector<layout> gemm_inst::transform_input_layouts(const std::shared_ptr<con
     size_t input_rank = (reordered && !allow_new_shape_infer) ? output_rank : primitive->input_rank;
     size_t weight_rank = (reordered && !allow_new_shape_infer) ? output_rank : primitive->weight_rank;
 
-    auto transposed_input0_pshape = get_transposed_input_shape(input0_pshape, input_rank, output_rank, primitive->transpose_input0, true);
-    auto transposed_input1_pshape = get_transposed_input_shape(input1_pshape, weight_rank, output_rank, primitive->transpose_input1, false);
+    auto transposed_input0_pshape = get_transposed_input_shape(input0_pshape, input_rank, output_rank, primitive->transpose_input0 != 0u, true);
+    auto transposed_input1_pshape = get_transposed_input_shape(input1_pshape, weight_rank, output_rank, primitive->transpose_input1 != 0u, false);
 
     std::vector<layout> layouts = input_layouts;
     // Format update for rank > 4 case
     if (layouts[0].format.dimension() < transposed_input0_pshape.size())
         layouts[0].format = cldnn::format::get_default_format(transposed_input0_pshape.size());
     layouts[0].set_partial_shape(transposed_input0_pshape);
-    layouts[0].data_padding = get_transposed_padding(layouts[0].data_padding, input_rank, input_format_rank, primitive->transpose_input0, true);
+    layouts[0].data_padding = get_transposed_padding(layouts[0].data_padding, input_rank, input_format_rank, primitive->transpose_input0 != 0u, true);
     layouts[1].set_partial_shape(transposed_input1_pshape);
-    layouts[1].data_padding = get_transposed_padding(layouts[1].data_padding, weight_rank, weight_format_rank, primitive->transpose_input1, false);
+    layouts[1].data_padding = get_transposed_padding(layouts[1].data_padding, weight_rank, weight_format_rank, primitive->transpose_input1 != 0u, false);
 
     if (primitive->input_size() == 3) {
         auto bias_pshape = input_layouts[2].get_partial_shape();
-        auto updated_bias_pshape = get_transposed_input_shape(bias_pshape, weight_rank, output_rank, primitive->transpose_input1, false);
+        auto updated_bias_pshape = get_transposed_input_shape(bias_pshape, weight_rank, output_rank, primitive->transpose_input1 != 0u, false);
         layouts[2].set_partial_shape(updated_bias_pshape);
     }
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -229,7 +229,7 @@ void add_required_reorders::run(program& p) {
                 // Some kernels use blocked aligned subgroup reads for a vector of elements from dependency tensor
                 // In that case jitter checks that layout of input tensor from fused op is same as output layout or broadcast is possible
                 // The code below is intended to insert additional reorder node for const eltwise dependency to ensure jitter can process such fusion
-                if (!fused_op.is_type<eltwise>() && !(fused_op.is_type<activation>() && fused_op.total_num_deps == 2))
+                if (!fused_op.is_type<eltwise>() && (!fused_op.is_type<activation>() || fused_op.total_num_deps != 2))
                     continue;
 
                 if (!fused_op.has_outer_dep())

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
@@ -33,7 +33,7 @@ void compile_graph::run(program& p) {
     for (size_t idx = 0; idx < proc_order.size(); idx++) {
         const auto& node = *(std::next(proc_order.begin(), idx));
 
-        bool can_select_impl = !node->is_type<data>() && !(node->is_type<mutable_data>() && node->get_dependencies().empty());
+        bool can_select_impl = !node->is_type<data>() && (!node->is_type<mutable_data>() || !node->get_dependencies().empty());
 
         if (can_select_impl) {
             tasks.emplace_back([node, &forcing_map, &exception] {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/fuse_primitives_with_layout.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/fuse_primitives_with_layout.cpp
@@ -16,12 +16,8 @@ void fuse_primitives_with_layout::run(program& p) {
     auto eltwise_supports_fusings = [&](eltwise_node& node) -> bool {
         auto out_layout = node.get_output_layout();
         // This condition refers to optimizied kernel EltwiseKernel_fs_b_yx_fsv32
-        if (out_layout.data_type == data_types::f16 && out_layout.batch() > 1 &&
-            (p.get_layout_optimizer().get_optimization_attributes().fs_b_yx_fsv32_network || out_layout.format == format::fs_b_yx_fsv32)) {
-            return false;
-        }
-
-        return true;
+        return out_layout.data_type != data_types::f16 || out_layout.batch() <= 1 ||
+            ((p.get_layout_optimizer().get_optimization_attributes().fs_b_yx_fsv32_network == 0) && out_layout.format != format::fs_b_yx_fsv32);
     };
 
     bool need_recalc_processing_order = false;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
@@ -93,7 +93,7 @@ void handle_reshape::run(program& p) {
             // find users who are onednn impl
             for (const auto& user : node->get_users()) {
                 if (user->is_type<reorder>() &&
-                    (*user).as<reorder>().get_primitive()->truncate == false)   // not to split conversion only reorder
+                    !(*user).as<reorder>().get_primitive()->truncate)   // not to split conversion only reorder
                     reorder_node_to_split.push_back(user);
                 if (user->can_use(impl_types::onednn))
                     onednn_users.push_back(user);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
@@ -123,7 +123,7 @@ void mark_runtime_skippable_nodes::run(program& p) {
                 || !prim->new_axis_mask.empty()
                 || !prim->shrink_axis_mask.empty()
                 || !prim->ellipsis_mask.empty()
-                || !(all_zeroes(begin) || all_ones(begin_mask))
+                || (!all_zeroes(begin) && !all_ones(begin_mask))
                 || !all_ones(strides))
                 return;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/oooq_memory_dependencies.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/oooq_memory_dependencies.cpp
@@ -20,7 +20,7 @@ public:
     bool is_set(size_t idx) const {
         size_t storage_idx = idx >> 6;
         uint64_t mask = 1ULL << (idx & 0x3F);
-        return storage[storage_idx] & mask;
+        return (storage[storage_idx] & mask) != 0u;
     }
     void set(size_t idx) {
         size_t storage_idx = idx >> 6;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
@@ -54,8 +54,8 @@ void pre_replace_deconv::run(program& p) {
                 // fp16 and fp32 bfyx implementation supports transposed convolution
                 perform_opt |= cldnn::format::dimension(input_layout.format) == 4 &&
                                (input_layout.data_type == data_types::f32 || input_layout.data_type == data_types::f16) &&
-                               !((lo.get_optimization_attributes().b_fs_yx_fsv16_network || input_layout.format == format::b_fs_yx_fsv16) &&
-                                lo.is_format_optimized(deconv_node, format::b_fs_yx_fsv16));
+                               (((lo.get_optimization_attributes().b_fs_yx_fsv16_network == 0) && input_layout.format != format::b_fs_yx_fsv16) ||
+                                !lo.is_format_optimized(deconv_node, format::b_fs_yx_fsv16));
                 // int8/uint8 input
                 perform_opt |= (input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8);
 
@@ -162,7 +162,7 @@ void pre_replace_deconv::run(program& p) {
 
                 update_processing_order = true;
             // current optimization only available for specific deconvolution parameters
-            } else if (deconv_node.is_output() == false &&
+            } else if (!deconv_node.is_output() &&
                deconv_node.get_output_layout().feature() == 1 &&
                deconv_prim->stride[deconv_prim->stride.size() - 1] == 2 && deconv_prim->stride[deconv_prim->stride.size() - 2] == 2 &&
                filter_layout.spatial(0) == 9 && filter_layout.spatial(1) == 9 &&

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -67,13 +67,11 @@ bool concat_in_place_optimization::match(concatenation_node& node) {
 // and is not optimized concatenation then do not fuse buffers
 // TODO: we need add padding support for all optimized kernels to remove this condition
 auto available_pred = [](const program_node& input) {
-    if (!input.is_type<pooling>() && !input.is_type<convolution>() && !input.is_type<quantize>() &&
-        !input.is_type<activation>() && !input.is_type<deconvolution>() && !input.is_type<concatenation>() &&
-        !input.is_type<crop>() && !input.is_type<eltwise>() && !input.is_type<resample>() &&
-        !input.is_type<reorder>() && !(input.is_type<permute>() && !input.as<permute>().is_rotating_except_batch()) &&
-        !input.is_type<strided_slice>())
-        return false;
-    return true;
+    return input.is_type<pooling>() || input.is_type<convolution>() || input.is_type<quantize>() ||
+        input.is_type<activation>() || input.is_type<deconvolution>() || input.is_type<concatenation>() ||
+        input.is_type<crop>() || input.is_type<eltwise>() || input.is_type<resample>() ||
+        input.is_type<reorder>() || (input.is_type<permute>() && !input.as<permute>().is_rotating_except_batch()) ||
+        input.is_type<strided_slice>();
 };
 
 bool concat_in_place_optimization::match(const program_node& concat_node,
@@ -365,10 +363,7 @@ static bool can_reshape_be_optimized(const reshape_node& node) {
         node.get_users().front()->get_preferred_impl_type() == impl_types::onednn)
         return true;
 
-    if (node.is_in_place())
-        return true;
-
-    return false;
+    return node.is_in_place();
 }
 
 static bool is_optimizable_padding_for_crop(const crop_node& node,
@@ -422,17 +417,13 @@ bool crop_in_place_optimization::can_crop_be_optimized_along_feature(const layou
     const auto& crop_size = crop_layout.get_tensor();
     const auto& out_pad = crop_layout.data_padding;
 
-    if (format == format::bfyx && crop_size.batch[0] == input_layout.batch() &&
+    return format == format::bfyx && crop_size.batch[0] == input_layout.batch() &&
         crop_size.spatial[0] == input_layout.spatial(0) &&
         crop_size.spatial[1] == input_layout.spatial(1) && out_pad._lower_size[1] == 0 &&
         out_pad._upper_size[1] == 0 && out_pad._lower_size[0] == 0 &&
         out_pad._upper_size[0] == 0 && out_pad._lower_size[2] == 0 &&
         out_pad._lower_size[3] == 0 && out_pad._upper_size[2] == 0 &&
-        out_pad._upper_size[3] == 0) {
-        return true;
-    }
-
-    return false;
+        out_pad._upper_size[3] == 0;
 }
 
 bool crop_in_place_optimization::can_crop_be_optimized_simple_data_format(const layout& crop_layout,
@@ -441,11 +432,7 @@ bool crop_in_place_optimization::can_crop_be_optimized_simple_data_format(const 
     const auto& in_padding = input_layout.data_padding;
     const auto& out_padding = crop_layout.data_padding;
 
-    if (format::is_simple_data_format(format) && !out_padding && !in_padding) {
-        return true;
-    }
-
-    return false;
+    return format::is_simple_data_format(format) && !out_padding && !in_padding;
 }
 
 static bool can_read_value_be_optimize(const read_value_node& node) {
@@ -589,8 +576,8 @@ bool crop_in_place_optimization::match(const program_node& node,
         if ((!dyn_aware || is_runtime) &&
             !is_optimizable_padding_for_crop(node, crop_layout, input_layout, crop_params.input_offsets[0]))
             return false;
-        if (!(((!dyn_aware || is_runtime) && can_crop_be_optimized_along_feature(crop_layout, input_layout))
-            || can_crop_be_optimized_simple_data_format(crop_layout, input_layout)))
+        if (((dyn_aware && !is_runtime) || !can_crop_be_optimized_along_feature(crop_layout, input_layout))
+            && !can_crop_be_optimized_simple_data_format(crop_layout, input_layout))
             return false;
     } else {
         return false;
@@ -883,10 +870,7 @@ void prepare_buffer_fusing::run(program& p) {
             return true;
         }
 
-        if (is_dynamic || node->is_output() || node->has_fused_primitives() || node->is_in_shape_of_subgraph()) {
-            return false;
-        }
-        return true;
+        return !is_dynamic && !node->is_output() && !node->has_fused_primitives() && !node->is_in_shape_of_subgraph();
     };
 
     // [1] First try to optimize all concats

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -220,7 +220,7 @@ void prepare_primitive_fusing::fuse_swiglu(program &p) {
         if (node->get_dependencies().size() > 1)
             continue;
         if (swiglu_prim->glu_type != ov::op::internal::GLU::GluType::Swish ||
-           !(swiglu_prim->axis == -1 || swiglu_prim->axis == static_cast<int64_t>(node->get_output_layout(false).get_partial_shape().size()) - 1))
+           (swiglu_prim->axis != -1 && swiglu_prim->axis != static_cast<int64_t>(node->get_output_layout(false).get_partial_shape().size()) - 1))
             continue;
 
         auto& dep_node = node->get_dependency(0);
@@ -565,23 +565,23 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 return true;
 
             if ((node.get_output_layout().format == format::bfzyx &&
-                (!lo.get_optimization_attributes().b_fs_zyx_fsv16_network || !lo.is_format_optimized(node, format::b_fs_zyx_fsv16))))
+                ((lo.get_optimization_attributes().b_fs_zyx_fsv16_network == 0) || !lo.is_format_optimized(node, format::b_fs_zyx_fsv16))))
                 return true;
 
             if ((node.get_output_layout().format == format::fs_b_yx_fsv32 ||
-                (lo.get_optimization_attributes().fs_b_yx_fsv32_network &&
+                ((lo.get_optimization_attributes().fs_b_yx_fsv32_network != 0) &&
                  lo.is_format_optimized(node, format::fs_b_yx_fsv32) && node.get_primitive()->groups == 1)))
                     return true;
 
             const size_t in_feature = node.get_input_layout(0).feature();
             if ((node.get_output_layout().format == format::b_fs_zyx_fsv16 ||
                  (lo.is_format_optimized(node, format::b_fs_zyx_fsv16) &&
-                  lo.get_optimization_attributes().b_fs_zyx_fsv16_network)) && in_feature != 3)
+                  (lo.get_optimization_attributes().b_fs_zyx_fsv16_network != 0))) && in_feature != 3)
                 return true;
 
             if ((node.get_output_layout().format == format::bs_fs_yx_bsv16_fsv16 ||
                  (lo.is_format_optimized(node, format::bs_fs_yx_bsv16_fsv16) &&
-                  lo.get_optimization_attributes().bs_fs_yx_bsv16_fsv16_network)) && node.get_primitive()->groups == 1)
+                  (lo.get_optimization_attributes().bs_fs_yx_bsv16_fsv16_network != 0))) && node.get_primitive()->groups == 1)
                 return true;
 
             if (node.get_output_layout().format == format::bs_fs_yx_bsv32_fsv32 || lo.is_format_optimized(node, format::bs_fs_yx_bsv32_fsv32))
@@ -629,7 +629,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 if (node.get_inputs_count() == 3) {
                     auto in2_dt = node.get_input_layout(2).data_type;
                     auto in2_fmt = node.get_input_layout(2).format;
-                    does_support_fusings = data_type_traits::is_i8_u8(in2_dt) && in2_fmt == format::bfyx ? true : false;
+                    does_support_fusings = data_type_traits::is_i8_u8(in2_dt) && in2_fmt == format::bfyx;
                 } else {
                     does_support_fusings = true;
                 }
@@ -649,9 +649,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
 
         auto mvn_supports_fusings = [](mvn_node& node) -> bool {
             auto in_layout = node.get_input_layout(0);
-            if (node.get_primitive()->requires_alignment(in_layout.get_partial_shape()))
-                return false;
-            return true;
+            return !node.get_primitive()->requires_alignment(in_layout.get_partial_shape());
         };
 
         auto dts_supports_fusings = [](depth_to_space_node& node) -> bool {
@@ -677,10 +675,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
         auto reduce_supports_fusings = [&](reduce_node& node) -> bool {
             auto keep_dims = node.as<reduce>().get_primitive()->keep_dims;
 
-            if (keep_dims)
-                return true;
-
-            return false;
+            return keep_dims;
         };
 
         auto eltwise_supports_fusings = [&](eltwise_node& node) -> bool {
@@ -700,13 +695,10 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
 
             auto out_layout = node.get_output_layout();
             // Do not fuse if the estimated format is fs_b_yx_fsv32 because the optimized kernel does not support fusion
-            if (out_layout.data_type == data_types::f16 && out_layout.is_static() && out_layout.batch() > 1 &&
-                ((lo.get_optimization_attributes().fs_b_yx_fsv32_network &&
-                  !lo.has_all_enabled_onednn_impls_optimization_attribute() && !has_reorder_behind_mvn()) ||
-                 out_layout.format == format::fs_b_yx_fsv32)) {
-                return false;
-            }
-            return true;
+            return out_layout.data_type != data_types::f16 || !out_layout.is_static() || out_layout.batch() <= 1 ||
+                (((lo.get_optimization_attributes().fs_b_yx_fsv32_network == 0) ||
+                  lo.has_all_enabled_onednn_impls_optimization_attribute() || has_reorder_behind_mvn()) &&
+                 out_layout.format != format::fs_b_yx_fsv32);
         };
 
         auto get_users_from_fusing_history = [&](const primitive_id& id) {
@@ -784,10 +776,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             if (consumer->is_type<eltwise>()) {
                 const auto& input_layout = bcast_node.get_output_layout();
                 const auto& output_layout = consumer->get_output_layout();
-                if (input_layout.data_type != output_layout.data_type) {
-                    return false;
-                }
-                return true;
+                return input_layout.data_type == output_layout.data_type;
             }
 
             return false;
@@ -998,8 +987,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             // float-to-int8 output narrowing (e.g., f16->u8). Prevent fusion in this case
             // to keep deconv output as float (optimized kernel) + separate quantize.
             should_fuse |= input_data.is_type<deconvolution>() && quantize_node.get_scale_shift_opt() &&
-                           !(lo.has_all_enabled_onednn_impls_optimization_attribute() &&
-                             !in_dt_is_i8_u8 && out_dt_is_i8_u8);
+                           (!lo.has_all_enabled_onednn_impls_optimization_attribute() ||
+                             in_dt_is_i8_u8 || !out_dt_is_i8_u8);
 
             should_fuse |= input_data.is_type<gather>() && quantize_node.get_scale_shift_opt();
 
@@ -1311,10 +1300,10 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                     auto curr_users = current_node.first->get_users();
                     auto invalid_user_iter = std::find_if(curr_users.begin(), curr_users.end(), [&](cldnn::program_node* user) {
                         return (user->is_output() ||
-                                    (!(user->is_type<eltwise>() && user->get_primitive()->input.size() == 2 &&
-                                        (std::find(supported_modes.begin(), supported_modes.end(),
+                                    ((!user->is_type<eltwise>() || user->get_primitive()->input.size() != 2 ||
+                                        !(std::find(supported_modes.begin(), supported_modes.end(),
                                         (user->as<eltwise>()).get_primitive()->mode) != supported_modes.end())) &&
-                                    !(user->is_type<activation>() && user->get_dependency(0).get_users().size() == 1)));
+                                    (!user->is_type<activation>() || user->get_dependency(0).get_users().size() != 1)));
                     });
 
                     if (invalid_user_iter != curr_users.end()) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing_through.cpp
@@ -49,11 +49,8 @@ void prepare_primitive_fusing_through::run(program& p) {
                 return false;
 
             // Not to raise up target node through reshape or reorder where the size of dimension is changed (e.g. Unsqueeze or Squeeze)
-            if ((node->is_type<reshape>() || node->is_type<reorder>()) &&
-                node->get_output_pshape().size() != node->get_input_pshape(0).size())
-                return false;
-
-            return true;
+            return (!node->is_type<reshape>() && !node->is_type<reorder>()) ||
+                node->get_output_pshape().size() == node->get_input_pshape(0).size();
         };
 
         std::vector<program_node*> pass_through;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -236,7 +236,7 @@ void prepare_quantization::prepare_scale_shift_opt(program &p, quantize_node& qu
 
     auto out_is_int8 = quantize_node.get_output_layout().data_type == data_types::i8;
     auto out_is_uint8 = quantize_node.get_output_layout().data_type == data_types::u8;
-    auto out_is_fp = !(out_is_int8 || out_is_uint8);
+    auto out_is_fp = !out_is_int8 && !out_is_uint8;
     bool need_clamp = levels != 256 || out_is_fp;
     bool need_min_clamp = need_clamp;
     bool need_max_clamp = need_clamp;
@@ -419,7 +419,7 @@ void prepare_quantization::remove_fake_reorders(program& p, reorder_node& reorde
 
     auto &usr = reorder_node.get_users().front();
     auto &dep = reorder_node.get_dependency(0);
-    if (!(usr->is_type<convolution>() && usr->get_input_layout(1).data_type == data_types::i8) ||
+    if (!usr->is_type<convolution>() || usr->get_input_layout(1).data_type != data_types::i8 ||
         !dep.is_input() ||
         dep.get_output_layout().data_type != data_types::u8 ||
         (reorder_node.get_output_layout().data_type != data_types::f32 && reorder_node.get_output_layout().data_type != data_types::f16) ||

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/propagate_constants.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/propagate_constants.cpp
@@ -32,7 +32,7 @@ namespace {
 // Refreshes stale output layouts before building kernel params to avoid
 // incorrect shape_type classification.
 void try_reselect_impl_for_node(program_node* node) {
-    bool can_select_impl = !node->is_type<data>() && !(node->is_type<mutable_data>() && node->get_dependencies().empty());
+    bool can_select_impl = !node->is_type<data>() && (!node->is_type<mutable_data>() || !node->get_dependencies().empty());
     if (!can_select_impl)
         return;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -99,7 +99,7 @@ void remove_redundant_reorders::run(program& p) {
                                input.get_output_layout().data_type == data_types::u8;
             auto quantize_user = has_quantize_user(node);
 
-            if (!same_data_type && !(i8_u8_input && quantize_user))
+            if (!same_data_type && (!i8_u8_input || !quantize_user))
                 continue;
 
             // Avoid optimization of nv12 reorder

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -328,7 +328,7 @@ void minimize_local_reorders(program& p, std::map<program_node*, format::type>& 
                         continue;
                     io_formats.insert(fmt_map.at(dep.first));
                 }
-                if (!(io_formats.size() == 1 && io_formats.count(preferred_format) == 0))
+                if (io_formats.size() != 1 || io_formats.count(preferred_format) != 0)
                     continue;
             } else {
                 continue;

--- a/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/paged_attention_gen.cpp
@@ -51,11 +51,7 @@ inline size_t get_input_kv_len(const RuntimeParams& params) {
 
 inline bool get_kv_compressed(const RuntimeParams& params) {
     auto key_cache_layout = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE];
-    if (data_type_traits::is_i8_u8(key_cache_layout.data_type)) {
-        return true;
-    } else {
-        return false;
-    }
+    return data_type_traits::is_i8_u8(key_cache_layout.data_type);
 }
 
 // max_context_len = max(past_lens + prompt_lens)

--- a/src/plugins/intel_gpu/src/graph/impls/cm/vl_sdpa_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/vl_sdpa_opt.hpp
@@ -63,11 +63,7 @@ struct VLSDPAOptImplementationManager : public ImplementationManager {
             return false;
         }
 
-        if (!one_of(in0_layout.data_type, supported_types) || !one_of(out_layout.data_type, supported_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(in0_layout.data_type, supported_types) && one_of(out_layout.data_type, supported_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/common/condition.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/condition.cpp
@@ -98,7 +98,7 @@ struct condition_impl : typed_primitive_impl<condition> {
                 }
                 GPU_DEBUG_LOG << "    set output layout : " << output_layout.to_short_string() << std::endl;
                 instance.set_output_layout(output_layout, out_idx);
-                instance.set_output_memory(output_mem_ptr, out_idx);
+                instance.set_output_memory(output_mem_ptr, out_idx != 0u);
                 instance.set_flag(ExecutionFlags::MEMORY_CHANGED);
             }
             return stream.group_events(output_events);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/proposal.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/proposal.cpp
@@ -135,7 +135,7 @@ std::vector<roi_t> perform_nms(const std::vector<proposal_t>& proposals,
 
         bool overlaps = std::any_of(res.begin(), res.end(), [&](const roi_t& res_bbox) {
             bool intersecting =
-                (bbox.x0 < res_bbox.x1) & (res_bbox.x0 < bbox.x1) & (bbox.y0 < res_bbox.y1) & (res_bbox.y0 < bbox.y1);
+                (static_cast<int>(bbox.x0 < res_bbox.x1) & static_cast<int>(res_bbox.x0 < bbox.x1) & static_cast<int>(bbox.y0 < res_bbox.y1) & static_cast<int>(res_bbox.y0 < bbox.y1)) != 0;
             float overlap = 0.0f;
             if (intersecting) {
                 const float x0 = std::max(bbox.x0, res_bbox.x0);

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
@@ -66,7 +66,7 @@ struct read_value_impl : public typed_primitive_impl<read_value> {
             }
             if (!instance.get_user_insts().empty()) {
                 auto user_inst = instance.get_user_insts().front();
-                if (!(user_inst->get_node().is_type<assign>() || user_inst->get_node().is_type<kv_cache>()) &&
+                if (!user_inst->get_node().is_type<assign>() && !user_inst->get_node().is_type<kv_cache>() &&
                     instance.get_network().contains_state(variable_id)) {
                     variable.set();
                 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -83,7 +83,7 @@ public:
         argm_params.argMaxMinAxis = GetArgMaxMinAxis(axis, impl_param.get_output_layout().get_rank());
 
         auto& constant_mem = impl_param.memory_deps;
-        if (constant_mem.count(1) && !argm_params.has_dynamic_outputs()) {
+        if ((constant_mem.count(1) != 0u) && !argm_params.has_dynamic_outputs()) {
             // The topK could be got by reading impl_param.memory_deps.at(1).
             // However, here we utilize output_layout and axis information to minimize mem_lock.
             auto output_layout = impl_param.get_output_layout(0);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -182,7 +182,7 @@ public:
                 && cp.outputs[0].GetLayout() == kernel_selector::Tensor::DataLayout::bfyx
                 && cp.outputs[0].X().v == 1 && cp.outputs[0].Y().v > 1
                 && cp.weights.X().v == 1 && cp.weights.Y().v > 1
-                && !(cp.groups == cp.inputs[0].Feature().v && cp.inputs[0].Feature().v == cp.outputs[0].Feature().v)) {
+                && (cp.groups != cp.inputs[0].Feature().v || cp.inputs[0].Feature().v != cp.outputs[0].Feature().v)) {
                 auto can_swap = [](const kernel_selector::Tensor::DataTensor& dt) -> bool {
                     auto x_channel_idx = kernel_selector::Tensor::DataTensor::Channelndex(dt.GetLayout(),
                                                                                         kernel_selector::Tensor::DataChannelName::X);
@@ -209,7 +209,7 @@ public:
         };
 
         // Swap XY axes
-        if (can_swap_xy(conv_params) && primitive->deformable_mode == false) {
+        if (can_swap_xy(conv_params) && !primitive->deformable_mode) {
             conv_params.inputs[0].SwapXY();
             conv_params.outputs[0].SwapXY();
             conv_params.weights.SwapXY();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -29,7 +29,7 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
 
         bool allow_new_shape_infer = impl_param.get_program().is_new_shape_infer();
         if (allow_new_shape_infer && primitive->axes.empty() && primitive->signal_size.empty()) {
-            if (memory_deps.count(1)) {
+            if (memory_deps.count(1) != 0u) {
                 auto axes_mem = memory_deps.at(1);
                 cldnn::mem_lock<uint8_t, mem_lock_type::read> axes_lock(axes_mem, impl_param.get_stream());
 
@@ -44,7 +44,7 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
                 params.axes = axes;
             }
 
-            if (memory_deps.count(2)) {
+            if (memory_deps.count(2) != 0u) {
                 auto signal_size_mem = memory_deps.at(2);
                 cldnn::mem_lock<uint8_t, mem_lock_type::read> signal_size_lock(signal_size_mem, impl_param.get_stream());
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
@@ -31,8 +31,8 @@ struct experimental_detectron_prior_grid_generator_impl
         params.flatten = primitive->flatten;
         params.layer_height = primitive->h ? primitive->h : primitive->featmap_height;
         params.layer_width = primitive->w ? primitive->w : primitive->featmap_width;
-        params.step_x = primitive->stride_x ? primitive->stride_x : static_cast<float>(primitive->image_width) / params.layer_width;
-        params.step_y = primitive->stride_y ? primitive->stride_y : static_cast<float>(primitive->image_height) / params.layer_height;
+        params.step_x = (primitive->stride_x != 0.0f) ? primitive->stride_x : static_cast<float>(primitive->image_width) / params.layer_width;
+        params.step_y = (primitive->stride_y != 0.0f) ? primitive->stride_y : static_cast<float>(primitive->image_height) / params.layer_height;
 
         return params;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.hpp
@@ -43,10 +43,7 @@ struct GatherNDImplementationManager : public ImplementationManager {
         if (!one_of(in0_layout.data_type, supported_in_types) || !one_of(in1_layout.data_type, supported_in_types))
             return false;
 
-        if (!one_of(out_layout.data_type, supported_out_types))
-            return false;
-
-        return true;
+        return one_of(out_layout.data_type, supported_out_types);
     }
 
     in_out_fmts_t query_formats(const program_node& node) const override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -981,7 +981,7 @@ kernel_selector::n_dims compute_tensor_dimensions(const layout& l,
         elm.pitch = pitch;
         elm.pad.before = dynamic_pad_dims[tensor_index] ? 0 : lp;
         elm.pad.after = dynamic_pad_dims[tensor_index] ? 0 : up;
-        elm.pad.is_dynamic = dynamic_pad_dims[tensor_index];
+        elm.pad.is_dynamic = (dynamic_pad_dims[tensor_index] != 0);
         elm.is_dynamic = d.is_dynamic();
 
         pitch *= (reserved_in_mem_count + lp + up);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
@@ -255,7 +255,7 @@ inline bool broadcastable(const ov::PartialShape& first_pshape, const ov::Partia
     size_t min_size = std::min(first_pshape.size(), second_pshape.size());
 
     for (size_t i = 0; i < min_size; ++i) {
-        if (!(first_pshape[i] == 1 || (!first_to_second_only && second_pshape[i] == 1) || first_pshape[i] == second_pshape[i])) {
+        if (first_pshape[i] != 1 && (first_to_second_only || second_pshape[i] != 1) && first_pshape[i] != second_pshape[i]) {
             return false;
         }
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernels_cache.cpp
@@ -133,7 +133,7 @@ void kernels_cache::get_program_source(const kernels_code& kernels_source_code, 
 
             std::string key = options;
 
-            if (batch_compilation == false) {
+            if (!batch_compilation) {
                 key += " __PROGRAM__" + std::to_string(program_buckets.size());
             }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
@@ -115,12 +115,12 @@ static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, b
 
         auto get_additional_output_node_idx = [&] (bool is_third) {
             size_t offset = 2;
-            offset += arg.has_num_select_per_class();
-            offset += arg.has_iou_threshold();
-            offset += arg.has_score_threshold();
-            offset += arg.has_soft_nms_sigma();
+            offset += static_cast<size_t>(arg.has_num_select_per_class());
+            offset += static_cast<size_t>(arg.has_iou_threshold());
+            offset += static_cast<size_t>(arg.has_score_threshold());
+            offset += static_cast<size_t>(arg.has_soft_nms_sigma());
             if (is_third)
-                offset += arg.has_second_output();
+                offset += static_cast<size_t>(arg.has_second_output());
             return offset;
         };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -90,9 +90,9 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
     static std::unique_ptr<primitive_impl> create(const typed_program_node<PType>& arg, const kernel_impl_params& impl_param) {
         // concat buffer fusing for dynamic shape is adaptively applied at runtime. So we need to build dynamic impl at build time.
         if (impl_param.can_be_optimized() &&
-            !((impl_param.is_type<concatenation>() ||
-               impl_param.is_type<crop>() ||
-               impl_param.runtime_skippable()) && impl_param.is_dynamic())) {
+            ((!impl_param.is_type<concatenation>() &&
+               !impl_param.is_type<crop>() &&
+               !impl_param.runtime_skippable()) || !impl_param.is_dynamic())) {
             return std::make_unique<ImplType>(kernel_selector::kernel_data{});
         }
         auto kernel_params = ImplType::get_kernel_params(ImplType::static_canonicalize_shapes(impl_param));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
@@ -84,7 +84,7 @@ struct reduce_impl : typed_primitive_impl_ocl<reduce> {
         auto params = get_default_params<kernel_selector::reduce_params>(impl_param, is_shape_agnostic);
 
         params.reduceAxes = convert_axes(primitive->axes, impl_param.input_layouts[0].get_rank());
-        params.keepDims = primitive->keep_dims;
+        params.keepDims = static_cast<int32_t>(primitive->keep_dims);
         params.reduceMode = cldnn_2_reduce_mode(primitive->mode);
         return params;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -78,7 +78,7 @@ public:
                 params.mean = convert_data_tensor(mean_layout);
                 params.mode = kernel_selector::mean_subtruct_mode::IN_BUFFER;
             }
-        } else if (primitive->subtract_per_feature.empty() == false) {
+        } else if (!primitive->subtract_per_feature.empty()) {
             params.mode = kernel_selector::mean_subtruct_mode::INSIDE_PARAMS;
             params.meanValues = primitive->subtract_per_feature;
         } else {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.hpp
@@ -22,10 +22,7 @@ struct ReorderImplementationManager : public ImplementationManager {
 
         const auto& output_layout = node.get_output_layout(0);
         auto output_fmt = output_layout.format;
-        if (output_fmt == format::custom)
-            return false;
-
-        return true;
+        return output_fmt != format::custom;
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.hpp
@@ -55,10 +55,7 @@ struct ScatterElementsUpdateImplementationManager : public ImplementationManager
         if (!one_of(in0_layout.data_type, supported_in_types) || !one_of(in1_layout.data_type, supported_in_types))
             return false;
 
-        if (!one_of(out_layout.data_type, supported_out_types))
-            return false;
-
-        return true;
+        return one_of(out_layout.data_type, supported_out_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.hpp
@@ -63,10 +63,7 @@ struct ScatterUpdateImplementationManager : public ImplementationManager {
         if (!one_of(in0_layout.data_type, supported_in_types) || !one_of(in1_layout.data_type, supported_in_types))
             return false;
 
-        if (!one_of(out_layout.data_type, supported_out_types))
-            return false;
-
-        return true;
+        return one_of(out_layout.data_type, supported_out_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -196,10 +196,7 @@ public:
                 // Check out of bounds values for Clamping
                 auto check_out_of_bounds = [&](int32_t value) -> bool {
                     auto size = out_shape[dim];
-                    if (value >= size || value < (size * -1))
-                        return true;
-                    else
-                        return false;
+                    return value >= size || value < (size * -1);
                 };
                 bool should_clamp_begin = check_out_of_bounds(begin);
                 bool should_clamp_end = check_out_of_bounds(end);
@@ -209,7 +206,7 @@ public:
                     begin += out_shape[dim];  // converted value can be negative if the original one was out of bounds
                 if (end < 0)
                     end += out_shape[dim];
-                bool is_stride_reverse = (stride < 0) ? true : false;
+                bool is_stride_reverse = stride < 0;
 
                 // Clamping
                 begin = std::min(std::max(begin, (int32_t)0), out_shape[dim]);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/col2im.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/col2im.cpp
@@ -38,11 +38,7 @@ bool check_col2im_contain_batch(const kernel_impl_params& params) {
 
     // Check input size L which is the total number of blocks : product from d=1
     // to 2 of origin size
-    if (input_layout.spatial(1) == 1 && input_layout.spatial(1) != static_cast<tensor::value_type>(orig_size[0] * orig_size[1])) {
-        return false;
-    }
-
-    return true;
+    return input_layout.spatial(1) != 1 || input_layout.spatial(1) == static_cast<tensor::value_type>(orig_size[0] * orig_size[1]);
 }
 
 class Col2ImGenerator : public KernelGenerator {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gated_delta_net_ref.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gated_delta_net_ref.hpp
@@ -39,10 +39,7 @@ struct GatedDeltaNetRef : public ImplementationManager {
         }
 
         const auto& out_layout = node.get_output_layout(0);
-        if (!one_of(out_layout.format, supported_fmts) || !one_of(out_layout.data_type, supported_types)) {
-            return false;
-        }
-        return true;
+        return one_of(out_layout.format, supported_fmts) && one_of(out_layout.data_type, supported_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gather_matmul/gather_matmul.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gather_matmul/gather_matmul.cpp
@@ -81,7 +81,7 @@ inline dnnl::memory::data_type convert_data_type(cldnn::data_types dt) {
 inline bool weights_need_onednn_grouped(const kernel_impl_params& params) {
     const auto& weights_layout = params.input_layouts[gather_matmul::BGMInputIdx::WEIGHT];
     const auto dt = weights_layout.data_type;
-    return !(dt == cldnn::data_types::u4 || dt == cldnn::data_types::i4);
+    return dt != cldnn::data_types::u4 && dt != cldnn::data_types::i4;
 }
 #endif
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_bfyx_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_bfyx_opt.hpp
@@ -49,11 +49,7 @@ struct GroupNormalizationBfyxOpt : public GroupNormalizationBase {
             return false;
         }
 
-        if (!fused_ops_are_one_of<eltwise, activation, reorder>(node.get_fused_primitives())) {
-            return false;
-        }
-
-        return true;
+        return fused_ops_are_one_of<eltwise, activation, reorder>(node.get_fused_primitives());
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_ref.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_ref.hpp
@@ -38,11 +38,7 @@ struct GroupNormalizationRef : public GroupNormalizationBase {
             return false;
         }
 
-        if (!fused_ops_are_one_of<eltwise, activation>(node.get_fused_primitives())) {
-            return false;
-        }
-
-        return true;
+        return fused_ops_are_one_of<eltwise, activation>(node.get_fused_primitives());
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora.cpp
@@ -201,7 +201,7 @@ public:
         const auto& lora_input_lo = params.input_layouts[1];
         size_t batch = extract_channel(ChannelName::BATCH, lora_input_lo);
         size_t feature = extract_channel(ChannelName::FEATURE, lora_input_lo);
-        return batch * feature > 1;
+        return static_cast<size_t>(batch * feature > 1);
     }
 
     static constexpr size_t gemm_a_sg_bk = 32ul;
@@ -766,11 +766,7 @@ bool is_optimized_kernel_supported(const RuntimeParams& params) {
 
     const auto& state_b_layout = params.get_input_layout(4);
     size_t output_state = state_b_layout.get_shape().front();
-    if (output_state % subgroup_size != 0) {
-        return false;
-    }
-
-    return true;
+    return output_state % subgroup_size == 0;
 }
 
 std::vector<size_t> get_stages_execution_order_single_lora(const cldnn::kernel_impl_params& impl_params) {
@@ -975,7 +971,7 @@ public:
     }
 
     std::vector<size_t> get_stages_execution_order(const cldnn::kernel_impl_params& impl_params) const override {
-        size_t is_single_lora = LoraRefBase<>::get_lora_count(impl_params) == 1;
+        size_t is_single_lora = static_cast<size_t>(LoraRefBase<>::get_lora_count(impl_params) == 1);
         if (is_single_lora) {
             return get_stages_execution_order_single_lora(impl_params);
         } else {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/lora.hpp
@@ -33,11 +33,7 @@ struct Lora : public ImplementationManager {
         }
 
         const auto& output_layout = node.get_output_layout(0);
-        if (!one_of(output_layout.format, supported_fmts) || !one_of(output_layout.data_type, supported_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(output_layout.format, supported_fmts) && one_of(output_layout.data_type, supported_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_swiglu_opt.cpp
@@ -975,7 +975,7 @@ public:
 
         // Remove this limitation once micro_gemm kernels has supported i8/u8 weights.
         const auto& weight_dt = params.get_input_layout(static_cast<size_t>(MOE3GemmInputIndex::WEIGHT_0)).data_type;
-        if (!(weight_dt == data_types::u4 || weight_dt == data_types::i4) && use_micro_gemm_prefill) {
+        if (weight_dt != data_types::u4 && weight_dt != data_types::i4 && use_micro_gemm_prefill) {
             use_micro_gemm_prefill = false;
         }
 
@@ -1535,7 +1535,7 @@ public:
             on_before_batched_gemv(stream, instance, scratch, topk_count, needs_fallback);
             if (needs_fallback) {
                 // Cannot fit all experts simultaneously → fall back to per-expert onednn loop
-                instance.output_memory_ptr(0)->fill(stream, false);
+                instance.output_memory_ptr(0)->fill(stream, 0u);
                 return exec_prefill_onednn(events, stream, instance, scratch);
             }
         }
@@ -1666,7 +1666,7 @@ public:
             bool needs_fallback = false;
             on_before_prefill(stream, instance, scratch, batch_mem_ptr, topk_count, needs_fallback);
             if (needs_fallback) {
-                instance.output_memory_ptr(0)->fill(stream, false);
+                instance.output_memory_ptr(0)->fill(stream, 0u);
                 return exec_prefill_onednn(events, stream, instance, scratch);
             }
         }
@@ -2194,7 +2194,7 @@ public:
             if (expert_no >= expert_mask.pred_flag.size()) {
                 OPENVINO_THROW("expert_no=", expert_no, " is out of bounds");
             }
-            auto can_skip_subgraph = !expert_mask.pred_flag[expert_no];
+            auto can_skip_subgraph = expert_mask.pred_flag[expert_no] == 0;
             if (can_skip_subgraph) {
                 continue;
             }
@@ -2575,7 +2575,7 @@ public:
         // fallback to exec_prefill_onednn (when unique_experts > lru slots)
         // also accumulates via index_add.
         if (!use_micro_gemm_prefill && should_pre_zero_output()) {
-            final_hidden_states_mem_ptr->fill(stream, false);
+            final_hidden_states_mem_ptr->fill(stream, 0u);
         }
         // GPU mask gen is only supported for micro_gemm; both grouped_gemm and onednn loop
         // always use CPU mask gen and therefore always need topk to be ready first.

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gather.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gather.hpp
@@ -44,11 +44,7 @@ struct MoeGatherRef : public ImplementationManager {
             return false;
         }
 
-        if (!one_of(in0_layout.data_type, supported_types) || !one_of(out_layout.data_type, supported_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(in0_layout.data_type, supported_types) && one_of(out_layout.data_type, supported_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gemm_gen_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_gemm_gen_opt.hpp
@@ -54,11 +54,7 @@ public:
             auto scale_group_dim = params.input_layouts[moe_cfg.weight_scale_idx].get_shape().size() - 2;
             auto num_scale_groups = (weight_shape.size() == 4) ? params.input_layouts[moe_cfg.weight_scale_idx].get_shape()[scale_group_dim] : 1;
             moe_cfg.weight_group_size = static_cast<int32_t>(k / num_scale_groups);
-            if (static_cast<int32_t>(params.input_layouts.size()) > moe_cfg.weight_zp_idx) {
-                moe_cfg.is_weight_symmetric_quantized = false;
-            } else {
-                moe_cfg.is_weight_symmetric_quantized = true;
-            }
+            moe_cfg.is_weight_symmetric_quantized = static_cast<int32_t>(params.input_layouts.size()) <= moe_cfg.weight_zp_idx;
         }
         moe_cfg.has_batch_dim = desc->has_batch_dim;
         return moe_cfg;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_mask_gen.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_mask_gen.hpp
@@ -36,11 +36,7 @@ struct MoeMaskGenRef : public ImplementationManager {
             return false;
         }
 
-        if (!one_of(in0_layout.data_type, supported_types) || !one_of(out_layout.data_type, supported_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(in0_layout.data_type, supported_types) && one_of(out_layout.data_type, supported_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_router_fused_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_router_fused_opt.hpp
@@ -24,10 +24,7 @@ struct MoeRouterFusedOpt : public ImplementationManager {
         };
 
         const auto& in_layout = node.get_input_layout(0);
-        if (!one_of(in_layout.data_type, supported_types))
-            return false;
-
-        return true;
+        return one_of(in_layout.data_type, supported_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_opt.hpp
@@ -42,11 +42,7 @@ struct MoeScatterReductionOpt : public MoeScatterReductionBase {
             return false;
         }
 
-        if (!one_of(in0_layout.data_type, supported_types) || !one_of(out_layout.data_type, supported_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(in0_layout.data_type, supported_types) && one_of(out_layout.data_type, supported_types);
     }
     static constexpr size_t block_size = 4;
 };

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_ref.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_scatter_reduction_ref.hpp
@@ -43,11 +43,7 @@ struct MoeScatterReductionRef : public MoeScatterReductionBase {
             return false;
         }
 
-        if (!one_of(in0_layout.data_type, supported_types) || !one_of(out_layout.data_type, supported_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(in0_layout.data_type, supported_types) && one_of(out_layout.data_type, supported_types);
     }
 };
 }  // namespace ov::intel_gpu::ocl

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/pa_kv_reorder.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/pa_kv_reorder.hpp
@@ -21,9 +21,7 @@ struct PA_KV_reorder : public ImplementationManager {
     [[nodiscard]] std::unique_ptr<primitive_impl> create_impl(const program_node& node, const RuntimeParams& params) const override;
 
     [[nodiscard]] bool validate_impl(const program_node& node) const override {
-        if (node.has_fused_primitives())
-            return false;
-        return true;
+        return !node.has_fused_primitives();
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_causal_conv1d_ref.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_causal_conv1d_ref.hpp
@@ -47,11 +47,7 @@ struct PagedCausalConv1DRef : public ImplementationManager {
         }
 
         const auto& out_layout = node.get_output_layout(0);
-        if (!one_of(out_layout.format, supported_fmts) || !one_of(out_layout.data_type, supported_real_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(out_layout.format, supported_fmts) && one_of(out_layout.data_type, supported_real_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.hpp
@@ -34,11 +34,7 @@ struct RopeOpt : public ImplementationManager {
             return false;
         }
 
-        if (!one_of(in0_layout.data_type, supported_types) || !one_of(out_layout.data_type, supported_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(in0_layout.data_type, supported_types) && one_of(out_layout.data_type, supported_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/scatter_nd_update.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/scatter_nd_update.hpp
@@ -43,11 +43,7 @@ struct ScatterNDUpdate : public ImplementationManager {
             return false;
         }
 
-        if (!fused_ops_are_one_of<eltwise, activation, quantize>(node.get_fused_primitives())) {
-            return false;
-        }
-
-        return true;
+        return fused_ops_are_one_of<eltwise, activation, quantize>(node.get_fused_primitives());
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -36,11 +36,7 @@ constexpr size_t u4_elems_per_byte = 2;
 
 inline bool get_kv_compressed(const RuntimeParams& params) {
     auto key_cache_layout = params.input_layouts[PagedAttentionInputIdx::KEY_CACHE];
-    if (data_type_traits::is_i8_u8(key_cache_layout.data_type) || data_type_traits::is_i4_u4(key_cache_layout.data_type)) {
-        return true;
-    } else {
-        return false;
-    }
+    return data_type_traits::is_i8_u8(key_cache_layout.data_type) || data_type_traits::is_i4_u4(key_cache_layout.data_type);
 }
 
 inline bool is_v_head_aligned_for_dual_nibble(size_t v_head_size) {
@@ -1388,9 +1384,7 @@ public:
         if (!supports_micro_sdpa(params) || !valid_micro_stage(stage))
             return false;
         const auto desc = params.typed_desc<paged_attention>();
-        if (desc->has_token_type_ids && stage != PagedAttentionStage::PREFILL)
-            return false;
-        return true;
+        return !desc->has_token_type_ids || stage == PagedAttentionStage::PREFILL;
     }
 
     bool supports_micro_sdpa(const kernel_impl_params& params) const {
@@ -1439,11 +1433,7 @@ public:
 
         // Disable micro SDPA for INT4 BY_TOKEN due to accuracy issues
         const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
-        if (data_type_traits::is_i4_u4(kv_cache_dt) && !desc->is_key_by_channel) {
-            return false;
-        }
-
-        return true;
+        return !data_type_traits::is_i4_u4(kv_cache_dt) || desc->is_key_by_channel;
     }
 
     static size_t get_micro_tile_qsize(KernelData& kernel_data) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.hpp
@@ -74,11 +74,7 @@ struct PagedAttentionOpt : public ImplementationManager {
             return false;
         }
 
-        if (!one_of(q_layout.data_type, supported_q_types) || !one_of(out_layout.data_type, supported_q_types)) {
-            return false;
-        }
-
-        return true;
+        return one_of(q_layout.data_type, supported_q_types) && one_of(out_layout.data_type, supported_q_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
@@ -274,11 +274,7 @@ JitConstants SDPABase::get_jit_constants(const kernel_impl_params& params) const
                 return true;
             }
 
-            if (m_indirect && !is_query) {
-                return true;
-            }
-
-            return false;
+            return m_indirect && !is_query;
         };
 
         if (m_indirect) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -227,7 +227,7 @@ inline ov::Dimension micro_get_aligned_seq_length(const kernel_impl_params& para
 
 inline size_t micro_get_input_num(const kernel_impl_params& params, const sdpa_configuration& config) {
     auto data_inputs_num = config.input_num;
-    bool is_paged_attention = params.is_type<paged_attention>() ? true : false;
+    bool is_paged_attention = params.is_type<paged_attention>();
     if (!is_paged_attention) {
         auto desc = params.typed_desc<scaled_dot_product_attention>();
         data_inputs_num = get_data_inputs_num(*desc);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
@@ -23,7 +23,7 @@ static bool unaligned_head_size(const size_t k_head_size, const size_t v_head_si
 JitConstants SDPAOptGeneratorBase::get_jit_constants_base(const kernel_impl_params& params, size_t stage, bool add_tensor_definitions) const {
     auto jit = SDPABase::get_jit_constants(params);
     const auto& info = params.get_device_info();
-    const bool is_paged_attention = params.is_type<paged_attention>() ? true : false;
+    const bool is_paged_attention = params.is_type<paged_attention>();
 
     if (add_tensor_definitions) {
         jit.add(make_tensors_jit_constants(params));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
@@ -245,10 +245,7 @@ bool SDPAOpt::supports_micro_sdpa(const RuntimeParams& params) {
     // Known limitation: In vision encoding model of qwen-vl, when the shape of sdpa is 3D and num_heads is 1,
     // there is an accuracy issue with sdpa_micro kernel. Therefore, it is currently restricted to execute with sdpa_opt kernel.
     const bool is_output_rank_4d = desc->output_transpose_order.size() == 4;
-    if (!is_output_rank_4d)
-        return false;
-
-    return true;
+    return is_output_rank_4d;
 #else
     return false;
 #endif

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_ref.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_ref.hpp
@@ -38,10 +38,7 @@ struct SDPARef : public ImplementationManager {
         if (!one_of(k_layout.data_type, supported_kv_types) || !one_of(v_layout.data_type, supported_kv_types))
             return false;
 
-        if (!one_of(q_layout.data_type, supported_q_types) || !one_of(out_layout.data_type, supported_q_types))
-            return false;
-
-        return true;
+        return one_of(q_layout.data_type, supported_q_types) && one_of(out_layout.data_type, supported_q_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
@@ -46,11 +46,7 @@ inline bool sdpa_has_runtime_attn_mask_input(const cldnn::kernel_impl_params& pa
         params.get_input_layout(cldnn::scaled_dot_product_attention::ScaledDotProductAttentionInputIdx::ATTN_MASK).get_partial_shape();
 
     // Keep scalar and 1D placeholders out of the real attention-mask path.
-    if (attn_mask_pshape.rank().is_static() && attn_mask_pshape.rank().get_length() <= 1) {
-        return false;
-    }
-
-    return true;
+    return !attn_mask_pshape.rank().is_static() || attn_mask_pshape.rank().get_length() > 1;
 }
 
 inline size_t get_key_cache_id(const cldnn::scaled_dot_product_attention& desc) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/segment_max.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/segment_max.hpp
@@ -43,11 +43,7 @@ struct SegmentMax : public ImplementationManager {
             return false;
         }
 
-        if (node.has_fused_primitives()) {
-            return false;
-        }
-
-        return true;
+        return !node.has_fused_primitives();
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/slice_scatter.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/slice_scatter.hpp
@@ -43,10 +43,7 @@ struct SliceScatter : public ImplementationManager {
         if (out_layout.get_rank() > 5)
             return false;
 
-        if (node.has_fused_primitives())
-            return false;
-
-        return true;
+        return !node.has_fused_primitives();
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.hpp
@@ -102,11 +102,8 @@ struct ConvolutionImplementationManager : public ImplementationManager {
             return false;
 
         // oneDNN only supports asymmetric weights quantization by scalar zero-points
-        if (conv_node.weights_zero_points_term() &&
-            conv_node.weights_zero_points().get_output_layout().count() != 1)
-            return false;
-
-        return true;
+        return !conv_node.weights_zero_points_term() ||
+            conv_node.weights_zero_points().get_output_layout().count() == 1;
     }
 
     in_out_fmts_t query_formats(const program_node& node) const override;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.hpp
@@ -97,10 +97,7 @@ struct DeconvolutionImplementationManager : public ImplementationManager {
         if (!f16_deconv && !bf16_deconv && !f32_deconv && !u8s8_deconv)
             return false;
 
-        if (!is_supported_post_ops(deconv_node))
-            return false;
-
-        return true;
+        return is_supported_post_ops(deconv_node);
     }
 
     in_out_fmts_t query_formats(const program_node& node) const override;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -154,9 +154,7 @@ protected:
             size_t last_idx = transpose_order.size() - 1;
             if (static_cast<size_t>(transpose_order[last_idx]) != last_idx - 1)
                 return false;
-            if (static_cast<size_t>(transpose_order[last_idx - 1]) != last_idx)
-                return false;
-            return true;
+            return static_cast<size_t>(transpose_order[last_idx - 1]) == last_idx;
         };
 
         auto transpose_dims_and_format_tag = [](std::vector<int64_t> transpose_order,

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
@@ -84,10 +84,7 @@ struct GemmImplementationManager : public ImplementationManager {
         if (gemm_prim->indirect_a || gemm_prim->indirect_b)
             return false;
 
-        if (!is_supported_post_ops(node))
-            return false;
-
-        return true;
+        return is_supported_post_ops(node);
     }
 
     in_out_fmts_t query_formats(const program_node& node) const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/grouped_gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/grouped_gemm_onednn.hpp
@@ -54,7 +54,7 @@ struct GroupedMatmulImplementationManager : public ImplementationManager {
         const auto& out = node.get_output_layout(0);
 
         const auto* desc = node.as<grouped_matmul>().get_primitive().get();
-        const bool compressed = desc && desc->compressed_weights;
+        const bool compressed = (desc != nullptr) && desc->compressed_weights;
 
         if (!one_of(in0.format, supported_fmts) || !one_of(in0.data_type, supported_activation_types))
             return false;
@@ -72,12 +72,9 @@ struct GroupedMatmulImplementationManager : public ImplementationManager {
             return false;
 
         // oneDNN does not support mixed fp16 x bf16 configurations
-        if (!compressed &&
-            ((in0.data_type == data_types::f16 && in1.data_type == data_types::bf16) ||
-             (in0.data_type == data_types::bf16 && in1.data_type == data_types::f16)))
-            return false;
-
-        return true;
+        return compressed ||
+            ((in0.data_type != data_types::f16 || in1.data_type != data_types::bf16) &&
+             (in0.data_type != data_types::bf16 || in1.data_type != data_types::f16));
     }
 
     in_out_fmts_t query_formats(const program_node& node) const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/grouped_matmul_helper.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/grouped_matmul_helper.hpp
@@ -287,7 +287,7 @@ struct onednn_linear {
         OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, openvino::itt::handle("onednn_linear::forward()"));
         dnnl::memory::dim M = m;
 
-        if (!(m_batch == 0 || m_batch == M)) {
+        if (m_batch != 0 && m_batch != M) {
             OPENVINO_THROW("onednn_linear::forward(): invalid batch size m_batch=", m_batch, " M=", M);
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/moe_gemm_onednn.hpp
@@ -173,11 +173,7 @@ struct MoEGemmImplementationManager : public ImplementationManager {
             const auto& scale_shape = params.input_layouts[moe_cfg.weight_scale_idx].get_shape();
             auto num_scale_groups = (scale_shape.size() >= 3) ? scale_shape[2] : 1;
             moe_cfg.weight_group_size = (num_scale_groups == 1) ? -1 : static_cast<int32_t>(k / num_scale_groups);
-            if (static_cast<int32_t>(params.input_layouts.size()) > moe_cfg.weight_zp_idx) {
-                moe_cfg.is_weight_symmetric_quantized = false;
-            } else {
-                moe_cfg.is_weight_symmetric_quantized = true;
-            }
+            moe_cfg.is_weight_symmetric_quantized = static_cast<int32_t>(params.input_layouts.size()) <= moe_cfg.weight_zp_idx;
         }
         moe_cfg.has_batch_dim = desc->has_batch_dim;
         return moe_cfg;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.hpp
@@ -76,10 +76,7 @@ struct PoolingImplementationManager : public ImplementationManager {
         if (!one_of(in_layout.format.value, supported_formats) || !one_of(out_layout.format.value, supported_formats))
             return false;
 
-        if (!is_supported_post_ops(node))
-            return false;
-
-        return true;
+        return is_supported_post_ops(node);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp
@@ -114,10 +114,7 @@ struct ReduceImplementationManager : public ImplementationManager {
 
         // Onednn reduction does NOT support reordering of unreduced-axes.
         // Currently, an Onednn reduce layer which contains reduction of blocked axes(b-f) is expected to select planar format.
-        if (reduce_prim->keep_dims == false && is_reduce_blocked_axes(node))
-            return false;
-
-        return true;
+        return reduce_prim->keep_dims || !is_reduce_blocked_axes(node);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.hpp
@@ -85,10 +85,7 @@ struct ReorderImplementationManager : public ImplementationManager {
             return false;
         if (output_fmt == format::b_fs_yx_fsv16 && data_type_traits::is_i8_u8(in_dt))
             return false;
-        if (output_fmt == format::bfyx && out_dt == data_types::f32)
-            return false;
-
-        return true;
+        return output_fmt != format::bfyx || out_dt != data_types::f32;
     }
 
     static bool is_supported_pad_for_reorder(const layout& layout) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -515,7 +515,7 @@ dnnl::memory::desc layout_to_memory_desc_strides(const cldnn::layout& l, dnnl::m
 }
 
 dnnl::memory::desc layout_to_memory_desc(cldnn::layout l, bool use_default_format, bool is_output_blocked) {
-    OPENVINO_ASSERT(!(use_default_format && is_output_blocked), "[GPU] use_default_format and is_output_blocked are mutually exclusive.");
+    OPENVINO_ASSERT(!use_default_format || !is_output_blocked, "[GPU] use_default_format and is_output_blocked are mutually exclusive.");
 
     if (use_default_format) {
         return MemoryDescriptorBuilder(l, get_default_data_format(l)).build();

--- a/src/plugins/intel_gpu/src/graph/include/batch_to_space_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/batch_to_space_inst.h
@@ -35,11 +35,7 @@ public:
 
     bool need_reset_output_memory() const override {
         const auto desc = _impl_params->typed_desc<batch_to_space>();
-        if (desc->shape_constant) {
-            return true;
-        }
-
-        return false;
+        return desc->shape_constant != 0;
     }
 
     typed_primitive_inst(network& network, batch_to_space_node const& desc);

--- a/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
@@ -50,15 +50,15 @@ public:
     }
 
     program_node& weights_zero_points() const {
-        return get_dependency(2 + (1 * bias_term()) + get_deform_conv_dep_offset());
+        return get_dependency(2 + (1 * static_cast<int>(bias_term())) + get_deform_conv_dep_offset());
     }
 
     program_node& activations_zero_points() const {
-        return get_dependency(2 + (1 * bias_term() + 1 * weights_zero_points_term()) + get_deform_conv_dep_offset());
+        return get_dependency(2 + (1 * static_cast<int>(bias_term()) + 1 * static_cast<int>(weights_zero_points_term())) + get_deform_conv_dep_offset());
     }
 
     program_node& compensation() const {
-        return get_dependency(2 + (1 * bias_term() + 1 * weights_zero_points_term() + 1*activations_zero_points_term()) + get_deform_conv_dep_offset());
+        return get_dependency(2 + (1 * static_cast<int>(bias_term()) + 1 * static_cast<int>(weights_zero_points_term()) + 1*static_cast<int>(activations_zero_points_term())) + get_deform_conv_dep_offset());
     }
 
     program_node& trans() const {
@@ -133,7 +133,7 @@ public:
             return false;
 
         auto input_layout = _deps[0].first->_impl_params->get_output_layout(0);
-        return input_layout.data_padding ? true : false;
+        return static_cast<bool>(input_layout.data_padding);
     }
 
     bool need_reset_output_memory() const override {
@@ -162,7 +162,7 @@ public:
     }
 
     memory::ptr weights_zero_points_memory() const {
-        return dep_memory_ptr(2 + 1 * bias_term() + _deform_conv_dep_offset);
+        return dep_memory_ptr(2 + 1 * static_cast<int>(bias_term()) + _deform_conv_dep_offset);
     }
 
     memory::ptr trans_memory() const {
@@ -172,14 +172,14 @@ public:
     }
 
     memory::ptr activations_zero_points_memory() const {
-        return dep_memory_ptr(2 + 1 * bias_term() + 1 * weights_zero_points_term()
+        return dep_memory_ptr(2 + 1 * static_cast<int>(bias_term()) + 1 * static_cast<int>(weights_zero_points_term())
                               + _deform_conv_dep_offset);
     }
 
     memory::ptr compensation_memory() const {
-        return dep_memory_ptr(2 + 1 * bias_term()
-                              + 1 * weights_zero_points_term()
-                              + 1 * activations_zero_points_term()
+        return dep_memory_ptr(2 + 1 * static_cast<int>(bias_term())
+                              + 1 * static_cast<int>(weights_zero_points_term())
+                              + 1 * static_cast<int>(activations_zero_points_term())
                               + _deform_conv_dep_offset);
     }
 

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -65,7 +65,7 @@ public:
             return false;
 
         auto input_layout = _deps[0].first->_impl_params->get_output_layout(0);
-        return input_layout.data_padding ? true : false;
+        return static_cast<bool>(input_layout.data_padding);
     }
 
     bool need_reset_output_memory() const override {

--- a/src/plugins/intel_gpu/src/graph/include/non_max_suppression_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/non_max_suppression_inst.h
@@ -38,45 +38,45 @@ public:
     bool has_iou_threshold() const { return get_primitive()->iou_threshold.is_valid(); }
     program_node& iou_threshold_node() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
+        offset += static_cast<size_t>(has_num_select_per_class());
         return get_dependency(offset);
     }
 
     bool has_score_threshold() const { return get_primitive()->score_threshold.is_valid(); }
     program_node& score_threshold_node() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
-        offset += has_iou_threshold();
+        offset += static_cast<size_t>(has_num_select_per_class());
+        offset += static_cast<size_t>(has_iou_threshold());
         return get_dependency(offset);
     }
 
     bool has_soft_nms_sigma() const { return get_primitive()->soft_nms_sigma.is_valid(); }
     program_node& soft_nms_sigma_node() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
-        offset += has_iou_threshold();
-        offset += has_score_threshold();
+        offset += static_cast<size_t>(has_num_select_per_class());
+        offset += static_cast<size_t>(has_iou_threshold());
+        offset += static_cast<size_t>(has_score_threshold());
         return get_dependency(offset);
     }
 
     bool has_second_output() const { return get_primitive()->second_output.is_valid(); }
     program_node& second_output_node() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
-        offset += has_iou_threshold();
-        offset += has_score_threshold();
-        offset += has_soft_nms_sigma();
+        offset += static_cast<size_t>(has_num_select_per_class());
+        offset += static_cast<size_t>(has_iou_threshold());
+        offset += static_cast<size_t>(has_score_threshold());
+        offset += static_cast<size_t>(has_soft_nms_sigma());
         return get_dependency(offset);
     }
 
     bool has_third_output() const { return get_primitive()->third_output.is_valid(); }
     program_node& third_output_node() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
-        offset += has_iou_threshold();
-        offset += has_score_threshold();
-        offset += has_soft_nms_sigma();
-        offset += has_second_output();
+        offset += static_cast<size_t>(has_num_select_per_class());
+        offset += static_cast<size_t>(has_iou_threshold());
+        offset += static_cast<size_t>(has_score_threshold());
+        offset += static_cast<size_t>(has_soft_nms_sigma());
+        offset += static_cast<size_t>(has_second_output());
         return get_dependency(offset);
     }
     bool use_multiple_outputs() const { return get_primitive()->output_size() == 3; }
@@ -93,22 +93,22 @@ class typed_primitive_inst<non_max_suppression> : public typed_primitive_inst_ba
 
     size_t get_iou_threshold_offset() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
+        offset += static_cast<size_t>(has_num_select_per_class());
         return offset;
     }
 
     size_t get_score_threshold_offset() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
-        offset += has_iou_threshold();
+        offset += static_cast<size_t>(has_num_select_per_class());
+        offset += static_cast<size_t>(has_iou_threshold());
         return offset;
     }
 
     size_t get_soft_nms_sigma_offset() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
-        offset += has_iou_threshold();
-        offset += has_score_threshold();
+        offset += static_cast<size_t>(has_num_select_per_class());
+        offset += static_cast<size_t>(has_iou_threshold());
+        offset += static_cast<size_t>(has_score_threshold());
         return offset;
     }
 
@@ -165,21 +165,21 @@ public:
     bool has_second_output() const { return get_typed_desc<non_max_suppression>()->second_output.is_valid(); }
     memory::ptr second_output_mem() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
-        offset += has_iou_threshold();
-        offset += has_score_threshold();
-        offset += has_soft_nms_sigma();
+        offset += static_cast<size_t>(has_num_select_per_class());
+        offset += static_cast<size_t>(has_iou_threshold());
+        offset += static_cast<size_t>(has_score_threshold());
+        offset += static_cast<size_t>(has_soft_nms_sigma());
         return dep_memory_ptr(offset);
     }
 
     bool has_third_output() const { return get_typed_desc<non_max_suppression>()->third_output.is_valid(); }
     memory::ptr third_output_mem() const {
         size_t offset = 2;
-        offset += has_num_select_per_class();
-        offset += has_iou_threshold();
-        offset += has_score_threshold();
-        offset += has_soft_nms_sigma();
-        offset += has_second_output();
+        offset += static_cast<size_t>(has_num_select_per_class());
+        offset += static_cast<size_t>(has_iou_threshold());
+        offset += static_cast<size_t>(has_score_threshold());
+        offset += static_cast<size_t>(has_soft_nms_sigma());
+        offset += static_cast<size_t>(has_second_output());
         return dep_memory_ptr(offset);
     }
 };

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -625,11 +625,9 @@ private:
                 return false;
         }
 
-        if (typ_node.template have_user_with_type<concatenation>() && typ_node.get_users().size() == 1 &&
-            typ_node.get_users().front()->can_be_optimized()) {  // check if the only user is concat
-            return false;
-        }
-        return true;
+        // check if the only user is concat
+        return !(typ_node.template have_user_with_type<concatenation>() && typ_node.get_users().size() == 1 &&
+                 typ_node.get_users().front()->can_be_optimized());
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -218,7 +218,7 @@ public:
     // At least the following scenarios are not allocating from memory pool:
     // 1. constant nodes
     // 2. read_value nodes that are optimized out to reuse from Variables.
-    bool may_use_mempool() const { return !(is_constant() || (is_type<read_value>() && optimized)); }
+    bool may_use_mempool() const { return !is_constant() && (!is_type<read_value>() || !optimized); }
 
     template <class PType>
     bool have_user_with_type() const {
@@ -295,7 +295,7 @@ public:
     bool is_valid_output_layout(size_t idx = 0) const { return valid_output_layouts[idx]; }
     bool is_all_valid_output_layouts() const {
         for (auto l : valid_output_layouts) {
-            if (l == false) return false;
+            if (!l) return false;
         }
         return true;
     }

--- a/src/plugins/intel_gpu/src/graph/include/reduce_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reduce_inst.h
@@ -38,11 +38,8 @@ public:
             return false;
 
         auto input_layout = _deps[0].first->_impl_params->get_output_layout(_deps[0].second);
-        if (!format::format::is_simple_data_format(input_layout.format) &&
-            (input_layout.is_static() && input_layout.feature() % 16 != 0)) {
-            return true;
-        }
-        return false;
+        return !format::format::is_simple_data_format(input_layout.format) &&
+            (input_layout.is_static() && input_layout.feature() % 16 != 0);
     }
 
     typed_primitive_inst(network& network, reduce_node const& desc);

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -80,9 +80,7 @@ public:
             // e.g. [1,C,H,W] -> [1,C,H*W] has pattern [1,-1] => reject
             //      [1,N,H,W,C] -> [N,H,W,C] has pattern [-1,H,W,C] => allow
             auto first_out_pattern = prim->output_pattern[0];
-            if (first_out_pattern == 0 || first_out_pattern == 1)
-                return false;
-            return true;
+            return first_out_pattern != 0 && first_out_pattern != 1;
         }
 
         auto input_rank = input_pshape.size();
@@ -113,10 +111,7 @@ public:
         // Reject when reshape drops the cropped axis (e.g. [N,M,1] -> [N,M]): no output axis can
         // carry the cropped axis padding, so sibling crop outputs would all point to the same
         // base buffer region (aliased).
-        if (matched_trailing_dims == 0 && output_pshape.size() < input_pshape.size())
-            return false;
-
-        return true;
+        return matched_trailing_dims != 0 || output_pshape.size() >= input_pshape.size();
     }
 
     bool has_padding() const {
@@ -144,11 +139,8 @@ public:
             input_pad._upper_size[1] != 0)
             return false;
 
-        if (format::is_multi_blocked(input_layout.format))
-            return false;
-
         // Outer padding exists. It might need to update padding size of output layout
-        return true;
+        return !format::is_multi_blocked(input_layout.format);
     }
 
     bool is_in_place() const {
@@ -158,10 +150,7 @@ public:
         if (input().get_output_layout(false).data_padding.is_dynamic() && is_runtime_propagatable_padding())
             return true;
 
-        if (has_padding())
-            return false;
-
-        return true;
+        return !has_padding();
     }
 
     void adjust_output_padding() {

--- a/src/plugins/intel_gpu/src/graph/include/space_to_batch_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/space_to_batch_inst.h
@@ -37,11 +37,7 @@ public:
 
     bool need_reset_output_memory() const override {
         const auto desc = _impl_params->typed_desc<space_to_batch>();
-        if (!desc->shape_constant) {
-            return true;
-        }
-
-        return false;
+        return desc->shape_constant == 0;
     }
 
     typed_primitive_inst(network& network, space_to_batch_node const& desc);

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -293,9 +293,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
         auto is_input_idx = [&](size_t idx) -> bool {
             if (&next.get_dependency(idx) == &prev)
                 return true;
-            if (next.get_dependency(idx).is_type<reorder>() && &next.get_dependency(idx).get_dependency(0) == &prev)
-                return true;
-            return false;
+            return next.get_dependency(idx).is_type<reorder>() && &next.get_dependency(idx).get_dependency(0) == &prev;
         };
 
         auto& conv_node = next.as<convolution>();
@@ -345,7 +343,7 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
                 return true;
         }
 
-        if (!(prev.is_type<quantize>() && (prev_dt == data_types::i8 || prev_dt == data_types::u8)) &&
+        if ((!prev.is_type<quantize>() || (prev_dt != data_types::i8 && prev_dt != data_types::u8)) &&
             (fmt_prev == format::b_fs_yx_fsv4 || fmt_prev == format::bfyx)  && in_channel_count == 3 &&
             (fmt_next == format::b_fs_yx_fsv4 ||
             fmt_next == format::bs_fs_yx_bsv16_fsv16))
@@ -488,11 +486,8 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, reorder_node
 
     if (prev.is_type<permute>()) {
         if (is_dynamic) {
-            if (!prev.has_fused_primitives() &&
-                fmt_prev == format::bfyx && fmt_next == format::b_fs_yx_fsv16)
-                return true;
-
-            return false;
+            return !prev.has_fused_primitives() &&
+                fmt_prev == format::bfyx && fmt_next == format::b_fs_yx_fsv16;
         } else {
             if (fmt_prev == format::b_fs_yx_fsv32 && fmt_next == format::byxf)
                 return true;
@@ -509,10 +504,7 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, reorder_node
                 return false;
 
             // Skip reorder fusing to permute when allow_new_shape_infer is True and input and output rank is different
-            if (allow_new_shape_infer && (fmt_prev.dimension() != fmt_next.dimension()))
-                return false;
-
-            return true;
+            return !allow_new_shape_infer || (fmt_prev.dimension() == fmt_next.dimension());
         }
     }
 
@@ -545,7 +537,7 @@ bool should_use_winograd_2x3_s1(const convolution_node& node,
     // count()/spatial() below require a static shape.
     if (input_layout.is_dynamic())
         return false;
-    if (input_layout.data_type != data_types::f16
+    const bool skip_winograd = input_layout.data_type != data_types::f16
         || (input_layout.is_static() && input_layout.feature() % 64 != 0)  // current algorithm is effective for ifm to be multiply of 64
         || weights_layout.spatial(0) != 3     // weights have to be 3x3 by definiton
         || weights_layout.spatial(1) != 3     // weights have to be 3x3 by definition
@@ -559,10 +551,8 @@ bool should_use_winograd_2x3_s1(const convolution_node& node,
         || (input_layout.count() < 50000)          // limit min input size as winograd is not effective for small input
         || (input_layout.spatial(0) < 8 &&
             input_layout.spatial(1) < 8)      // disable winograd for small spatials as perf is poor
-        || prim->groups != 1) {                    // disable winograd for groups
-        return false;
-    }
-    return true;
+        || prim->groups != 1;                    // disable winograd for groups
+    return !skip_winograd;
 }
 }  // namespace
 
@@ -587,31 +577,28 @@ bool layout_optimizer::convolution_bfyx_opt(layout const& output_layout,
                                             const layout& weights_layout,
                                             std::shared_ptr<const convolution> conv) {
     // A set of rules that define when bfyx mem format has better performance than yxfb
-    if (output_layout.batch() == 16 || output_layout.batch() % 16 != 0 ||
+    return output_layout.batch() == 16 || output_layout.batch() % 16 != 0 ||
         output_layout.data_type != data_types::f16 || weights_layout.batch() % 16 != 0 ||
-        !((weights_layout.spatial(0) == 1 && weights_layout.spatial(1) == 1) ||
-          (weights_layout.spatial(0) >= 5 && weights_layout.spatial(1) >= 5) ||
-          (conv->stride[0] > 1 && conv->stride[1] > 1) ||
-          (weights_layout.feature() <= 32 && output_layout.spatial(0) < 224 &&
-           output_layout.spatial(1) < 224) ||
-          (weights_layout.feature() <= 64 && output_layout.spatial(0) < 112 &&
-           output_layout.spatial(1) < 112) ||
-          (weights_layout.feature() <= 128 && output_layout.spatial(0) < 56 &&
-           output_layout.spatial(1) < 56) ||
-          (weights_layout.feature() <= 256 && output_layout.spatial(0) < 28 &&
-           output_layout.spatial(1) < 28) ||
-          (weights_layout.feature() <= 512 && output_layout.spatial(0) < 14 &&
-           output_layout.spatial(1) < 14) ||
-          (weights_layout.feature() <= 1024 && output_layout.spatial(0) <= 7 &&
-           output_layout.spatial(1) <= 7)) ||
+        ((weights_layout.spatial(0) != 1 || weights_layout.spatial(1) != 1) &&
+          (weights_layout.spatial(0) < 5 || weights_layout.spatial(1) < 5) &&
+          (conv->stride[0] <= 1 || conv->stride[1] <= 1) &&
+          (weights_layout.feature() > 32 || output_layout.spatial(0) >= 224 ||
+           output_layout.spatial(1) >= 224) &&
+          (weights_layout.feature() > 64 || output_layout.spatial(0) >= 112 ||
+           output_layout.spatial(1) >= 112) &&
+          (weights_layout.feature() > 128 || output_layout.spatial(0) >= 56 ||
+           output_layout.spatial(1) >= 56) &&
+          (weights_layout.feature() > 256 || output_layout.spatial(0) >= 28 ||
+           output_layout.spatial(1) >= 28) &&
+          (weights_layout.feature() > 512 || output_layout.spatial(0) >= 14 ||
+           output_layout.spatial(1) >= 14) &&
+          (weights_layout.feature() > 1024 || output_layout.spatial(0) > 7 ||
+           output_layout.spatial(1) > 7)) ||
         // WA for AgeGender, which has one convolution that is better on yxfb, but due to additonal reorder overall
         // performance is worse than bfyx
         (output_layout.spatial(0) == 82 && output_layout.spatial(1) == 82) ||
         (output_layout.batch() >= 128) ||
-        _optimization_attributes.bfyx_only_layer)
-        return true;
-
-    return false;
+        _optimization_attributes.bfyx_only_layer != 0;
 }
 
 bool layout_optimizer::convolution_byxf_opt(const layout& input_layout,
@@ -627,7 +614,7 @@ bool layout_optimizer::convolution_byxf_opt(const layout& input_layout,
     }
 
     // A set of rules that define when byxf mem format has better performance
-    if ((output_layout.data_type == data_types::f16 && weights_layout.spatial(0) == 1 &&
+    return (output_layout.data_type == data_types::f16 && weights_layout.spatial(0) == 1 &&
         all_ones(conv->dilation) &&
         !node.get_transposed() &&
          node.get_groups() == 1 &&
@@ -638,10 +625,7 @@ bool layout_optimizer::convolution_byxf_opt(const layout& input_layout,
          all_zeroes(conv->padding_begin) &&
          all_zeroes(conv->padding_end)) ||
         // Winograd
-        should_use_winograd_2x3_s1(node, input_layout, weights_layout, _output_size_handling_enabled))
-        return true;
-
-    return false;
+        should_use_winograd_2x3_s1(node, input_layout, weights_layout, _output_size_handling_enabled);
 }
 
 bool layout_optimizer::convolution_b_fs_yx_fsv16_opt(const layout& input_layout,
@@ -718,13 +702,11 @@ bool layout_optimizer::convolution_b_fs_yx_fsv16_opt(const layout& input_layout,
                        (in_features_per_group != 1)) ||
                       ((out_features_per_group % feature_block_size == 0 || feature_block_size % out_features_per_group == 0) &&
                        (in_features_per_group % feature_block_size == 0));
-    if (correct_data_type &&
+    return correct_data_type &&
         correct_batch &&
         correct_spatial_dims &&
         correct_in_feature &&
-        (conv->groups == 1 || depthwise || grouped))
-        return true;
-    return false;
+        (conv->groups == 1 || depthwise || grouped);
 }
 
 static bool has_reorder_before_mvn(const program_node& node, size_t cur_depth, size_t max_depth, uint64_t reorder_size_threshold = 0) {
@@ -768,7 +750,7 @@ bool layout_optimizer::should_select_b_fs_yx_fsv16_layout(convolution_node const
     auto current_conv_partially_supports_layout = convolution_b_fs_yx_fsv16_opt(input_layout, output_layout, weights_layout, prim, true);
     auto may_use_weak_restrictions = is_prev_conv_node_supports_layout || weak_restriction_cond;
 
-    return (((_optimization_attributes.b_fs_yx_fsv16_network) &&
+    return ((((_optimization_attributes.b_fs_yx_fsv16_network) != 0) &&
             (current_conv_supports_layout || (may_use_weak_restrictions && current_conv_partially_supports_layout))) ||
            input_layout.format == format::b_fs_yx_fsv16) &&
            !has_reorder_before_mvn(reinterpret_cast<program_node const&>(node), 0, 3, 8300000);
@@ -844,11 +826,8 @@ bool layout_optimizer::convolution_fs_b_yx_fsv32_opt(const layout& input_layout,
         return false;
     }
 
-    if ((input_layout.format == format::fs_b_yx_fsv32) || (correct_out_feature && correct_in_feature && correct_batch &&
-        (dw_conv || conv->groups == 1) )) {
-        return true;
-    }
-    return false;
+    return (input_layout.format == format::fs_b_yx_fsv32) || (correct_out_feature && correct_in_feature && correct_batch &&
+        (dw_conv || conv->groups == 1) );
 }
 
 bool layout_optimizer::deconvolution_b_fs_zyx_fsv16_opt(layout const &input_layout,
@@ -861,11 +840,8 @@ bool layout_optimizer::deconvolution_b_fs_zyx_fsv16_opt(layout const &input_layo
         (input_layout.data_type == data_types::f32 || input_layout.data_type == data_types::f16))
         return true;
 
-    if (input_layout.format.dimension() == 5 &&
-        (input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8))
-        return true;
-
-    return false;
+    return input_layout.format.dimension() == 5 &&
+        (input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8);
 }
 
 bool layout_optimizer::deconvolution_b_fs_yx_fsv16_opt(layout const &input_layout,
@@ -877,11 +853,8 @@ bool layout_optimizer::deconvolution_b_fs_yx_fsv16_opt(layout const &input_layou
         (deconv->groups == 1 || (static_cast<int>(deconv->groups) == weights_layout.group())))
         return true;
 
-    if (input_layout.format.dimension() == 4 &&
-        (input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8))
-        return true;
-
-    return false;
+    return input_layout.format.dimension() == 4 &&
+        (input_layout.data_type == data_types::i8 || input_layout.data_type == data_types::u8);
 }
 
 // This function is needed to avoid performance regressions for the convolutions with byxf layout
@@ -904,10 +877,7 @@ static bool is_scale_shift(const eltwise_node& node) {
     if (!fused_op0.is_type<eltwise>())
         return false;
 
-    if (fused_op0.typed_desc<eltwise>()->mode != eltwise_mode::sum)
-        return false;
-
-    return true;
+    return fused_op0.typed_desc<eltwise>()->mode == eltwise_mode::sum;
 }
 
 bool layout_optimizer::users_for_convolution_byxf_opt(program_node const& node, uint32_t depth) {
@@ -1023,14 +993,12 @@ bool layout_optimizer::is_mixed_layout(program_node& prev, program_node& next, b
         if ((prev_fmt == pair.first && next_fmt == pair.second) &&
             (!check_data_type || (data_type_traits::is_i8_u8(prev_dt) && data_type_traits::is_floating_point(next_dt)))) {
             if ((next_fmt == format::bs_fs_yx_bsv32_fsv16 || next_fmt == format::bs_fs_zyx_bsv32_fsv16) && (next_dt == data_types::f32)) return false;
-            if ((next_fmt == format::bs_fs_yx_bsv16_fsv16 || next_fmt == format::bs_fs_zyx_bsv16_fsv16) && (next_dt == data_types::f16)) return false;
-            return true;
+            return (next_fmt != format::bs_fs_yx_bsv16_fsv16 && next_fmt != format::bs_fs_zyx_bsv16_fsv16) || (next_dt != data_types::f16);
         }
         if ((next_fmt == pair.first && prev_fmt == pair.second) &&
             (!check_data_type || (data_type_traits::is_i8_u8(next_dt) && data_type_traits::is_floating_point(prev_dt)))) {
             if ((prev_fmt == format::bs_fs_yx_bsv32_fsv16 || prev_fmt == format::bs_fs_zyx_bsv32_fsv16) && (prev_dt == data_types::f32)) return false;
-            if ((prev_fmt == format::bs_fs_yx_bsv16_fsv16 || prev_fmt == format::bs_fs_zyx_bsv16_fsv16) && (prev_dt == data_types::f16)) return false;
-            return true;
+            return (prev_fmt != format::bs_fs_yx_bsv16_fsv16 && prev_fmt != format::bs_fs_zyx_bsv16_fsv16) || (prev_dt != data_types::f16);
         }
     }
 
@@ -1150,7 +1118,7 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
 
     // Use planar bfyx format for dynamic convolutions with explicit padding in clDNN
     if (node.is_dynamic() && output_layout.get_partial_shape().size() == 4 && node.use_explicit_padding() && !i8_u8_input &&
-        !(use_onednn_impls && onednn_valid_post_ops && !node.has_padded_dependency())) {
+        (!use_onednn_impls || !onednn_valid_post_ops || node.has_padded_dependency())) {
         return format::bfyx;
     }
 
@@ -1176,16 +1144,16 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
             else
                 expected_format = cldnn::format::b_fs_zyx_fsv32;
         } else if (i8_u8_input) {
-            if ((_optimization_attributes.b_fs_yx_fsv16_network &&
+            if (((_optimization_attributes.b_fs_yx_fsv16_network != 0) &&
                 convolution_b_fs_yx_fsv16_opt(input_layout, output_layout, weights_layout, prim))) {
                 expected_format = cldnn::format::b_fs_yx_fsv16;
-            } else if ((_optimization_attributes.b_fs_zyx_fsv16_network &&
+            } else if (((_optimization_attributes.b_fs_zyx_fsv16_network != 0) &&
                 convolution_b_fs_zyx_fsv16_opt(input_layout, output_layout, weights_layout, prim))) {
                 expected_format = cldnn::format::b_fs_zyx_fsv16;
             } else {
                 expected_format = imad_case(node);
             }
-        } else if (_optimization_attributes.b_fs_zyx_fsv16_network &&
+        } else if ((_optimization_attributes.b_fs_zyx_fsv16_network != 0) &&
                 convolution_b_fs_zyx_fsv16_opt(input_layout, output_layout, weights_layout, prim)) {
             if ((output_layout.data_type == data_types::f32 && output_layout.batch() % 16 == 0) ||
                 (output_layout.data_type == data_types::f16 && output_layout.batch() % 32 == 0))
@@ -1195,10 +1163,10 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
 
         } else if (output_layout.format == format::bfzyx) {
             expected_format = cldnn::format::bfzyx;
-        } else if (_optimization_attributes.bs_fs_yx_bsv16_fsv16_network &&
+        } else if ((_optimization_attributes.bs_fs_yx_bsv16_fsv16_network != 0) &&
                 convolution_bs_fs_yx_bsv16_fsv16_opt(node.get_input_layout(), output_layout, weights_layout, prim)) {
             expected_format = cldnn::format::bs_fs_yx_bsv16_fsv16;
-        } else if (_optimization_attributes.fs_b_yx_fsv32_network && !node.get_transposed() &&
+        } else if ((_optimization_attributes.fs_b_yx_fsv32_network != 0) && !node.get_transposed() &&
                 ((convolution_fs_b_yx_fsv32_opt(input_layout,
                                                 output_layout,
                                                 weights_layout, prim) ||
@@ -1207,8 +1175,8 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
                   convolution_fs_b_yx_fsv32_opt(input_layout,
                                                 output_layout,
                                                 weights_layout, prim, true)))) &&
-                 !(has_reorder_before_mvn(reinterpret_cast<program_node const&>(*node.get_users().front()), 0, 3, 1000000) &&
-                     !static_cast<bool>(prepare_padding::get_needed_padding_for_convolution(const_cast<convolution_node&>(node))))) {
+                 (!has_reorder_before_mvn(reinterpret_cast<program_node const&>(*node.get_users().front()), 0, 3, 1000000) ||
+                     static_cast<bool>(prepare_padding::get_needed_padding_for_convolution(const_cast<convolution_node&>(node))))) {
             // Chose fs_b_yx_fsv32 layout in two cases: 1-st: the current conv primitive totally supports fs_b_yx_fsv32 layout
             //                                          2-nd: the previous conv primitive supports fs_b_yx_fsv32 layout and
             //                                                current conv primitives supports this one with weak restrictions -
@@ -1267,14 +1235,14 @@ format layout_optimizer::get_expected_format(deconvolution_node const& node) {
     if (use_onednn_impls && available.count(impl_types::onednn) > 0) {
         // XXX: need to take the situation into consideration where it is called from prepare_primitive_fusing
         expected_format = node.get_preferred_output_fmt();
-    } else if (_optimization_attributes.b_fs_zyx_fsv16_network &&
+    } else if ((_optimization_attributes.b_fs_zyx_fsv16_network != 0) &&
         deconvolution_b_fs_zyx_fsv16_opt(output_layout, weights_layout, prim)) {
         if ((output_layout.data_type == data_types::f32 && expected_shape[0] % 16 == 0) ||
             (output_layout.data_type == data_types::f16 && expected_shape[0] % 32 == 0))
             expected_format = cldnn::format::bs_fs_zyx_bsv16_fsv16;
         else
             expected_format = cldnn::format::b_fs_zyx_fsv16;
-    } else if ((_optimization_attributes.b_fs_yx_fsv16_network) &&
+    } else if (((_optimization_attributes.b_fs_yx_fsv16_network) != 0) &&
                deconvolution_b_fs_yx_fsv16_opt(output_layout, weights_layout, prim)) {
         auto input_shape = input_layout.get_shape();
         auto input_features = input_shape[1];
@@ -1346,13 +1314,9 @@ format layout_optimizer::get_expected_format(quantize_node const& node) {
 }
 
 bool layout_optimizer::is_primitive_implemented_for_onednn(program_node& node) {
-    if (node.is_type<fully_connected>() || node.is_type<gemm>() || node.is_type<pooling>() ||
+    return node.is_type<fully_connected>() || node.is_type<gemm>() || node.is_type<pooling>() ||
         node.is_type<convolution>() || node.is_type<deconvolution>() ||
-        node.is_type<reduce>() || node.is_type<reorder>() || node.is_type<concatenation>() || node.is_type<lstm_seq>() || node.is_type<gru_seq>()) {
-        return true;
-    }
-
-    return false;
+        node.is_type<reduce>() || node.is_type<reorder>() || node.is_type<concatenation>() || node.is_type<lstm_seq>() || node.is_type<gru_seq>();
 }
 
 impl_types layout_optimizer::get_preferred_impl_type(program_node& node, format preferred_format) {

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -587,7 +587,7 @@ std::vector<event::ptr> network::set_output_memory(const primitive_id& id, memor
 
         ret_ev.push_back(prim->set_output_memory(mem, (!prim->is_dynamic() || !is_remote)));
         if (!_reset_arguments &&
-            (prim->type() != cldnn::data::type_id() && !(prim->type() == cldnn::mutable_data::type_id() && prim->dependencies().empty()))) {
+            (prim->type() != cldnn::data::type_id() && (prim->type() != cldnn::mutable_data::type_id() || !prim->dependencies().empty()))) {
             prim->set_arguments();
         }
     }
@@ -612,7 +612,7 @@ bool network::does_node_need_lockable_output(const primitive_id& id) const {
     if (node.is_type<input_layout>()) {
         for (const auto& user : node.get_users()) {
             const auto& lockable_input_ids = user->get_lockable_input_ids();
-            if (lockable_input_ids.count(user->get_dependency_index(node))) {
+            if (lockable_input_ids.count(user->get_dependency_index(node)) != 0u) {
                 return true;
             }
         }
@@ -736,7 +736,7 @@ void network::build_exec_order() {
     GPU_DEBUG_DEFINE_MEM_LOGGER("build_exec_order");
     if (!_is_dynamic) {
         for (auto& node : _program->get_processing_order()) {
-            if (!node->is_type<data>() && !(node->is_type<mutable_data>() && node->get_dependencies().empty())) {
+            if (!node->is_type<data>() && (!node->is_type<mutable_data>() || !node->get_dependencies().empty())) {
                 add_to_exec_order(node->id());
             }
         }
@@ -745,11 +745,11 @@ void network::build_exec_order() {
             return (node->is_dynamic() && node->is_type<concatenation>() && node->can_be_optimized());
         };
         auto is_allowed_pred_for_runtime_optimized_concat = [&](const program_node* node) {
-            return (!node->is_type<data>() && !(node->is_type<mutable_data>() && node->get_dependencies().empty()) &&
+            return (!node->is_type<data>() && (!node->is_type<mutable_data>() || !node->get_dependencies().empty()) &&
                     node->get_users().size() == 1 && is_runtime_optimized_concat(node->get_users().front()));
         };
         for (auto& node : _program->get_processing_order()) {
-            if (!node->is_type<data>() && !(node->is_type<mutable_data>() && node->get_dependencies().empty())) {
+            if (!node->is_type<data>() && (!node->is_type<mutable_data>() || !node->get_dependencies().empty())) {
                 if (is_allowed_pred_for_runtime_optimized_concat(node)) {
                     continue;
                 } else if (is_runtime_optimized_concat(node)) {
@@ -769,10 +769,7 @@ void network::build_exec_order() {
 
 bool network::contains_state(const std::string& variable_id) {
     auto it = _state_initializers.find(variable_id);
-    if (it != _state_initializers.end())
-        return true;
-    else
-        return false;
+    return it != _state_initializers.end();
 }
 
 memory& network::get_output_remote_memory(const primitive_id& id) const {
@@ -782,10 +779,7 @@ memory& network::get_output_remote_memory(const primitive_id& id) const {
 
 bool network::has_output_remote_memory_ptr(const primitive_id& id) const {
     auto it = _output_remote_mem_ptrs.find(id);
-    if (it != _output_remote_mem_ptrs.end())
-        return true;
-    else
-        return false;
+    return it != _output_remote_mem_ptrs.end();
 }
 
 void network::reset_output_remote_memory_ptrs() {

--- a/src/plugins/intel_gpu/src/graph/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/non_zero.cpp
@@ -57,7 +57,7 @@ layout gather_nonzero_inst::calc_output_layout(gather_nonzero_node const& node, 
     assert(static_cast<bool>(node.get_primitive()->output_data_types[0]) == false &&
            "Output data type forcing is not supported for gather_nonzero_node!");
     auto rank = impl_param.get_input_layout(0).get_partial_shape().rank().get_length();
-    if (impl_param.memory_deps.count(1)) {
+    if (impl_param.memory_deps.count(1) != 0u) {
         auto out_size = read_vector<int64_t>(impl_param.memory_deps.at(1), impl_param.get_stream());
         return layout{{rank, out_size[0], 1, 1}, cldnn::data_types::i32, cldnn::format::bfyx};
     } else {

--- a/src/plugins/intel_gpu/src/graph/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/one_hot.cpp
@@ -21,9 +21,7 @@ static bool is_output_bfzyx(const layout& input, int64_t axis) {
     if (axis == 4)
         return true;
     auto in_dims = input.get_tensor().sizes(format::bfyx);
-    if (in_dims[3] != 1)
-        return true;
-    return false;
+    return in_dims[3] != 1;
 }
 
 layout one_hot_inst::calc_output_layout(one_hot_node const& node, kernel_impl_params const& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -526,7 +526,7 @@ void primitive_inst::update_shape() {
         auto desc = get_node().as<kv_cache>().get_primitive();
         const auto trim_length = kv_cache_inst::compute_trim_length(*_impl_params, *desc);
         if (trim_length > 0) {
-            OPENVINO_ASSERT(!(desc->indirect || desc->compressed),
+            OPENVINO_ASSERT(!desc->indirect && !desc->compressed,
                             "[GPU] Unsupported trim for indirect or compressed kvcache:  indirect:",
                             desc->indirect,
                             "  compressed:",
@@ -1185,7 +1185,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
                 break;
             }
         }
-        if (present_layout.data_padding._dynamic_dims_mask[sequence_axis] == 1) {
+        if (static_cast<int>(present_layout.data_padding._dynamic_dims_mask[sequence_axis]) == 1) {
             // Apply padding of variable to make it be optimized in the next iteration
             auto max_pad = kv_cache_inst::get_max_pad(present_layout,
                                                       _max_output_layout_count[0],
@@ -1304,17 +1304,17 @@ bool primitive_inst::use_async_compilation() {
     if (compile_gemm_impls) {
         // Do not async-compile if opt_gemm is chosen for iGPU
         // Do async-compile if it is to be executed from onednn
-        compile_gemm_impls = get_node().get_selected_impl() && get_node().get_selected_impl()->get_kernel_name().find("gemm_ref") != std::string::npos;
-        compile_gemm_impls |= _impls_factory->has(impl_types::onednn) && get_node().get_selected_impl() && !get_node().get_selected_impl()->is_onednn();
+        compile_gemm_impls = (get_node().get_selected_impl() != nullptr) && get_node().get_selected_impl()->get_kernel_name().find("gemm_ref") != std::string::npos;
+        compile_gemm_impls |= _impls_factory->has(impl_types::onednn) && (get_node().get_selected_impl() != nullptr) && !get_node().get_selected_impl()->is_onednn();
     }
 
     bool compile_conv_impls = get_node().is_type<convolution>();
     if (compile_conv_impls) {
-        compile_conv_impls = !_impls_factory->has(impl_types::onednn) && get_node().get_selected_impl() && !get_node().get_selected_impl()->is_onednn();
+        compile_conv_impls = !_impls_factory->has(impl_types::onednn) && (get_node().get_selected_impl() != nullptr) && !get_node().get_selected_impl()->is_onednn();
     }
 
     return (compile_conv_impls || compile_fc_impls || compile_gemm_impls ||
-            (get_node().is_type<softmax>() && get_node().get_selected_impl() &&
+            (get_node().is_type<softmax>() && (get_node().get_selected_impl() != nullptr) &&
              get_node().get_selected_impl()->get_kernel_name().find("softmax_gpu_ref") != std::string::npos));
 }
 
@@ -1337,7 +1337,7 @@ void primitive_inst::fill_shape_info_data(const layout& runtime_layout, const la
     const auto& lower_pads = data_padding._lower_size;
     const auto& upper_pads = data_padding._upper_size;
     for (size_t j = 0; j < shape_with_max_rank.size(); ++j) {
-        if (dynamic_pad[j] == 1) {
+        if (static_cast<int>(dynamic_pad[j]) == 1) {
             GPU_DEBUG_TRACE_DETAIL << " shape_info[" << offset << "] = " << lower_pads[j]
                                    << "(pad_before for " << j << "-th dim)" << std::endl;
             shape_info_ptr[offset++] = static_cast<int32_t>(lower_pads[j]);  // pad_before
@@ -1398,7 +1398,7 @@ void primitive_inst::update_impl(bool use_async_compilation) {
         return;
     }
 
-    if (!get_node().is_type<data>() && !(get_node().is_type<mutable_data>() && get_node().get_dependencies().empty())) {
+    if (!get_node().is_type<data>() && (!get_node().is_type<mutable_data>() || !get_node().get_dependencies().empty())) {
 #ifdef ENABLE_ONEDNN_FOR_GPU
         if (_impls_factory->has(impl_types::onednn)) {
             auto attrs_onednn = std::make_shared<dnnl::primitive_attr>();
@@ -1558,7 +1558,7 @@ void primitive_inst::do_runtime_in_place_kv_cache() {
     }
 
     auto sequence_axis = kv_cache_inst::get_sequence_axis(desc->concat_axis, past_layout.get_partial_shape().size());
-    if (present_layout.data_padding._dynamic_dims_mask[sequence_axis] != 1)
+    if (static_cast<int>(present_layout.data_padding._dynamic_dims_mask[sequence_axis]) != 1)
         return;
 
     GPU_DEBUG_TRACE_DETAIL << "[do runtime kv_cache opt] " << id() << " initial present_layout : " << present_layout.to_string() << std::endl;
@@ -1806,7 +1806,7 @@ void primitive_inst::do_runtime_in_place_concat() {
 
     auto concat_inst = get_user_insts().front();
 
-    if (!concat_inst->get_node().is_type<concatenation>() || !(concat_inst->get_node().can_be_optimized() && concat_inst->get_node().is_runtime_skippable()))
+    if (!concat_inst->get_node().is_type<concatenation>() || !concat_inst->get_node().can_be_optimized() || !concat_inst->get_node().is_runtime_skippable())
         return;
 
     if (has_subgraph_dependency(concat_inst->dependencies())) {
@@ -1874,9 +1874,9 @@ void primitive_inst::do_runtime_in_place_concat() {
 void primitive_inst::do_runtime_skip_scatter_update() {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, openvino::itt::handle("do_runtime_skip_scatter_update: " + id()));
     // Check pattern
-    if (!(get_node().is_type<scatter_update>()
-        || get_node().is_type<scatter_elements_update>()
-        || get_node().is_type<scatter_nd_update>())
+    if ((!get_node().is_type<scatter_update>()
+        && !get_node().is_type<scatter_elements_update>()
+        && !get_node().is_type<scatter_nd_update>())
         || !get_node().is_runtime_skippable())
         return;
 
@@ -2660,7 +2660,7 @@ void primitive_inst::update_weights() {
 
 static bool user_requesting_mem_reuse_false(const program_node& node) {
     for (auto& user : node.get_users()) {
-        if ((user->get_selected_impl() != nullptr) && (user->get_selected_impl()->can_reuse_memory == false)) {
+        if ((user->get_selected_impl() != nullptr) && (!user->get_selected_impl()->can_reuse_memory)) {
             return true;
         } else if (user->get_selected_impl() == nullptr) {
             if (user->is_dynamic()) {

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -748,8 +748,8 @@ void program::transfer_memory_to_device() {
             allocation_type target_alloc_type = alloc_type;
             // usm_device memory does not provide performance benefits on the LNL platform
             if ((alloc_type == allocation_type::usm_host || alloc_type == allocation_type::usm_shared) &&
-                !(get_engine().get_device_info().arch >= gpu_arch::xe2 &&
-                  get_engine().get_device_info().dev_type == device_type::integrated_gpu)) {
+                (get_engine().get_device_info().arch < gpu_arch::xe2 ||
+                  get_engine().get_device_info().dev_type != device_type::integrated_gpu)) {
                 // Convert to usm_device for performance optimization
                 target_alloc_type = allocation_type::usm_device;
             }
@@ -898,10 +898,7 @@ bool program::has_state_initializers(const std::string& variable_id, const primi
 
 bool program::contains_state(const std::string& variable_id) {
     auto it = state_initializers.find(variable_id);
-    if (it != state_initializers.end())
-        return true;
-    else
-        return false;
+    return it != state_initializers.end();
 }
 
 program_node& program::get_or_create(std::shared_ptr<primitive> prim) {
@@ -1280,7 +1277,7 @@ void program::fuse_nodes(program_node &fused_node,
         }
 
         fused_node.dependencies.push_back({dep, port});
-        local_desc.inputs.emplace_back(FusedInputType::EXTERNAL, fused_node.dependencies.size() - 1, dep->get_output_layout(port).data_type);
+        local_desc.inputs.emplace_back(FusedInputType::EXTERNAL, fused_node.dependencies.size() - 1, dep->get_output_layout(port != 0).data_type);
         local_desc.deps.emplace_back(dep->id(), deps_idx++);
         dep->users.push_back(&fused_node);
     }

--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -50,8 +50,8 @@ void program_helpers::reshape_deconvolution_weights(const std::vector<float> &de
     const int kernel_sz = kernel_width + pad_zero_x;
 
     auto get_row_index = [](int index, const int kernel_sz)->int {
-        bool isRowEven = (index / (kernel_sz)) % 2 == 0 ? true : false;
-        bool isColEven = (index % 2) == 0 ? true : false;
+        bool isRowEven = (index / (kernel_sz)) % 2 == 0;
+        bool isColEven = (index % 2) == 0;
         int kernel_num = isRowEven ? (isColEven ? 0 : 1) : isColEven ? 2 : 3;
         return kernel_num;
     };
@@ -74,11 +74,8 @@ void program_helpers::reshape_deconvolution_weights(const std::vector<float> &de
 }
 
 bool onednn_add_fusing_helpers::is_full_tensor(const layout& l) {
-    if (l.spatial(0) > 1 || l.spatial(1) > 1 || (l.get_spatial_rank() == 3 && l.spatial(2) > 1)
-        || l.batch() > 1) {
-        return true;
-    }
-    return false;
+    return l.spatial(0) > 1 || l.spatial(1) > 1 || (l.get_spatial_rank() == 3 && l.spatial(2) > 1)
+        || l.batch() > 1;
 }
 
 void onednn_add_fusing_helpers::for_eltwise(
@@ -149,7 +146,7 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
             && !dep_node.is_constant()
             && !p_node.is_type<pooling>()
             && !p_node.is_output()
-            && !(dep_node.is_type<input_layout>() && dep_node.get_users().size() > 1)) {
+            && (!dep_node.is_type<input_layout>() || dep_node.get_users().size() <= 1)) {
             return add_fusing_type::sum;
         } else if (p_layout.get_tensor() == d_layout.get_tensor()) {
             return add_fusing_type::binary_per_tensor;

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -39,7 +39,7 @@ static size_t get_shape_data_size(const layout& l) {
     size_t size = layout::max_rank(); // all dimensions are stored
     const auto& dynamic_pad = l.data_padding._dynamic_dims_mask;
     for (size_t j = 0; j < layout::max_rank(); ++j) {
-        if (dynamic_pad[j] == 1) {
+        if (static_cast<int>(dynamic_pad[j]) == 1) {
             size += 2; // lower + upper
         }
     }
@@ -368,9 +368,7 @@ size_t program_node::get_dependency_index(const program_node& node) const {
 bool program_node::is_detached(bool whole_branch) {
     if (!users.empty())
         return false;
-    if (!whole_branch && !dependencies.empty())
-        return false;
-    return true;
+    return whole_branch || dependencies.empty();
 }
 
 layout program_node::calc_output_layout() const {
@@ -533,7 +531,7 @@ bool program_node::is_fused_dep(size_t dep_idx) const {
 
 std::set<size_t> program_node::get_lockable_input_ids() const {
     const auto impl = get_selected_impl();
-    const bool has_cpu_impl = get_preferred_impl_type() == impl_types::cpu || (impl && impl->is_cpu());
+    const bool has_cpu_impl = get_preferred_impl_type() == impl_types::cpu || ((impl != nullptr) && impl->is_cpu());
     if (has_cpu_impl && !is_type<shape_of>()) {
         std::set<size_t> dependencies_indexes;
         for (size_t i = 0; i < get_dependencies().size(); i++)

--- a/src/plugins/intel_gpu/src/graph/registry/implementation_manager.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/implementation_manager.cpp
@@ -48,10 +48,7 @@ bool ImplementationManager::is_supported(const program_node& node, const std::se
     auto key_out = implementation_key()(node.get_outputs_count() > 0
                                         ? node.is_valid_output_layout(0) ? node.get_output_layout(0) : node.calc_output_layouts()[0]
                                         : layout{ov::PartialShape{}, data_types::f32, format::any});
-    if (!supported_keys.empty() && supported_keys.find(key_out) == supported_keys.end())
-        return false;
-
-    return true;
+    return supported_keys.empty() || supported_keys.find(key_out) != supported_keys.end();
 }
 
 std::unique_ptr<primitive_impl> ImplementationManager::create(const program_node& node, const kernel_impl_params& params) const {

--- a/src/plugins/intel_gpu/src/graph/registry/pooling_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/pooling_impls.cpp
@@ -25,9 +25,7 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<pooli
             // ws_undef::undef:::,attr-scratchpad:user attr-post-ops:eltwise_linear:1.52456,alg:pooling_avg_include_padding,
             // mb1ic96_ih56oh28kh2sh2dh0ph0_iw56ow28kw2sw2dw0pw0,0.0400391
             // issue: 12579
-            if (in_layout.format == format::byxf && out_layout.format == format::bfyx)
-                return false;
-            return true;
+            return in_layout.format != format::byxf || out_layout.format != format::bfyx;
         })
         OV_GPU_GET_INSTANCE_OCL(pooling, shape_types::static_shape)
     };

--- a/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/reorder_impls.cpp
@@ -50,10 +50,8 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<reord
                     return false;
                 // CPU impl does not support b_fs_yx_fsv16 format, so prefer CPU impl only
                 // when both input and output formats are simple (CPU-compatible)
-                if (node.is_in_shape_of_subgraph() && format::is_simple_data_format(out_layout.format)
-                    && format::is_simple_data_format(in_layout.format))
-                    return false;
-                return true;
+                return !node.is_in_shape_of_subgraph() || !format::is_simple_data_format(out_layout.format)
+                    || !format::is_simple_data_format(in_layout.format);
             })
         OV_GPU_GET_INSTANCE_CPU(reorder, shape_types::static_shape, in_shape_flow())
         OV_GPU_GET_INSTANCE_CPU(reorder, shape_types::dynamic_shape, in_shape_flow())

--- a/src/plugins/intel_gpu/src/graph/registry/softmax_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/softmax_impls.cpp
@@ -53,10 +53,7 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<softm
                 if (!one_of(in_layout.data_type, supported_in_types))
                     return false;
 
-                if (!one_of(out_layout.data_type, supported_out_types))
-                    return false;
-
-                return true;
+                return one_of(out_layout.data_type, supported_out_types);
         })
         OV_GPU_CREATE_INSTANCE_OCL(ocl::SoftmaxImplementationManager, shape_types::dynamic_shape,
             [](const program_node& node) {
@@ -68,10 +65,7 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<softm
                 if (!one_of(in_layout.data_type, supported_in_types))
                     return false;
 
-                if (!one_of(out_layout.data_type, supported_out_types))
-                    return false;
-
-                return true;
+                return one_of(out_layout.data_type, supported_out_types);
         })
     };
 

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -102,7 +102,7 @@ padding propagate_padding(const layout& in_layout, const ov::PartialShape& out_s
     padding::DynamicDimsMask ret_update_pad_mask;
     OPENVINO_ASSERT(update_pad_mask.size() <= ret_update_pad_mask.size(), "invalid update_pad_mask.size().");
     for (size_t i = 0; i < update_pad_mask.size(); i++) {
-        ret_update_pad_mask[i] = update_pad_mask[i];
+        ret_update_pad_mask[i] = (update_pad_mask[i] != 0);
     }
     return padding(update_pad_lower, update_pad_upper, ret_update_pad_mask);
 }
@@ -289,7 +289,7 @@ std::string reshape_inst::to_string(reshape_node const& node) {
 }
 
 reshape_inst::typed_primitive_inst(network& network, reshape_node const& node) :
-        parent(network, node, (!node.can_be_optimized() && node.get_output_layout().is_static()) ? true : false) {
+        parent(network, node, !node.can_be_optimized() && node.get_output_layout().is_static()) {
     auto input_layout = node.get_input_layout();
     auto output_layout = node.get_output_layout();
     CLDNN_ERROR_DATA_TYPES_MISMATCH(node.id(),

--- a/src/plugins/intel_gpu/src/graph/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/select.cpp
@@ -135,7 +135,7 @@ select_inst::typed_primitive_inst(network& network, select_node const& node) : p
 
                     CLDNN_ERROR_BOOL(node.id(),
                                         "Sizes equal or broadcast is possible",
-                                        !(current_dim == output_tensor.raw[d] || current_dim == 1),
+                                        current_dim != output_tensor.raw[d] && current_dim != 1,
                                         "Invalid input shapes");
                 }
             }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
@@ -453,18 +453,15 @@ bool ParamsKey::Support(const ParamsKey& k) const {
         return false;
     if (!((key.outputWeightsType.raw & k.key.outputWeightsType.raw) == k.key.outputWeightsType.raw))
         return false;
-    if (!((key.inputLayout & k.key.inputLayout) != 0 || key.inputLayout == k.key.inputLayout))
+    if ((key.inputLayout & k.key.inputLayout) == 0 && key.inputLayout != k.key.inputLayout)
         return false;
-    if (!((key.outputLayout & k.key.outputLayout) != 0 || key.outputLayout == k.key.outputLayout))
+    if ((key.outputLayout & k.key.outputLayout) == 0 && key.outputLayout != k.key.outputLayout)
         return false;
-    if (!((key.weightsInputLayout & k.key.weightsInputLayout) != 0 ||
-          key.weightsInputLayout == k.key.weightsInputLayout))
+    if ((key.weightsInputLayout & k.key.weightsInputLayout) == 0 &&
+        key.weightsInputLayout != k.key.weightsInputLayout)
         return false;
-    if (!((key.weightsOutputLayout & k.key.weightsOutputLayout) != 0 ||
-          key.weightsOutputLayout == k.key.weightsOutputLayout))
-        return false;
-
-    return true;
+    return (key.weightsOutputLayout & k.key.weightsOutputLayout) != 0 ||
+          key.weightsOutputLayout == k.key.weightsOutputLayout;
 }
 
 ParamsKey ParamsKey::Merge(const ParamsKey& k) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -342,7 +342,7 @@ public:
     void EnableArgMaxMinAxis(ArgMaxMinAxis a);
     bool Support(const ParamsKey& k) const;
     bool isEnabledDifferentInputWeightsTypes() const {
-        return key.restrict.val.different_input_weights_types ? true : false;
+        return key.restrict.val.different_input_weights_types != 0;
     }
     ParamsKey Merge(const ParamsKey& k) const;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_utils.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_utils.cpp
@@ -54,8 +54,8 @@ static WeightsFormatSupportType CheckWeights(const weight_bias_params& newParams
     reorderNeeded |= rotate;
 
     if (reorderNeeded && !pitchesDifferFromLS && !rotate) {
-        reorderNeeded = !((reqLayouts == WeightsLayout::io && tensor.GetLayout() == WeightsLayout::iyxo) ||
-                          (reqLayouts == WeightsLayout::oi && tensor.GetLayout() == WeightsLayout::oiyx));
+        reorderNeeded = (reqLayouts != WeightsLayout::io || tensor.GetLayout() != WeightsLayout::iyxo) &&
+                          (reqLayouts != WeightsLayout::oi || tensor.GetLayout() != WeightsLayout::oiyx);
     }
 
     return reorderNeeded ? REORDER_NEEDED : SUPPORTED;
@@ -85,11 +85,8 @@ bool CheckImageSize(const weight_bias_params& newParams, const WeightsLayout lay
         return false;
 
     auto image_sizes = GetImageSizes(newParams.weights, layout);
-    if (image_sizes[0] == 0 || image_sizes[1] == 0 || image_sizes[0] > newParams.engineInfo.maxImage2dWidth ||
-        image_sizes[1] > newParams.engineInfo.maxImage2dHeight)
-        return false;
-
-    return true;
+    return image_sizes[0] != 0 && image_sizes[1] != 0 && image_sizes[0] <= newParams.engineInfo.maxImage2dWidth &&
+        image_sizes[1] <= newParams.engineInfo.maxImage2dHeight;
 }
 
 bool UpdateWeightsParams(weight_bias_params& newParams,
@@ -354,8 +351,8 @@ std::vector<size_t> GetOptimalLocalWorkGroupSizes(std::vector<size_t> gws, const
                                             16;
     // Reduces max local wgs for some cases on Gen12+ devices
     if (lws_max >= 512) {
-        auto two_dims_are_odd_and_equal = (gws[0] % 2 && gws[0] > 7 && (gws[0] == gws[1] || gws[0] == gws[2])) ||
-                                          (gws[1] % 2 && gws[1] > 7 && gws[1] == gws[2]);
+        auto two_dims_are_odd_and_equal = (((gws[0] % 2) != 0u) && gws[0] > 7 && (gws[0] == gws[1] || gws[0] == gws[2])) ||
+                                          (((gws[1] % 2) != 0u) && gws[1] > 7 && gws[1] == gws[2]);
 
         // Known cases when lws_max = 256 works better than lws_max > 256
         auto max_wgs_exception1 = gws[priority_order[0]] == 1278 && gws[priority_order[1]] == 718 && gws[priority_order[2]] % 10 == 0;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv4_int8.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv4_int8.cpp
@@ -70,7 +70,7 @@ bool ConvolutionKernel_b_fs_yx_fsv4_int8::Validate(const Params& p) const {
     }
 
     const auto& params = static_cast<const convolution_params&>(p);
-    if (params.inputs[0].X().v % 64)
+    if ((params.inputs[0].X().v % 64) != 0u)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
     bool bFilterSize = (params.filterSize.x == 5 && params.filterSize.y == 5) ||

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.cpp
@@ -287,7 +287,7 @@ ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw::SetDefault(const convolution_params
     dispatchData.gemmStyle = { 0, 0, 0, 0, 0, 0 };
 
     dispatchData.cldnnStyle.blockWidth = tune_params.tile_x;
-    dispatchData.cldnnStyle.prefetch = tune_params.preload_input_slm;
+    dispatchData.cldnnStyle.prefetch = static_cast<size_t>(tune_params.preload_input_slm);
 
     return dispatchData;
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_imad.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_imad.cpp
@@ -129,10 +129,10 @@ Convolution_kernel_b_fs_zyx_fsv16_imad::GetBlockParams(const convolution_params&
         for (size_t split = 1; split <= max_slm_split; split *= 2) {
             for (size_t temp_block_features = simd; temp_block_features <= simd * 2; temp_block_features += simd) {
                 for (size_t d = 1; d < max_d; ++d) {
-                    if (d != 1 && params.outputs[0].Z().v % d)
+                    if (d != 1 && ((params.outputs[0].Z().v % d) != 0u))
                         continue;
                     for (size_t h = 1; h < max_h; ++h) {
-                        if (h != 1 && params.outputs[0].Y().v % h)
+                        if (h != 1 && ((params.outputs[0].Y().v % h) != 0u))
                             continue;
 
                         bool c_ifm_mul = CeilDiv(params.weights.IFM().v, fsv) % split == 0;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.cpp
@@ -341,11 +341,7 @@ bool ConvolutionCheckInput(const Params& p) {
     const bool bProperInputDesc = CheckConvolutionPaddedInputDesc(params, req_input);
     const bool bInputPadded = params.allowInputReordering || bProperInputDesc;
 
-    if (!bInputPadded) {
-        return false;
-    }
-
-    return true;
+    return bInputPadded;
 }
 
 bool ConvolutionUpdateInputParams(convolution_params& params) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1.cpp
@@ -85,7 +85,7 @@ bool ConvolutionKernel_bfyx_1x1::Validate(const Params& p) const {
 JitConstants ConvolutionKernel_bfyx_1x1::GetJitConstants(const convolution_params& params, const DispatchData& dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
 
-    if (params.outputs[0].Feature().v % 16)
+    if ((params.outputs[0].Feature().v % 16) != 0u)
         jit.AddConstant(MakeJitConstant("LEFTOVERS", 1));
 
     return jit;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_iyxo.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_iyxo.cpp
@@ -57,7 +57,7 @@ bool ConvolutionKernel_bfyx_iyxo::Validate(const Params& p) const {
     }
 
     const auto& params = static_cast<const convolution_params&>(p);
-    if (params.inputs[0].X().v % 64)
+    if ((params.inputs[0].X().v % 64) != 0u)
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
     bool bFilterSize = (params.filterSize.x == 5 && params.filterSize.y == 5) ||

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_b_fs_yx_fsv4_1x1.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_b_fs_yx_fsv4_1x1.cpp
@@ -108,11 +108,7 @@ bool ConvolutionKernel_imad_b_fs_yx_fsv4_1x1::Validate(const Params& params) con
 
 bool ConvolutionKernel_imad_b_fs_yx_fsv4_1x1::ValidateAutoTuneParams(const convolution_params& params, const AutoTuneParams& tune_params) const {
     auto sel_lwg_d = tune_params.lwg_depth;
-    if (CeilDiv(params.weights.IFM().v, fsv) % sel_lwg_d != 0) {
-        return false;
-    }
-
-    return true;
+    return CeilDiv(params.weights.IFM().v, fsv) % sel_lwg_d == 0;
 }
 
 ConvolutionKernel_imad_b_fs_yx_fsv4_1x1::AutoTuneParams ConvolutionKernel_imad_b_fs_yx_fsv4_1x1::GetAutoTuneParams(const convolution_params& params,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_b_fs_yx_fsv4_dw.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_b_fs_yx_fsv4_dw.cpp
@@ -132,7 +132,7 @@ bool ConvolutionKernel_imad_b_fs_yx_fsv4_dw::ValidateAutoTuneParams(const convol
 
         size_t reg_usage = tune_params.block_x * 4
                          + line_size * weights.Y().v
-                         + Align(weights.X().v * weights.Y().v, 4) * tune_params.preload_weights;
+                         + Align(weights.X().v * weights.Y().v, 4) * static_cast<typename std::enable_if<std::is_integral<unsigned long>::value, unsigned long>::type>(tune_params.preload_weights);
         if (reg_usage > max_reg_usage)
             DO_NOT_USE_THIS_KERNEL(params.layerID);
 
@@ -142,7 +142,7 @@ bool ConvolutionKernel_imad_b_fs_yx_fsv4_dw::ValidateAutoTuneParams(const convol
         if (tune_params.block_y > params.outputs[0].Y().v)
             DO_NOT_USE_THIS_KERNEL(params.layerID);
     } else {
-        size_t block_size = tune_params.block_x * 4 + Align(weights.X().v * weights.Y().v, 4) * tune_params.preload_weights;
+        size_t block_size = tune_params.block_x * 4 + Align(weights.X().v * weights.Y().v, 4) * static_cast<typename std::enable_if<std::is_integral<unsigned long>::value, unsigned long>::type>(tune_params.preload_weights);
         if (block_size > max_reg_usage)
             DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
@@ -165,9 +165,9 @@ ConvolutionKernel_imad_b_fs_yx_fsv4_dw::AutoTuneParams ConvolutionKernel_imad_b_
 
     // Check that we can preload x and calculate at least two output values
     constexpr size_t min_preload_width = 2;
-    size_t min_preload_regs = ((min_preload_width - 1) * params.stride.x + (weights.X().v - 1) * params.dilation.x + 1) * params.weights.Y().v
+    size_t min_preload_regs = static_cast<size_t>(((min_preload_width - 1) * params.stride.x + (weights.X().v - 1) * params.dilation.x + 1) * params.weights.Y().v
                             + min_preload_width * 4
-                            + Align(weights.X().v * weights.Y().v, 4) <= max_reg_usage;
+                            + Align(weights.X().v * weights.Y().v, 4) <= max_reg_usage);
     bool can_preload_input = min_preload_regs <= max_reg_usage && !is_1_by_x;
 
     if (can_preload_input) {
@@ -256,11 +256,7 @@ ConvolutionKernel_imad_b_fs_yx_fsv4_dw::AutoTuneParams ConvolutionKernel_imad_b_
         tune_params.block_x = best_x_8 != 0 ? best_x_8 : best_x_1;
         tune_params.block_y = 1;
         tune_params.preload_input = false;
-        if (tune_params.block_x > 1 && (tune_params.block_x * 4 + Align(weights.X().v * weights.Y().v, 4)) <= max_reg_usage) {
-            tune_params.preload_weights = true;
-        } else {
-            tune_params.preload_weights = false;
-        }
+        tune_params.preload_weights = tune_params.block_x > 1 && (tune_params.block_x * 4 + Align(weights.X().v * weights.Y().v, 4)) <= max_reg_usage;
         tune_params.tiled_simd = 0;
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_2x3_s1_fused.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_2x3_s1_fused.cpp
@@ -125,7 +125,7 @@ bool ConvolutionKernel_Winograd_2x3_s1_fused::Validate(const Params& p) const {
 
     if ((params.weights.X().v != 3) || (params.weights.Y().v != 3) || (params.stride.x != 1) ||
         (params.stride.y != 1) || (params.filterSize.x != 3) || (params.filterSize.y != 3) ||
-        (params.outputs[0].Feature().v % 32) || (params.inputs[0].Feature().v % 32) ||
+        ((params.outputs[0].Feature().v % 32) != 0u) || ((params.inputs[0].Feature().v % 32) != 0u) ||
         (params.outputs[0].Feature().pad.before != 0) || (params.outputs[0].Feature().pad.after != 0) ||
         (params.outputs[0].Batch().pad.before != 0) || (params.outputs[0].Batch().pad.after != 0) ||
         // TODO: add support to batch > 1

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_6x3_s1_fused.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_6x3_s1_fused.cpp
@@ -136,7 +136,7 @@ bool ConvolutionKernel_Winograd_6x3_s1_fused::Validate(const Params& p) const {
 
     if ((params.weights.X().v != 3) || (params.weights.Y().v != 3) || (params.stride.x != 1) ||
         (params.stride.y != 1) || (params.filterSize.x != 3) || (params.filterSize.y != 3) ||
-        (params.outputs[0].Feature().v % 32) || (params.inputs[0].Feature().v % 32) ||
+        ((params.outputs[0].Feature().v % 32) != 0u) || ((params.inputs[0].Feature().v % 32) != 0u) ||
         (params.outputs[0].Feature().pad.before != 0) || (params.outputs[0].Feature().pad.after != 0) ||
         (params.outputs[0].Batch().pad.before != 0) || (params.outputs[0].Batch().pad.after != 0) ||
         // TODO: add support to batch > 1

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16_dw.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16_dw.cpp
@@ -81,7 +81,7 @@ DeconvolutionKernel_b_fs_zyx_fsv16_dw::GetDispatchParams(const deconvolution_par
         bool good_block_size_x = params.outputs[0].X().v % d_params.block_size_x == 0 || params.outputs[0].X().v > d_params.block_size_x * 3;
         bool good_reg_pressure = EstimateRegPressure(params, d_params) <= max_reg_pressure;
         // No support for no input preload and weights line preload in kernel
-        bool good_preloads = !(d_params.preload_input == input_preload::none && d_params.preload_weights == weights_preload::line);
+        bool good_preloads = d_params.preload_input != input_preload::none || d_params.preload_weights != weights_preload::line;
         // At least one input preload
         bool full_input_preload = d_params.preload_input != input_preload::line ||
                                   CeilDiv(d_params.block_size_x + params.filterSize.x - 1, params.stride.x) <= params.inputs[0].X().v;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.cpp
@@ -491,7 +491,7 @@ JitConstants EltwiseKernelBase::MakeIndexJitConstants(const eltwise_params& para
         jit.AddConstant(MakeJitConstant(out_idx_order, "d1"));
     } else {
         if (CheckInputsOutputNoPitchSameDims(params) &&
-            !(params.layoutBased || params.int8_quantization || params.broadcast)) {
+            !params.layoutBased && !params.int8_quantization && !params.broadcast) {
             jit.AddConstant(MakeJitConstant(out_idx_order, "d1"));
         } else {
             size_t out_c = DataTensor::ChannelsCount(params.outputs[0].GetLayout());
@@ -530,7 +530,7 @@ JitConstants EltwiseKernelBase::MakeIndexJitConstants(const eltwise_params& para
             jit.AddConstant(MakeJitConstant(idx_order, "d1"));
         } else {
             if (CheckInputsOutputNoPitchSameDims(params) &&
-                !(params.layoutBased || params.int8_quantization || params.broadcast)) {
+                !params.layoutBased && !params.int8_quantization && !params.broadcast) {
                 jit.AddConstant(MakeJitConstant(idx_order, "d1"));
             } else {
                 size_t in_c = DataTensor::ChannelsCount(params.inputs[i].GetLayout());

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.cpp
@@ -485,11 +485,8 @@ static inline int GetInnerFeatureBlockSize(const DataTensor& tensor) {
 }
 
 static inline bool IsBroadcastingPossibleInput(const DataTensor& input, const DataTensor& output) {
-    if ((input.LogicalSize() == 1) ||
-        (input.LogicalSize() == output.Feature().v && input.Feature().v == output.Feature().v)) {
-            return true;
-        }
-    return false;
+    return (input.LogicalSize() == 1) ||
+        (input.LogicalSize() == output.Feature().v && input.Feature().v == output.Feature().v);
 }
 
 static inline bool InputHasFeatureBroadcast(const eltwise_params& params, const size_t op_num, const size_t input_idx) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_fs_b_yx_fsv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_fs_b_yx_fsv32.cpp
@@ -38,7 +38,7 @@ bool EltwiseKernel_fs_b_yx_fsv32::Validate(const Params& params) const {
     bool bCheckSizes = true;
     for (size_t i = 0; i < ewParams.inputs.size(); i++) {
         // allow only the same input sizes or scalars, without pitches
-        if (!(ewParams.inputs[0] == ewParams.inputs[i] && ewParams.inputs[i] == ewParams.outputs[0]) && ewParams.inputs[i].PhysicalSize() != 1)
+        if ((ewParams.inputs[0] != ewParams.inputs[i] || ewParams.inputs[i] != ewParams.outputs[0]) && ewParams.inputs[i].PhysicalSize() != 1)
             bCheckSizes = false;
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_vload8.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_vload8.cpp
@@ -72,7 +72,7 @@ bool EltwiseKernel_vload8::Validate(const Params& params) const {
     for (size_t i = 0; i < ewParams.inputs.size(); i++) {
         // allow only the same input sizes or scalars, without pitches
         if (ewParams.inputs[i].PitchesDifferFromLogicalDims() ||
-            (!(ewParams.inputs[0] == ewParams.inputs[i] && ewParams.inputs[i] == ewParams.outputs[0]) &&
+            ((ewParams.inputs[0] != ewParams.inputs[i] || ewParams.inputs[i] != ewParams.outputs[0]) &&
              ewParams.inputs[i].PhysicalSize() != 1))
             bCheckSizes = false;
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/embedding_bag/embedding_bag_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/embedding_bag/embedding_bag_kernel_ref.cpp
@@ -107,9 +107,7 @@ bool EmbeddingBagKernelRef::Validate(const Params& p) const {
     const embedding_bag_params& params = static_cast<const embedding_bag_params&>(p);
 
     auto checkIntType = [](Datatype dt) {
-        if (dt != Datatype::INT32 && dt != Datatype::UINT32)
-            return false;
-        return true;
+        return dt == Datatype::INT32 || dt == Datatype::UINT32;
     };
 
     if (!checkIntType(params.inputs[1].GetDType()))

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -39,7 +39,7 @@ static inline bool should_use_dyn_b_kernel(size_t batch, size_t ifm, size_t ofm,
     if (std::min(ifm, ofm) < simd)
         return false;
     uint64_t mask = (ifm < ofm) ? dyn_b_batches_ifm_lt_ofm : dyn_b_batches_ifm_gt_ofm;
-    return (mask >> batch) & 1ULL;
+    return ((mask >> batch) & 1ULL) != 0u;
 }
 
 namespace kernel_selector {
@@ -68,15 +68,15 @@ std::pair<size_t, size_t> get_output_aligned_bf_size(const fully_connected_param
                                                      uint32_t align_b,
                                                      int32_t align_f) {
     size_t output_f =
-        (needs_align == true) ? CeilDiv(params.outputs[0].Feature().v, align_f) : params.outputs[0].Feature().v;
+        (needs_align) ? CeilDiv(params.outputs[0].Feature().v, align_f) : params.outputs[0].Feature().v;
     size_t output_b = params.outputs[0].Batch().v;
     // 3D output
     if (params.outputs[0].GetLayout() == DataLayout::bfyx) {
-        output_f = (needs_align == true) ? CeilDiv(params.outputs[0].Y().v, align_f) : params.outputs[0].Y().v;
+        output_f = (needs_align) ? CeilDiv(params.outputs[0].Y().v, align_f) : params.outputs[0].Y().v;
         output_b = params.outputs[0].Batch().v * params.outputs[0].Feature().v;
     }
 
-    output_b = (needs_align == true) ? CeilDiv(output_b, align_b) : output_b;
+    output_b = (needs_align) ? CeilDiv(output_b, align_b) : output_b;
 
     return {output_b, output_f};
 }
@@ -88,10 +88,7 @@ size_t get_scale_group_size(const fully_connected_params& params) {
 bool is_8bit_asym_wei(const fully_connected_params& params) {
     auto weight_type = params.weights.GetDType();
     // UINT8 weight type is supported by FC dyn-quantize(with SLM).
-    if (weight_type == WeightsType::UINT8 && params.has_decompression_zp)
-        return true;
-
-    return false;
+    return weight_type == WeightsType::UINT8 && params.has_decompression_zp;
 }
 
 bool is_weight_dyn_quantizable(const fully_connected_params& params) {
@@ -99,18 +96,12 @@ bool is_weight_dyn_quantizable(const fully_connected_params& params) {
     if (weight_type == WeightsType::INT4 || weight_type == WeightsType::UINT4)
         return true;
     // No validated case of sym 8bit weight
-    if (is_8bit_asym_wei(params))
-        return true;
-
-    return false;
+    return is_8bit_asym_wei(params);
 }
 
 bool is_per_token_dynamic_quantize(const fully_connected_params& params) {
     auto dynamic_quantization_group_size = params.dynamic_quantization_group_size;
-    if (dynamic_quantization_group_size == UINT64_MAX)
-        return true;
-
-    return false;
+    return dynamic_quantization_group_size == UINT64_MAX;
 }
 
 // DYNAMIC_QUANTIZE
@@ -130,7 +121,7 @@ size_t get_dynamic_quantize_group_size(const fully_connected_params& params) {
             dynamic_quantization_group_size = scale_group_size;
 
             // For int8 ASYM model, activation_sum should fit to weight zp
-            if (is_8bit_asym_wei(params) && params.has_decompression_zp == true &&
+            if (is_8bit_asym_wei(params) && params.has_decompression_zp &&
                 dynamic_quantization_group_size > zp_group_size && (zp_group_size % input_load_size) == 0) {
                 dynamic_quantization_group_size = zp_group_size;
             }
@@ -442,17 +433,12 @@ bool TuneParamsSelector::VerifyTuneParams(const fully_connected_params& params, 
             return false;
 
         const auto required_slm_size = tparams.tile_ofm * simd * tparams.tile_ifm * simd * 2; // 2 bytes per value (FP16 data type)
-        if (params.engineInfo.maxLocalMemSize < required_slm_size)
-            return false;
-
-        return true;
+        return params.engineInfo.maxLocalMemSize >= required_slm_size;
     }
     if (params.compressed && is_dyn_quantable_type) {
-        if (!(tparams.tile_ofm == 2 || tparams.tile_ofm == 4))
+        if (tparams.tile_ofm != 2 && tparams.tile_ofm != 4)
             return false;
-        if (tparams.tile_ofm == 4 && tparams.outer_ofm == 2 && !is_suitable_outer_ofm(params, output_f))
-            return false;
-        return true;
+        return tparams.tile_ofm != 4 || tparams.outer_ofm != 2 || is_suitable_outer_ofm(params, output_f);
     }
 
     // Reject tile sizes that are guaranteed to spill out of registers.
@@ -463,10 +449,7 @@ bool TuneParamsSelector::VerifyTuneParams(const fully_connected_params& params, 
     unsigned total_register_bytes = acc_register_bytes + in_register_bytes + wei_register_bytes;
     unsigned max_register_bytes = 128 * 32;
 
-    if (total_register_bytes > max_register_bytes)
-        return false;
-
-    return true;
+    return total_register_bytes <= max_register_bytes;
 }
 
 }  // namespace

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled_dyn_b.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled_dyn_b.cpp
@@ -87,10 +87,7 @@ bool FullyConnected_bf_tiled_dyn_b::IsBeneficial(const fully_connected_params& p
     auto ofm = weights.OFM().v;
     if (std::min(ifm, ofm) < simd)
         return false;
-    if (!(2 * ifm < ofm || ifm > 2 * ofm))
-        return false;
-
-    return true;
+    return 2 * ifm < ofm || ifm > 2 * ofm;
 }
 
 bool FullyConnected_bf_tiled_dyn_b::Validate(const Params& params) const {
@@ -165,7 +162,7 @@ bool FullyConnected_bf_tiled_dyn_b::Validate(const Params& params) const {
         auto ofm = weights.OFM().v;
         if (std::min(ifm, ofm) < simd)
             DO_NOT_USE_THIS_KERNEL(params.layerID);
-        if (!(2 * ifm < ofm || ifm > 2 * ofm))
+        if (2 * ifm >= ofm && ifm <= 2 * ofm)
             DO_NOT_USE_THIS_KERNEL(params.layerID);
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_gemv.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_gemv.cpp
@@ -88,9 +88,9 @@ bool FullyConnected_GEMV::Validate(const Params& params) const {
         if (input_size.first != 1) {
             DO_NOT_USE_THIS_KERNEL(params.layerID);
         }
-        if (!(wl == WeightsLayout::os_is_yx_osv32_isv2 && wo % 32 == 0) &&
-            !(wl == WeightsLayout::os_is_yx_osv64_isv2 && wo % 64 == 0) &&
-            !(wl == WeightsLayout::os_iyx_osv16 && wo % 16 == 0)) {
+        if ((wl != WeightsLayout::os_is_yx_osv32_isv2 || wo % 32 != 0) &&
+            (wl != WeightsLayout::os_is_yx_osv64_isv2 || wo % 64 != 0) &&
+            (wl != WeightsLayout::os_iyx_osv16 || wo % 16 != 0)) {
             DO_NOT_USE_THIS_KERNEL(params.layerID);
         }
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_mmad.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_mmad.cpp
@@ -204,11 +204,11 @@ JitConstants FullyConnectedKernelMMAD::GetJitConstants(const fully_connected_par
         jit.AddConstant(MakeJitConstant("MMAD_INPUT_FBLOCK_PITCH", input.Feature().pitch * sub_group_pack_size));
     }
 
-    bool has_feature_leftovers = (input.GetLayout() == DataLayout::bfyx && input.Feature().v % sub_group_pack_size) ||
-                                 (input.GetLayout() != DataLayout::bfyx && tuning_data.sub_group_size == 16 && CeilDiv(input.Feature().v, 32) % 2);
+    bool has_feature_leftovers = (input.GetLayout() == DataLayout::bfyx && ((input.Feature().v % sub_group_pack_size) != 0u)) ||
+                                 (input.GetLayout() != DataLayout::bfyx && tuning_data.sub_group_size == 16 && ((CeilDiv(input.Feature().v, 32) % 2) != 0u));
 
     if (output.GetLayout() == DataLayout::bfyx)
-        has_feature_leftovers = input.Y().v % sub_group_pack_size;
+        has_feature_leftovers = ((input.Y().v % sub_group_pack_size) != 0u);
 
     jit.AddConstant(MakeJitConstant("HAS_FEATURE_LEFTOVERS", has_feature_leftovers));
     jit.AddConstant(MakeJitConstant("FEATURE_BLOCKS_COUNT", tuning_data.feature_blocks_count));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
@@ -328,13 +328,9 @@ bool GatherKernelRef::Validate(const Params& p) const {
 
     if (params.outputs[0].is_dynamic()) {
         auto supported_tensor_layout = [](const DataTensor& t) -> bool {
-            if (t.GetLayout() == DataLayout::bfyx ||
+            return t.GetLayout() == DataLayout::bfyx ||
                 t.GetLayout() == DataLayout::bfzyx ||
-                t.GetLayout() == DataLayout::bfwzyx) {
-                return true;
-            }
-
-            return false;
+                t.GetLayout() == DataLayout::bfwzyx;
         };
 
         for (auto& in : params.inputs) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.h
@@ -13,7 +13,7 @@ namespace kernel_selector {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct gemm_params : public base_params {
     gemm_params()
-        : base_params(KernelType::GEMM), alpha(1.0f), beta(0.0f), transpose_input0(false), transpose_input1(false) {}
+        : base_params(KernelType::GEMM), alpha(1.0f), beta(0.0f), transpose_input0(0u), transpose_input1(0u) {}
 
     float alpha;
     float beta;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8.cpp
@@ -97,11 +97,11 @@ inline size_t GemmKernelMMADint8::GetMmadOperationsNumber(const GemmTuningData& 
 
 bool GemmKernelMMADint8::HasLeftovers(const GemmTuningData& tuning_data, int tile_size) const {
     if (tile_size == 32) {
-        return tuning_data.size_m % 32 || tuning_data.size_n % 16 || tuning_data.size_k % 64;
+        return ((tuning_data.size_m % 32) != 0u) || ((tuning_data.size_n % 16) != 0u) || ((tuning_data.size_k % 64) != 0u);
     } else if (tile_size == 16) {
-        return tuning_data.size_m % 16 || tuning_data.size_n % 16 || tuning_data.size_k % 64;
+        return ((tuning_data.size_m % 16) != 0u) || ((tuning_data.size_n % 16) != 0u) || ((tuning_data.size_k % 64) != 0u);
     } else if (tile_size == 8) {
-        return tuning_data.size_m % 8 || tuning_data.size_n % 8 || tuning_data.size_k % 32;
+        return ((tuning_data.size_m % 8) != 0u) || ((tuning_data.size_n % 8) != 0u) || ((tuning_data.size_k % 32) != 0u);
     } else {
         return true;
     }
@@ -117,7 +117,7 @@ GemmKernelMMADint8::GemmTuningData GemmKernelMMADint8::SetTuningParams(const gem
 
     bool small_matrices = mmad_operations_number <= 128 * 128 * 128;
     bool very_big_matrices = mmad_operations_number >= 1024 * 1024 * 1024;
-    bool no_input2 = params.inputs.size() == 3 ? false : true;
+    bool no_input2 = params.inputs.size() != 3;
 
     size_t simd_size = 16;
     size_t tile_num = 1;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8_slm.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_mmad_int8_slm.cpp
@@ -91,8 +91,8 @@ inline size_t GemmKernelMMADslmInt8::GetMmadOperationsNumber(const GemmTuningDat
 }
 
 inline bool GemmKernelMMADslmInt8::HasLeftovers(const GemmTuningData& tuning_data) const {
-    return tuning_data.size_m % tuning_data.slm_tile_size || tuning_data.size_n % tuning_data.slm_tile_size ||
-           tuning_data.size_k % (tuning_data.slm_tile_size * tuning_data.slm_decimation_factor);
+    return ((tuning_data.size_m % tuning_data.slm_tile_size) != 0u) || ((tuning_data.size_n % tuning_data.slm_tile_size) != 0u) ||
+           ((tuning_data.size_k % (tuning_data.slm_tile_size * tuning_data.slm_decimation_factor)) != 0u);
 }
 
 GemmKernelMMADslmInt8::GemmTuningData GemmKernelMMADslmInt8::SetTuningParams(const gemm_params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -87,7 +87,7 @@ GemmKernelTiledOpt::GemmTuningData GemmKernelTiledOpt::SetTuningParams(const gem
         tuning_data.tile_k_size = tuning_data.simd_size;
         tuning_data.tile_m_size = tuning_data.simd_size;
 
-        bool leftovers = m_size % tuning_data.tile_m_size || k_size % tuning_data.tile_k_size || n_size % tuning_data.tile_n_size;
+        bool leftovers = ((m_size % tuning_data.tile_m_size) != 0u) || ((k_size % tuning_data.tile_k_size) != 0u) || ((n_size % tuning_data.tile_n_size) != 0u);
 
         if (leftovers || total_batches > 1 || params.transpose_input0 || params.transpose_input1 || !IsSIMDSizeSupported(params.engineInfo, 8)) {
             tuning_data.simd_size = 16;
@@ -527,13 +527,13 @@ void GemmKernelTiledOpt::GetUpdateDispatchDataFunc(KernelData& kd) const {
             bool not_divisible_k = ((k_size % tuning_data.tile_k_size) != 0);
             bool not_divisible_n = ((n_size % tuning_data.tile_n_size) != 0);
             size_t execute_kernel_idx = 0;
-            if (not_divisible_k == false && not_divisible_n == false) {
+            if (!not_divisible_k && !not_divisible_n) {
                 execute_kernel_idx = 0;
-            } else if (not_divisible_k == false && not_divisible_n == true) {
+            } else if (!not_divisible_k && not_divisible_n) {
                 execute_kernel_idx = 1;
-            } else if (not_divisible_k == true && not_divisible_n == false) {
+            } else if (not_divisible_k && !not_divisible_n) {
                 execute_kernel_idx = 2;
-            } else if (not_divisible_k == true && not_divisible_n == true) {
+            } else if (not_divisible_k && not_divisible_n) {
                 execute_kernel_idx = 3;
             }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.h
@@ -64,11 +64,7 @@ protected:
     KernelsData GetCommonKernelsData(const Params& params) const;
 
     bool Validate(const Params& p) const override {
-        if (p.GetType() != KernelType::LSTM_SEQ_CELL) {
-            return false;
-        }
-
-        return true;
+        return p.GetType() == KernelType::LSTM_SEQ_CELL;
     }
 };
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_bfzyx_to_bfyxz.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_bfzyx_to_bfyxz.cpp
@@ -66,7 +66,7 @@ JitConstants PermuteKernel_bfzyx_to_bfyxz::GetJitConstants(const permute_params&
     std::string x_remainder_cond = "true";
     std::string z_remainder_cond = "true";
 
-    if (params.inputs[0].X().v % tile_size) {
+    if ((params.inputs[0].X().v % tile_size) != 0u) {
         jit.AddConstant(MakeJitConstant("X_REMAINDER_ITEM", params.inputs[0].X().v / tile_size));
         jit.AddConstant(MakeJitConstant("X_REMAINDER_SIZE", params.inputs[0].X().v % tile_size));
         jit.AddConstant(MakeJitConstant("X_REMAINDER_SIZE_AS_VECTOR", CeilDiv(params.inputs[0].X().v % tile_size, vector_width)));
@@ -74,7 +74,7 @@ JitConstants PermuteKernel_bfzyx_to_bfyxz::GetJitConstants(const permute_params&
         x_remainder_cond += " && (x == X_REMAINDER_ITEM)";
         z_remainder_cond += " && (x < X_REMAINDER_ITEM)";
     }
-    if (params.inputs[0].Z().v % tile_size) {
+    if ((params.inputs[0].Z().v % tile_size) != 0u) {
         jit.AddConstant(MakeJitConstant("Z_REMAINDER_ITEM", params.inputs[0].Z().v / tile_size));
         jit.AddConstant(MakeJitConstant("Z_REMAINDER_SIZE", params.inputs[0].Z().v % tile_size));
         jit.AddConstant(MakeJitConstant("Z_REMAINDER_SIZE_AS_VECTOR", CeilDiv(params.inputs[0].Z().v % tile_size, vector_width)));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_f_y_axes.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_f_y_axes.cpp
@@ -211,10 +211,7 @@ bool PermuteKernel_f_y_axes::Validate(const Params& p) const {
         if (order.size() != 4) {
             return false;
         }
-        if (order[0] != 0 || order[1] != 3 || order[2] != 2 || order[3] != 1) {
-            return false;
-        }
-        return true;
+        return order[0] == 0 && order[1] == 3 && order[2] == 2 && order[3] == 1;
     };
 
     const auto& params = dynamic_cast<const permute_params&>(p);
@@ -244,8 +241,8 @@ bool PermuteKernel_f_y_axes::Validate(const Params& p) const {
         const auto feature_block_size = GetFeatureBlockSize(params);
         const auto tile_size = GetTileSize(params);
         const auto subgroup_size = Is3DTranspose(params) ? feature_block_size : tile_size;
-        if (!(IsSIMDSizeSupported(params.engineInfo, subgroup_size) &&
-              (in_layout == DataLayout::b_fs_yx_fsv32 || in_layout == DataLayout::b_fs_yx_fsv16))) {
+        if (!IsSIMDSizeSupported(params.engineInfo, subgroup_size) ||
+              (in_layout != DataLayout::b_fs_yx_fsv32 && in_layout != DataLayout::b_fs_yx_fsv16)) {
             DO_NOT_USE_THIS_KERNEL(p.layerID);
         }
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4.cpp
@@ -176,7 +176,7 @@ JitConstants PermuteKernel_tile_8x8_4x4::GetJitConstants(const permute_params& p
         std::string x_remainder_cond = "true";
         std::string f_remainder_cond = "true";
 
-        if (params.inputs[0].X().v % tile_size) {
+        if ((params.inputs[0].X().v % tile_size) != 0u) {
             jit.AddConstant(MakeJitConstant("X_REMAINDER_ITEM", params.inputs[0].X().v / tile_size));
             jit.AddConstant(MakeJitConstant("X_REMAINDER_SIZE", params.inputs[0].X().v % tile_size));
             jit.AddConstant(MakeJitConstant("X_REMAINDER_SIZE_AS_VECTOR", CeilDiv(params.inputs[0].X().v % tile_size, vector_width)));
@@ -184,7 +184,7 @@ JitConstants PermuteKernel_tile_8x8_4x4::GetJitConstants(const permute_params& p
             x_remainder_cond += " && (x == X_REMAINDER_ITEM)";
             f_remainder_cond += " && (x < X_REMAINDER_ITEM)";
         }
-        if (params.inputs[0].Feature().v % tile_size) {
+        if ((params.inputs[0].Feature().v % tile_size) != 0u) {
             jit.AddConstant(MakeJitConstant("F_REMAINDER_ITEM", params.inputs[0].Feature().v / tile_size));
             jit.AddConstant(MakeJitConstant("F_REMAINDER_SIZE", params.inputs[0].Feature().v % tile_size));
             jit.AddConstant(MakeJitConstant("F_REMAINDER_SIZE_AS_VECTOR", CeilDiv(params.inputs[0].Feature().v % tile_size, vector_width)));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_base.cpp
@@ -114,7 +114,7 @@ bool PoolingKernelBase::NeedsBoundaryCheck(const pooling_params& pp) const {
     auto mod_y = (input.Y().v - pp.poolSize.y) % pp.poolStride.y;
     auto mod_z = (input.Z().v - pp.poolSize.z) % pp.poolStride.z;
 
-    return mod_x || mod_y || mod_z;
+    return (mod_x != 0u) || (mod_y != 0u) || (mod_z != 0u);
 }
 
 bool PoolingKernelBase::EnableRound(const kernel_selector::pooling_params& params) const {
@@ -126,13 +126,9 @@ bool PoolingKernelBase::EnableRound(const kernel_selector::pooling_params& param
         }
     }
 
-    if (!has_fused_quantize_to_int8 &&
+    return !has_fused_quantize_to_int8 &&
         (params.outputs[0].GetDType() == Datatype::INT8 || params.outputs[0].GetDType() == Datatype::UINT8) &&
-        params.poolType == PoolType::AVG) {
-        return true;
-    }
-
-    return false;
+        params.poolType == PoolType::AVG;
 }
 
 PoolingKernelBase::DispatchData PoolingKernelBase::SetDefault(const pooling_params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_opt.cpp
@@ -86,7 +86,7 @@ JitConstants QuantizeKernelScaleShift::GetJitConstants(const quantize_params& pa
     }
 
     auto can_use_output_range = params.per_tensor_output_range && params.out_lo < params.out_hi;
-    auto has_output_range_round = !(params.outputs[0].GetDType() == Datatype::INT8 || params.outputs[0].GetDType() == Datatype::UINT8);
+    auto has_output_range_round = params.outputs[0].GetDType() != Datatype::INT8 && params.outputs[0].GetDType() != Datatype::UINT8;
 
     jit.AddConstant(MakeJitConstant("HAS_POST_SCALE", params.has_post_scale));
     jit.AddConstant(MakeJitConstant("HAS_POST_SHIFT", params.has_post_shift));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_vload8_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_vload8_opt.cpp
@@ -49,7 +49,7 @@ JitConstants QuantizeKernelScaleShift_vload8::GetJitConstants(const quantize_par
 
     auto can_use_output_range = params.per_tensor_output_range && params.out_lo < params.out_hi;
     auto has_output_range_round =
-        !(params.outputs[0].GetDType() == Datatype::INT8 || params.outputs[0].GetDType() == Datatype::UINT8);
+        params.outputs[0].GetDType() != Datatype::INT8 && params.outputs[0].GetDType() != Datatype::UINT8;
 
     jit.AddConstant(MakeJitConstant("HAS_POST_SCALE", params.has_post_scale));
     jit.AddConstant(MakeJitConstant("HAS_POST_SHIFT", params.has_post_shift));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_b_fs_yx_fsv16.cpp
@@ -172,7 +172,7 @@ JitConstants ReduceKernel_b_fs_yx_fsv16::GetJitConstants(const reduce_params& pa
         std::vector<std::string> idx_order = {"b", "f", "y", "x"};
         std::string var_name = "reduce_result";
 
-        bool cant_handle_vec16 = read_offset > 8 ? true : false;
+        bool cant_handle_vec16 = read_offset > 8;
         size_t vec_size = cant_handle_vec16 ? 8 : read_offset;
 
         FusedOpsConfiguration conf_scalar = {"_SCALAR",

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.cpp
@@ -119,16 +119,13 @@ static inline std::pair<size_t, size_t> GetSliceSizes(WeightsLayout l) {
 }
 
 static inline bool IsOsvFirst(WeightsLayout l) {
-    if (l == WeightsLayout::os_is_yx_isv16_osv16 || l == WeightsLayout::os_is_zyx_isv16_osv16 ||
+    return l == WeightsLayout::os_is_yx_isv16_osv16 || l == WeightsLayout::os_is_zyx_isv16_osv16 ||
         l == WeightsLayout::g_os_is_yx_isv16_osv16 || l == WeightsLayout::g_os_is_zyx_isv16_osv16 ||
         l == WeightsLayout::os_iyx_osv16 || l == WeightsLayout::g_os_iyx_osv16||
         l == WeightsLayout::os_iyx_osv32 || l == WeightsLayout::g_os_iyx_osv32 ||
         l == WeightsLayout::os_iyx_osv32__ai32 || l == WeightsLayout::is_os_yx_isv16_osv16 ||
         l == WeightsLayout::is_os_zyx_isv16_osv16 || l == WeightsLayout::g_is_os_yx_isv16_osv16 ||
-        l == WeightsLayout::g_is_os_zyx_isv16_osv16)
-        return true;
-    else
-        return false;
+        l == WeightsLayout::g_is_os_zyx_isv16_osv16;
 }
 
 static inline size_t GetOptimalSize(size_t val, std::vector<size_t> optimal_sizes) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorg_yolo/reorg_yolo_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorg_yolo/reorg_yolo_kernel_ref.cpp
@@ -82,9 +82,9 @@ bool ReorgYoloKernelRef::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
-    if (!(input.Feature().v >= params.stride * params.stride
-            && input.X().v % params.stride == 0
-            && input.Y().v % params.stride == 0)) {
+    if (input.Feature().v < params.stride * params.stride
+            || input.X().v % params.stride != 0
+            || input.Y().v % params.stride != 0) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_onnx.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_onnx.cpp
@@ -141,10 +141,7 @@ static bool IsThreeSpatialResample(const resample_params& params) {
     const auto& input = params.inputs[0];
     const auto& output = params.outputs[0];
 
-    if (input.Dimentions() == 5 && input.Z().v != output.Z().v)
-        return true;
-
-    return false;
+    return input.Dimentions() == 5 && input.Z().v != output.Z().v;
 }
 
 JitConstants ResampleKernelOnnx::GetJitConstants(const resample_params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_ref.cpp
@@ -85,10 +85,7 @@ static bool use_packing(const resample_params& params) {
     size_t max_work_items_per_eu = 32 * static_cast<size_t>(params.engineInfo.maxThreadsPerExecutionUnit);
     auto minimum_work_items = params.engineInfo.computeUnitsCount * max_work_items_per_eu;
 
-    if (packed_work_items < minimum_work_items)
-        return false;
-
-    return true;
+    return packed_work_items >= minimum_work_items;
 }
 
 JitConstants ResampleKernelRef::GetJitConstants(const resample_params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
@@ -90,7 +90,7 @@ JitConstants RMSKernelBfyxOpt::GetJitConstants(const rms_params& params, Dispatc
 
         const std::string lws_0 = "get_local_size(0)";
         // data_size string starts digit when it has static dim.
-        bool is_static_data_size = std::isdigit(data_size[0]);
+        bool is_static_data_size = std::isdigit(data_size[0]) != 0;
         size_t stack_size = 33;
         if (is_static_data_size) {
             auto item_num_and_lws = get_item_num_and_lws(params, stoi(data_size));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_align/roi_align_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_align/roi_align_kernel_ref.cpp
@@ -108,7 +108,7 @@ JitConstants ROIAlignKernelRef::GetJitConstants(const roi_align_params& params) 
     jit.AddConstant(MakeJitConstant("SAMPLE_X", "sample_x"));
     jit.AddConstant(MakeJitConstant("SAMPLE_Y", "sample_y"));
 
-    if (params.rotated_mode == false) {
+    if (!params.rotated_mode) {
         const char* prepare_roi_macro =
             R"( \
         const INPUT1_TYPE X1 = (roi_ptr[0] + (INPUT1_TYPE)OFFSET_SRC) * (INPUT1_TYPE)SPATIAL_SCALE + (INPUT1_TYPE)OFFSET_DST; \

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -196,9 +196,9 @@ JitConstants ScatterUpdateKernelRef::GetJitConstants(const scatter_update_params
     const auto input2_has_padding = params.inputs[2].has_dynamic_pad() || params.inputs[2].PitchesDifferFromLogicalDims();
 
     // In case of padded input2 (updates), we also need non-planar indexing, because UPDATES_INDEX is calculated based on output sizes
-    const auto use_layout_aware_indexing = !(SimpleLayout(params.inputs[0].GetLayout()) &&
-                                             SimpleLayout(params.inputs[1].GetLayout()) &&
-                                             SimpleLayout(params.inputs[2].GetLayout())) || input2_has_padding;
+    const auto use_layout_aware_indexing = !SimpleLayout(params.inputs[0].GetLayout()) ||
+                                             !SimpleLayout(params.inputs[1].GetLayout()) ||
+                                             !SimpleLayout(params.inputs[2].GetLayout()) || input2_has_padding;
 
     if (use_layout_aware_indexing) {
         jit.AddConstant(MakeJitConstant("USE_LAYOUT_AWARE_INDEXING", "1"));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sparse_fill_empty_rows/sparse_fill_empty_rows_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sparse_fill_empty_rows/sparse_fill_empty_rows_kernel_ref.cpp
@@ -91,10 +91,7 @@ float SparseFillEmptyRowsKernelRef::GetKernelsPriority(const Params &params) con
 }
 
 bool SparseFillEmptyRowsKernelRef::Validate(const Params& p) const {
-    if (p.GetType() != KernelType::SPARSE_FILL_EMPTY_ROWS) {
-        return false;
-    }
-    return true;
+    return p.GetType() == KernelType::SPARSE_FILL_EMPTY_ROWS;
 }
 
 JitConstants SparseFillEmptyRowsKernelRef::GetJitConstants(const sparse_fill_empty_rows_params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/stft/stft_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/stft/stft_kernel_opt.cpp
@@ -69,7 +69,7 @@ CommonDispatchData STFTKernelOpt::CalcLaunchConfig(const STFT_params& params) co
 }
 
 bool STFTKernelOpt::Validate(const Params& p) const {
-    if (STFTKernelBase::Validate(p) == false)
+    if (!STFTKernelBase::Validate(p))
         DO_NOT_USE_THIS_KERNEL(p.layerID);
 
     const auto& params = static_cast<const STFT_params&>(p);

--- a/src/plugins/intel_gpu/src/kernel_selector/weight_bias_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/weight_bias_kernel_base.cpp
@@ -12,7 +12,7 @@ JitConstants WeightBiasKernelBase::GetJitConstants(const weight_bias_params& par
         MakeJitConstant("BIAS_TERM", !params.bias.empty()),
     });
 
-    if (params.bias.empty() == false) {
+    if (!params.bias.empty()) {
         const bool sameDims = params.bias[0].SameDims(params.outputs[0]);
         jit.AddConstants({
             MakeJitConstant("BIAS", params.bias[0]),

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -185,14 +185,10 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
     };
 
     auto is_binary_eltwise = [&] (ov::Node* op) -> bool {
-        if (ov::op::util::is_binary_elementwise_arithmetic(op) ||
+        return ov::op::util::is_binary_elementwise_arithmetic(op) ||
             ov::op::util::is_binary_elementwise_logical(op) ||
             ov::op::util::is_binary_elementwise_comparison(op) ||
-            is_btiwise(op)) {
-            return true;
-        } else {
-            return false;
-        }
+            is_btiwise(op);
     };
 
     auto is_all_inputs_1d = [&] (ov::Node* op) -> bool {

--- a/src/plugins/intel_gpu/src/plugin/ops/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convert_color.cpp
@@ -25,7 +25,7 @@ static void CreateCommonConvertColorOp(ProgramBuilder& p, const std::shared_ptr<
     auto batch = op->get_input_partial_shape(0)[0];
 
     auto memory_type = cldnn::convert_color::memory_type::buffer;
-    if (op->get_input_node_ptr(0)->output(0).get_rt_info().count(ov::preprocess::TensorInfoMemoryType::get_type_info_static())) {
+    if (op->get_input_node_ptr(0)->output(0).get_rt_info().count(ov::preprocess::TensorInfoMemoryType::get_type_info_static()) != 0u) {
         std::string mem_type = op->get_input_node_ptr(0)->output(0).get_rt_info().at(ov::preprocess::TensorInfoMemoryType::get_type_info_static())
                                                                                  .as<ov::preprocess::TensorInfoMemoryType>().value;
         if (mem_type.find(ov::intel_gpu::memory_type::surface) != std::string::npos) {

--- a/src/plugins/intel_gpu/src/plugin/ops/custom.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/custom.cpp
@@ -49,7 +49,7 @@ public:
         m_values[name] = adapter.get();
     }
     void on_adapter(const std::string& name, ov::ValueAccessor<bool>& adapter) override {
-        m_values[name] = std::to_string(adapter.get());
+        m_values[name] = std::to_string(static_cast<int>(adapter.get()));
     }
     void on_adapter(const std::string& name, ov::ValueAccessor<int64_t>& adapter) override {
         m_values[name] = std::to_string(adapter.get());

--- a/src/plugins/intel_gpu/src/plugin/ops/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/detection_output.cpp
@@ -51,8 +51,8 @@ static void CreateCommonDetectionOutputOp(ProgramBuilder& p,
     float objectness_score          = attrs.objectness_score;
 
     cldnn::prior_box_code_type cldnnCodeType = PriorBoxCodeFromString(code_type);
-    int32_t prior_info_size = normalized != 0 ? 4 : 5;
-    int32_t prior_coordinates_offset = normalized != 0 ? 0 : 1;
+    int32_t prior_info_size = static_cast<int>(normalized) != 0 ? 4 : 5;
+    int32_t prior_coordinates_offset = static_cast<int>(normalized) != 0 ? 0 : 1;
 
     auto detectionPrim = cldnn::detection_output(layerName,
                                                  inputs,

--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -101,7 +101,7 @@ void CreateGatherOpBase(ProgramBuilder& p, const std::shared_ptr<T>& op, const i
     const auto& indices = op->input_value(1);
     const auto& indices_node = indices.get_node_shared_ptr();
     auto indices_constant = ov::as_type_ptr<ov::op::v0::Constant>(indices_node);
-    bool is_indices_constant = (indices_constant) ? true : false;
+    bool is_indices_constant = static_cast<bool>(indices_constant);
 
     if (is_static && axis == 0 && input_rank > 1 && indices.get_partial_shape().rank().get_length() == 0 &&
         std::equal(input_shape.begin()+1, input_shape.end(), out_shape.begin()+1) && is_indices_constant) {

--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -62,10 +62,7 @@ static void CreateMatMulOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::
             // but the perf is worse than permute + gemm_tiled_opt.
             // So we'll use this permute + gemm_tiled_opt strategy as a temporal solution,
             // until we have an essential solution, i.e., fixing the gemm_tiled_opt kernel to support unaligned shape.
-            if (p.get_engine().get_device_info().dev_type == cldnn::device_type::integrated_gpu)
-                return true;
-            else
-                return false;
+            return p.get_engine().get_device_info().dev_type == cldnn::device_type::integrated_gpu;
         }
         if (shapes[0].size() < 2 || shapes[1].size() < 2)
             return false;

--- a/src/plugins/intel_gpu/src/plugin/ops/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/non_max_suppression.cpp
@@ -95,7 +95,7 @@ static void CreateNonMaxSuppressionIEInternalOp(ProgramBuilder& p, const std::sh
                     reordered_inputs[0],
                     reordered_inputs[1],
                     0,
-                    op->m_center_point_box,
+                    op->m_center_point_box != 0,
                     op->m_sort_result_descending,
                     "", "", "", "", "", "", num_outputs);
 
@@ -157,7 +157,7 @@ static void CreateNonMaxSuppressionIEInternalOp(ProgramBuilder& p, const std::sh
                     reordered_inputs[0],
                     reordered_inputs[1],
                     static_cast<int>(outputIndices),
-                    op->m_center_point_box,
+                    op->m_center_point_box != 0,
                     op->m_sort_result_descending,
                     "", "", "", "", "", "");
 

--- a/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
@@ -23,7 +23,7 @@ static void CreateNormalizeL2Op(ProgramBuilder& p, const std::shared_ptr<ov::op:
     OPENVINO_ASSERT(const_axis != nullptr, "[GPU] Unsupported axis node type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
     auto axis = const_axis->cast_vector<size_t>();
-    bool across_spatial = !(axis.size() == 1 && axis[0] == 1);
+    bool across_spatial = axis.size() != 1 || axis[0] != 1;
     float eps = op->get_eps();
 
     // WA for OVC outputting %.6f

--- a/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
@@ -63,7 +63,7 @@ static void CreateParameterOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v
     std::function<bool(const std::shared_ptr<ov::Node>&)> has_surface_input =
         [](const std::shared_ptr<ov::Node> &node) -> bool {
         bool surface_input_found = false;
-        if (node->output(0).get_rt_info().count(ov::preprocess::TensorInfoMemoryType::get_type_info_static())) {
+        if (node->output(0).get_rt_info().count(ov::preprocess::TensorInfoMemoryType::get_type_info_static()) != 0u) {
             std::string mem_type = node->output(0).get_rt_info().at(ov::preprocess::TensorInfoMemoryType::get_type_info_static())
                                                                 .as<ov::preprocess::TensorInfoMemoryType>().value;
             if (mem_type.find(ov::intel_gpu::memory_type::surface) != std::string::npos) {

--- a/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roi_pooling.cpp
@@ -32,7 +32,7 @@ static void CreateDeformablePSROIPoolingOp(ProgramBuilder& p, const std::shared_
     cldnn::pooling_mode mode = GetPoolingMode(op->get_mode());
     float trans_std = op->get_trans_std();
     int part_size = static_cast<int>(op->get_part_size());
-    bool no_trans = op->get_input_size() == 2 ? true : false;
+    bool no_trans = op->get_input_size() == 2;
 
     // temporary workaround due to incorrect usage of group_size in the nGraph operation for the DeformablePSROIPooling
     int pooled_width = static_cast<int>(op->get_group_size());

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -37,7 +37,7 @@
 namespace {
 
 bool is_convert_required(ov::element::Type src_et, ov::element::Type dst_et) {
-    return src_et != dst_et && !(dst_et == ov::element::boolean && src_et == ov::element::u8);
+    return src_et != dst_et && (dst_et != ov::element::boolean || src_et != ov::element::u8);
 }
 
 bool same_host_mem(cldnn::memory::cptr memory, const uint8_t* host_ptr) {
@@ -206,7 +206,7 @@ void SyncInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
         // We need to properly handle PLUGIN -> USER ownership change to prevent invalid PLUGIN's ush_host buffer sharing,
         // so remove plugin's tensor to reallocate it in prepare_input() method
         if (current_tensor_owner == TensorOwner::PLUGIN && new_tensor_owner == TensorOwner::USER) {
-            if (plugin_tensors.count(port_index) && std::dynamic_pointer_cast<RemoteTensorImpl>(plugin_tensors[port_index].ptr)->is_shared())
+            if ((plugin_tensors.count(port_index) != 0u) && std::dynamic_pointer_cast<RemoteTensorImpl>(plugin_tensors[port_index].ptr)->is_shared())
                 plugin_tensors.erase(plugin_tensors.find(port_index));
         }
     };
@@ -380,7 +380,7 @@ void SyncInferRequest::enqueue() {
     if (!m_output_memory_blocks.empty() && !input_host_ptrs.empty()) {
         auto network = m_graph->get_network();
         for (auto& [idx, block] : m_output_memory_blocks) {
-            if (block->rawPtr() && input_host_ptrs.count(block->rawPtr())) {
+            if ((block->rawPtr() != nullptr) && (input_host_ptrs.count(block->rawPtr()) != 0u)) {
                 block->nextMemory();
                 network->invalidate_ext_block_compute_nodes(m_output_names_map.at(idx));
                 GPU_DEBUG_TRACE_DETAIL << "Output block [" << idx << "]: input aliases output - switching to alternate buffer" << std::endl;
@@ -453,7 +453,7 @@ void SyncInferRequest::wait() {
 
     // wait for completion & collect outputs as requested by the model
     // for in_order_queue, it is enough to call finish only once
-    bool do_sync_per_output = (network.get_stream().get_queue_type() == QueueTypes::in_order) ? false : true;
+    bool do_sync_per_output = network.get_stream().get_queue_type() != QueueTypes::in_order;
     if (!do_sync_per_output) {
         auto sync_start = std::chrono::high_resolution_clock::now();
         network.get_stream().finish();
@@ -805,7 +805,7 @@ void SyncInferRequest::allocate_inputs() {
         GPU_DEBUG_LOG << "[init input blob with index: " << input_idx << "]" << " shape: " << port.get_partial_shape() << " type: " << port.get_element_type() << std::endl;
 
         bool is_nv12_input = false;
-        if (port.get_rt_info().count(ov::preprocess::TensorInfoMemoryType::get_type_info_static())) {
+        if (port.get_rt_info().count(ov::preprocess::TensorInfoMemoryType::get_type_info_static()) != 0u) {
             std::string mem_type = port.get_rt_info().at(ov::preprocess::TensorInfoMemoryType::get_type_info_static())
                                                      .as<ov::preprocess::TensorInfoMemoryType>().value;
             if (mem_type.find(ov::intel_gpu::memory_type::surface) != std::string::npos) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
@@ -46,9 +46,9 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
         if (!fc || transformation_callback(fc)) {
             return false;
         }
-        bool has_transpose = pattern_map.count(transpose_m);
+        bool has_transpose = pattern_map.count(transpose_m) != 0u;
         auto scale_shape = pattern_map.at(mul_const_m).get_shape();
-        bool sub_with_convert = (pattern_map.count(sub_with_convert_m) > 0) ? true : false;
+        bool sub_with_convert = pattern_map.count(sub_with_convert_m) > 0;
 
         auto weight_shape = fc->get_input_shape(1);
         bool is_weight_3d = (std::count_if(weight_shape.begin(), weight_shape.end(), [](size_t d) { return d > 1; }) == 3);

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_stridedslices_to_variadicsplit.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_stridedslices_to_variadicsplit.cpp
@@ -110,7 +110,7 @@ ConvertStridedSlicesToVariadicSplit::ConvertStridedSlicesToVariadicSplit() {
                         return false;
                     if (!check_mask(end_mask))
                         return false;
-                    if (!((values.back() == end_offset) || (values.back() == max_value)))
+                    if ((values.back() != end_offset) && (values.back() != max_value))
                         return false;
                 } else {
                     return false;

--- a/src/plugins/intel_gpu/src/plugin/transformations/einsum_decomposition.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/einsum_decomposition.cpp
@@ -866,8 +866,8 @@ void contract_two_inputs(EinsumDecomposition* einsum_decompose_ptr,
                 subgraph_nodes);
 
     // step 3. apply MatMul operation for formatted inputs
-    const bool transpose_a = (is_separate_first1 ? false : true);
-    const bool transpose_b = (is_separate_first2 ? true : false);
+    const bool transpose_a = (!is_separate_first1);
+    const bool transpose_b = (is_separate_first2);
     const auto matmul = std::make_shared<ov::op::v0::MatMul>(matmul_operand1, matmul_operand2, transpose_a, transpose_b);
 
     // step 4. reshape back by unrolling dimensions corresponding to separate labels if needed

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
@@ -51,9 +51,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
                 return true;
             if (ov::as_type_ptr<ov::op::v0::Convert>(node) && ov::as_type_ptr<ov::op::v0::Constant>(node->get_input_node_shared_ptr(0)))
                 return true;
-            if (ov::as_type_ptr<ov::op::v1::Transpose>(node) && ov::as_type_ptr<ov::op::v0::Constant>(node->get_input_node_shared_ptr(0)))
-                return true;
-            return false;
+            return ov::as_type_ptr<ov::op::v1::Transpose>(node) && ov::as_type_ptr<ov::op::v0::Constant>(node->get_input_node_shared_ptr(0));
         };
         auto is_placeholder = [](const std::shared_ptr<ov::Node> node) {
             return ov::as_type_ptr<op::Placeholder>(node);

--- a/src/plugins/intel_gpu/src/plugin/transformations/lora_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/lora_horizontal_fusion.cpp
@@ -57,10 +57,10 @@ LoRAHorizontalFusion::LoRAHorizontalFusion() {
             const auto& variable_alpha =
                 ov::as_type_ptr<ov::op::util::ReadValueBase>(multiply->get_input_node_shared_ptr(alpha_idx));                 check(variable_alpha)
 
-            const auto& variable_a = ov::as_type_ptr<ov::op::util::ReadValueBase>(matmul1->get_input_node_shared_ptr(1));     check(variable_a)
+            const auto& variable_a = ov::as_type_ptr<ov::op::util::ReadValueBase>(matmul1->get_input_node_shared_ptr(1));
 
             #undef check
-            return true;
+            return variable_a != nullptr;
         };
 
         for (const auto& user : split_node->get_users()) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/optimize_subsequent_reshapes.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/optimize_subsequent_reshapes.cpp
@@ -32,10 +32,7 @@ OptimizeSubsequentReshapes::OptimizeSubsequentReshapes() {
         for (size_t i = 0; i < shape.size(); i++)
             dynamic_dims += shape[i].is_dynamic() ? 1 : 0;
 
-        if (dynamic_dims != 1)
-            return false;
-
-        return true;
+        return dynamic_dims == 1;
     };
 
     auto first_reshape_data = any_input(single_dynamic_dim);

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -416,10 +416,7 @@ static bool should_decompose_sdpa_for_memory_size(size_t max_size,
         // Calculate mem size of gemm for Q*K
         // Gemm layer decomposed from sdpa could exceed max size of memory allocation.
         size_t sdpa_intermediate_buffer_size = q.get_shape().at(0) * q.get_shape().at(1) * k.get_shape().at(1) * dt_size;
-        if (sdpa_intermediate_buffer_size > max_size * 0.5)
-            return false;
-
-        return true;
+        return sdpa_intermediate_buffer_size <= max_size * 0.5;
     }
 
     return false;
@@ -505,7 +502,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             auto const_node = ov::as_type_ptr<ov::op::v0::Constant>(op);
             if (!const_node)
                 continue;
-            if (const_node->get_rt_info().count(ov::WeightlessCacheAttribute::get_type_info_static()))
+            if (const_node->get_rt_info().count(ov::WeightlessCacheAttribute::get_type_info_static()) != 0u)
                 continue;
             auto source_buf = ov::weight_sharing::Extension::get_constant_source_buffer(*const_node);
             if (source_buf) {
@@ -608,11 +605,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                         return true;
                     }
 
-                    if (infer_precision != ov::element::f16) {
-                        return true;  // CM vlsdpa kernel only supports f16
-                    }
-
-                    return false;
+                    // CM vlsdpa kernel only supports f16
+                    return infer_precision != ov::element::f16;
                 });
 
         // Temporary solution, global rt info cleanup is needed
@@ -699,7 +693,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         // Add conversion from unsupported FP data types to f32 if we don't have a conversion to something valid already in the list
         for (auto& et : fp_element_types) {
             if (!fp_precision_supported(et)) {
-                bool has_valid_conversion = fp_convert_precision_map.count(et) && fp_precision_supported(fp_convert_precision_map[et]);
+                bool has_valid_conversion = (fp_convert_precision_map.count(et) != 0u) && fp_precision_supported(fp_convert_precision_map[et]);
                 if (!has_valid_conversion) {
                     fp_convert_precision_map.insert(std::make_pair(et, fallback_precision));
                 }
@@ -936,9 +930,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             }
 
             // - The number of dimensions for each input is expected to be 4 or 3
-            if (!(query_ps.size() == 3 || query_ps.size() == 4) ||
-                !(key_ps.size() == 3 || key_ps.size() == 4) ||
-                !(value_ps.size() == 3 || value_ps.size() == 4))
+            if ((query_ps.size() != 3 && query_ps.size() != 4) ||
+                (key_ps.size() != 3 && key_ps.size() != 4) ||
+                (value_ps.size() != 3 && value_ps.size() != 4))
                 return false;
 
             // - The head size of all Q, K, and V inputs should be the same static value
@@ -1040,11 +1034,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     auto num_dir = output[1];
                     auto hidden_size = output[3];
 
-                    if (hidden_size != 128 || batch_size != 1 || num_dir != 2 || (input_size != 64 && input_size != 256)) {
-                        return false;
-                    }
-
-                    return true;
+                    return hidden_size == 128 && batch_size == 1 && num_dir == 2 && (input_size == 64 || input_size == 256);
                 });
 
         manager.register_pass<ConvertShapeOf1To3>();
@@ -1266,10 +1256,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 return false;
             };
 
-            if (!isSupportedAxes(axes, inputRank) && ov::shape_size(axesNode->get_shape()) != 0) {
-                return false;
-            }
-            return true;
+            return isSupportedAxes(axes, inputRank) || ov::shape_size(axesNode->get_shape()) == 0;
             });
 
         pass_config->enable<ov::pass::SoftmaxDecomposition>();
@@ -1284,7 +1271,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             [&](const_node_ptr &node) -> bool {
             // Convert to NMSIEInternal when input shape is static
             // Otherwise keep NMS op
-            return !node->get_input_partial_shape(0).is_dynamic() ? false : true;
+            return node->get_input_partial_shape(0).is_dynamic();
         });
 
         // List of enabled/disabled transformations
@@ -1458,11 +1445,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
             // disable MultiplyToGroupConvolution for Multiply with scalar
 
-            if (MultiplyToGroupConvolutionTransformation::isDynamicOrScalar(node)) {
-                return true;
-            }
-
-            return false;
+            return MultiplyToGroupConvolutionTransformation::isDynamicOrScalar(node);
         });
 
         bool reshapeIgnorePerTensorQuantizationCheck = false;
@@ -1688,7 +1671,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             const bool asymmetric_dyn_quant = config.get_asym_dynamic_quantization();
             auto dynamic_quantization_group_size = config.get_dynamic_quantization_group_size();
             auto dynamic_quantization_group_size_max = config.get_dynamic_quantization_group_size_max();
-            const bool precomputed_reduction = config.get_dynamic_quantization_precomputed_reduction();
+            const bool precomputed_reduction = config.get_dynamic_quantization_precomputed_reduction() != 0u;
 
             // WA: hybrid linear-attention (Mamba2 / Gated DeltaNet) models are unstable
             // under per-token INT8 dyn-quant on `linear_attn.out_proj`. Force gs=128 for

--- a/src/plugins/intel_gpu/src/runtime/device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/device.cpp
@@ -154,10 +154,7 @@ bool device::use_unified_shared_memory() const {
     GPU_DEBUG_IF(ExecutionConfig::get_disable_usm()) {
         return false;
     }
-    if (get_mem_caps().supports_usm()) {
-        return true;
-    }
-    return false;
+    return get_mem_caps().supports_usm();
 }
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/engine.cpp
@@ -78,10 +78,7 @@ bool engine::use_unified_shared_memory() const {
     GPU_DEBUG_IF(ExecutionConfig::get_disable_usm()) {
         return false;
     }
-    if (_device->get_mem_caps().supports_usm()) {
-        return true;
-    }
-    return false;
+    return _device->get_mem_caps().supports_usm();
 }
 
 uint64_t engine::get_max_memory_size() const {

--- a/src/plugins/intel_gpu/src/runtime/layout.cpp
+++ b/src/plugins/intel_gpu/src/runtime/layout.cpp
@@ -535,10 +535,7 @@ bool layout::compatible(const layout& other) const {
 
     auto l1_offset = l1.get_linear_offset();
     auto l2_offset = l2.get_linear_offset();
-    if (l1_pitch == l2_pitch && l1_offset == l2_offset)
-        return true;
-
-    return false;
+    return l1_pitch == l2_pitch && l1_offset == l2_offset;
 }
 
 bool layout::identical(const layout& other) const {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -233,7 +233,7 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
     info.max_alloc_mem_size = static_cast<uint64_t>(device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>());
     info.max_global_cache_size = static_cast<uint64_t>(device.getInfo<CL_DEVICE_GLOBAL_MEM_CACHE_SIZE>());
 
-    info.supports_image = static_cast<uint8_t>(device.getInfo<CL_DEVICE_IMAGE_SUPPORT>());
+    info.supports_image = (static_cast<uint8_t>(device.getInfo<CL_DEVICE_IMAGE_SUPPORT>()) != 0u);
     info.max_image2d_width = static_cast<uint64_t>(device.getInfo<CL_DEVICE_IMAGE2D_MAX_WIDTH>());
     info.max_image2d_height = static_cast<uint64_t>(device.getInfo<CL_DEVICE_IMAGE2D_MAX_HEIGHT>());
 
@@ -264,8 +264,8 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
     // refer: https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#optional-functionality
     // These flags are supported from OPENCL_300: CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT, CL_DEVICE_OPENCL_C_FEATURES
     // OpenCL C3.0: work_group_<ops> are optional. It should be checked 'work group collective functions' are supported in OpenCL C 3.0.
-    info.supports_work_group_collective_functions = device.getInfo<CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT>();
-    info.supports_non_uniform_work_group = device.getInfo<CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT>();
+    info.supports_work_group_collective_functions = (device.getInfo<CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT>() != 0u);
+    info.supports_non_uniform_work_group = (device.getInfo<CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT>() != 0u);
 #elif CL_HPP_TARGET_OPENCL_VERSION >= 200
     // OpenCL C2.0: work_group_<ops> are mandatory.
     info.supports_work_group_collective_functions = true;
@@ -307,8 +307,8 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
         info.num_threads_per_eu = device.getInfo<CL_DEVICE_NUM_THREADS_PER_EU_INTEL>();
         auto features = device.getInfo<CL_DEVICE_FEATURE_CAPABILITIES_INTEL>();
 
-        info.supports_imad = info.supports_imad || (features & CL_DEVICE_FEATURE_FLAG_DP4A_INTEL);
-        info.supports_immad = info.supports_immad || (features & CL_DEVICE_FEATURE_FLAG_DPAS_INTEL);
+        info.supports_imad = info.supports_imad || ((features & CL_DEVICE_FEATURE_FLAG_DP4A_INTEL) != 0u);
+        info.supports_immad = info.supports_immad || ((features & CL_DEVICE_FEATURE_FLAG_DPAS_INTEL) != 0u);
         if (info.dev_type == device_type::discrete_gpu ||
             info.gfx_ver.major > 12 || (info.gfx_ver.major == 12 && info.gfx_ver.minor >= 70)) {
             info.has_separate_cache = true;


### PR DESCRIPTION
This enables the readability-implicit-bool-conversion and readability-simplify-boolean-expr clang-tidy checks for the Intel GPU plugin. The implicit-bool-conversion check flags implicit conversions to or from bool and requires them to be written explicitly (for example comparing an integer against zero or wrapping it in static_cast<bool>), while the simplify-boolean-expr check removes redundant boolean literals in conditional returns and rewrites negated compound boolean expressions using DeMorgan's theorem. The plugin sources under src/plugins/intel_gpu were updated accordingly: implicit integer-to-bool conversions were made explicit, conditional returns of the form "if (cond) return true; return false;" were collapsed to return the condition directly, and negated conjunctions and disjunctions were rewritten into their equivalent DeMorgan form. Integer-condition and pointer-condition allowances are kept enabled so idiomatic conditions remain untouched, and the chained-conditional and DeMorgan options are enabled to keep the code consistent. Next check in the incremental clang-tidy rollout for the plugin.
