### PR TITLE
[PyOV] Dynamically detect Python version in setupvars based on available modules

### DIFF
--- a/scripts/setupvars/setupvars.bat
+++ b/scripts/setupvars/setupvars.bat
@@ -134,6 +134,7 @@ exit /B 0
 set "available_python_versions="
 set "ov_python_dir=%INTEL_OPENVINO_DIR%\python\openvino"
 if not exist "%ov_python_dir%" exit /B 0
+if not exist "%ov_python_dir%\_pyopenvino.cp*.pyd" exit /B 0
 for %%F in ("%ov_python_dir%\_pyopenvino.cp*.pyd") do call :parse_pyd_version "%%~nxF"
 exit /B 0
 

--- a/scripts/setupvars/setupvars.bat
+++ b/scripts/setupvars/setupvars.bat
@@ -96,7 +96,7 @@ for /F "tokens=1,2 delims=. " %%a in ("%python_version%") do (
 )
 
 :: Strip non-numeric suffix from minor version (e.g., 14t -> 14)
-call :strip_suffix pyversion_minor
+for /f "delims=t" %%i in ("%pyversion_minor%") do set "pyversion_minor=%%i"
 
 set "current_python_version=%pyversion_major%.%pyversion_minor%"
 
@@ -147,7 +147,9 @@ set "fname=%~1"
 set "tag=%fname:*_pyopenvino.cp=%"
 for /f "delims=-" %%A in ("%tag%") do set "vernum=%%A"
 call :strip_suffix vernum
-set "available_python_versions=%available_python_versions% %vernum:~0,1%.%vernum:~1%"
+set "ver=%vernum:~0,1%.%vernum:~1%"
+echo %available_python_versions% | findstr /C:" %ver%" >NUL 2>&1 || set "available_python_versions=%available_python_versions% %ver%"
+set "ver="
 exit /B 0
 
 :match_python_version

--- a/scripts/setupvars/setupvars.bat
+++ b/scripts/setupvars/setupvars.bat
@@ -66,10 +66,6 @@ if exist %INTEL_OPENVINO_DIR%\runtime\3rdparty\tbb (
 set "PATH=%OPENVINO_LIB_PATHS%;%PATH%"
 
 :: Check if Python is installed
-set PYTHON_VERSION_MAJOR=3
-set MIN_REQUIRED_PYTHON_VERSION_MINOR=10
-set MAX_SUPPORTED_PYTHON_VERSION_MINOR=14
-
 python --version 2>NUL
 if errorlevel 1 (call :python_not_installed) else (call :check_python_version)
 
@@ -78,7 +74,12 @@ echo [setupvars.bat] OpenVINO environment initialized
 exit /B 0
 
 :python_not_installed
-echo Warning^: Python is not installed. Please install one of Python %PYTHON_VERSION_MAJOR%.%MIN_REQUIRED_PYTHON_VERSION_MINOR% - %PYTHON_VERSION_MAJOR%.%MAX_SUPPORTED_PYTHON_VERSION_MINOR% ^(64-bit^) from https://www.python.org/downloads/
+call :get_available_python_versions
+if "%available_python_versions%"=="" (
+   echo Warning^: Python is not installed. Please install Python ^(64-bit^) from https://www.python.org/downloads/
+) else (
+   echo Warning^: Python is not installed. Please install one of Python%available_python_versions% ^(64-bit^) from https://www.python.org/downloads/
+)
 exit /B 0
 
 :check_python_version
@@ -97,19 +98,21 @@ for /F "tokens=1,2 delims=. " %%a in ("%python_version%") do (
 :: Strip non-numeric suffix from minor version (e.g., 14t -> 14)
 call :strip_suffix pyversion_minor
 
-if %pyversion_major% equ %PYTHON_VERSION_MAJOR% (
-   if %pyversion_minor% geq %MIN_REQUIRED_PYTHON_VERSION_MINOR% (
-      if %pyversion_minor% leq %MAX_SUPPORTED_PYTHON_VERSION_MINOR% (
-         set "check_pyversion=true"
-      )
-   )
-)
+set "current_python_version=%pyversion_major%.%pyversion_minor%"
 
-if not "%check_pyversion%"=="true" (
-   echo Unsupported Python version %pyversion_major%.%pyversion_minor%. Please install one of Python %PYTHON_VERSION_MAJOR%.%MIN_REQUIRED_PYTHON_VERSION_MINOR% - %PYTHON_VERSION_MAJOR%.%MAX_SUPPORTED_PYTHON_VERSION_MINOR% ^(64-bit^) from https://www.python.org/downloads/
-   exit /B 0
-)
+:: Match the current interpreter against the Python versions the OpenVINO
+:: Python API in this package was actually compiled for.
+call :get_available_python_versions
+if "%available_python_versions%"=="" goto :python_version_ok
 
+set "check_pyversion="
+for %%v in (%available_python_versions%) do call :match_python_version "%%v"
+if "%check_pyversion%"=="true" goto :python_version_ok
+
+echo Unsupported Python version %current_python_version%. The OpenVINO Python API in this package is built for Python:%available_python_versions%. Please activate a Python environment with a matching version.
+exit /B 0
+
+:python_version_ok
 :: Check Python bitness
 python -c "import sys; print(64 if sys.maxsize > 2**32 else 32)" 2 > NUL
 if errorlevel 1 (
@@ -122,11 +125,35 @@ for /F "tokens=* USEBACKQ" %%F IN (`python -c "import sys; print(64 if sys.maxsi
 )
 
 if not "%bitness%"=="64" (
-   echo Unsupported Python bitness. Please install one of Python %PYTHON_VERSION_MAJOR%.%MIN_REQUIRED_PYTHON_VERSION_MINOR% - %PYTHON_VERSION_MAJOR%.%MAX_SUPPORTED_PYTHON_VERSION_MINOR%^(64-bit^) from https://www.python.org/downloads/
+   echo Unsupported Python bitness. Please install a 64-bit Python interpreter from https://www.python.org/downloads/
    exit /B 0
 )
 
 set PYTHONPATH=%INTEL_OPENVINO_DIR%\python;%INTEL_OPENVINO_DIR%\python\python3;%PYTHONPATH%
+exit /B 0
+
+:get_available_python_versions
+:: Build a space-separated list (with a leading space) of the Python versions the
+:: OpenVINO Python API was compiled for, based on the shipped extension modules
+:: (e.g. _pyopenvino.cp312-win_amd64.pyd -> 3.12).
+set "available_python_versions="
+set "ov_python_dir=%INTEL_OPENVINO_DIR%\python\openvino"
+if not exist "%ov_python_dir%" exit /B 0
+for %%F in ("%ov_python_dir%\_pyopenvino.cp*.pyd") do call :parse_pyd_version "%%~nxF"
+exit /B 0
+
+:parse_pyd_version
+:: %1 is a file name like _pyopenvino.cp312-win_amd64.pyd
+set "fname=%~1"
+set "tag=%fname:*_pyopenvino.cp=%"
+for /f "delims=-" %%A in ("%tag%") do set "vernum=%%A"
+:: Strip non-numeric suffix from version tag (e.g., 313t -> 313)
+call :strip_suffix vernum
+set "available_python_versions=%available_python_versions% %vernum:~0,1%.%vernum:~1%"
+exit /B 0
+
+:match_python_version
+if "%~1"=="%current_python_version%" set "check_pyversion=true"
 exit /B 0
 
 :strip_suffix

--- a/scripts/setupvars/setupvars.bat
+++ b/scripts/setupvars/setupvars.bat
@@ -100,8 +100,6 @@ call :strip_suffix pyversion_minor
 
 set "current_python_version=%pyversion_major%.%pyversion_minor%"
 
-:: Match the current interpreter against the Python versions the OpenVINO
-:: Python API in this package was actually compiled for.
 call :get_available_python_versions
 if "%available_python_versions%"=="" goto :python_version_ok
 
@@ -133,9 +131,6 @@ set PYTHONPATH=%INTEL_OPENVINO_DIR%\python;%INTEL_OPENVINO_DIR%\python\python3;%
 exit /B 0
 
 :get_available_python_versions
-:: Build a space-separated list (with a leading space) of the Python versions the
-:: OpenVINO Python API was compiled for, based on the shipped extension modules
-:: (e.g. _pyopenvino.cp312-win_amd64.pyd -> 3.12).
 set "available_python_versions="
 set "ov_python_dir=%INTEL_OPENVINO_DIR%\python\openvino"
 if not exist "%ov_python_dir%" exit /B 0
@@ -147,7 +142,6 @@ exit /B 0
 set "fname=%~1"
 set "tag=%fname:*_pyopenvino.cp=%"
 for /f "delims=-" %%A in ("%tag%") do set "vernum=%%A"
-:: Strip non-numeric suffix from version tag (e.g., 313t -> 313)
 call :strip_suffix vernum
 set "available_python_versions=%available_python_versions% %vernum:~0,1%.%vernum:~1%"
 exit /B 0

--- a/scripts/setupvars/setupvars.bat
+++ b/scripts/setupvars/setupvars.bat
@@ -101,7 +101,10 @@ call :strip_suffix pyversion_minor
 set "current_python_version=%pyversion_major%.%pyversion_minor%"
 
 call :get_available_python_versions
-if "%available_python_versions%"=="" goto :python_version_ok
+if "%available_python_versions%"=="" (
+   echo Warning^: Could not detect which Python versions the OpenVINO Python API in this package was built for. The installed Python version will not be verified.
+   goto :python_version_ok
+)
 
 set "check_pyversion="
 for %%v in (%available_python_versions%) do call :match_python_version "%%v"

--- a/scripts/setupvars/setupvars.ps1
+++ b/scripts/setupvars/setupvars.ps1
@@ -63,9 +63,6 @@ Write-Host "[setupvars] OpenVINO environment initialized"
 
 # Check if Python is installed
 
-# Detect the Python versions the OpenVINO Python API in this package was actually
-# compiled for, based on the shipped extension modules
-# (e.g. _pyopenvino.cp312-win_amd64.pyd or _pyopenvino.cpython-312-...so -> 3.12).
 function Get-AvailablePythonVersions
 {
     $ov_python_dir = Join-Path $Env:INTEL_OPENVINO_DIR "python/openvino"
@@ -126,8 +123,6 @@ else
 $current_python_version = "$installed_python_version_major.$installed_python_version_minor"
 $available_python_versions = @(Get-AvailablePythonVersions)
 
-# If the package ships a compiled Python API, ensure the current interpreter
-# matches one of the versions the API was actually built for.
 if ($available_python_versions.Count -gt 0 -and ($available_python_versions -notcontains $current_python_version))
 {
     Write-Host "Warning: Unsupported Python version $current_python_version. The OpenVINO Python API in this package is built for Python: $($available_python_versions -join ', '). Please activate a Python environment with a matching version."

--- a/scripts/setupvars/setupvars.ps1
+++ b/scripts/setupvars/setupvars.ps1
@@ -123,7 +123,11 @@ else
 $current_python_version = "$installed_python_version_major.$installed_python_version_minor"
 $available_python_versions = @(Get-AvailablePythonVersions)
 
-if ($available_python_versions.Count -gt 0 -and ($available_python_versions -notcontains $current_python_version))
+if ($available_python_versions.Count -eq 0)
+{
+    Write-Host "Warning: Could not detect which Python versions the OpenVINO Python API in this package was built for. The installed Python version will not be verified."
+}
+elseif ($available_python_versions -notcontains $current_python_version)
 {
     Write-Host "Warning: Unsupported Python version $current_python_version. The OpenVINO Python API in this package is built for Python: $($available_python_versions -join ', '). Please activate a Python environment with a matching version."
     # Python is not mandatory so we can safely exit with 0

--- a/scripts/setupvars/setupvars.ps1
+++ b/scripts/setupvars/setupvars.ps1
@@ -62,9 +62,31 @@ $Env:PATH = "$Env:OPENVINO_LIB_PATHS;$Env:PATH"
 Write-Host "[setupvars] OpenVINO environment initialized"
 
 # Check if Python is installed
-$PYTHON_VERSION_MAJOR = 3
-$MIN_REQUIRED_PYTHON_VERSION_MINOR = 10
-$MAX_SUPPORTED_PYTHON_VERSION_MINOR = 14
+
+# Detect the Python versions the OpenVINO Python API in this package was actually
+# compiled for, based on the shipped extension modules
+# (e.g. _pyopenvino.cp312-win_amd64.pyd or _pyopenvino.cpython-312-...so -> 3.12).
+function Get-AvailablePythonVersions
+{
+    $ov_python_dir = Join-Path $Env:INTEL_OPENVINO_DIR "python/openvino"
+    $versions = @()
+    if (Test-Path -Path $ov_python_dir)
+    {
+        foreach ($lib in Get-ChildItem -Path $ov_python_dir -Filter "_pyopenvino.*" -ErrorAction SilentlyContinue)
+        {
+            if ($lib.Name -match '_pyopenvino\.(?:cpython-|cp)(\d+)')
+            {
+                $tag = $matches[1]
+                $version = "$($tag.Substring(0, 1)).$($tag.Substring(1))"
+                if ($versions -notcontains $version)
+                {
+                    $versions += $version
+                }
+            }
+        }
+    }
+    return $versions
+}
 
 try
 {
@@ -73,7 +95,15 @@ try
 }
 catch
 {
-    Write-Host "Warning: Python is not installed. Please install one of Python $PYTHON_VERSION_MAJOR.$MIN_REQUIRED_PYTHON_VERSION_MINOR - $PYTHON_VERSION_MAJOR.$MAX_SUPPORTED_PYTHON_VERSION_MINOR (64-bit) from https://www.python.org/downloads/"
+    $available_python_versions = @(Get-AvailablePythonVersions)
+    if ($available_python_versions.Count -gt 0)
+    {
+        Write-Host "Warning: Python is not installed. Please install one of Python $($available_python_versions -join ', ') (64-bit) from https://www.python.org/downloads/"
+    }
+    else
+    {
+        Write-Host "Warning: Python is not installed. Please install Python (64-bit) from https://www.python.org/downloads/"
+    }
     # Python is not mandatory so we can safely exit with 0
     Exit 0
 }
@@ -93,9 +123,14 @@ else
     $installed_python_version_minor = [int]$minor_version_string
 }
 
-if (-not ($PYTHON_VERSION_MAJOR -eq $installed_python_version_major -and $installed_python_version_minor -ge $MIN_REQUIRED_PYTHON_VERSION_MINOR -and $installed_python_version_minor -le $MAX_SUPPORTED_PYTHON_VERSION_MINOR))
+$current_python_version = "$installed_python_version_major.$installed_python_version_minor"
+$available_python_versions = @(Get-AvailablePythonVersions)
+
+# If the package ships a compiled Python API, ensure the current interpreter
+# matches one of the versions the API was actually built for.
+if ($available_python_versions.Count -gt 0 -and ($available_python_versions -notcontains $current_python_version))
 {
-    Write-Host "Warning: Unsupported Python version $installed_python_version_major.$installed_python_version_minor. Please install one of Python $PYTHON_VERSION_MAJOR.$MIN_REQUIRED_PYTHON_VERSION_MINOR - $PYTHON_VERSION_MAJOR.$MAX_SUPPORTED_PYTHON_VERSION_MINOR (64-bit) from https://www.python.org/downloads/"
+    Write-Host "Warning: Unsupported Python version $current_python_version. The OpenVINO Python API in this package is built for Python: $($available_python_versions -join ', '). Please activate a Python environment with a matching version."
     # Python is not mandatory so we can safely exit with 0
     Exit 0
 }
@@ -115,7 +150,7 @@ catch
 
 if ($python_bitness -ne "64")
 {
-    Write-Host "Warning: Unsupported Python bitness. Please install one of Python $PYTHON_VERSION_MAJOR.$MIN_REQUIRED_PYTHON_VERSION_MINOR - $PYTHON_VERSION_MAJOR.$MAX_SUPPORTED_PYTHON_VERSION_MINOR (64-bit) from https://www.python.org/downloads/"
+    Write-Host "Warning: Unsupported Python bitness. Please install a 64-bit Python interpreter from https://www.python.org/downloads/"
     # Python is not mandatory so we can safely exit with 0
     Exit 0
 }

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -107,7 +107,11 @@ get_available_python_versions () {
             [ -e "$lib" ] || continue
             ver_tag=$(basename "$lib" | sed -n 's/^_pyopenvino\.cpython-\([0-9][0-9]*\)[a-z]*-.*/\1/p')
             [ -z "$ver_tag" ] && continue
-            available_python_versions="${available_python_versions:+$available_python_versions }${ver_tag%"${ver_tag#?}"}.${ver_tag#?}"
+            ver_str="${ver_tag%"${ver_tag#?}"}.${ver_tag#?}"
+            case " $available_python_versions " in
+                *" $ver_str "*) ;;
+                *) available_python_versions="${available_python_versions:+$available_python_versions }$ver_str" ;;
+            esac
         done
     fi
 }

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -99,8 +99,6 @@ if command -v lsb_release >/dev/null 2>&1; then
     OS_NAME=$(lsb_release -i -s)
 fi
 
-PYTHON_VERSION_MAJOR="3"
-
 get_available_python_versions () {
     available_python_versions=""
     ov_python_dir="$INTEL_OPENVINO_DIR/python/openvino"
@@ -109,7 +107,7 @@ get_available_python_versions () {
             [ -e "$lib" ] || continue
             ver_tag=$(basename "$lib" | sed -n 's/^_pyopenvino\.cpython-\([0-9][0-9]*\)[a-z]*-.*/\1/p')
             [ -z "$ver_tag" ] && continue
-            available_python_versions="${available_python_versions:+$available_python_versions }${ver_tag%${ver_tag#?}}.${ver_tag#?}"
+            available_python_versions="${available_python_versions:+$available_python_versions }${ver_tag%"${ver_tag#?}"}.${ver_tag#?}"
         done
     fi
 }
@@ -145,6 +143,9 @@ check_python_version () {
             unset python_version
             return 0
         fi
+    else
+        echo "[setupvars.sh] WARNING: Could not detect which Python versions the OpenVINO Python API" \
+        "in this package was built for. The installed Python version will not be verified."
     fi
 
     if command -v python"$python_version" > /dev/null 2>&1; then
@@ -193,7 +194,6 @@ fi
 
 unset python_version
 unset python_version_to_check
-unset PYTHON_VERSION_MAJOR
 unset available_python_versions
 unset OS_NAME
 

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -101,9 +101,6 @@ fi
 
 PYTHON_VERSION_MAJOR="3"
 
-# Detect the Python versions the OpenVINO Python API in this package was actually
-# compiled for, based on the shipped extension modules
-# (e.g. _pyopenvino.cpython-312-x86_64-linux-gnu.so -> 3.12).
 get_available_python_versions () {
     available_python_versions=""
     ov_python_dir="$INTEL_OPENVINO_DIR/python/openvino"
@@ -133,8 +130,6 @@ check_python_version () {
 
     get_available_python_versions
 
-    # If the package ships a compiled Python API, ensure the current interpreter
-    # matches one of the versions the API was actually built for.
     if [ -n "$available_python_versions" ]; then
         version_supported=""
         for v in $available_python_versions; do

--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -100,8 +100,22 @@ if command -v lsb_release >/dev/null 2>&1; then
 fi
 
 PYTHON_VERSION_MAJOR="3"
-MIN_REQUIRED_PYTHON_VERSION_MINOR="10"
-MAX_SUPPORTED_PYTHON_VERSION_MINOR="14"
+
+# Detect the Python versions the OpenVINO Python API in this package was actually
+# compiled for, based on the shipped extension modules
+# (e.g. _pyopenvino.cpython-312-x86_64-linux-gnu.so -> 3.12).
+get_available_python_versions () {
+    available_python_versions=""
+    ov_python_dir="$INTEL_OPENVINO_DIR/python/openvino"
+    if [ -d "$ov_python_dir" ]; then
+        for lib in "$ov_python_dir"/_pyopenvino.cpython-*.so; do
+            [ -e "$lib" ] || continue
+            ver_tag=$(basename "$lib" | sed -n 's/^_pyopenvino\.cpython-\([0-9][0-9]*\)[a-z]*-.*/\1/p')
+            [ -z "$ver_tag" ] && continue
+            available_python_versions="${available_python_versions:+$available_python_versions }${ver_tag%${ver_tag#?}}.${ver_tag#?}"
+        done
+    fi
+}
 
 check_python_version () {
     if [ -z "$python_version" ]; then
@@ -115,15 +129,27 @@ check_python_version () {
 
     # Strip non-numeric suffix from minor version (e.g., 14t -> 14)
     python_version_minor_numeric="${python_version_minor%%[!0-9]*}"
+    current_python_version="${python_version_major}.${python_version_minor_numeric}"
 
-    if  [ "$PYTHON_VERSION_MAJOR" != "$python_version_major" ] ||
-        [ "$python_version_minor_numeric" -lt "$MIN_REQUIRED_PYTHON_VERSION_MINOR" ] ||
-        [ "$python_version_minor_numeric" -gt "$MAX_SUPPORTED_PYTHON_VERSION_MINOR" ] ; then
-        echo "[setupvars.sh] WARNING: Unsupported Python version ${python_version}. Please install one of Python" \
-        "${PYTHON_VERSION_MAJOR}.${MIN_REQUIRED_PYTHON_VERSION_MINOR} -" \
-        "${PYTHON_VERSION_MAJOR}.${MAX_SUPPORTED_PYTHON_VERSION_MINOR} (64-bit) from https://www.python.org/downloads/"
-        unset python_version
-        return 0
+    get_available_python_versions
+
+    # If the package ships a compiled Python API, ensure the current interpreter
+    # matches one of the versions the API was actually built for.
+    if [ -n "$available_python_versions" ]; then
+        version_supported=""
+        for v in $available_python_versions; do
+            if [ "$v" = "$current_python_version" ]; then
+                version_supported="yes"
+                break
+            fi
+        done
+        if [ -z "$version_supported" ]; then
+            echo "[setupvars.sh] WARNING: Unsupported Python version ${current_python_version}." \
+            "The OpenVINO Python API in this package is built for Python: ${available_python_versions}." \
+            "Please activate a Python environment with a matching version."
+            unset python_version
+            return 0
+        fi
     fi
 
     if command -v python"$python_version" > /dev/null 2>&1; then
@@ -158,9 +184,14 @@ if [ -z "$python_version" ]; then
 fi
 
 if ! command -v python"$python_version_to_check" > /dev/null 2>&1; then
-    echo "[setupvars.sh] WARNING: Python is not installed. Please install one of Python" \
-    "${PYTHON_VERSION_MAJOR}.${MIN_REQUIRED_PYTHON_VERSION_MINOR} -" \
-    "${PYTHON_VERSION_MAJOR}.${MAX_SUPPORTED_PYTHON_VERSION_MINOR} (64-bit) from https://www.python.org/downloads/"
+    get_available_python_versions
+    if [ -n "$available_python_versions" ]; then
+        echo "[setupvars.sh] WARNING: Python is not installed. Please install one of Python" \
+        "${available_python_versions} (64-bit) from https://www.python.org/downloads/"
+    else
+        echo "[setupvars.sh] WARNING: Python is not installed." \
+        "Please install Python (64-bit) from https://www.python.org/downloads/"
+    fi
 else
     check_python_version
 fi
@@ -168,8 +199,7 @@ fi
 unset python_version
 unset python_version_to_check
 unset PYTHON_VERSION_MAJOR
-unset MIN_REQUIRED_PYTHON_VERSION_MINOR
-unset MAX_SUPPORTED_PYTHON_VERSION_MINOR
+unset available_python_versions
 unset OS_NAME
 
 echo "[setupvars.sh] OpenVINO environment initialized"


### PR DESCRIPTION
### Details:
 - Replaces the hardcoded Python version range with dynamic detection of the Python versions the PyAPI was actually compiled for, by inspecting the extension modules (`_pyopenvino.cpython-<ver>-*.so` for Linux / `_pyopenvino.cp<ver>-*.pyd` for Windows)
 - Fixes false rejection of valid interpreters: users who compile OpenVINO with, for example, Python 3.15 no longer get a warning when running setupvars scripts
 - Fixes false acceptance of mismatched interpreters: a version inside the old hardcoded range (ex. 3.11) that has no compiled `.so`/`.pyd` in the install is now correctly rejected; before that would be apparent only at `import openvino`, causing confusion
 - When a mismatch is detected, the warning lists the exact Python versions available in the package rather than a generic range
 - Tested manually on Linux and Windows machines

### Tickets:
 - CVS-125727