### PR TITLE
[GPU] Add bf16 support for reorder kernel and compute type

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cpu/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/reorder.cpp
@@ -100,6 +100,7 @@ attach_reorder_impl::attach_reorder_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i32,
         data_types::i64,
         data_types::i8,

--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -48,7 +48,7 @@ layout reorder_inst::calc_output_layout(reorder_node const& node, kernel_impl_pa
 
         CLDNN_ERROR_MESSAGE(desc->id, "Reordering between winograd weights and data formats is unsupported");
     } else if (ifmt == format::image_2d_rgba) {
-        return layout(data_types::f16, format::bfyx, input_layout.get_tensor(), op);
+        return odt == data_types::bf16 ? layout(data_types::bf16, format::bfyx, input_layout.get_tensor(), op) : layout(data_types::f16, format::bfyx, input_layout.get_tensor(), op);
     }
 
     // transformation of data from standard to winograd

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/bf16_utils.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/bf16_utils.cl
@@ -1,6 +1,35 @@
-#ifdef intel_convert_as_bfloat16_float
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "common.cl"
+
+#ifdef cl_intel_bfloat16_conversions
+
+// ===================== Hardware built-in bfloat16 conversions =====================
+
+// --- scalar ---
 #define _convert_as_bfloat16_float(val) intel_convert_as_bfloat16_float(val)
+#define _convert_bfloat16_as_ushort(val) intel_convert_bfloat16_as_ushort(val)
+
+// --- bfloat16_as_ushort (float -> ushort) vectorized ---
+#define _convert_bfloat162_as_ushort2(val)   intel_convert_bfloat162_as_ushort2(val)
+#define _convert_bfloat163_as_ushort3(val)   intel_convert_bfloat163_as_ushort3(val)
+#define _convert_bfloat164_as_ushort4(val)   intel_convert_bfloat164_as_ushort4(val)
+#define _convert_bfloat168_as_ushort8(val)   intel_convert_bfloat168_as_ushort8(val)
+#define _convert_bfloat1616_as_ushort16(val) intel_convert_bfloat1616_as_ushort16(val)
+
+// --- as_bfloat16_float (ushort -> float) vectorized ---
+#define _convert_as_bfloat162_float2(val)   intel_convert_as_bfloat162_float2(val)
+#define _convert_as_bfloat163_float3(val)   intel_convert_as_bfloat163_float3(val)
+#define _convert_as_bfloat164_float4(val)   intel_convert_as_bfloat164_float4(val)
+#define _convert_as_bfloat168_float8(val)   intel_convert_as_bfloat168_float8(val)
+#define _convert_as_bfloat1616_float16(val) intel_convert_as_bfloat1616_float16(val)
+
 #else
+
+// ===================== Software fallback bfloat16 conversions =====================
+
+// --- scalar ---
 inline float _convert_as_bfloat16_float(ushort source) {
     uint u = 0;
     //sign
@@ -11,24 +40,131 @@ inline float _convert_as_bfloat16_float(ushort source) {
     u += ( ( (source >> 7) & 0b11111111)) << 23;
     //fraction 
     u += (source & 0b1111111) << 16;
-    float* f = (float*)&u;
-    return *f;
+    return as_float(u);
 }
+
+inline ushort _convert_bfloat16_as_ushort(float source) {
+    // float -> bfloat16 using round-to-nearest, ties-to-even (ROUND_MODE_TO_NEAREST_EVEN).
+    // Mirrors ov::bfloat16::round_to_nearest_even in
+    // src/core/include/openvino/core/type/bfloat16.hpp.
+    uint u = as_uint(source);
+    // NaN handling: a float is NaN when its exponent bits are all ones and the
+    // mantissa is non-zero (abs(bits) > 0x7F800000). Plain truncation/rounding can
+    // drop all significant mantissa bits (or carry into the exponent) and silently
+    // turn a NaN into +/-Inf. Preserve the sign and emit a quiet bfloat16 NaN.
+    if ((u & 0x7FFFFFFFu) > 0x7F800000u) {
+        return (ushort)((u >> 16) | 0x0040u);
+    }
+    return (ushort)((u + ((u & 0x00010000u) >> 1)) >> 16);
+}
+
+// --- bfloat16_as_ushort (float -> ushort) vectorized ---
+inline ushort2 _convert_bfloat162_as_ushort2(float2 source) {
+    return (ushort2)(_convert_bfloat16_as_ushort(source.s0),
+                     _convert_bfloat16_as_ushort(source.s1));
+}
+
+inline ushort3 _convert_bfloat163_as_ushort3(float3 source) {
+    return (ushort3)(_convert_bfloat16_as_ushort(source.s0),
+                     _convert_bfloat16_as_ushort(source.s1),
+                     _convert_bfloat16_as_ushort(source.s2));
+}
+
+inline ushort4 _convert_bfloat164_as_ushort4(float4 source) {
+    return (ushort4)(_convert_bfloat16_as_ushort(source.s0),
+                     _convert_bfloat16_as_ushort(source.s1),
+                     _convert_bfloat16_as_ushort(source.s2),
+                     _convert_bfloat16_as_ushort(source.s3));
+}
+
+inline ushort8 _convert_bfloat168_as_ushort8(float8 source) {
+    return (ushort8)(_convert_bfloat16_as_ushort(source.s0),
+                     _convert_bfloat16_as_ushort(source.s1),
+                     _convert_bfloat16_as_ushort(source.s2),
+                     _convert_bfloat16_as_ushort(source.s3),
+                     _convert_bfloat16_as_ushort(source.s4),
+                     _convert_bfloat16_as_ushort(source.s5),
+                     _convert_bfloat16_as_ushort(source.s6),
+                     _convert_bfloat16_as_ushort(source.s7));
+}
+
+inline ushort16 _convert_bfloat1616_as_ushort16(float16 source) {
+    return (ushort16)(_convert_bfloat16_as_ushort(source.s0),
+                      _convert_bfloat16_as_ushort(source.s1),
+                      _convert_bfloat16_as_ushort(source.s2),
+                      _convert_bfloat16_as_ushort(source.s3),
+                      _convert_bfloat16_as_ushort(source.s4),
+                      _convert_bfloat16_as_ushort(source.s5),
+                      _convert_bfloat16_as_ushort(source.s6),
+                      _convert_bfloat16_as_ushort(source.s7),
+                      _convert_bfloat16_as_ushort(source.s8),
+                      _convert_bfloat16_as_ushort(source.s9),
+                      _convert_bfloat16_as_ushort(source.sa),
+                      _convert_bfloat16_as_ushort(source.sb),
+                      _convert_bfloat16_as_ushort(source.sc),
+                      _convert_bfloat16_as_ushort(source.sd),
+                      _convert_bfloat16_as_ushort(source.se),
+                      _convert_bfloat16_as_ushort(source.sf));
+}
+
+// --- as_bfloat16_float (ushort -> float) vectorized ---
+inline float2 _convert_as_bfloat162_float2(ushort2 source) {
+    return (float2)(_convert_as_bfloat16_float(source.s0),
+                    _convert_as_bfloat16_float(source.s1));
+}
+
+inline float3 _convert_as_bfloat163_float3(ushort3 source) {
+    return (float3)(_convert_as_bfloat16_float(source.s0),
+                    _convert_as_bfloat16_float(source.s1),
+                    _convert_as_bfloat16_float(source.s2));
+}
+
+inline float4 _convert_as_bfloat164_float4(ushort4 source) {
+    return (float4)(_convert_as_bfloat16_float(source.s0),
+                    _convert_as_bfloat16_float(source.s1),
+                    _convert_as_bfloat16_float(source.s2),
+                    _convert_as_bfloat16_float(source.s3));
+}
+
+inline float8 _convert_as_bfloat168_float8(ushort8 source) {
+    return (float8)(_convert_as_bfloat16_float(source.s0),
+                    _convert_as_bfloat16_float(source.s1),
+                    _convert_as_bfloat16_float(source.s2),
+                    _convert_as_bfloat16_float(source.s3),
+                    _convert_as_bfloat16_float(source.s4),
+                    _convert_as_bfloat16_float(source.s5),
+                    _convert_as_bfloat16_float(source.s6),
+                    _convert_as_bfloat16_float(source.s7));
+}
+
+inline float16 _convert_as_bfloat1616_float16(ushort16 source) {
+    return (float16)(_convert_as_bfloat16_float(source.s0),
+                     _convert_as_bfloat16_float(source.s1),
+                     _convert_as_bfloat16_float(source.s2),
+                     _convert_as_bfloat16_float(source.s3),
+                     _convert_as_bfloat16_float(source.s4),
+                     _convert_as_bfloat16_float(source.s5),
+                     _convert_as_bfloat16_float(source.s6),
+                     _convert_as_bfloat16_float(source.s7),
+                     _convert_as_bfloat16_float(source.s8),
+                     _convert_as_bfloat16_float(source.s9),
+                     _convert_as_bfloat16_float(source.sa),
+                     _convert_as_bfloat16_float(source.sb),
+                     _convert_as_bfloat16_float(source.sc),
+                     _convert_as_bfloat16_float(source.sd),
+                     _convert_as_bfloat16_float(source.se),
+                     _convert_as_bfloat16_float(source.sf));
+}
+
 #endif
 
-#ifdef intel_convert_bfloat16_as_ushort
-#define _convert_bfloat16_as_ushort(val) intel_convert_bfloat16_as_ushort(val)
-#else
-inline ushort _convert_bfloat16_as_ushort(float source) {
-    uint* in = (uint*)&source;
-    ushort u = 0;
-    if ( (*in>>31) ) { 
-        u = 1 << 15;
-    }
-    //exponent
-    u += ( ( (*in >> 23) & 0b11111111)) << 7;
-    //fraction
-    u += (*in >> 16) & 0b1111111;
-    return u;
-}
-#endif
+// Scalar aliases so that size=1 concatenation resolves correctly.
+#define _convert_bfloat161_as_ushort1(val) _convert_bfloat16_as_ushort(val)
+#define _convert_as_bfloat161_float1(val)  _convert_as_bfloat16_float(val)
+
+// Dispatch macros: concatenate size into the per-vector-width function names.
+// Usage: CONVERT_BFLOAT16_AS_USHORT(val, 1)  -> _convert_bfloat16_as_ushort(val)
+//        CONVERT_BFLOAT16_AS_USHORT(val, 4)  -> _convert_bfloat164_as_ushort4(val)
+//        CONVERT_AS_BFLOAT16_FLOAT(val, 8)   -> _convert_as_bfloat168_float8(val)
+#define CONVERT_BFLOAT16_AS_USHORT(val, size) CAT(_convert_bfloat16, CAT(size, CAT(_as_ushort, size)))(val)
+#define CONVERT_AS_BFLOAT16_FLOAT(val, size)  CAT(_convert_as_bfloat16, CAT(size, CAT(_float, size)))(val)

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_biplanar_nv12.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_biplanar_nv12.cl
@@ -64,26 +64,26 @@ KERNEL(reorder_biplanar_nv12)(
     B -= VALUE_TO_SUBTRACT[2];
 #elif defined MEAN_SUBTRACT_IN_BUFFER
     uint8 msv = RESHAPE_DIMS(INPUT0, MEAN_SUBTRACT, b, 0, 0, 0, w, z, y, x);
-    R -= mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, msv.s6, msv.s7)];
+    R -= DECODE_MEAN_SUBTRACT_COMPUTE_TYPE(mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, msv.s6, msv.s7)]);
 
     msv = RESHAPE_DIMS(INPUT0, MEAN_SUBTRACT, b, 1, 0, 0, w, z, y, x);
-    G -= mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, msv.s6, msv.s7)];
+    G -= DECODE_MEAN_SUBTRACT_COMPUTE_TYPE(mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, msv.s6, msv.s7)]);
 
     msv = RESHAPE_DIMS(INPUT0, MEAN_SUBTRACT, b, 2, 0, 0, w, z, y, x);
-    B -= mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, msv.s6, msv.s7)];
+    B -= DECODE_MEAN_SUBTRACT_COMPUTE_TYPE(mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, msv.s6, msv.s7)]);
 #endif
 
     uint8 ov = RESHAPE_DIMS(INPUT0, OUTPUT, b, 0, 0, 0, w, z, y, x);
     uint output_idx = FUNC_CALL(get_output_index)(ov.s0, ov.s1, ov.s2, ov.s3, ov.s4, ov.s5, ov.s6, ov.s7);
-    output[output_idx] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(R), NL_M, NL_N);
+    output[output_idx] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(R), NL_M, NL_N));
 
     ov = RESHAPE_DIMS(INPUT0, OUTPUT, b, 1, 0, 0, w, z, y, x);
     output_idx = FUNC_CALL(get_output_index)(ov.s0, ov.s1, ov.s2, ov.s3, ov.s4, ov.s5, ov.s6, ov.s7);
-    output[output_idx] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(G), NL_M, NL_N);
+    output[output_idx] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(G), NL_M, NL_N));
 
     ov = RESHAPE_DIMS(INPUT0, OUTPUT, b, 2, 0, 0, w, z, y, x);
     output_idx = FUNC_CALL(get_output_index)(ov.s0, ov.s1, ov.s2, ov.s3, ov.s4, ov.s5, ov.s6, ov.s7);
-    output[output_idx] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(B), NL_M, NL_N);
+    output[output_idx] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(B), NL_M, NL_N));
 
 
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data.cl
@@ -16,6 +16,8 @@
 
 #define INPUT_TYPE4 MAKE_VECTOR_TYPE(INPUT_REORDER_TYPE, 4)
 #define OUTPUT_TYPE4 MAKE_VECTOR_TYPE(OUTPUT_REORDER_TYPE, 4)
+#define INPUT_COMPUTE_TYPE4 MAKE_VECTOR_TYPE(INPUT_REORDER_COMPUTE_TYPE, 4)
+#define OUTPUT_COMPUTE_TYPE4 MAKE_VECTOR_TYPE(OUTPUT_REORDER_COMPUTE_TYPE, 4)
 
 KERNEL (reorder_data)(
     OPTIONAL_SHAPE_INFO_ARG
@@ -117,17 +119,17 @@ KERNEL (reorder_data)(
     float G = clamp(mad(Vcomponent, -0.813f, mad(Ucomponent, -0.391f, Ycomponent)), 0.f, 255.f);
 #elif defined INPUT0_LAYOUT_IMAGE_2D_RGBA
     const sampler_t imageSampler = CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_CLAMP;
-    OUTPUT_TYPE4 colorRGBA = IMAGE_READ(input, (int2)(x, y));
+    OUTPUT_COMPUTE_TYPE4 colorRGBA = IMAGE_READ(input, (int2)(x, y));
 #elif defined OUTPUT_LAYOUT_IMAGE_2D_RGBA
     uint8 ov = RESHAPE_DIMS(INPUT0, OUTPUT, b, f, v, u, w, z, y, x);
     const uint input_idx_R  = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, 0, v, u, w, z, y, x);
     const uint input_idx_G  = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, 1, v, u, w, z, y, x);
     const uint input_idx_B  = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, 2, v, u, w, z, y, x);
 #if OUTPUT_FEATURE_NUM == 3
-    INPUT_TYPE4 colorRGBA = { TO_INPUT_REORDER_TYPE(input[input_idx_R]), TO_INPUT_REORDER_TYPE(input[input_idx_G]), TO_INPUT_REORDER_TYPE(input[input_idx_B]), TO_INPUT_REORDER_TYPE(0.f) };
+    INPUT_COMPUTE_TYPE4 colorRGBA = { DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx_R]), DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx_G]), DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx_B]), TO_INPUT_REORDER_COMPUTE_TYPE(0.f) };
 #else
     const uint input_idx_A  = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, 3, v, u, w, z, y, x);
-    INPUT_TYPE4 colorRGBA = { TO_INPUT_REORDER_TYPE(input[input_idx_R]), TO_INPUT_REORDER_TYPE(input[input_idx_G]), TO_INPUT_REORDER_TYPE(input[input_idx_B]), TO_INPUT_REORDER_TYPE(input[input_idx_A]) };
+    INPUT_COMPUTE_TYPE4 colorRGBA = { DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx_R]), DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx_G]), DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx_B]), DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx_A]) };
 #endif
 #else
     uint8 ov = RESHAPE_DIMS(INPUT0, OUTPUT, b, f, v, u, w, z, y, x);
@@ -135,35 +137,33 @@ KERNEL (reorder_data)(
     const uint output_idx = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR ov.s0, ov.s1, ov.s2, ov.s3, ov.s4, ov.s5, ov.s6, ov.s7);
 
 #if defined MEAN_SUBTRACT_INSIDE_PARAMS
-    float res = TO_MEAN_TYPE(input[input_idx]);
-    res = MEAN_OP(res, VALUE_TO_SUBTRACT[f % VALUE_TO_SUBTRACT_SIZE]);
+    float res_tmp = TO_MEAN_TYPE(DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx]));
+    res_tmp = MEAN_OP(res_tmp, VALUE_TO_SUBTRACT[f % VALUE_TO_SUBTRACT_SIZE]);
 #elif defined MEAN_SUBTRACT_IN_BUFFER
 #if defined MEAN_PER_FEATURE
-    MEAN_SUBTRACT_TYPE res = TO_MEAN_TYPE(input[input_idx]);
-    res = MEAN_OP(res, mean_subtract[f]);
+    MEAN_SUBTRACT_COMPUTE_TYPE res_tmp = TO_MEAN_TYPE(DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx]));
+    res_tmp = MEAN_OP(res_tmp, DECODE_MEAN_SUBTRACT_COMPUTE_TYPE(mean_subtract[f]));
 #else
     // TODO Add support for 6D mean
-    MEAN_SUBTRACT_TYPE res = TO_MEAN_TYPE(input[input_idx]);
+    MEAN_SUBTRACT_COMPUTE_TYPE res_tmp = TO_MEAN_TYPE(DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx]));
     uint8 msv = RESHAPE_DIMS(INPUT0, MEAN_SUBTRACT, b, f, v, u, w, z, y, x);
-    res = MEAN_OP(res, mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, /*msv.s2, msv.s3, msv.s4,msv.s5,*/ msv.s6, msv.s7)]);
+    res_tmp = MEAN_OP(res_tmp, DECODE_MEAN_SUBTRACT_COMPUTE_TYPE(mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, /*msv.s2, msv.s3, msv.s4,msv.s5,*/ msv.s6, msv.s7)]));
 #endif
 #elif SURFACE_INPUT
     float4 Y = read_imagef(input, (int2)(y, f));
     float Ycomponent = mad(Y.x, 296.82f, -18.624f);
-    float res = clamp(Ycomponent, 0.f, 255.f);
+    float res_tmp = clamp(Ycomponent, 0.f, 255.f);
 #else
-    #ifdef BF16_INPUT
-        CALC_TYPE res = TO_CALC_TYPE(_convert_as_bfloat16_float(input[input_idx]));
-    #elif defined INT4_INPUT
+    #ifdef INT4_INPUT
         const uint uint4_idx = input_idx >> 1;
-        OUTPUT_TYPE res = TO_OUTPUT_REORDER_TYPE(convert_as_int4_float(input[uint4_idx], input_idx));
+        OUTPUT_COMPUTE_TYPE res_tmp = TO_OUTPUT_REORDER_COMPUTE_TYPE(convert_as_int4_float(input[uint4_idx], input_idx));
     #elif defined UINT4_INPUT
         const uint uint4_idx = input_idx >> 1;
-        OUTPUT_TYPE res = TO_OUTPUT_REORDER_TYPE(convert_as_uint4_float(input[uint4_idx], input_idx));
+        OUTPUT_COMPUTE_TYPE res_tmp = TO_OUTPUT_REORDER_COMPUTE_TYPE(convert_as_uint4_float(input[uint4_idx], input_idx));
     #elif (F8E5M2_INPUT || F8E4M3_INPUT || F8E8M0_INPUT)
-            OUTPUT_TYPE res = TO_OUTPUT_REORDER_TYPE(_convert_float(input[input_idx]));
+            OUTPUT_COMPUTE_TYPE res_tmp = TO_OUTPUT_REORDER_COMPUTE_TYPE(_convert_float(input[input_idx]));
     #else
-        CALC_TYPE res = TO_CALC_TYPE(input[input_idx]);
+        CALC_TYPE res_tmp = TO_CALC_TYPE(DECODE_INPUT_REORDER_COMPUTE_TYPE(input[input_idx]));
     #endif
 #endif
 #endif
@@ -176,7 +176,7 @@ KERNEL (reorder_data)(
     uint output_idx_G = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR ov1.s0, ov1.s1, ov1.s2, ov1.s3, ov1.s4, ov1.s5, ov1.s6, ov1.s7);
     uint output_idx_B = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR ov2.s0, ov2.s1, ov2.s2, ov2.s3, ov2.s4, ov2.s5, ov2.s6, ov2.s7);
     #if HAS_FUSED_OPS
-        res = TO_OUTPUT_REORDER_TYPE(R);
+        OUTPUT_REORDER_TYPE res = TO_OUTPUT_REORDER_TYPE(R);
         FUSED_OPS;
         output[output_idx_R] = FUSED_OPS_RESULT;
         res = TO_OUTPUT_REORDER_TYPE(G);
@@ -186,9 +186,9 @@ KERNEL (reorder_data)(
         FUSED_OPS;
         output[output_idx_B] = FUSED_OPS_RESULT;
     #else
-        output[output_idx_R] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(R), NL_M, NL_N);
-        output[output_idx_G] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(G), NL_M, NL_N);
-        output[output_idx_B] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(B), NL_M, NL_N);
+        output[output_idx_R] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(R), NL_M, NL_N));
+        output[output_idx_G] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(G), NL_M, NL_N));
+        output[output_idx_B] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(B), NL_M, NL_N));
     #endif
 #elif INPUT0_LAYOUT_IMAGE_2D_RGBA
     uint8 ov0 = RESHAPE_DIMS(INPUT0, OUTPUT, b, 0, v, u, w, z, y, x);
@@ -198,7 +198,7 @@ KERNEL (reorder_data)(
     uint output_idx_1 = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR ov1.s0, ov1.s1, ov1.s2, ov1.s3, ov1.s4, ov1.s5, ov1.s6, ov1.s7);
     uint output_idx_2 = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR ov2.s0, ov2.s1, ov2.s2, ov2.s3, ov2.s4, ov2.s5, ov2.s6, ov2.s7);
     #if HAS_FUSED_OPS
-        res = TO_OUTPUT_REORDER_TYPE(colorRGBA.s0);
+        OUTPUT_REORDER_TYPE res = TO_OUTPUT_REORDER_TYPE(colorRGBA.s0);
         FUSED_OPS;
         output[output_idx_0] = FUSED_OPS_RESULT;
         res = TO_OUTPUT_REORDER_TYPE(colorRGBA.s1);
@@ -208,9 +208,9 @@ KERNEL (reorder_data)(
         FUSED_OPS;
         output[output_idx_2] = FUSED_OPS_RESULT;
     #else
-        output[output_idx_0] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(colorRGBA.s0), NL_M, NL_N);
-        output[output_idx_1] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(colorRGBA.s1), NL_M, NL_N);
-        output[output_idx_2] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(colorRGBA.s2), NL_M, NL_N);
+        output[output_idx_0] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(colorRGBA.s0), NL_M, NL_N));
+        output[output_idx_1] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(colorRGBA.s1), NL_M, NL_N));
+        output[output_idx_2] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(colorRGBA.s2), NL_M, NL_N));
     #endif
     #if INPUT0_FEATURE_NUM == 4
         uint8 ov = RESHAPE_DIMS(INPUT0, OUTPUT, b, 3, v, u, w, z, y, x);
@@ -220,7 +220,7 @@ KERNEL (reorder_data)(
             FUSED_OPS;
             output[output_idx] = FUSED_OPS_RESULT;
         #else
-            output[output_idx] = ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE(colorRGBA.s3), NL_M, NL_N);
+            output[output_idx] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_FUNC_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(colorRGBA.s3), NL_M, NL_N));
         #endif
     #endif
 #elif OUTPUT_LAYOUT_IMAGE_2D_RGBA
@@ -232,20 +232,23 @@ KERNEL (reorder_data)(
     #else
         #define __TO_OUTPUT_REORDER_TYPE(res) TO_OUTPUT_REORDER_TYPE_SAT(res)
     #endif
+	    #define __TO_OUTPUT_REORDER_COMPUTE_TYPE(res) __TO_OUTPUT_REORDER_TYPE(res)
     #elif F8E5M2_OUTPUT || F8E4M3_OUTPUT || F8E8M0_OUTPUT
         // fp8 encoders are overloaded on float/half only; a non-float `res` (e.g. uchar from an integer
         // input) makes the call ambiguous, so encode from float. (f8->f8 identity is handled below.)
         #define __TO_OUTPUT_REORDER_TYPE(res) TO_OUTPUT_REORDER_TYPE(convert_float(res))
+		#define __TO_OUTPUT_REORDER_COMPUTE_TYPE(res) __TO_OUTPUT_REORDER_TYPE(res)
     #else
         #define __TO_OUTPUT_REORDER_TYPE(res) TO_OUTPUT_REORDER_TYPE(res)
+		#define __TO_OUTPUT_REORDER_COMPUTE_TYPE(res) TO_OUTPUT_REORDER_COMPUTE_TYPE(res)
     #endif
 
     #if HAS_FUSED_OPS
-        res = __TO_OUTPUT_REORDER_TYPE(res);
+        OUTPUT_REORDER_TYPE res = __TO_OUTPUT_REORDER_TYPE(res_tmp);
         FUSED_OPS;
         output[output_idx] = FUSED_OPS_RESULT;
     #elif defined(INT4_OUTPUT) || defined(UINT4_OUTPUT)
-        OUTPUT_TYPE val_char = __TO_OUTPUT_REORDER_TYPE(res);
+        OUTPUT_TYPE val_char = __TO_OUTPUT_REORDER_TYPE(res_tmp);
         int val_i32 = convert_int(val_char);
 
         #if !CONVERT_TRUNCATE
@@ -268,11 +271,12 @@ KERNEL (reorder_data)(
     #elif (F8E5M2_INPUT && F8E5M2_OUTPUT) || (F8E4M3_INPUT && F8E4M3_OUTPUT) || (F8E8M0_INPUT && F8E8M0_OUTPUT)
         // f8->f8 layout reorder: `res` is already the fp8 OUTPUT_TYPE, so store it directly. Re-encoding
         // via TO_OUTPUT_TYPE/ACTIVATION has no overload for the fp8 struct (and a copy needs none).
-        output[output_idx] = res;
+        output[output_idx] = res_tmp;
     #else
-        output[output_idx] = ACTIVATION_TYPED(OUTPUT_REORDER, __TO_OUTPUT_REORDER_TYPE(res), ACTIVATION_PARAMS_TYPED);
+        output[output_idx] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_TYPED(OUTPUT_REORDER, __TO_OUTPUT_REORDER_COMPUTE_TYPE(res_tmp), ACTIVATION_PARAMS_TYPED));
     #endif
 #undef __TO_OUTPUT_REORDER_TYPE
+#undef __TO_OUTPUT_REORDER_COMPUTE_TYPE
 #endif
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx.cl
@@ -13,7 +13,7 @@
 #define OUTPUTVTYPE CAT(OUTPUT_TYPE, TILE_SIZE)
 #define VSTORE CAT(vstore, TILE_SIZE)
 #define AS_INPUTVTYPE CAT(as_, INPUTVTYPE)
-#define TO_OUTPUTVTYPE CAT(convert_, OUTPUTVTYPE)
+#define TO_OUTPUTVTYPE(v) TO_OUTPUT_VECTOR_TYPE(v, TILE_SIZE)
 
 #define GET_GLOBAL_ID(IDX) ((uint)get_global_id(IDX))
 #define GET_LOCAL_ID(IDX) ((uint)get_local_id(IDX))

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_bfyx_to_blocked_format.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_bfyx_to_blocked_format.cl
@@ -7,11 +7,12 @@
 #define INPUT0_GET_TILED_INDEX(ORDER) INPUT0_GET_INDEX(ORDER)
 
 #define INPUTVTYPE CAT(INPUT0_TYPE, TILE_SIZE)
+#define INPUTVCOMPUTETYPE CAT(INPUT0_COMPUTE_TYPE, TILE_SIZE)
 #define OUTPUTVTYPE CAT(OUTPUT_TYPE, TILE_SIZE)
 #define VLOAD CAT(vload, TILE_SIZE)
 #define VSTORE CAT(vstore, TILE_SIZE)
 #define AS_INPUTVTYPE CAT(as_, INPUTVTYPE)
-#define TO_OUTPUTVTYPE CAT(convert_, OUTPUTVTYPE)
+#define TO_OUTPUTVTYPE(v) TO_OUTPUT_VECTOR_TYPE(v, TILE_SIZE)
 
 #define GET_GLOBAL_ID(IDX) ((uint)get_global_id(IDX))
 #define GET_LOCAL_ID(IDX) ((uint)get_local_id(IDX))
@@ -22,7 +23,7 @@
                                         INPUTVTYPE read_data = AS_INPUTVTYPE(VLOAD(0, input + input_idx)); \
                                         unroll_for (uint lw = 0; lw < inner; ++lw) { \
                                             const uint dst = local_buf_offset + lw; \
-                                            transpose_buf[dst][lh] = read_data[lw]; \
+                                            transpose_buf[dst][lh] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(read_data[lw])); \
                                         } \
                                     }
 
@@ -34,19 +35,19 @@
                                         } \
                                         unroll_for (uint lw = 0; lw < inner; ++lw) { \
                                             const uint dst = local_buf_offset + lw; \
-                                            transpose_buf[dst][lh] = read_data[lw]; \
+                                            transpose_buf[dst][lh] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(read_data[lw])); \
                                         } \
                                     }
 
 #define FUNC_VSTORE(loop)           unroll_for (uint lw = 0; lw < loop; ++lw) { \
                                         const uint output_idx = output_idx_tile + (lw * x_pitch); \
-                                        VSTORE(TO_OUTPUTVTYPE(transpose_buf[local_buf_offset + lw]), 0, output + output_idx); \
+                                        VSTORE(transpose_buf[local_buf_offset + lw], 0, output + output_idx); \
                                     }
 
 #define FUNC_WRITE(inner, outer)    unroll_for (uint lw = 0; lw < outer; ++lw) { \
                                         const uint output_idx = output_idx_tile + (lw * x_pitch); \
                                         unroll_for (uint i = 0; i < inner; ++i) { \
-                                            output[output_idx + i] = ACTIVATION(TO_OUTPUT_TYPE(transpose_buf[local_buf_offset + lw][i]), ACTIVATION_PARAMS); \
+                                            output[output_idx + i] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_OUTPUT_COMPUTE_TYPE(transpose_buf[local_buf_offset + lw][i]), ACTIVATION_PARAMS)); \
                                         } \
                                     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_fast_b1.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_fast_b1.cl
@@ -190,15 +190,15 @@ KERNEL (reorder_data_fast_b1)(
 #endif
 
 #if   defined MEAN_SUBTRACT_INSIDE_PARAMS
-    float res = TO_MEAN_TYPE(input[input_idx]);
+    float res = TO_MEAN_TYPE(LOAD_(input_idx));
     res -= VALUE_TO_SUBTRACT[f % VALUE_TO_SUBTRACT_SIZE];
 #elif defined MEAN_SUBTRACT_IN_BUFFER
-    MEAN_SUBTRACT_TYPE res = TO_MEAN_TYPE(input[input_idx]);
+    MEAN_SUBTRACT_COMPUTE_TYPE res = TO_MEAN_TYPE(LOAD_(input_idx));
     uint8 msv = RESHAPE_DIMS(INPUT0, MEAN_SUBTRACT, b, f, 0, 0, w, z, y, x);
-    res -= mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, msv.s6, msv.s7)];
+    res -= DECODE_MEAN_SUBTRACT_COMPUTE_TYPE(mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv.s0, msv.s1, msv.s6, msv.s7)]);
 #else
-    CALC_TYPE res = TO_CALC_TYPE(input[input_idx]);
+    CALC_TYPE res = TO_CALC_TYPE(LOAD_(input_idx));
 #endif
 
-    output[output_idx] = ACTIVATION_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE_SAT(res), ACTIVATION_PARAMS_TYPED);
+    STORE_(output_idx, res);
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_fsv.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_fsv.cl
@@ -9,10 +9,12 @@
 
 #ifdef FSV_VECTORIZED
     #define INPUT_VEC_TYPE  MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_SIZE)
+	#define INPUT_VEC_COMPUTE_TYPE  MAKE_VECTOR_TYPE(INPUT0_COMPUTE_TYPE, VEC_SIZE)
     #define OUTPUT_VEC_TYPE MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE)
-    #define CONVERT_OUT_VEC CAT(convert_, OUTPUT_VEC_TYPE)
+    #define CONVERT_OUT_VEC(v) TO_OUTPUT_VECTOR_TYPE(v, VEC_SIZE)
     #define VLOAD_VEC       CAT(vload, VEC_SIZE)
     #define VSTORE_VEC      CAT(vstore, VEC_SIZE)
+	#define DECODE_VEC(v) DECODE_INPUT0_COMPUTE_VECTOR_TYPE(v, VEC_SIZE)
 #endif
 
 KERNEL (reorder_data_fsv)(
@@ -64,7 +66,7 @@ KERNEL (reorder_data_fsv)(
             const uint fs_in = fs_out * RATIO + r;
             const uint f_chunk = f_base + r * VEC_SIZE;
             if (f_chunk < INPUT0_FEATURE_NUM) {
-                INPUT_VEC_TYPE v = VLOAD_VEC(0, input + in_spatial_base + fs_in * in_fs_pitch);
+                INPUT_VEC_COMPUTE_TYPE v = DECODE_VEC(VLOAD_VEC(0, input + in_spatial_base + fs_in * in_fs_pitch));
                 VSTORE_VEC(CONVERT_OUT_VEC(v), 0, output + OUT_INDEX(f_chunk));
             } else {
                 OUTPUT_VEC_TYPE zero = (OUTPUT_VEC_TYPE)(0);
@@ -76,7 +78,7 @@ KERNEL (reorder_data_fsv)(
         const uint fs_in = fs_out / RATIO;
         const uint sub = fs_out % RATIO;
         if (f_base < INPUT0_FEATURE_NUM) {
-            INPUT_VEC_TYPE v = VLOAD_VEC(0, input + in_spatial_base + fs_in * in_fs_pitch + sub * VEC_SIZE);
+            INPUT_VEC_COMPUTE_TYPE v = DECODE_VEC(VLOAD_VEC(0, input + in_spatial_base + fs_in * in_fs_pitch + sub * VEC_SIZE));
             VSTORE_VEC(CONVERT_OUT_VEC(v), 0, output + OUT_INDEX(f_base));
         } else {
             OUTPUT_VEC_TYPE zero = (OUTPUT_VEC_TYPE)(0);
@@ -91,7 +93,7 @@ KERNEL (reorder_data_fsv)(
             const uint fs_in = f / IN_FSV;
             const uint fsv_in = f % IN_FSV;
             const uint in_offset = in_spatial_base + fs_in * in_fs_pitch + fsv_in;
-            output[OUT_INDEX(f)] = ACTIVATION(TO_OUTPUT_TYPE(input[in_offset]), ACTIVATION_PARAMS);
+            output[OUT_INDEX(f)] = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(DECODE_INPUT0_COMPUTE_TYPE(input[in_offset])), ACTIVATION_PARAMS));
         } else {
             output[OUT_INDEX(f)] = TO_OUTPUT_TYPE(0);
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_to_yxfb_batched.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_data_to_yxfb_batched.cl
@@ -6,7 +6,6 @@
 #include "include/batch_headers/fetch_data.cl"
 
 
-
 inline void FUNC(get_yxfb_coords_from_linear_idx_no_padding)(uint data_idx, uint* b, uint* f, uint* x, uint* y)
 {
     uint tmp_data_idx = data_idx / INPUT0_BATCH_NUM;
@@ -49,21 +48,21 @@ KERNEL (reorder_data_to_yxfb_batched)(
         const uint input_idx = INPUT0_GET_INDEX(b, f, y, x);
 
     #if defined MEAN_SUBTRACT_INSIDE_PARAMS
-        float res = TO_MEAN_TYPE(input[input_idx]);
+        float res = TO_MEAN_TYPE(LOAD_(input_idx));
         res = MEAN_OP(res, VALUE_TO_SUBTRACT[f % VALUE_TO_SUBTRACT_SIZE]);
     #elif defined MEAN_SUBTRACT_IN_BUFFER
     #if defined MEAN_PER_FEATURE
-        MEAN_SUBTRACT_TYPE res = TO_MEAN_TYPE(input[input_idx]);
-        res = MEAN_OP(res, mean_subtract[f]);
+        MEAN_SUBTRACT_COMPUTE_TYPE res = TO_MEAN_TYPE(LOAD_(input_idx));
+        res = MEAN_OP(res, DECODE_MEAN_SUBTRACT_COMPUTE_TYPE(mean_subtract[f]));
     #else
-        MEAN_SUBTRACT_TYPE res = TO_MEAN_TYPE(input[input_idx]);
+        MEAN_SUBTRACT_COMPUTE_TYPE res = TO_MEAN_TYPE(LOAD_(input_idx));
         uint8 msv = RESHAPE_DIMS(INPUT0, MEAN_SUBTRACT, b, f, 0, 0, y,x);
-        res = MEAN_OP(res, mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv[1], msv[2], msv[5], msv[6])]);
+        res = MEAN_OP(res, DECODE_MEAN_SUBTRACT_COMPUTE_TYPE(mean_subtract[GET_DATA_INDEX_SAFE(MEAN_SUBTRACT, msv[1], msv[2], msv[5], msv[6])]));
     #endif
     #else
-        CALC_TYPE res = TO_CALC_TYPE(input[input_idx]);
+        CALC_TYPE res = TO_CALC_TYPE(LOAD_(input_idx));
     #endif
 
-        output[output_idx] = ACTIVATION_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_TYPE_SAT(res), ACTIVATION_PARAMS_TYPED);
+        STORE_(output_idx, res);
     }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_fs_b_yx_fsv32_to_bfyx.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_fs_b_yx_fsv32_to_bfyx.cl
@@ -5,6 +5,8 @@
 #include "include/batch_headers/fetch_data.cl"
 #include "include/unit_type.cl"
 
+#define STORE_RAW_(idx, val) output[idx] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_TYPED(OUTPUT_REORDER, val, ACTIVATION_PARAMS_TYPED))
+
 __attribute__((reqd_work_group_size(1, LWS1, 1)))
 KERNEL (reorder_fs_b_yx_fsv32_to_bfyx)(
         const __global INPUT_REORDER_TYPE* input,
@@ -25,11 +27,11 @@ KERNEL (reorder_fs_b_yx_fsv32_to_bfyx)(
     for (int i = 0; i < X_BLOCK_SIZE; i++) {
 #if defined(LEFTOVERS_OX)
         if (x + i < INPUT0_SIZE_X)
-            in_data[sglid * X_BLOCK_SIZE + i] = input[in_idx + (i * FSV) + sglid];
+            in_data[sglid * X_BLOCK_SIZE + i] = DECODE_INPUT_REORDER_COMPUTE_TYPE(input[in_idx + (i * FSV) + sglid]);
         else
             in_data[sglid * X_BLOCK_SIZE + i] = 0;
 #else
-        in_data[sglid * X_BLOCK_SIZE + i] = input[in_idx + (i * FSV) + sglid];
+        in_data[sglid * X_BLOCK_SIZE + i] = DECODE_INPUT_REORDER_COMPUTE_TYPE(input[in_idx + (i * FSV) + sglid]);
 #endif
     }
 
@@ -48,10 +50,10 @@ KERNEL (reorder_fs_b_yx_fsv32_to_bfyx)(
         const bool skip = x_idx >= OUTPUT_SIZE_X;
 #endif
         if (!skip) {
-            output[out_idx] = ACTIVATION_TYPED(OUTPUT_REORDER, in_data[data_idx], ACTIVATION_PARAMS_TYPED);
+            STORE_RAW_(out_idx, in_data[data_idx]);
         }
 #else
-        output[out_idx] = ACTIVATION_TYPED(OUTPUT_REORDER, in_data[data_idx], ACTIVATION_PARAMS_TYPED);
+        STORE_RAW_(out_idx, in_data[data_idx]);
 #endif
     }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/common_tools.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/common_tools.h
@@ -22,6 +22,7 @@ inline uint32_t BytesPerElement(Datatype dt) {
         case Datatype::UINT8:
             return 1;
         case Datatype::F16:
+        case Datatype::BF16:
         case Datatype::INT16:
         case Datatype::UINT16:
             return 2;
@@ -42,6 +43,7 @@ inline uint32_t BytesPerElement(WeightsType wt) {
         case WeightsType::UINT8:
             return 1;
         case WeightsType::F16:
+        case WeightsType::BF16:
             return 2;
         case WeightsType::F32:
         case WeightsType::INT32:
@@ -49,6 +51,20 @@ inline uint32_t BytesPerElement(WeightsType wt) {
         default:
             throw std::runtime_error("[GPU] BytesPerElement doesn't support given precision");
     }
+}
+
+inline Datatype GetComputeDatatype(Datatype dt) {
+    if (dt == Datatype::BF16)
+        return Datatype::F32;
+    else
+        return dt;
+}
+
+inline WeightsType GetComputeWeightsType(WeightsType dt) {
+    if (dt == WeightsType::BF16)
+        return WeightsType::F32;
+    else
+        return dt;
 }
 
 inline uint8_t GetActivationAdditionalParamsNumber(ActivationFunction func) {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -136,6 +136,8 @@ std::string toCLType(WeightsType wType) {
             return GetTypeName<uint8_t>();
         case WeightsType::F16:
             return "half";
+        case WeightsType::BF16:
+            return GetTypeName<uint16_t>();
         case WeightsType::F32:
             return GetTypeName<float>();
         case WeightsType::INT32:
@@ -156,6 +158,7 @@ std::string toCLType(Datatype dType) {
         case Datatype::INT16:
             return GetTypeName<int16_t>();
         case Datatype::UINT16:
+        case Datatype::BF16:
             return GetTypeName<uint16_t>();
         case Datatype::INT32:
             return GetTypeName<int32_t>();
@@ -1146,7 +1149,7 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
         return jit_term;
     };
     auto to_type = [type_handler](const JitTerm& arg) -> JitTerm {
-        JitTerm jit_term{type_handler("TO_", "_TYPE") + "(" + arg.str() + ")"};
+        JitTerm jit_term{type_handler("TO_", "_COMPUTE_TYPE") + "(" + arg.str() + ")"};
         return jit_term;
     };
 
@@ -1451,6 +1454,12 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
     std::string min_func = "undefined";
     std::string abs_func = "undefined";
     std::string type_size = "undefined";
+    std::string compute_type;
+    std::string to_compute_type;
+    std::string decode_compute_type;
+    std::string decode_compute_vector_type;
+    std::string to_vector_type = "undefined";
+    std::string to_vector_type_sat = "undefined";
     bool is_fp;
     switch (dataType) {
         case Datatype::INT8:
@@ -1461,6 +1470,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "(char) 0";
             to_type = "convert_char(v)";
             to_type_sat = "convert_char_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(char, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(char, size)), _sat)(v)";
             as_type = "as_char(v)";
             max_func = "max";
             min_func = "min";
@@ -1476,6 +1487,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "(uchar) 0";
             to_type = "convert_uchar(v)";
             to_type_sat = "convert_uchar_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(uchar, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(uchar, size)), _sat)(v)";
             as_type = "as_uchar(v)";
             max_func = "max";
             min_func = "min";
@@ -1491,6 +1504,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "(short) 0";
             to_type = "convert_short(v)";
             to_type_sat = "convert_short_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(short, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(short, size)), _sat)(v)";
             as_type = "as_short(v)";
             max_func = "max";
             min_func = "min";
@@ -1506,6 +1521,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "(ushort) 0";
             to_type = "convert_ushort(v)";
             to_type_sat = "convert_ushort_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(ushort, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(ushort, size)), _sat)(v)";
             as_type = "as_ushort(v)";
             max_func = "max";
             min_func = "min";
@@ -1521,6 +1538,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "(int) 0";
             to_type = "convert_int(v)";
             to_type_sat = "convert_int_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(int, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(int, size)), _sat)(v)";
             as_type = "as_int(v)";
             max_func = "max";
             min_func = "min";
@@ -1536,6 +1555,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "(uint) 0";
             to_type = "convert_uint(v)";
             to_type_sat = "convert_uint_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(uint, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(uint, size)), _sat)(v)";
             as_type = "as_uint(v)";
             max_func = "max";
             min_func = "min";
@@ -1551,6 +1572,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "(long) 0";
             to_type = "convert_long(v)";
             to_type_sat = "convert_long_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(long, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(long, size)), _sat)(v)";
             as_type = "as_long(v)";
             max_func = "max";
             min_func = "min";
@@ -1566,6 +1589,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "0.0h";
             to_type = "convert_half(v)";
             to_type_sat = "convert_half(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(half, size))(v)";
+            to_vector_type_sat = "CAT(convert_, MAKE_VECTOR_TYPE(half, size))(v)";
             as_type = "as_half(v)";
             max_func = "fmax";
             min_func = "fmin";
@@ -1577,6 +1602,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             type = "char";
             to_type = "convert_char(v)";
             to_type_sat = "convert_char_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(char, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(char, size)), _sat)(v)";
             type_size = "0.5f";
             is_fp = false;
             break;
@@ -1584,17 +1611,30 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             type = "uchar";
             to_type = "convert_uchar(v)";
             to_type_sat = "convert_uchar_sat(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(uchar, size))(v)";
+            to_vector_type_sat = "CAT(CAT(convert_, MAKE_VECTOR_TYPE(uchar, size)), _sat)(v)";
             type_size = "0.5f";
             is_fp = false;
             break;
         case Datatype::BF16:
             type = "ushort";
-            val_one = "(ushort) 1";
-            val_zero = "(ushort) 0";
-            to_type = "_convert_bfloat16_as_ushort(v)";
-            to_type_sat = "_convert_bfloat16_as_ushort(v)";
+            max_val = "_convert_as_bfloat16_float((ushort)0x7f7f)";
+            min_val = "-" + macroName + "_VAL_MAX";
+            val_one = "1.0f";
+            val_zero = "0.0f";
+            to_type = "_convert_bfloat16_as_ushort(convert_float(v))";
+            to_type_sat = "_convert_bfloat16_as_ushort(convert_float(v))";
+            to_vector_type = "CONVERT_BFLOAT16_AS_USHORT(CAT(convert_, MAKE_VECTOR_TYPE(float, size))(v), size)";
+            to_vector_type_sat = "CONVERT_BFLOAT16_AS_USHORT(CAT(convert_, MAKE_VECTOR_TYPE(float, size))(v), size)";
+            compute_type = "float";
+            to_compute_type = "convert_float(v)";
+            decode_compute_type = "_convert_as_bfloat16_float(v)";
+            decode_compute_vector_type = "CONVERT_AS_BFLOAT16_FLOAT(v, size)";
+            max_func = "fmax";
+            min_func = "fmin";
+            abs_func = "fabs";
             type_size = "2";
-            is_fp = false;
+            is_fp = true;
             break;
         case Datatype::F8E4M3:
             type = "fp8e4m3_t";
@@ -1640,6 +1680,8 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             val_zero = "0.0f";
             to_type = "convert_float(v)";
             to_type_sat = "convert_float(v)";
+            to_vector_type = "CAT(convert_, MAKE_VECTOR_TYPE(float, size))(v)";
+            to_vector_type_sat = "CAT(convert_, MAKE_VECTOR_TYPE(float, size))(v)";
             as_type = "as_float(v)";
             max_func = "fmax";
             min_func = "fmin";
@@ -1649,6 +1691,15 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             break;
     }
 
+    if (compute_type.empty())
+        compute_type = type;
+    if (to_compute_type.empty())
+        to_compute_type = to_type;
+    if (decode_compute_type.empty())
+        decode_compute_type = "(v)";
+    if (decode_compute_vector_type.empty())
+        decode_compute_vector_type = "(v)";
+
     return JitConstants{
         MakeJitConstant(macroName + "_TYPE", type),
         MakeJitConstant(macroName + "_VAL_MAX", max_val),
@@ -1657,12 +1708,18 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
         MakeJitConstant(macroName + "_VAL_ZERO", val_zero),
         MakeJitConstant("TO_" + macroName + "_TYPE(v)", to_type),
         MakeJitConstant("TO_" + macroName + "_TYPE_SAT(v)", to_type_sat),
+        MakeJitConstant("TO_" + macroName + "_VECTOR_TYPE(v, size)", to_vector_type),
+        MakeJitConstant("TO_" + macroName + "_VECTOR_TYPE_SAT(v, size)", to_vector_type_sat),
         MakeJitConstant("AS_" + macroName + "_TYPE(v)", as_type),
         MakeJitConstant(macroName + "_MAX_FUNC", max_func),
         MakeJitConstant(macroName + "_MIN_FUNC", min_func),
         MakeJitConstant(macroName + "_ABS_FUNC", abs_func),
         MakeJitConstant(macroName + "_TYPE_SIZE", type_size),
         MakeJitConstant(macroName + "_IS_FP", is_fp),
+        MakeJitConstant(macroName + "_COMPUTE_TYPE", compute_type),
+        MakeJitConstant("TO_" + macroName + "_COMPUTE_TYPE(v)", to_compute_type),
+        MakeJitConstant("DECODE_" + macroName + "_COMPUTE_TYPE(v)", decode_compute_type),
+        MakeJitConstant("DECODE_" + macroName + "_COMPUTE_VECTOR_TYPE(v, size)", decode_compute_vector_type),
     };
 }
 JitConstants MakeTypeJitConstants(WeightsType weightsType, const std::string& macroName) {
@@ -1967,7 +2024,7 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
         std::vector<Datatype> types_prioritized = { };
         if (floor_integer_div) {
             if (std::all_of(input_types.begin(), input_types.end(),
-                            [=](const Datatype& t) -> bool { return (t != Datatype::F32 && t != Datatype::F16); })) {
+                            [=](const Datatype& t) -> bool { return (t != Datatype::F32 && t != Datatype::F16 && t != Datatype::BF16); })) {
                 types_prioritized = { Datatype::INT64, Datatype::INT32, Datatype::UINT32, Datatype::INT16, Datatype::UINT16, Datatype::INT8, Datatype::UINT8 };
                 for (auto& type : types_prioritized) {
                     if (std::any_of(input_types.begin(), input_types.end(),
@@ -1977,8 +2034,12 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
                 }
             }
         }
-
         floor_integer_div = false;
+
+        // If at least one type is BF16, do calculations in F32
+        if (std::find(input_types.begin(), input_types.end(), Datatype::BF16) != input_types.end())
+            return Datatype::F32;
+
         types_prioritized.clear();
         types_prioritized = { Datatype::F32, Datatype::F16 };
         for (auto& type : types_prioritized) {
@@ -1996,6 +2057,9 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
                             (dep.dep_type == kernel_selector::DepType::INTERNAL)? GetOutputVarName(in_var, dep.op_id)
                                 : GetInputVarName(dep.op_id, is_shuffled, shuffle_var);
         auto input_type = (dep.dep_type == kernel_selector::DepType::ORIGINAL)? in_type : dep.data_type;
+        // Decode bf16 inputs
+        input_name = DecodeComputeType(input_name, input_type, vec_size);
+        input_type = GetComputeDatatype(input_type);
         auto acc_t = get_acc_t();
 
         if (input_type != acc_t)
@@ -2047,6 +2111,9 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
 
             std::string in_converted = (first_fused_ops_idx < 0) ? in_var : GetOutputVarName(in_var, dep_data[first_fused_ops_idx].op_id);
             Datatype input_type = (first_fused_ops_idx < 0) ? in_type : dep_data[first_fused_ops_idx].data_type;
+            // Decode bf16 inputs
+            in_converted = DecodeComputeType(in_converted, input_type, vec_size);
+            input_type = GetComputeDatatype(input_type);
             Datatype tmp_type = Datatype::F32;
             std::string tmp_type_str = GetType(tmp_type, vec_size);
             std::string tmp_var = out_var + "_tmp";
@@ -2056,13 +2123,13 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
             }
 
             auto post_scale = p->per_tensor_output_scale ? Broadcast(toCodeString(p->out_scale), tmp_type, vec_size)
-                                                         : ConvertToType(GetInputVarName(p->out_scale_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
+                                                         : ConvertToType(GetDecodedInputVarName(p->out_scale_idx, is_shuffled, shuffle_var, vec_size), tmp_type, vec_size);
             auto post_shift = p->per_tensor_output_shift ? Broadcast(toCodeString(p->out_shift), tmp_type, vec_size)
-                                                         : ConvertToType(GetInputVarName(p->out_shift_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
+                                  : ConvertToType(GetDecodedInputVarName(p->out_shift_idx, is_shuffled, shuffle_var, vec_size), tmp_type, vec_size);
             auto pre_scale = p->per_tensor_input_scale ? Broadcast(toCodeString(p->in_scale), tmp_type, vec_size)
-                                                       : ConvertToType(GetInputVarName(p->in_scale_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
+                                 : ConvertToType(GetDecodedInputVarName(p->in_scale_idx, is_shuffled, shuffle_var, vec_size), tmp_type, vec_size);
             auto pre_shift = p->per_tensor_input_shift ? Broadcast(toCodeString(p->in_shift), tmp_type, vec_size)
-                                                       : ConvertToType(GetInputVarName(p->in_shift_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
+                                 : ConvertToType(GetDecodedInputVarName(p->in_shift_idx, is_shuffled, shuffle_var, vec_size), tmp_type, vec_size);
 
             if (p->per_tensor_output_range && p->out_lo < p->out_hi) {
                 // Input scale
@@ -2105,9 +2172,9 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
             } else {
                 // Input range
                 auto in_lo = p->per_tensor_input_range ? Broadcast(std::to_string(p->in_lo), tmp_type, vec_size)
-                                                       : ConvertToType(GetInputVarName(p->in_range_lo_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
+                                 : ConvertToType(GetDecodedInputVarName(p->in_range_lo_idx, is_shuffled, shuffle_var, vec_size), tmp_type, vec_size);
                 auto in_hi = p->per_tensor_input_range ? Broadcast(std::to_string(p->in_hi), tmp_type, vec_size)
-                                                       : ConvertToType(GetInputVarName(p->in_range_hi_idx, is_shuffled, shuffle_var), tmp_type, vec_size);
+                                 : ConvertToType(GetDecodedInputVarName(p->in_range_hi_idx, is_shuffled, shuffle_var, vec_size), tmp_type, vec_size);
 
                 // Input clamp
                 if (p->has_clamp) {
@@ -2150,6 +2217,9 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
             auto p = desc.GetOpParams<activation_fuse_params>();
             base_activation_params activation_p = p->param;
             std::string new_in_var = (first_fused_ops_idx < 0) ? in_var : GetOutputVarName(in_var, dep_data[first_fused_ops_idx].op_id);
+            Datatype input_type = (first_fused_ops_idx < 0) ? in_type : dep_data[first_fused_ops_idx].data_type;
+            // Decode bf16 inputs
+            new_in_var = DecodeComputeType(new_in_var, input_type, vec_size);
             op_decls += "\\\n\t" + GetOutputType(vec_size) + " " + out_var + " = " + ConvertToOutputType(new_in_var, vec_size) + ";";
             if (activation_p.function != ActivationFunction::NONE) {
                 auto suffix = "_FUSED_OP"+toCodeString(desc.op_id) + conf.suffix;
@@ -2165,24 +2235,24 @@ JitConstants FusedOpsCodeGenerator::MakeOpJitConstants(const FusedOpsConfigurati
                         nl_n = toCodeString(std::min<float>(activation_p.n, std::numeric_limits<unsigned char>::max()));
                     }
                 }
-
+                auto out_compute_type = GetComputeDatatype(out_type);
                 if (desc.tensors.size() == 1) {
                     if (desc.tensors[0].GetDType() != out_type) {
-                        nl_m = ConvertToOutputType(GetInputVarName(0), vec_size);
+                        nl_m = ConvertToType(GetDecodedInputVarName(0, false, "", vec_size), out_compute_type, vec_size);
                     } else {
-                        nl_m = GetInputVarName(0);
+                        nl_m = GetDecodedInputVarName(0, false, "", vec_size);
                     }
                 } else {
-                    nl_m = Broadcast(nl_m, out_type, vec_size);
+                    nl_m = Broadcast(nl_m, out_compute_type, vec_size);
                 }
 
-                nl_n = Broadcast(nl_n, out_type, vec_size);
+                nl_n = Broadcast(nl_n, out_compute_type, vec_size);
 
                 // Disable type casts in activation, since current jit generator for activation don't respect vector size of parameters.
                 // So conversion is explicitly done in params declaration
-                jit.Merge(MakeActivationJitConstants(activation_p.function, out_type, suffix, false, true));
+                jit.Merge(MakeActivationJitConstants(activation_p.function, out_compute_type, suffix, false, true));
                 std::string params = nl_m + ","+ nl_n;
-                op_decls += "\\\n\t" + out_var + " = ACTIVATION_FUNC" + suffix + "(" + out_var + ", " + params + ");";
+                op_decls += "\\\n\t" + out_var + " = " + ConvertToOutputType("ACTIVATION_FUNC" + suffix + "(" + DecodeComputeType(out_var, out_type, vec_size) + ", " + params + ")", vec_size) + ";";
             }
             break;
         }
@@ -2328,7 +2398,7 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
                 block_read = CastToType(" _sub_group_block_read" + vs + "("
                                         + "(const __global uint*)(" + GetInputPtrName(input_id) + " + " + index_func_call_vec + "))",
                                         input_dt, vec_size);
-            } else if (input_dt == Datatype::F16) {
+            } else if (input_dt == Datatype::F16 || input_dt == Datatype::BF16) {
                 block_read = CastToType(" _sub_group_block_read_us" + vs + "("
                                         + "(const __global ushort*)(" + GetInputPtrName(input_id) + " + " + index_func_call_vec + "))",
                                         input_dt, vec_size);
@@ -2382,6 +2452,10 @@ std::string FusedOpsCodeGenerator::GetInputVarName(size_t input_id, bool is_shuf
     return GetTypeStr() + toCodeString(desc.op_id) + "_data" + toCodeString(input_id);
 }
 
+std::string FusedOpsCodeGenerator::GetDecodedInputVarName(size_t input_id, bool is_shuffled, std::string shuffle_var, size_t vec_size) const {
+    return "DECODE_" + GetInputTensorName(input_id) + "_COMPUTE_VECTOR_TYPE(" + GetInputVarName(input_id, is_shuffled, shuffle_var) + ", " + toCodeString(vec_size) + ")";
+}
+
 std::string FusedOpsCodeGenerator::GetOutputVarName(std::string input_var, size_t op_id) const {
     std::replace(input_var.begin(), input_var.end(), '[', '_');
     std::replace(input_var.begin(), input_var.end(), ']', '_');
@@ -2402,7 +2476,10 @@ std::string FusedOpsCodeGenerator::GetOutputType(size_t vec_size) const {
 }
 
 std::string FusedOpsCodeGenerator::ConvertToType(std::string var, Datatype dt, size_t vec_size) const {
-    return "convert_" + GetType(dt, vec_size) + "(" + var + ")";
+    if (dt == Datatype::BF16)
+        return "CONVERT_BFLOAT16_AS_USHORT(" + var + ", " + toCodeString(vec_size) + ")";
+    else
+        return "convert_" + GetType(dt, vec_size) + "(" + var + ")";
 }
 
 std::string FusedOpsCodeGenerator::CastToType(std::string var, Datatype dt, size_t vec_size) const {
@@ -2413,13 +2490,20 @@ std::string FusedOpsCodeGenerator::ConvertToOutputType(std::string var, size_t v
     return ConvertToType(var, desc.output_tensor.GetDType(), vec_size);
 }
 
+std::string FusedOpsCodeGenerator::DecodeComputeType(std::string var, Datatype dt, size_t vec_size) const {
+    if (dt == Datatype::BF16)
+        return "CONVERT_AS_BFLOAT16_FLOAT(" + var + ", " + toCodeString(vec_size) + ")";
+    else
+        return var;
+}
+
 std::string FusedOpsCodeGenerator::Broadcast(std::string var, Datatype dt, size_t vec_size) const {
     return "(" + GetType(dt, vec_size) + ")(" + var + ")";
 }
 
 std::string FusedOpsCodeGenerator::ConvertToOutputTypeSat(std::string var, size_t vec_size) const {
-    if (desc.output_tensor.GetDType() == Datatype::F32 || desc.output_tensor.GetDType() == Datatype::F16)
-        return "convert_" + GetOutputType(vec_size) + "(" + var + ")";
+    if (desc.output_tensor.GetDType() == Datatype::F32 || desc.output_tensor.GetDType() == Datatype::F16 || desc.output_tensor.GetDType() == Datatype::BF16)
+        return ConvertToOutputType(var, vec_size);
     else
         return "convert_" + GetOutputType(vec_size) + "_sat_rte(" + var + ")";
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.h
@@ -400,8 +400,10 @@ public:
     std::string GetIdx(size_t input_id, idx_desc idx, bool should_be_safe) const;
     std::string GetInputPtrName(size_t input_id) const;
     std::string GetInputVarName(size_t input_id, bool is_shuffled = false, std::string shuffle_var = "") const;
+    std::string GetDecodedInputVarName(size_t input_id, bool is_shuffled = false, std::string shuffle_var = "", size_t vec_size = 1) const;
     std::string GetOutputVarName(std::string input_var_name, size_t op_id) const;
     std::string ConvertToOutputType(std::string var, size_t vec_size = 1) const;
+    std::string DecodeComputeType(std::string var, Datatype dt, size_t vec_size = 1) const;
     std::string ConvertToType(std::string var, Datatype dt, size_t vec_size = 1) const;
     std::string CastToType(std::string var, Datatype dt, size_t vec_size = 1) const;
     std::string Broadcast(std::string var,  Datatype dt, size_t vec_size = 1) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base.cpp
@@ -62,7 +62,7 @@ static bool IsTypeUsedIn(Datatype type, const base_params& params) {
 
 Datatype KernelBase::GetUnitType(const base_params& params) const {
     Datatype types_prioritized[] =
-        {Datatype::INT8, Datatype::F16, Datatype::INT32, Datatype::INT64, Datatype::UINT8, Datatype::UINT32};
+        {Datatype::INT8, Datatype::F16, Datatype::BF16, Datatype::INT32, Datatype::INT64, Datatype::UINT8, Datatype::UINT32};
 
     for (Datatype type : types_prioritized)
         if (IsTypeUsedIn(type, params))
@@ -95,7 +95,7 @@ JitConstants KernelBase::MakeBaseParamsJitConstants(const base_params& params, b
     // and unit type are different and activation param is existed
     bool convert_input_to_output_dt = (params.outputs[0].GetDType() == Datatype::F32 && params.inputs[0].GetDType() == Datatype::F16);
     // If input is FP16 and output is FP32, convert input to float before running activation function.
-    jit.Merge(MakeActivationJitConstants(params.activations, params.outputs[0].GetDType(), "", false, false, convert_input_to_output_dt));
+    jit.Merge(MakeActivationJitConstants(params.activations, GetComputeDatatype(params.outputs[0].GetDType()), "", false, false, convert_input_to_output_dt));
 
     if (add_tensor_definitions) {
         for (size_t i = 0; i < params.inputs.size(); i++) {
@@ -157,7 +157,7 @@ JitConstants KernelBase::MakeFusedOpsJitConstants(const kernel_selector::base_pa
             std::string out_name;
             Datatype in_type = c.input_dt;
             bool can_all_use_preload = true;
-
+            Datatype last_fused_out_dtype = c.input_dt;
             for (size_t i = 0; i < params.fused_ops.size(); i++) {
                 // Reorder is not processed by jitter
                 if (params.fused_ops[i].GetType() == FusedOpType::REORDER)
@@ -180,11 +180,18 @@ JitConstants KernelBase::MakeFusedOpsJitConstants(const kernel_selector::base_pa
                 if (c.allow_for_partial_preload && (!can_use_preload || !can_preload_eltwise))
                     fused_ops_calc += "\\\n\tFUSED_OP" + toCodeString(i) + "_LOAD" + c.suffix;
                 fused_ops_calc += "\\\n\tFUSED_OP" + toCodeString(i) + "_ACTION" + c.suffix;
+                last_fused_out_dtype = params.fused_ops[i].output_tensor.GetDType();
             }
 
             jit.AddConstant(MakeJitConstant("FUSED_OPS" + c.suffix, fused_ops));
             jit.AddConstant(MakeJitConstant("FUSED_OPS_PRELOAD" + c.suffix, fused_ops_preload));
             jit.AddConstant(MakeJitConstant("FUSED_OPS_CALC" + c.suffix, fused_ops_calc));
+            // Convert dtype, only if last fused op has a different one from kernel output
+            if (!params.outputs.empty() && params.outputs[0].GetDType() != last_fused_out_dtype) {
+                if (last_fused_out_dtype == Datatype::BF16)
+                    out_name = "CONVERT_AS_BFLOAT16_FLOAT(" + out_name + ", " + toCodeString(c.vec_size) + ")";
+                out_name = "TO_OUTPUT_VECTOR_TYPE(" + out_name + ", " + toCodeString(c.vec_size) + ")";
+            }
             jit.AddConstant(MakeJitConstant("FUSED_OPS_RESULT" + c.suffix, out_name));
 
             bool can_any_use_preload = !fused_ops_preload.empty();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_biplanar_nv12.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_biplanar_nv12.cpp
@@ -11,6 +11,7 @@ ParamsKey reorder_biplanar_nv12::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableDifferentTypes();
     k.EnableInputLayout(DataLayout::nv12);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.cpp
@@ -70,10 +70,6 @@ JitConstants ReorderKernelRef::GetJitConstants(const reorder_params& params) con
         jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
     }
 
-    if ( params.inputs[0].GetDType() == Datatype::BF16 ) {
-         jit.AddConstant(MakeJitConstant("BF16_INPUT", true));
-    }
-
     if ( params.inputs[0].GetDType() == Datatype::INT4 ) {
          jit.AddConstant(MakeJitConstant("INT4_INPUT", true));
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_base.cpp
@@ -109,14 +109,15 @@ JitConstants ReorderKernelBase::GetJitConstants(const reorder_params& params) co
         jit.AddConstant(MakeJitConstant("TO_MEAN_TYPE", "convert_float"));
     } else if (params.mode == MeanSubtractMode::IN_BUFFER) {
         jit.AddConstant(MakeJitConstant("MEAN_SUBTRACT", params.mean));
-        jit.AddConstant(MakeJitConstant("TO_MEAN_TYPE", "convert_" + toCLType(params.mean.GetDType())));
+        jit.AddConstant(MakeJitConstant("TO_MEAN_TYPE", "convert_" + toCLType(GetComputeDatatype(params.mean.GetDType()))));
     }
 
     // Type JITs:
 
     // half->half without subtraction and activation (so plain reorder) can be done on shorts without explicit fp16 support
-    bool useUshort = (params.inputs[0].GetDType() == Datatype::F16 && params.outputs[0].GetDType() == Datatype::F16 &&
-                      params.mode == MeanSubtractMode::NONE && params.activations.empty());
+    bool useUshort = (((params.inputs[0].GetDType() == Datatype::F16 && params.outputs[0].GetDType() == Datatype::F16) || 
+        (params.inputs[0].GetDType() == Datatype::BF16 && params.outputs[0].GetDType() == Datatype::BF16)) &&
+                      params.mode == MeanSubtractMode::NONE && params.activations.empty() && params.fused_ops.empty());
 
     Datatype calc_type = useUshort ? Datatype::UINT16 : params.inputs[0].GetDType();
     if (params.inputs[0].GetDType() == Datatype::BF16 || params.inputs[0].GetDType() == Datatype::F8E8M0) {
@@ -135,7 +136,9 @@ JitConstants ReorderKernelBase::GetJitConstants(const reorder_params& params) co
     jit.AddConstant(MakeJitConstant("MEAN_OP(val, mean_val)", getMeanOpString(params.mean_op)));
 
     // Type parametrized activation:
-    jit.Merge(MakeActivationJitConstants(params.activations, GetUnitType(params), "_TYPED", true));
+    jit.Merge(MakeActivationJitConstants(params.activations, GetComputeDatatype(GetUnitType(params)), "_TYPED", true));
+    jit.AddConstant(MakeJitConstant("LOAD_(idx)", "DECODE_INPUT_REORDER_COMPUTE_TYPE(input[idx])"));
+    jit.AddConstant(MakeJitConstant("STORE_(idx, val)", "output[idx] = TO_OUTPUT_REORDER_TYPE(ACTIVATION_TYPED(OUTPUT_REORDER, TO_OUTPUT_REORDER_COMPUTE_TYPE(val), ACTIVATION_PARAMS_TYPED))"));
 
     // TODO: Move to lower classes
     jit.AddConstant(MakeJitConstant("SUB_GROUP_SIZE", SubGroupSize(params.outputs[0].GetLayout())));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fast_b1.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fast_b1.cpp
@@ -11,8 +11,10 @@ namespace kernel_selector {
 ParamsKey ReorderKernelFastBatch1::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableDifferentTypes();
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fs_b_yx_fsv32_to_bfyx.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fs_b_yx_fsv32_to_bfyx.cpp
@@ -23,9 +23,12 @@ static size_t GetOptimalSize(size_t val, std::vector<size_t> optimal_sizes) {
 ParamsKey ReorderKernel_fs_b_yx_fsv32_to_bfyx::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableInputLayout(DataLayout::fs_b_yx_fsv32);
     k.EnableOutputLayout(DataLayout::bfyx);
+    k.EnableDifferentTypes();
     k.EnableTensorOffset();
     k.EnableTensorPitches();
     k.EnableBatching();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_to_yxfb_batched.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_to_yxfb_batched.cpp
@@ -9,8 +9,10 @@ namespace kernel_selector {
 ParamsKey ReorderKernel_to_yxfb_batched::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableDifferentTypes();
     k.EnableAllInputLayout();

--- a/src/plugins/intel_gpu/tests/unit/fusions/fusion_test_common.hpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/fusion_test_common.hpp
@@ -124,6 +124,9 @@ public:
         } else if (l.data_type == data_types::f16) {
             VF<ov::float16> rnd_vec = rg.generate_random_1d<ov::float16>(s.count(), -1, 1);
             set_values(prim, rnd_vec);
+        } else if (l.data_type == data_types::bf16) {
+            VF<ov::bfloat16> rnd_vec = rg.generate_random_1d<ov::bfloat16>(s.count(), -1, 1);
+            set_values(prim, rnd_vec);
         } else {
             VF<float> rnd_vec = rg.generate_random_1d<float>(s.count(), -1, 1);
             set_values(prim, rnd_vec);
@@ -137,6 +140,9 @@ public:
         tensor s = l.get_tensor();
         if (l.data_type == data_types::f16) {
             VF<uint16_t> rnd_vec(s.count(), ov::float16(fill_value).to_bits());
+            set_values(prim, rnd_vec);
+        } else if (l.data_type == data_types::bf16) {
+            VF<uint16_t> rnd_vec(s.count(), ov::bfloat16(fill_value).to_bits());
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::f32) {
             VF<float> rnd_vec(s.count(), fill_value);
@@ -169,6 +175,9 @@ public:
         } else if (l.data_type == data_types::f16) {
             VF<ov::float16> rnd_vec = rg.generate_random_norepetitions<ov::float16>(s.count(), min, max);
             set_values(prim, rnd_vec);
+        } else if (l.data_type == data_types::bf16) {
+            VF<ov::bfloat16> rnd_vec = rg.generate_random_norepetitions<ov::bfloat16>(s.count(), min, max);
+            set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::i8) {
             VF<int8_t> rnd_vec = rg.generate_random_norepetitions<int8_t>(s.count(), min, max);
             set_values(prim, rnd_vec);
@@ -185,6 +194,9 @@ public:
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::f16) {
             VF<ov::float16> rnd_vec = rg.generate_random_1d<ov::float16>(s.count(), min, max);
+            set_values(prim, rnd_vec);
+        } else if (l.data_type == data_types::bf16) {
+            VF<ov::bfloat16> rnd_vec = rg.generate_random_1d<ov::bfloat16>(s.count(), min, max);
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::i8) {
             VF<int8_t> rnd_vec = rg.generate_random_1d<int8_t>(s.count(), min, max);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -128,6 +128,8 @@ static void compare_bfyx2blocked_with_ref(const std::string& kernel_name,
         compare_result<int64_t>(outputs_ref, outputs);
     else if (output_data_type == data_types::f16)
         compare_result<int16_t>(outputs_ref, outputs);
+    else if (output_data_type == data_types::bf16)
+        compare_result<int16_t>(outputs_ref, outputs);
     else if (output_data_type == data_types::f32)
         compare_result<float>(outputs_ref, outputs);
 }
@@ -150,10 +152,12 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_different
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::u8, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 8 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i64, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 16 + 2, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f16, format::b_fs_yx_fsv32, format::bfyx, 1, 64, 16 + 1, 2, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::bf16, format::b_fs_yx_fsv32, format::bfyx, 1, 64, 16 + 1, 2, 0, 0, false);
     // i32 -> other types
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::i8, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 8 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::i64, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 16 + 2, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::f16, format::b_fs_yx_fsv32, format::bfyx, 1, 64, 16 + 1, 2, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::bf16, format::b_fs_yx_fsv32, format::bfyx, 1, 64, 16 + 1, 2, 0, 0, false);
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_f32) {
@@ -178,11 +182,13 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_different
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i32, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i64, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f16, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::bf16, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
     // i32 -> other types
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::u8, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::i8, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::i64, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::f16, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::bf16, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::f32, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, false);
 }
 
@@ -238,6 +244,15 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f16) {
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f16, data_types::f16, format::bfyx, format::bs_fs_yx_bsv16_fsv32, 32 + 2, 48 + 3, 16 + 1, 4, 0, 0, false);
 }
 
+TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_bf16) {
+    // bfyx to double blocked format (bs_fs_yx_bsv16_fsv32)
+    compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::bf16, data_types::bf16, format::bfyx, format::bs_fs_yx_bsv16_fsv32, 32, 48, 8, 4, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::bf16, data_types::bf16, format::bfyx, format::bs_fs_yx_bsv16_fsv32, 32 + 2, 48, 16, 4, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::bf16, data_types::bf16, format::bfyx, format::bs_fs_yx_bsv16_fsv32, 32, 48 + 5, 16, 4, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::bf16, data_types::bf16, format::bfyx, format::bs_fs_yx_bsv16_fsv32, 32, 48, 48 + 3, 4, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::bf16, data_types::bf16, format::bfyx, format::bs_fs_yx_bsv16_fsv32, 32 + 2, 48 + 3, 16 + 1, 4, 0, 0, false);
+}
+
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv16_fsv32) {
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv16_fsv32, 3, 16, 4, 5, 7, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f32, format::bfzyx, format::bs_fs_zyx_bsv16_fsv32, 1, 1, 1, 1, 1, 0, false);
@@ -266,6 +281,7 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv3
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_format_different_datatype) {
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f16, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, false);
+    compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::bf16, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::i8, data_types::f32, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, false);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::i64, data_types::f32, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, false);
 }
@@ -306,6 +322,13 @@ static void compare_bfyx2blocked_with_ref_dynamic(const std::string& kernel_name
             for (auto it = input_ptr.begin(); it != input_ptr.end(); ++it) {
                 *it = i;
                 i = ov::float16(static_cast<float>(i) + 1.0f);
+            }
+        } else if (input_data_type == data_types::bf16) {
+            mem_lock<ov::bfloat16> input_ptr{input, *stream};
+            ov::bfloat16 i = ov::bfloat16(1.0f);
+            for (auto it = input_ptr.begin(); it != input_ptr.end(); ++it) {
+                *it = i;
+                i = ov::bfloat16(static_cast<float>(i) + 1.0f);
             }
         } else {
             mem_lock<float> input_ptr{input, *stream};
@@ -363,6 +386,8 @@ static void compare_bfyx2blocked_with_ref_dynamic(const std::string& kernel_name
         compare_result<int64_t>(outputs_ref, outputs_dyn);
     else if (output_data_type == data_types::f16)
         compare_result<int16_t>(outputs_ref, outputs_dyn);
+    else if (output_data_type == data_types::bf16)
+        compare_result<int16_t>(outputs_ref, outputs_dyn);
     else if (output_data_type == data_types::f32)
         compare_result<float>(outputs_ref, outputs_dyn);
 }
@@ -413,6 +438,13 @@ static void compare_fsv_reorder_with_ref_output_padding(const data_types input_d
                 *it = i;
                 i = ov::float16(static_cast<float>(i) + 1.0f);
             }
+        } else if (input_data_type == data_types::bf16) {
+            mem_lock<ov::bfloat16> input_ptr{input, *stream};
+            ov::bfloat16 i = ov::bfloat16(1.0f);
+            for (auto it = input_ptr.begin(); it != input_ptr.end(); ++it) {
+                *it = i;
+                i = ov::bfloat16(static_cast<float>(i) + 1.0f);
+            }
         } else {
             mem_lock<float> input_ptr{input, *stream};
             float i = 1.f;
@@ -457,6 +489,8 @@ static void compare_fsv_reorder_with_ref_output_padding(const data_types input_d
     else if (output_data_type == data_types::i64)
         compare_result<int64_t>(outputs_ref, outputs_opt);
     else if (output_data_type == data_types::f16)
+        compare_result<int16_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::bf16)
         compare_result<int16_t>(outputs_ref, outputs_opt);
     else if (output_data_type == data_types::f32)
         compare_result<float>(outputs_ref, outputs_opt);
@@ -528,6 +562,8 @@ static void compare_fsv_reorder_with_ref_padding(const data_types input_data_typ
         fill_fsv_reorder_input<uint8_t>(input, padded_input_layout, b_in, f_in, x_in, y_in, z_in, w_in);
     } else if (input_data_type == data_types::f16) {
         fill_fsv_reorder_input<ov::float16>(input, padded_input_layout, b_in, f_in, x_in, y_in, z_in, w_in);
+    } else if (input_data_type == data_types::bf16) {
+        fill_fsv_reorder_input<ov::bfloat16>(input, padded_input_layout, b_in, f_in, x_in, y_in, z_in, w_in);
     } else {
         fill_fsv_reorder_input<float>(input, padded_input_layout, b_in, f_in, x_in, y_in, z_in, w_in);
     }
@@ -566,6 +602,8 @@ static void compare_fsv_reorder_with_ref_padding(const data_types input_data_typ
     else if (output_data_type == data_types::i64)
         compare_result<int64_t>(outputs_ref, outputs_opt);
     else if (output_data_type == data_types::f16)
+        compare_result<int16_t>(outputs_ref, outputs_opt);
+    else if (output_data_type == data_types::bf16)
         compare_result<int16_t>(outputs_ref, outputs_opt);
     else if (output_data_type == data_types::f32)
         compare_result<float>(outputs_ref, outputs_opt);
@@ -615,6 +653,11 @@ TEST(reorder_gpu_optimization, dynamic_bfyx_to_blocked_f16) {
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_bfyx_to_blocked_format", data_types::f16, data_types::f16, format::bfyx, format::b_fs_yx_fsv16, 2, 37, 13, 4, 0, 0);
 }
 
+TEST(reorder_gpu_optimization, dynamic_bfyx_to_blocked_bf16) {
+    compare_bfyx2blocked_with_ref_dynamic("reorder_data_bfyx_to_blocked_format", data_types::bf16, data_types::bf16, format::bfzyx, format::b_fs_zyx_fsv32, 1, 320, 8, 8, 8, 0);
+    compare_bfyx2blocked_with_ref_dynamic("reorder_data_bfyx_to_blocked_format", data_types::bf16, data_types::bf16, format::bfyx, format::b_fs_yx_fsv16, 2, 37, 13, 4, 0, 0);
+}
+
 TEST(reorder_gpu_optimization, dynamic_bfyx_to_blocked_u8) {
     // nnUNet actual pattern: u8:bfzyx -> u8:b_fs_zyx_fsv32
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_bfyx_to_blocked_format", data_types::u8, data_types::u8, format::bfzyx, format::b_fs_zyx_fsv32, 1, 320, 8, 8, 8, 0);
@@ -658,11 +701,18 @@ TEST(reorder_gpu_optimization, dynamic_fsv_reorder_f16) {
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_fsv", data_types::f16, data_types::f16, format::b_fs_yx_fsv32, format::b_fs_yx_fsv16, 2, 64, 16, 8, 0, 0);
 }
 
+TEST(reorder_gpu_optimization, dynamic_fsv_reorder_bf16) {
+    compare_bfyx2blocked_with_ref_dynamic("reorder_data_fsv", data_types::bf16, data_types::bf16, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32, 1, 32, 8, 8, 8, 0);
+    compare_bfyx2blocked_with_ref_dynamic("reorder_data_fsv", data_types::bf16, data_types::bf16, format::b_fs_yx_fsv32, format::b_fs_yx_fsv16, 2, 64, 16, 8, 0, 0);
+}
+
 TEST(reorder_gpu_optimization, dynamic_fsv_reorder_cross_type) {
     // Cross-type: u8 -> f32 with format change
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_fsv", data_types::u8, data_types::f32, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv32, 1, 32, 8, 8, 4, 0);
     // Cross-type: f16 -> f32 with format change
     compare_bfyx2blocked_with_ref_dynamic("reorder_data_fsv", data_types::f16, data_types::f32, format::b_fs_yx_fsv32, format::b_fs_yx_fsv16, 2, 48, 16, 8, 0, 0);
+    // Cross-type: bf16 -> f32 with format change
+    compare_bfyx2blocked_with_ref_dynamic("reorder_data_fsv", data_types::bf16, data_types::f32, format::b_fs_yx_fsv32, format::b_fs_yx_fsv16, 2, 48, 16, 8, 0, 0);
 }
 
 TEST(reorder_gpu_optimization, fsv_reorder_output_padding_feature_axis) {
@@ -1275,6 +1325,98 @@ TEST(reorder_gpu_f16, basic_subtract_f32_output_f32) {
     }
 }
 
+TEST(reorder_gpu_bf16, basic_subtract_f32_output_f32) {
+    //  Input               : 2x2x2x2 (BF16)
+    //  Output              : 2x2x2x2 (FP32)
+    //  Subtract            : 1x2x2x2 (FP32, only first batch is taken into consideration)
+    //
+    //  Input:
+    //  f0: b0:  1    2  b1:   0    0
+    //  f0: b0:  3    4  b1:   0.5 -0.5
+    //  f1: b0:  5    6  b1:   1.5  5.2
+    //  f1: b0:  7    8  b1:   12   8
+    //
+    //  Subtract (FP32 - converted internally to BF16 before subtraction):
+    //  f0: b0:  1    1.5
+    //  f0: b0:  2    2.5
+    //  f1: b0:  4    3
+    //  f1: b0:  2    1
+    //
+    //
+    //  Output:
+    //  b0 f0:  0    0.5
+    //  b0 f0:  1    1.5
+    //
+    //  b0 f1:  1    3
+    //  b0 f1:  5    7
+    //
+    //  b1 f0: -1   -1.5
+    //  b1 f0: -1.5 -3
+    //
+    //  b1 f1: -2.5  2.2
+    //  b1 f1: 10    7
+    //
+
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory({ data_types::bf16, format::yxfb, { 2, 2, 2, 2 } });
+    layout output_layout(data_types::f32, format::bfyx,{ 2, 2, 2, 2 });
+    auto subtract = engine.allocate_memory({ data_types::f32, format::byxf, { 1, 2, 2, 2 } });
+
+    set_values(input, {
+        ov::bfloat16(1.f), ov::bfloat16(0.f),
+        ov::bfloat16(5.f), ov::bfloat16(1.5f),
+
+        ov::bfloat16(2.f), ov::bfloat16(0.f),
+        ov::bfloat16(6.f), ov::bfloat16(5.2f),
+
+        ov::bfloat16(3.f), ov::bfloat16(0.5f),
+        ov::bfloat16(7.f), ov::bfloat16(12.f),
+
+        ov::bfloat16(4.f), ov::bfloat16(-0.5f),
+        ov::bfloat16(8.f), ov::bfloat16(8.f)
+    });
+
+    set_values(subtract, {
+        1.0f,  4.0f,      1.5f,  3.0f,
+        2.0f,  2.0f,      2.5f,  1.0f,
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(data("subtract", subtract));
+    topology.add(reorder("reorder", input_info("input"), output_layout, "subtract"));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
+
+    auto output = outputs.begin()->second.get_memory();
+
+    float answers[16] = { 0.0f,  0.5f,
+                          1.0f,  1.5f,
+
+                          1.0f,  3.0f,
+                          5.0f,  7.0f,
+
+                         -1.0f, -1.5f,
+                         -1.5f, -3.0f,
+
+                         -2.5f,  2.2f,
+                         10.0f,  7.0f
+    };
+
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    for (int i = 0; i < 16; i++)
+    {
+        // Relaxed tolerance: bf16 has only ~8 mantissa bits (~0.8% relative precision).
+        ASSERT_TRUE(are_equal(answers[i], output_ptr[i], 1e-2f));
+    }
+}
+
 TEST(reorder_gpu_f16, basic_subtract_value) {
     //  Values_to_subtract  : 2
     //  Input               : 2x2x2x2 (FP16)
@@ -1360,6 +1502,89 @@ TEST(reorder_gpu_f16, basic_subtract_value) {
     }
 }
 
+TEST(reorder_gpu_bf16, basic_subtract_value) {
+    //  Values_to_subtract  : 2
+    //  Input               : 2x2x2x2 (BF16)
+    //  Output              : 2x2x2x2 (BF16)
+    //
+    //  Input:
+    //  f0: b0:  1    2  b1:   0    0
+    //  f0: b0:  3    4  b1:   0.5 -0.5
+    //  f1: b0:  5    6  b1:   1.5  5.2
+    //  f1: b0:  7    8  b1:   12   8
+    //
+    //  subtract values (FP32 - converted internally to BF16 before subtraction)
+    //  f0: 0.5
+    //  f1: 2.5
+    //
+    //  Output:
+    //  b0 f0:  0.5  1.5
+    //  b0 f0:  2.5  3.5
+    //
+    //  b0 f1:  2.5  3.5
+    //  b0 f1:  4.5  5.5
+    //
+    //  b1 f0: -0.5 -0.5
+    //  b1 f0:  0.0 -1.0
+    //
+    //  b1 f1: -1.0  2.7
+    //  b1 f1:  9.5  5.5
+    //
+
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory({ data_types::bf16, format::yxfb, { 2, 2, 2, 2 } });
+    layout output_layout(data_types::bf16, format::bfyx,{ 2, 2, 2, 2 });
+    std::vector<float> subtract_val = { 0.5, 2.5 };
+
+    set_values(input, {
+        ov::bfloat16(1.f), ov::bfloat16(0.f),
+        ov::bfloat16(5.f), ov::bfloat16(1.5f),
+
+        ov::bfloat16(2.f), ov::bfloat16(0.f),
+        ov::bfloat16(6.f), ov::bfloat16(5.2f),
+
+        ov::bfloat16(3.f), ov::bfloat16(0.5f),
+        ov::bfloat16(7.f), ov::bfloat16(12.f),
+
+        ov::bfloat16(4.f), ov::bfloat16(-0.5f),
+        ov::bfloat16(8.f), ov::bfloat16(8.f)
+    });
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(reorder("reorder", input_info("input"), output_layout, subtract_val));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
+
+    auto output = outputs.begin()->second.get_memory();
+
+    float answers[16] = { 0.5f, 1.5f,
+                          2.5f, 3.5f,
+
+                          2.5f, 3.5f,
+                          4.5f, 5.5f,
+
+                         -0.5f, -0.5f,
+                          0.f, -1.f,
+
+                         -1.f, 2.7f,
+                          9.5f, 5.5f
+    };
+
+    cldnn::mem_lock<ov::bfloat16> output_ptr(output, get_test_stream());
+    for (int i = 0; i < 16; i++)
+    {
+        // Relaxed tolerance: bf16 has only ~8 mantissa bits (~0.8% relative precision).
+        ASSERT_TRUE(are_equal(answers[i], static_cast<float>(output_ptr[i]), 1e-2f));
+    }
+}
+
 TEST(reorder_gpu, basic_convert_f16_f32_f16) {
     //  Converts entire unambiguous range of FP16 numbers to FP32 and back.
     //
@@ -1437,6 +1662,82 @@ TEST(reorder_gpu, basic_convert_f16_f32_f16) {
     auto output = outputs.at("reorder_f32_f16").get_memory();
     cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 0xF802; ++i) // NOTE: do not test for possibly ambiguous values of floating point (-0, NaNs).
+    {
+        ASSERT_TRUE(are_equal(static_cast<uint16_t>(expected_values[i]), static_cast<uint16_t>(output_ptr[i])));
+    }
+}
+
+TEST(reorder_gpu, basic_convert_bf16_f32_bf16) {
+    //  Converts entire unambiguous range of BF16 numbers to FP32 and back.
+    //
+    //  BF16 layout: sign(1) + exponent(8) + mantissa(7), i.e. the high 16 bits of FP32.
+    //  +infinity = 0x7F80, -infinity = 0xFF80.
+    //
+    //  Output is expected to contain the same value as input in range of indices from 0x0000 to 0xFF01.
+    //
+
+    auto& engine = get_test_engine();
+
+    std::vector<ov::bfloat16> expected_values;
+    expected_values.resize(0xFF04);
+    for (int i = 0; i < 0x7F80; ++i)
+        expected_values[i] = ov::bfloat16::from_bits(i);          // norms/denorms/zero (positive).
+    for (int i = 0x7F80; i < 0xFF00; ++i)
+        expected_values[i] = ov::bfloat16::from_bits(i + 0x0080); // norms/denorms (negative).
+    expected_values[0x7F80] = ov::bfloat16::from_bits(0x0000);    // NOTE: do not do final test for negative 0 (-0).
+    // Special values.
+    expected_values[0xFF00] = ov::bfloat16::from_bits(0x7F80);    // +infinity
+    expected_values[0xFF01] = ov::bfloat16::from_bits(0xFF80);    // -infinity
+    // Special values (ambiguous ones).
+    expected_values[0xFF02] = ov::bfloat16::from_bits(0x8000);    // -0
+    expected_values[0xFF03] = ov::bfloat16::from_bits(0xFF92);    // A NaN (sample: -NaN.0x12).
+
+    auto input = engine.allocate_memory({ data_types::bf16, format::yxfb, { 1, static_cast<int32_t>(expected_values.size()) / 4, 2, 2 } });
+    layout interm_layout( data_types::f32, format::byxf, { 1, static_cast<int32_t>(expected_values.size()) / 4, 2, 2 });
+    auto output_layout = input->get_layout();
+
+    set_values(input, expected_values);
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(reorder("reorder_bf16_f32", input_info("input"), interm_layout));
+    topology.add(reorder("reorder_f32_bf16", input_info("reorder_bf16_f32"), output_layout));
+
+    ExecutionConfig cfg = get_test_default_config(engine);
+    cfg.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"reorder_bf16_f32", "reorder_f32_bf16"}));
+    network network(engine, topology, cfg);
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(2));
+    ASSERT_TRUE(outputs.find("reorder_bf16_f32") != outputs.end());
+    ASSERT_TRUE(outputs.find("reorder_f32_bf16") != outputs.end());
+
+    auto interm = outputs.at("reorder_bf16_f32").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> interm_ptr(interm, get_test_stream());
+
+    // Sample positive.
+    ASSERT_TRUE(are_equal(interm_ptr[0x3E80], 0.25f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3F00], 0.5f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3F80], 1.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x4000], 2.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x4080], 4.0f));
+    // Sample negative.
+    ASSERT_TRUE(are_equal(interm_ptr[0x3E80 + 0x7F80], -0.25f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3F00 + 0x7F80], -0.5f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x3F80 + 0x7F80], -1.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x4000 + 0x7F80], -2.0f));
+    ASSERT_TRUE(are_equal(interm_ptr[0x4080 + 0x7F80], -4.0f));
+    // Special values.
+    ASSERT_TRUE(are_equal(interm_ptr[0xFF00], std::numeric_limits<float>::infinity()));
+    ASSERT_TRUE(are_equal(interm_ptr[0xFF01], -std::numeric_limits<float>::infinity()));
+    ASSERT_TRUE(are_equal(interm_ptr[0xFF02], -0.0f));
+    ASSERT_TRUE(std::isnan(interm_ptr[0xFF03]));
+
+    auto output = outputs.at("reorder_f32_bf16").get_memory();
+    cldnn::mem_lock<ov::bfloat16, mem_lock_type::read> output_ptr(output, get_test_stream());
+    for (int i = 0; i < 0xFF02; ++i) // NOTE: do not test for possibly ambiguous values of floating point (-0, NaNs).
     {
         ASSERT_TRUE(are_equal(static_cast<uint16_t>(expected_values[i]), static_cast<uint16_t>(output_ptr[i])));
     }
@@ -1937,6 +2238,68 @@ TEST(reorder_gpu_f32, dynamic_bfyx_to_bfyx_dynamic_padding_x) {
 
 }
 
+TEST(reorder_gpu_bf16, dynamic_bfyx_to_bfyx_dynamic_padding_x) {
+    auto& engine = get_test_engine();
+
+    ov::Shape in_shape{1, 1, 4, 2};
+    padding::DynamicDimsMask dyn_pad_dims("1000"); // {0, 0, 0, 1}
+    layout in_dynamic_layout{ov::PartialShape::dynamic(in_shape.size()),
+                             data_types::bf16,
+                             format::bfyx,
+                             padding({0, 0, 0, 0}, {0, 0, 0, 0}, dyn_pad_dims /*dynamic_pad_dim : x*/)};
+
+    std::vector<float> subtract_val = {};
+    topology topology(input_layout("input", in_dynamic_layout),
+                      reorder("reorder",
+                              input_info("input"),
+                              format::bfyx,
+                              data_types::f32,
+                              subtract_val,
+                              cldnn::reorder_mean_mode::subtract,
+                              padding({0, 0, 0, 0}, {0, 0, 0, 0}, 0.0f)));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(false));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+    auto input_mem = engine.allocate_memory({ov::PartialShape(in_shape),
+                                             data_types::bf16,
+                                             format::bfyx,
+                                             padding({0, 0, 0, 2}, {0, 0, 0, 1}, dyn_pad_dims)});
+    set_values<ov::bfloat16>(input_mem, {
+        ov::bfloat16(0.f), ov::bfloat16(0.f), // padding
+        ov::bfloat16(1.f), ov::bfloat16(2.f), // data
+        ov::bfloat16(0.f),               // padding
+
+        ov::bfloat16(0.f), ov::bfloat16(0.f), // padding
+        ov::bfloat16(3.f), ov::bfloat16(4.f), // data
+        ov::bfloat16(0.f),               // padding
+
+        ov::bfloat16(0.f), ov::bfloat16(0.f), // padding
+        ov::bfloat16(5.f), ov::bfloat16(6.f), // data
+        ov::bfloat16(0.f),               // padding
+
+        ov::bfloat16(0.f), ov::bfloat16(0.f), // padding
+        ov::bfloat16(7.f), ov::bfloat16(8.f), // data
+        ov::bfloat16(0.f),               // padding
+    });
+
+    network.set_input_data("input", input_mem);
+
+    auto outputs = network.execute();
+    auto output = outputs.begin()->second.get_memory();
+
+    float answer[8] = {
+        1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f
+    };
+
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+    for (int i = 0; i < 8; i++) {
+        ASSERT_NEAR(answer[i], output_ptr[i], 1e-2f);
+    }
+
+}
+
 TEST(reorder_gpu_f32, dynamic_bfyx_to_bfyx_dynamic_padding_f) {
     auto& engine = get_test_engine();
 
@@ -1979,6 +2342,66 @@ TEST(reorder_gpu_f32, dynamic_bfyx_to_bfyx_dynamic_padding_f) {
         ov::float16(33.f), ov::float16(44.f), // b1 f1
         ov::float16(55.f), ov::float16(66.f), // b1 f2
         ov::float16(0.f), ov::float16(0.f),   // f after
+    });
+
+    network.set_input_data("input", input_mem);
+
+    auto outputs = network.execute();
+    auto output = outputs.begin()->second.get_memory();
+
+    float answer[12] = {
+        1.f, 2.f, 3.f, 4.f, 5.f, 6.f,
+        11.f, 22.f, 33.f, 44.f, 55.f, 66.f
+    };
+
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+    for (int i = 0; i < 12; i++) {
+        ASSERT_NEAR(answer[i], output_ptr[i], 1e-2f);
+    }
+}
+
+TEST(reorder_gpu_bf16, dynamic_bfyx_to_bfyx_dynamic_padding_f) {
+    auto& engine = get_test_engine();
+
+    ov::Shape in_shape{2, 3, 2, 1};
+    padding::DynamicDimsMask dyn_pad_dims("10");
+    layout in_dynamic_layout{ov::PartialShape::dynamic(in_shape.size()),
+                             data_types::bf16,
+                             format::bfyx,
+                             padding({0, 0, 0, 0}, {0, 0, 0, 0}, dyn_pad_dims)};
+
+    std::vector<float> subtract_val = {};
+    topology topology(input_layout("input", in_dynamic_layout),
+                      reorder("reorder",
+                              input_info("input"),
+                              format::bfyx,
+                              data_types::f32,
+                              subtract_val,
+                              cldnn::reorder_mean_mode::subtract,
+                              padding({0, 0, 0, 0}, {0, 0, 0, 0}, 0.0f)));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(false));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+    auto input_mem = engine.allocate_memory({ov::PartialShape(in_shape),
+                                             data_types::bf16,
+                                             format::bfyx,
+                                             padding({0, 2, 0, 0}, {0, 1, 0, 0}, dyn_pad_dims)});
+    set_values<ov::bfloat16>(input_mem, {
+        ov::bfloat16(0.f), ov::bfloat16(0.f), // f before
+        ov::bfloat16(0.f), ov::bfloat16(0.f), // f before
+        ov::bfloat16(1.f), ov::bfloat16(2.f), // b0 f0
+        ov::bfloat16(3.f), ov::bfloat16(4.f), // b0 f1
+        ov::bfloat16(5.f), ov::bfloat16(6.f), // b0 f2
+        ov::bfloat16(0.f), ov::bfloat16(0.f), // f after
+
+        ov::bfloat16(0.f), ov::bfloat16(0.f),   // f before
+        ov::bfloat16(0.f), ov::bfloat16(0.f),   // f before
+        ov::bfloat16(11.f), ov::bfloat16(22.f), // b1 f0
+        ov::bfloat16(33.f), ov::bfloat16(44.f), // b1 f1
+        ov::bfloat16(55.f), ov::bfloat16(66.f), // b1 f2
+        ov::bfloat16(0.f), ov::bfloat16(0.f),   // f after
     });
 
     network.set_input_data("input", input_mem);
@@ -2050,6 +2473,75 @@ TEST(reorder_gpu_f32, dynamic_bfyx_to_bfzyx) {
 
         2.f, 0.f,
         6.f, 5.2f,
+
+        3.f, 0.5f,
+        7.f, 12.f,
+
+        4.f, -0.5f,
+        8.f, 8.f
+    };
+
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    for (int i = 0; i < 16; i++) {
+        ASSERT_NEAR(answers[i], output_ptr[i], 1e-2f);
+    }
+}
+
+TEST(reorder_gpu_bf16, dynamic_bfyx_to_bfzyx) {
+    auto& engine = get_test_engine();
+
+    ov::Shape in_shape{ 1, 2, 4, 2 };
+    layout in_layout{ov::PartialShape::dynamic(in_shape.size()), data_types::bf16, format::bfyx};
+    auto input = engine.allocate_memory({ov::PartialShape(in_shape), data_types::bf16, format::bfyx});
+
+    set_values<ov::bfloat16>(input, {
+        ov::bfloat16(1.f), ov::bfloat16(0.f),
+        ov::bfloat16(5.f), ov::bfloat16(1.5f),
+
+        ov::bfloat16(2.f), ov::bfloat16(0.f),
+        ov::bfloat16(6.f), ov::bfloat16(5.2f),
+
+        ov::bfloat16(3.f), ov::bfloat16(0.5f),
+        ov::bfloat16(7.f), ov::bfloat16(12.f),
+
+        ov::bfloat16(4.f), ov::bfloat16(-0.5f),
+        ov::bfloat16(8.f), ov::bfloat16(8.f)
+    });
+
+    topology topology(
+        input_layout("input", in_layout),
+        reorder("reorder", input_info("input"), format::bfzyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+
+    auto inst = network.get_primitive("reorder");
+    auto impl = inst->get_impl();
+    ASSERT_TRUE(impl != nullptr);
+    ASSERT_TRUE(impl->is_dynamic());
+
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
+
+    auto output = outputs.begin()->second.get_memory();
+    ASSERT_TRUE(output->get_layout().format == format::bfzyx);
+    auto l = output->get_layout();
+    auto expected_shape = ov::PartialShape(in_shape);
+    ASSERT_EQ(l.get_partial_shape(), expected_shape);
+
+    // Expected values are compared against their bf16-rounded representation
+    // since bf16 (7 mantissa bits) cannot exactly represent values like 5.2.
+    float answers[16] = {
+        1.f, 0.f,
+        5.f, 1.5f,
+
+        2.f, 0.f,
+        6.f, static_cast<float>(ov::bfloat16(5.2f)),
 
         3.f, 0.5f,
         7.f, 12.f,
@@ -2582,6 +3074,37 @@ TEST(reorder_gpu_opt, mean_div)
     for (auto& val : ptr)
         ASSERT_FLOAT_EQ(*(a_ptr++), val);
 
+}
+
+TEST(reorder_gpu_bf16, subtract_bf16_mean_buffer_from_f32_input) {
+    auto& engine = get_test_engine();
+
+    auto in = engine.allocate_memory({ov::PartialShape{1, 3, 1, 2}, data_types::f32, format::bfyx});
+    auto sub = engine.allocate_memory({ov::PartialShape{1, 3, 1, 2}, data_types::bf16, format::bfyx});
+
+    set_values(in, {1.5f, 2.75f, 3.5f, 4.25f, 5.5f, 6.75f});
+    set_values(sub, {ov::bfloat16(0.5f), ov::bfloat16(0.25f), ov::bfloat16(0.5f), ov::bfloat16(0.25f), ov::bfloat16(0.5f), ov::bfloat16(0.25f)});
+
+    topology tpl{
+        input_layout("in", in->get_layout()),
+        data("sub", sub),
+        reorder("r1", input_info("in"), in->get_layout(), "sub"),
+    };
+
+    ExecutionConfig config = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc reorder_impl = {format::bfyx, "reorder_data"};
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"r1", reorder_impl}}));
+
+    network net(engine, tpl, config);
+    net.set_input_data("in", in);
+
+    auto outputs = net.execute();
+    mem_lock<float> ptr(outputs.at("r1").get_memory(), net.get_stream());
+    std::vector<float> expected = {1.0f, 2.5f, 3.0f, 4.0f, 5.0f, 6.5f};
+    ASSERT_EQ(ptr.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_FLOAT_EQ(ptr[i], expected[i]) << "i=" << i;
+    }
 }
 
 TEST(reorder_gpu_opt, mean_mul_val)
@@ -3498,6 +4021,52 @@ TEST(reorder_image2d_rgba_to_bfyx_gpu, basic)
 
 }
 
+TEST(reorder_image2d_rgba_to_bfyx_gpu, basic_bf16)
+{
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory({ data_types::u8, format::image_2d_rgba, { 1, 3, 2, 2 } });
+    layout output_layout(data_types::bf16, format::bfyx, { 1, 3, 2, 2 });
+
+    set_values<unsigned char>(input, {
+        1, 0, 5, 7,
+        2, 111, 123, 8,
+        124, 125, 50, 9,
+        251, 252, 253, 210
+        });
+
+    topology topology(
+        input_layout("input", input->get_layout()),
+        reorder("reorder", input_info("input"), output_layout));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "reorder");
+
+    auto output = outputs.begin()->second.get_memory();
+
+    float answers[12] = {
+        1.0f,  2.0f,
+        124.0f,  251.0f,
+
+        0.0f,  111.0f,
+        125.0f,  252.0f,
+
+        5.0f,  123.0f,
+        50.0f, 253.0f,
+    };
+
+    cldnn::mem_lock<ov::bfloat16> output_ptr (output, get_test_stream());
+    for (int i = 0; i < 12; i++)
+    {
+        ASSERT_NEAR(ov::bfloat16(answers[i] / 255.f), output_ptr[i], 1e-2f);
+    }
+
+}
+
 TEST(reorder_bfyx_to_image2d_rgba_gpu, basic)
 {
     auto& engine = get_test_engine();
@@ -3543,8 +4112,6 @@ TEST(reorder_bfyx_to_image2d_rgba_gpu, basic)
     }
 
 }
-
-using namespace cldnn;
 
 class reorder_test : public tests::generic_test
 {
@@ -3748,6 +4315,9 @@ public:
             set_values(prim, rnd_vec);
         } else if (l.data_type == data_types::f16) {
             VF<uint16_t> rnd_vec = rg.generate_random_1d<uint16_t>(s.count(), -1, 1);
+            set_values(prim, rnd_vec);
+        } else if (l.data_type == data_types::bf16) {
+            VF<ov::bfloat16> rnd_vec = rg.generate_random_1d<ov::bfloat16>(s.count(), -1, 1);
             set_values(prim, rnd_vec);
         } else {
             VF<float> rnd_vec = rg.generate_random_1d<float>(s.count(), -1, 1);
@@ -4097,10 +4667,12 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv32_to_bfyx_different
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::u8, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 8 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i64, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 16 + 2, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f16, format::b_fs_yx_fsv32, format::bfyx, 1, 64, 16 + 1, 2, 0, 0, true);
+    compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::bf16, format::b_fs_yx_fsv32, format::bfyx, 1, 64, 16 + 1, 2, 0, 0, true);
     // i32 -> other types
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::i8, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 8 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::i64, format::b_fs_yx_fsv32, format::bfyx, 2, 64, 16 + 2, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::f16, format::b_fs_yx_fsv32, format::bfyx, 1, 64, 16 + 1, 2, 0, 0, true);
+    compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::bf16, format::b_fs_yx_fsv32, format::bfyx, 1, 64, 16 + 1, 2, 0, 0, true);
 }
 
 TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_f32_cached) {
@@ -4125,11 +4697,13 @@ TEST(reorder_gpu_optimization, compare_with_ref__b_fs_yx_fsv16_to_bfyx_different
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i32, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::i64, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::f16, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
+    compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::f32, data_types::bf16, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     // i32 -> other types
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::u8, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::i8, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::i64, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::f16, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
+    compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::bf16, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_b_fs_yx_fsv16_fsv32_to_bfyx", data_types::i32, data_types::f32, format::b_fs_yx_fsv16, format::bfyx, 2, 32, 16 + 7, 2, 0, 0, true);
 }
 
@@ -4197,6 +4771,7 @@ TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_double_blocked_f32_bsv3
 
 TEST(reorder_gpu_optimization, compare_with_ref__bfyx_to_blocked_format_different_datatype_cached) {
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::f16, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);
+    compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::f32, data_types::bf16, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::i8, data_types::f32, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);
     compare_bfyx2blocked_with_ref("reorder_data_bfyx_to_blocked_format", data_types::i64, data_types::f32, format::bfyx, format::b_fs_yx_fsv16, 3, 32 + 4, 16 + 7, 2, 0, 0, true);
 }
@@ -4367,6 +4942,7 @@ TEST(reorder_weight_gpu_i4, reorder_for_padding_4d)
     run_reorder_weight_int4({2, 2, 2, 7}, {0, 0, 0, 1});
 }
 
+template <typename T>
 static void run_reorder_uint4(const ov::Shape in_shape) {
     auto& engine = get_test_engine();
 
@@ -4382,7 +4958,7 @@ static void run_reorder_uint4(const ov::Shape in_shape) {
 
     topology topology(
         input_layout("input", input->get_layout()),
-        reorder("reorder", input_info("input"), format::bfyx, data_types::f16));
+        reorder("reorder", input_info("input"), format::bfyx, element_type_to_data_type(ov::element::from<T>())));
 
     auto config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
@@ -4397,14 +4973,14 @@ static void run_reorder_uint4(const ov::Shape in_shape) {
 
     auto output = outputs.begin()->second.get_memory();
 
-    std::vector<ov::float16> expected_data  = {
+    std::vector<T> expected_data  = {
         0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8,
         0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x1,
         0x5, 0x2, 0x3, 0x8, 0xa, 0x2, 0xd, 0x7,
         0xf, 0x9, 0x8, 0xe, 0x1, 0x5, 0x3, 0xa
     };
 
-    cldnn::mem_lock<ov::float16> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
     ASSERT_EQ(expected_data.size(), output_ptr.size());
     for (size_t idx = 0; idx < output_ptr.size(); idx++)
@@ -4414,7 +4990,12 @@ static void run_reorder_uint4(const ov::Shape in_shape) {
 
 TEST(reorder_gpu_i4, basic_uint4)
 {
-    run_reorder_uint4({32, 1, 1, 1});
+    run_reorder_uint4<ov::float16>({32, 1, 1, 1});
+}
+
+TEST(reorder_gpu_i4, basic_uint4_bf16)
+{
+    run_reorder_uint4<ov::bfloat16>({32, 1, 1, 1});
 }
 
 static uint8_t pack_int4(int8_t a, int8_t b) {
@@ -4423,13 +5004,14 @@ static uint8_t pack_int4(int8_t a, int8_t b) {
     return packed_a | packed_b;
 }
 
+template <typename T>
 static void run_reorder_int4(const ov::Shape in_shape) {
     auto& engine = get_test_engine();
 
     layout in_layout({in_shape, data_types::i4, format::bfyx});
     auto input = engine.allocate_memory(in_layout);
 
-    std::vector<ov::float16> expected_data  = {
+    std::vector<T> expected_data  = {
          1,  2,  3,  4,  5,  6,  7, -6,
         -7, -6, -5, -4, -3, -2, -1,  0,
         -1,  2, -3,  4, -5,  6, -7,  6,
@@ -4447,7 +5029,7 @@ static void run_reorder_int4(const ov::Shape in_shape) {
 
     topology topology(
         input_layout("input", input->get_layout()),
-        reorder("reorder", input_info("input"), format::bfyx, data_types::f16));
+        reorder("reorder", input_info("input"), format::bfyx, element_type_to_data_type(ov::element::from<T>())));
 
     auto config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
@@ -4463,7 +5045,7 @@ static void run_reorder_int4(const ov::Shape in_shape) {
     auto output = outputs.begin()->second.get_memory();
 
 
-    cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
     ASSERT_EQ(expected_data.size(), output_ptr.size());
     for (size_t idx = 0; idx < output_ptr.size(); idx++)
@@ -4473,7 +5055,12 @@ static void run_reorder_int4(const ov::Shape in_shape) {
 
 TEST(reorder_gpu_i4, basic_int4)
 {
-    run_reorder_int4({32, 1, 1, 1});
+    run_reorder_int4<ov::float16>({32, 1, 1, 1});
+}
+
+TEST(reorder_gpu_i4, basic_int4_bf16)
+{
+    run_reorder_int4<ov::bfloat16>({32, 1, 1, 1});
 }
 
 template <typename T>
@@ -4522,4 +5109,14 @@ TEST(reorder_gpu_i4, fp16_to_i4) {
 TEST(reorder_gpu_i4, fp16_to_u4) {
     std::vector<ov::float16> input_data = {ov::float16(-8.5f), ov::float16(7.2f), ov::float16(0.0f), ov::float16(6.0f)};
     run_reorder_test_i4(data_types::f16, data_types::u4, input_data, {0x70, 0x60});
+}
+
+TEST(reorder_gpu_i4, bf16_to_i4) {
+    std::vector<ov::bfloat16> input_data = {ov::bfloat16(-8.5f), ov::bfloat16(7.2f), ov::bfloat16(0.0f), ov::bfloat16(6.0f)};
+    run_reorder_test_i4(data_types::bf16, data_types::i4, input_data, {0x78, 0x60});
+}
+
+TEST(reorder_gpu_i4, bf16_to_u4) {
+    std::vector<ov::bfloat16> input_data = {ov::bfloat16(-8.5f), ov::bfloat16(7.2f), ov::bfloat16(0.0f), ov::bfloat16(6.0f)};
+    run_reorder_test_i4(data_types::bf16, data_types::u4, input_data, {0x70, 0x60});
 }

--- a/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.cpp
@@ -417,6 +417,8 @@ std::vector<cldnn::data_types> generic_test::test_data_types() {
 
 double default_tolerance(data_types dt) {
     switch (dt) {
+    case data_types::bf16:
+        return 1e-2;
     case data_types::f16:
         return 1e-3;
     case data_types::f32:

--- a/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.h
+++ b/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.h
@@ -369,6 +369,19 @@ inline bool floating_point_equal(ov::float16 x, ov::float16 y, int max_ulps_diff
     }
 }
 
+inline bool floating_point_equal(ov::bfloat16 x, ov::bfloat16 y, int max_ulps_diff = 4) {
+    int16_t sign_bit_mask = 1;
+    sign_bit_mask <<= 15;
+    int16_t a = reinterpret_cast<int16_t&>(x), b = reinterpret_cast<int16_t&>(y);
+    if ((a & sign_bit_mask) != (b & sign_bit_mask)) {
+        a &= ~sign_bit_mask;
+        b &= ~sign_bit_mask;
+        return a == 0 && b == 0;
+    } else {
+        return std::abs(a - b) < (1 << (max_ulps_diff));
+    }
+}
+
 inline bool floating_point_equal(float x, float y, int max_ulps_diff = 4) {
     int32_t sign_bit_mask = 1;
     sign_bit_mask <<= 31;
@@ -603,6 +616,8 @@ inline std::vector<float> get_output_values_to_float(cldnn::network& net, const 
     switch(output.get_layout().data_type){
         case cldnn::data_types::f16:
             return get_output_values_to_float<ov::float16>(net, output, max_cnt);
+        case cldnn::data_types::bf16:
+            return get_output_values_to_float<ov::bfloat16>(net, output, max_cnt);
         case cldnn::data_types::f32:
             return get_output_values_to_float<float>(net, output, max_cnt);
         case cldnn::data_types::i8:


### PR DESCRIPTION
[GPU] Add bf16 support for reorder kernel and compute type

#### Details:
Description of the issue (symptom, root-cause, how it was resolved)
•	Reorder kernel lacked native bf16 support, forcing implicit type conversions on bf16 data movement paths.
•	Added bf16 registration in CPU/OCL reorder impls, extended jitter with bf16 compute type handling, vector type conversions, and added bf16↔f32 OpenCL conversion utilities.

#### Implementation changes:
•	Extended jitter with GetComputeDatatype(), bf16-aware JIT generation, and vector type conversion macros.
•	Added bf16 conversion utilities in bf16_utils.cl (bf16_to_f32, f32_to_bf16 for scalars and vectors).
•	Added common_tools.h helpers for compute datatype resolution.
•	Updated kernel_base.cpp to use compute datatype for activation and fused op output.
•	Registered bf16 in CPU reorder implementation.
•	Updated all reorder kernel variants (data, fast_b1, fsv, biplanar_nv12, fs_b_yx_fsv32_to_bfyx, to_yxfb_batched, bfyx_to_blocked_format) to handle bf16 at data boundaries.
•	Removed bf16 exclusion from reorder kernel selector.
•	Added comprehensive bf16 reorder unit tests covering multiple formats, dynamic shapes, padding, i4/u4 conversions, and image2d paths.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model): NA

#### Problematic graph: NA

#### Checklist:
•	[x] Is it a proper fix? Yes (enables native bf16 reorder execution without implicit type conversions)
•	[x] Did you include test case for this fix, if necessary? Yes, comprehensive bf16 reorder tests added
•	[x] Did you review existing test that can be extended to cover this scenario? Yes, extended existing reorder and test infrastructure

#### Tickets:
•	CVS-189707

#### AI Assistance:
•	AI assistance used: yes — code structuring, test generation, commit formatting.