### PR TITLE
[core] Fix reshape to support only 1D as shape pattern

### DIFF
--- a/src/core/shape_inference/include/reshape_shape_inference.hpp
+++ b/src/core/shape_inference/include/reshape_shape_inference.hpp
@@ -270,10 +270,7 @@ std::vector<TRShape> shape_infer(const Reshape* op,
     const auto input_rank = input_shape.rank();
     const auto pattern_shape_rank = pattern_shape.rank();
 
-    NODE_SHAPE_INFER_CHECK(op,
-                           input_shapes,
-                           pattern_shape_rank.compatible(0) || pattern_shape_rank.compatible(1),
-                           "Pattern shape must have rank 1 or be empty");
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, pattern_shape_rank.compatible(1), "Pattern shape must have rank 1");
 
     auto output_shapes = std::vector<TRShape>(1);
     auto& output_shape = output_shapes[0];
@@ -284,13 +281,6 @@ std::vector<TRShape> shape_infer(const Reshape* op,
         const auto minus_one_idx = pattern_and_minus_one_idx.second;
 
         reshape::set_pattern_symbols(op, output_pattern);
-
-        if (pattern_shape_rank.get_max_length() == 0) {
-            NODE_VALIDATION_CHECK(op,
-                                  output_pattern[0] == 1,
-                                  "The value of scalar shape pattern should be equal to 1!");
-            output_pattern.resize(0);
-        }
 
         const auto special_zero = op->get_special_zero();
 
@@ -375,15 +365,8 @@ std::vector<TRShape> shape_infer(const Reshape* op,
                                    " is incompatible with input shape");
         }
     } else if (pattern_shape_rank.is_static()) {
-        if (pattern_shape_rank.get_length() == 0) {
-            NODE_SHAPE_INFER_CHECK(op,
-                                   input_shapes,
-                                   input_rank.compatible(0),
-                                   "Input must be scalar as pattern is scalar!");
-        } else {
-            output_shape =
-                PartialShape::dynamic(Rank(pattern_shape[0].get_min_length(), pattern_shape[0].get_max_length()));
-        }
+        output_shape =
+            PartialShape::dynamic(Rank(pattern_shape[0].get_min_length(), pattern_shape[0].get_max_length()));
     } else {
         output_shape = PartialShape::dynamic();
     }

--- a/src/core/tests/type_prop/reshape.cpp
+++ b/src/core/tests/type_prop/reshape.cpp
@@ -628,7 +628,7 @@ TEST(type_prop, reshape_to_zero) {
 TEST(type_prop, reshape_to_scalar) {
     auto param = make_shared<ov::op::v0::Parameter>(element::f32, Shape{});
     auto r = make_shared<op::v1::Reshape>(param,
-                                          ov::op::v0::Constant::create(element::i64, {}, std::vector<int64_t>{1}),
+                                          ov::op::v0::Constant::create(element::i64, {0}, std::vector<int64_t>{}),
                                           false);
     ASSERT_EQ(r->get_element_type(), element::f32);
     ASSERT_EQ(r->get_output_shape(0), (Shape{}));
@@ -637,7 +637,7 @@ TEST(type_prop, reshape_to_scalar) {
 TEST(type_prop, reshape_to_scalar_2) {
     auto param = make_shared<ov::op::v0::Parameter>(element::f32, Shape{});
     auto r = make_shared<op::v1::Reshape>(param,
-                                          ov::op::v0::Constant::create(element::i64, {}, std::vector<int64_t>{1}),
+                                          ov::op::v0::Constant::create(element::i64, {0}, std::vector<int64_t>{}),
                                           false);
     ASSERT_EQ(r->get_element_type(), element::f32);
     ASSERT_EQ(r->get_output_shape(0), (Shape{}));
@@ -648,10 +648,10 @@ TEST(type_prop, reshape_to_scalar_3) {
 
     OV_EXPECT_THROW(
         ignore = make_shared<op::v1::Reshape>(param,
-                                              op::v0::Constant::create(element::i64, {}, std::vector<int64_t>{100}),
+                                              op::v0::Constant::create(element::i64, {0}, std::vector<int64_t>{}),
                                               false),
         NodeValidationFailure,
-        HasSubstr("The value of scalar shape pattern should be equal to 1"));
+        HasSubstr("Requested output shape [] is incompatible with input shape"));
 }
 
 TEST(type_prop, reshape_to_scalar_4) {
@@ -659,7 +659,7 @@ TEST(type_prop, reshape_to_scalar_4) {
 
     OV_EXPECT_THROW(
         ignore = make_shared<op::v1::Reshape>(param,
-                                              op::v0::Constant::create(element::i64, {}, std::vector<int64_t>{1}),
+                                              op::v0::Constant::create(element::i64, {0}, std::vector<int64_t>{}),
                                               false),
         NodeValidationFailure,
         HasSubstr("Requested output shape [] is incompatible with input shape"));
@@ -726,11 +726,11 @@ TEST(type_prop, reshape_when_pattern_has_interval_shape_only) {
 
 TEST(type_prop, reshape_when_pattern_has_scalar_shape_only) {
     auto param = make_shared<op::v0::Parameter>(element::f32, Shape{3, 4});
-    auto shape_pattern = make_shared<op::v0::Parameter>(element::u64, PartialShape{});
+    auto shape_pattern = make_shared<Constant>(element::u64, Shape{0});
 
     OV_EXPECT_THROW(ignore = make_shared<op::v1::Reshape>(param, shape_pattern, false),
                     NodeValidationFailure,
-                    HasSubstr("Input must be scalar as pattern is scalar!"));
+                    HasSubstr("Requested output shape [] is incompatible with input shape"));
 }
 
 TEST(type_prop, reshape_symbol_propagation) {
@@ -831,7 +831,7 @@ TEST(type_prop, reshape_pattern_shape_not_1d) {
         ignore =
             make_shared<op::v1::Reshape>(param, op::v0::Constant::create(element::u64, {3, 1}, Shape{3, 5, 4}), false),
         NodeValidationFailure,
-        HasSubstr("Pattern shape must have rank 1 or be empty"));
+        HasSubstr("Pattern shape must have rank 1"));
 }
 
 TEST(type_prop, reshape_multiple_minus_one_no_special_zero) {


### PR DESCRIPTION
### Details:
 -The current shape inference for Reshape operator allow provide scalar input for shape patter which is not according the OV specification which described it as 1D. Change disallow use scalar input as pattern.

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: no*
