### PR TITLE
[GPU] BF16 OCL: reshape and shape_of support

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cpu/shape_of.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/shape_of.cpp
@@ -91,6 +91,7 @@ attach_shape_of_impl::attach_shape_of_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::u8,
         data_types::i8,
         data_types::i32,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reshape_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reshape_ref.cl
@@ -42,5 +42,5 @@ KERNEL (reshape_ref)(const __global INPUT0_TYPE* input, __global OUTPUT_TYPE* ou
                          od5*OUTPUT_PITCHES[4] +
                          od6*OUTPUT_PITCHES[5];
 
-    output[output_offset] = ACTIVATION(TO_OUTPUT_TYPE(input[input_offset]), ACTIVATION_PARAMS);
+    output[output_offset] = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(DECODE_INPUT0_COMPUTE_TYPE(input[input_offset])), ACTIVATION_PARAMS));
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reshape/reshape_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reshape/reshape_kernel_ref.cpp
@@ -10,6 +10,7 @@ namespace kernel_selector {
 ParamsKey ReshapeKernelRef::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::UINT8);
@@ -17,6 +18,7 @@ ParamsKey ReshapeKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::UINT32);
     k.EnableInputDataType(Datatype::INT64);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT8);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
@@ -41,6 +41,8 @@ void generic_reshape_test(format fmt, tensor const& input_size, tensor const& re
     auto data_type = data_types::f32;
     if (std::is_same<ElemType, ov::float16>::value)
         data_type = data_types::f16;
+    else if (std::is_same<ElemType, ov::bfloat16>::value)
+        data_type = data_types::bf16;
     else if (std::is_same<ElemType, int8_t>::value)
         data_type = data_types::i8;
     else if (std::is_same<ElemType, int32_t>::value)
@@ -125,7 +127,7 @@ void generic_reshape_test(format fmt, tensor const& input_size, tensor const& re
                     for (int d4 = 0; d4 < sizes[3]; ++d4) {
                         auto& output_value = *output_itr;
                         ++output_itr;
-                        if (data_type == data_types::f16 || data_type == data_types::f32)
+                        if (data_type == data_types::f16 || data_type == data_types::f32 || data_type == data_types::bf16)
                             verify_float(static_cast<float>(output_value), static_cast<float>((ElemType)value));
                         else
                             verify_int(static_cast<int32_t>(output_value), static_cast<int32_t>(value));
@@ -154,6 +156,14 @@ TEST(reshape_gpu_f32, basic_2dim_in_place) {
 
 TEST(reshape_gpu_f16, basic_2dim_in_place) {
     generic_reshape_test<ov::float16>(
+        format::bfyx,
+        tensor(1, 1, 2, 2),
+        tensor(1, 1, 1, 4),
+        true);
+}
+
+TEST(reshape_gpu_bf16, basic_2dim_in_place) {
+    generic_reshape_test<ov::bfloat16>(
         format::bfyx,
         tensor(1, 1, 2, 2),
         tensor(1, 1, 1, 4),
@@ -200,6 +210,14 @@ TEST(reshape_gpu_f16, basic_4dim_in_place) {
         true);
 }
 
+TEST(reshape_gpu_bf16, basic_4dim_in_place) {
+    generic_reshape_test<ov::bfloat16>(
+        format::yxfb,
+        tensor(9, 9, 2, 4),
+        tensor(3, 4, 27, 2),
+        true);
+}
+
 TEST(reshape_gpu_i32, basic_4dim_in_place) {
     generic_reshape_test<int32_t>(
         format::yxfb,
@@ -228,6 +246,16 @@ TEST(reshpape_gpu_f32, basic_2dim_output_padd) {
 
 TEST(reshape_gpu_f16, basic_2dim_output_padd) {
     generic_reshape_test<ov::float16>(
+        format::byxf,
+        tensor(1, 1, 3, 4),
+        tensor(1, 1, 2, 6),
+        false,
+        padding(),
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}));
+}
+
+TEST(reshape_gpu_bf16, basic_2dim_output_padd) {
+    generic_reshape_test<ov::bfloat16>(
         format::byxf,
         tensor(1, 1, 3, 4),
         tensor(1, 1, 2, 6),
@@ -284,6 +312,15 @@ TEST(reshape_gpu_f16, basic_2dim_input_padd) {
         padding({0, 0, 4, 1}, {0, 0, 2, 3}));
 }
 
+TEST(reshape_gpu_bf16, basic_2dim_input_padd) {
+    generic_reshape_test<ov::bfloat16>(
+        format::fyxb,
+        tensor(1, 1, 3, 3),
+        tensor(1, 1, 1, 9),
+        false,
+        padding({0, 0, 4, 1}, {0, 0, 2, 3}));
+}
+
 TEST(reshape_gpu_i8, basic_2dim_input_padd) {
     generic_reshape_test<int8_t>(
         format::fyxb,
@@ -323,6 +360,16 @@ TEST(reshape_gpu_f32, basic_2dim_input_output_padd) {
 
 TEST(reshape_gpu_f16, basic_2dim_input_output_padd) {
     generic_reshape_test<ov::float16>(
+        format::byxf,
+        tensor(1, 1, 6, 6),
+        tensor(1, 1, 3, 12),
+        false,
+        padding({0, 0, 1, 1}, {0, 0, 0, 0}),
+        padding({0, 0, 2, 1}, {0, 0, 1, 2}));
+}
+
+TEST(reshape_gpu_bf16, basic_2dim_input_output_padd) {
+    generic_reshape_test<ov::bfloat16>(
         format::byxf,
         tensor(1, 1, 6, 6),
         tensor(1, 1, 3, 12),
@@ -381,6 +428,16 @@ TEST(reshape_gpu_f16, basic_4dim_output_padd) {
         padding({0, 2, 0, 1}, {0, 2, 3, 0}));
 }
 
+TEST(reshape_gpu_bf16, basic_4dim_output_padd) {
+    generic_reshape_test<ov::bfloat16>(
+        format::bfyx,
+        tensor(5, 4, 2, 2),
+        tensor(40, 2, 1, 1),
+        false,
+        padding(),
+        padding({0, 2, 0, 1}, {0, 2, 3, 0}));
+}
+
 TEST(reshape_gpu_f32, basic_4dim_input_padd) {
     generic_reshape_test<float>(
         format::yxfb,
@@ -392,6 +449,15 @@ TEST(reshape_gpu_f32, basic_4dim_input_padd) {
 
 TEST(reshape_gpu_f16, basic_4dim_input_padd) {
     generic_reshape_test<ov::float16>(
+        format::yxfb,
+        tensor(2, 32, 8, 8),
+        tensor(8, 128, 1, 4),
+        false,
+        padding({2, 2, 1, 0}, {1, 2, 2, 0}));
+}
+
+TEST(reshape_gpu_bf16, basic_4dim_input_padd) {
+    generic_reshape_test<ov::bfloat16>(
         format::yxfb,
         tensor(2, 32, 8, 8),
         tensor(8, 128, 1, 4),
@@ -411,6 +477,16 @@ TEST(reshape_gpu_f32, basic_4dim_input_output_padd) {
 
 TEST(reshape_gpu_f16, basic_4dim_input_output_padd) {
     generic_reshape_test<ov::float16>(
+        format::byxf,
+        tensor(32, 3, 227, 227),
+        tensor(8, 12, 227, 227),
+        false,
+        padding({0, 1, 4, 4}, {0, 1, 1, 1}),
+        padding({0, 29, 29, 0}, {0, 0, 0, 0}));
+}
+
+TEST(reshape_gpu_bf16, basic_4dim_input_output_padd) {
+    generic_reshape_test<ov::bfloat16>(
         format::byxf,
         tensor(32, 3, 227, 227),
         tensor(8, 12, 227, 227),
@@ -1224,6 +1300,54 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_activation_fusion) {
     }
 }
 
+TEST(reshape_gpu_bf16, basic_runtime_dynamic_shape_activation_fusion) {
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory(layout{ov::PartialShape{3, 3, 2, 2, 1, 1}, data_types::f32, format::bfwzyx});
+
+    topology topology;
+    topology.add(input_layout("input", layout{ov::PartialShape::dynamic(6), data_types::f32, format::bfwzyx }));
+    topology.add(reorder("input_reorder", input_info("input"), format::bfwzyx, data_types::bf16));
+    topology.add(shape_of("shape_of_input", input_info("input"), data_types::i32));
+    topology.add(reduce("reduced_shape", input_info("shape_of_input"), reduce_mode::prod, {0}, true));
+    topology.add(reshape("reshape", input_info("input_reorder"), input_info("reduced_shape"), false, ov::PartialShape::dynamic(1)));
+    topology.add(activation("activation", input_info("reshape"), activation_func::pow, {2.0f, 0.0f}));
+    topology.add(reorder("output_reorder", input_info("activation"), format::bfyx, data_types::f32));
+
+    std::vector<float> input_data = {
+        1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+        1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+        1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+        1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f,
+    };
+
+    set_values(input, input_data);
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output_reorder");
+
+    auto output = outputs.at("output_reorder").get_memory();
+
+    ASSERT_TRUE(network.get_primitive("reshape")->can_be_optimized());
+
+    ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
+    ASSERT_EQ(output->get_layout().format, format::bfyx);
+
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+    ASSERT_EQ(output_ptr.size(), input_data.size());
+
+    for (size_t i = 0; i < input_data.size(); i++) {
+        ASSERT_TRUE(are_equal(input_data[i] * input_data[i], output_ptr[i]));
+    }
+}
+
 TEST(reshape_gpu_f32, reshape_reorder_trucation_mode)
 {
     auto& engine = get_test_engine();
@@ -1309,6 +1433,17 @@ TEST(reshape_gpu_f16, basic_2dim_in_place_cached) {
         true);
 }
 
+TEST(reshape_gpu_bf16, basic_2dim_in_place_cached) {
+    generic_reshape_test<ov::bfloat16>(
+        format::bfyx,
+        tensor(1, 1, 2, 2),
+        tensor(1, 1, 1, 4),
+        true,
+        padding(),
+        padding(),
+        true);
+}
+
 TEST(reshape_gpu_i8, basic_2dim_in_place_cached) {
     generic_reshape_test<int8_t>(
         format::bfyx,
@@ -1364,6 +1499,17 @@ TEST(reshape_gpu_f16, basic_4dim_in_place_cached) {
         true);
 }
 
+TEST(reshape_gpu_bf16, basic_4dim_in_place_cached) {
+    generic_reshape_test<ov::bfloat16>(
+        format::yxfb,
+        tensor(9, 9, 2, 4),
+        tensor(3, 4, 27, 2),
+        true,
+        padding(),
+        padding(),
+        true);
+}
+
 TEST(reshape_gpu_i32, basic_4dim_in_place_cached) {
     generic_reshape_test<int32_t>(
         format::yxfb,
@@ -1399,6 +1545,17 @@ TEST(reshpape_gpu_f32, basic_2dim_output_padd_cached) {
 
 TEST(reshape_gpu_f16, basic_2dim_output_padd_cached) {
     generic_reshape_test<ov::float16>(
+        format::byxf,
+        tensor(1, 1, 3, 4),
+        tensor(1, 1, 2, 6),
+        false,
+        padding(),
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}),
+        true);
+}
+
+TEST(reshape_gpu_bf16, basic_2dim_output_padd_cached) {
+    generic_reshape_test<ov::bfloat16>(
         format::byxf,
         tensor(1, 1, 3, 4),
         tensor(1, 1, 2, 6),
@@ -1463,6 +1620,17 @@ TEST(reshape_gpu_f16, basic_2dim_input_padd_cached) {
         true);
 }
 
+TEST(reshape_gpu_bf16, basic_2dim_input_padd_cached) {
+    generic_reshape_test<ov::bfloat16>(
+        format::fyxb,
+        tensor(1, 1, 3, 3),
+        tensor(1, 1, 1, 9),
+        false,
+        padding({0, 0, 4, 1}, {0, 0, 2, 3}),
+        padding(),
+        true);
+}
+
 TEST(reshape_gpu_i8, basic_2dim_input_padd_cached) {
     generic_reshape_test<int8_t>(
         format::fyxb,
@@ -1509,6 +1677,17 @@ TEST(reshape_gpu_f32, basic_2dim_input_output_padd_cached) {
 
 TEST(reshape_gpu_f16, basic_2dim_input_output_padd_cached) {
     generic_reshape_test<ov::float16>(
+        format::byxf,
+        tensor(1, 1, 6, 6),
+        tensor(1, 1, 3, 12),
+        false,
+        padding({0, 0, 1, 1}, {0, 0, 0, 0}),
+        padding({0, 0, 2, 1}, {0, 0, 1, 2}),
+        true);
+}
+
+TEST(reshape_gpu_bf16, basic_2dim_input_output_padd_cached) {
+    generic_reshape_test<ov::bfloat16>(
         format::byxf,
         tensor(1, 1, 6, 6),
         tensor(1, 1, 3, 12),
@@ -1573,6 +1752,17 @@ TEST(reshape_gpu_f16, basic_4dim_output_padd_cached) {
         true);
 }
 
+TEST(reshape_gpu_bf16, basic_4dim_output_padd_cached) {
+    generic_reshape_test<ov::bfloat16>(
+        format::bfyx,
+        tensor(5, 4, 2, 2),
+        tensor(40, 2, 1, 1),
+        false,
+        padding(),
+        padding({0, 2, 0, 1}, {0, 2, 3, 0}),
+        true);
+}
+
 TEST(reshape_gpu_f32, basic_4dim_input_padd_cached) {
     generic_reshape_test<float>(
         format::yxfb,
@@ -1595,6 +1785,17 @@ TEST(reshape_gpu_f16, basic_4dim_input_padd_cached) {
         true);
 }
 
+TEST(reshape_gpu_bf16, basic_4dim_input_padd_cached) {
+    generic_reshape_test<ov::bfloat16>(
+        format::yxfb,
+        tensor(2, 32, 8, 8),
+        tensor(8, 128, 1, 4),
+        false,
+        padding({2, 2, 1, 0}, {1, 2, 2, 0}),
+        padding(),
+        true);
+}
+
 TEST(reshape_gpu_f32, basic_4dim_input_output_padd_cached) {
     generic_reshape_test<float>(
         format::fyxb,
@@ -1608,6 +1809,17 @@ TEST(reshape_gpu_f32, basic_4dim_input_output_padd_cached) {
 
 TEST(reshape_gpu_f16, basic_4dim_input_output_padd_cached) {
     generic_reshape_test<ov::float16>(
+        format::byxf,
+        tensor(32, 3, 227, 227),
+        tensor(8, 12, 227, 227),
+        false,
+        padding({0, 1, 4, 4}, {0, 1, 1, 1}),
+        padding({0, 29, 29, 0}, {0, 0, 0, 0}),
+        true);
+}
+
+TEST(reshape_gpu_bf16, basic_4dim_input_output_padd_cached) {
+    generic_reshape_test<ov::bfloat16>(
         format::byxf,
         tensor(32, 3, 227, 227),
         tensor(8, 12, 227, 227),


### PR DESCRIPTION
This PR adds bf16 data type support to the **reshape** and **shape_of** operations as part of the broader BF16 enablement effort for the Intel GPU plugin ([CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)).

Ticket: [CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)

> [!NOTE]
> This pull request is part of a larger implementation effort for BF16 support in the OpenVINO GPU Plugin.  On its own, this PR may not provide complete user-visible BF16 enablement.

---

### Changes

**Kernel selector / OCL kernel:**
- Registered `Datatype::BF16` in `reshape_kernel_ref.cpp`.
- Updated `reshape_ref.cl` to pass bf16 data through correctly.

**CPU fallback:**
- Added bf16 case to `cpu/shape_of.cpp`.

**Tests:**
- Added bf16 unit tests to `reshape_gpu_test.cpp`.

### AI assistance:
> [!NOTE]  
> AI assistance used during analysis and PR description preparation. All code originates from the original BF16 OCL enablement branch.
