### PR TITLE
[GPU] BF16 OCL: slice and tile kernels support

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cpu/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/tile.cpp
@@ -122,6 +122,7 @@ attach_tile_impl::attach_tile_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i32,
         data_types::i64,
         data_types::i8,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -181,7 +181,16 @@ private:
 namespace detail {
 
 attach_slice_impl::attach_slice_impl() {
-    auto types = {data_types::f32, data_types::f16, data_types::i8, data_types::u8, data_types::i32, data_types::i64, data_types::f8e4m3};
+    auto types = {
+        data_types::f32,
+        data_types::f16,
+        data_types::bf16,
+        data_types::i8,
+        data_types::u8,
+        data_types::i32,
+        data_types::i64,
+        data_types::f8e4m3
+    };
 
     auto formats = {
         format::bfyx,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -65,7 +65,7 @@ public:
 namespace detail {
 
 attach_tile_impl::attach_tile_impl() {
-    auto types = {data_types::i8, data_types::u8, data_types::i32, data_types::f16, data_types::f32};
+    auto types = {data_types::i8, data_types::u8, data_types::i32, data_types::f16, data_types::bf16, data_types::f32};
     auto static_formats = {
         format::bfyx,
         format::bfzyx,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
@@ -91,8 +91,9 @@ KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG
     // fp8 is a 1-byte struct; Slice just moves data, so copy the byte (ACTIVATION won't compile on it).
     output[output_index] = input[input_index];
 #else
-    output[output_index] = ACTIVATION(input[input_index], ACTIVATION_PARAMS);
+    output[output_index] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(input[input_index]), ACTIVATION_PARAMS));
 #endif
+    
 }
 
 #undef LOAD_BUFFER;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
@@ -93,7 +93,6 @@ KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG
 #else
     output[output_index] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(input[input_index]), ACTIVATION_PARAMS));
 #endif
-    
 }
 
 #undef LOAD_BUFFER;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
@@ -84,10 +84,12 @@ ParamsKey SliceKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::F8E4M3);
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT64);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT64);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/tile/tile_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/tile/tile_kernel_ref.cpp
@@ -14,11 +14,13 @@ ParamsKey TileKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableAllInputLayout();
     k.EnableAllOutputLayout();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/slice_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/slice_gpu_test.cpp
@@ -413,4 +413,57 @@ TEST(slice_gpu_f8e4m3, bfyx) {
         ASSERT_EQ(expected_results[i], output_ptr[i]) << "i=" << i;
 }
 
+// Standalone test for bf16, as values in typed tests are too big for bf16
+TEST(slice_gpu_bf16, bfyx_positive_step) {
+    auto& engine = get_test_engine();
+
+    // Input shape {1, 1, 4, 8} -> 32 elements holding values 0..31.
+    const ov::PartialShape input_shape{ 1, 1, 4, 8 };
+    const size_t input_size = ov::shape_size(input_shape.get_shape());
+    std::vector<ov::bfloat16> input_data(input_size);
+    for (size_t i = 0; i < input_size; ++i)
+        input_data[i] = static_cast<ov::bfloat16>(static_cast<float>(i));
+
+    auto input = engine.allocate_memory({ input_shape, data_types::bf16, format::bfyx });
+    set_values(input, input_data);
+
+    // Slice y in [1, 3) step 1 and x in [2, 7) step 2 (axes 2 and 3).
+    auto start = engine.allocate_memory({ ov::PartialShape{ 2 }, data_types::i64, format::bfyx });
+    set_values<int64_t>(start, { 1, 2 });
+    auto stop = engine.allocate_memory({ ov::PartialShape{ 2 }, data_types::i64, format::bfyx });
+    set_values<int64_t>(stop, { 3, 7 });
+    auto step = engine.allocate_memory({ ov::PartialShape{ 2 }, data_types::i64, format::bfyx });
+    set_values<int64_t>(step, { 1, 2 });
+    auto axes = engine.allocate_memory({ ov::PartialShape{ 2 }, data_types::i64, format::bfyx });
+    set_values<int64_t>(axes, { 2, 3 });
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(data("start", start));
+    topology.add(data("stop", stop));
+    topology.add(data("step", step));
+    topology.add(data("axes", axes));
+    topology.add(slice("slice", { input_info("input"), input_info("start"),
+                                  input_info("stop"), input_info("step"), input_info("axes") }));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+    network->set_input_data("input", input);
+
+    auto outputs = network->execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "slice");
+
+    auto output = outputs.at("slice").get_memory();
+    cldnn::mem_lock<ov::bfloat16, mem_lock_type::read> output_ptr(output, get_test_stream());
+
+    // value(y, x) = y * 8 + x for y in {1, 2}, x in {2, 4, 6}.
+    const std::vector<float> expected = { 10, 12, 14, 18, 20, 22 };
+    ASSERT_EQ(output_ptr.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i)
+        ASSERT_TRUE(are_equal(expected[i], static_cast<float>(output_ptr[i]), 2e-3));
+}
+
 }  // anonymous namespace

--- a/src/plugins/intel_gpu/tests/unit/test_cases/tile_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/tile_gpu_test.cpp
@@ -786,12 +786,17 @@ public:
 
 using tile_test_f32 = tile_test<float>;
 using tile_test_f16 = tile_test<ov::float16>;
+using tile_test_bf16 = tile_test<ov::bfloat16>;
 
 TEST_P(tile_test_f32, test_case) {
     ASSERT_NO_FATAL_FAILURE(test(false));
 }
 
 TEST_P(tile_test_f16, test_case) {
+    ASSERT_NO_FATAL_FAILURE(test(false));
+}
+
+TEST_P(tile_test_bf16, test_case) {
     ASSERT_NO_FATAL_FAILURE(test(false));
 }
 
@@ -811,6 +816,14 @@ INSTANTIATE_TEST_SUITE_P(tile_gpu_2D,
                              ::testing::ValuesIn(layouts_2d)),
                          PrintToStringParamName());
 
+INSTANTIATE_TEST_SUITE_P(tile_gpu_2D,
+                         tile_test_bf16,
+                         ::testing::Combine(
+                             ::testing::ValuesIn(generateTileParams2D<ov::bfloat16>()),
+                             ::testing::Values(format::bfyx),
+                             ::testing::ValuesIn(layouts_2d)),
+                         PrintToStringParamName());
+
 INSTANTIATE_TEST_SUITE_P(tile_gpu_3D,
                          tile_test_f32,
                          ::testing::Combine(
@@ -823,6 +836,14 @@ INSTANTIATE_TEST_SUITE_P(tile_gpu_3D,
                          tile_test_f16,
                          ::testing::Combine(
                              ::testing::ValuesIn(generateTileParams3D<ov::float16>()),
+                             ::testing::Values(format::bfzyx),
+                             ::testing::ValuesIn(layouts_3d)),
+                         PrintToStringParamName());
+
+INSTANTIATE_TEST_SUITE_P(tile_gpu_3D,
+                         tile_test_bf16,
+                         ::testing::Combine(
+                             ::testing::ValuesIn(generateTileParams3D<ov::bfloat16>()),
                              ::testing::Values(format::bfzyx),
                              ::testing::ValuesIn(layouts_3d)),
                          PrintToStringParamName());
@@ -853,6 +874,10 @@ TEST_P(tile_test_f32, test_case_cached) {
 }
 
 TEST_P(tile_test_f16, test_case_cached) {
+    ASSERT_NO_FATAL_FAILURE(test(true));
+}
+
+TEST_P(tile_test_bf16, test_case_cached) {
     ASSERT_NO_FATAL_FAILURE(test(true));
 }
 #endif


### PR DESCRIPTION
This PR adds bf16 data type support to the **slice** and **tile** OCL kernels as part of the broader BF16 enablement effort for the Intel GPU plugin ([CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)).

Ticket: [CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)

> [!NOTE]
> This pull request is part of a larger implementation effort for BF16 support in the OpenVINO GPU Plugin.  On its own, this PR may not provide complete user-visible BF16 enablement.

---

### Changes

**Kernel selector / OCL kernels:**
- Registered `Datatype::BF16` in `slice_kernel_ref.cpp` and `tile_kernel_ref.cpp`.
- Updated `slice_ref.cl` to use compute-type macros for bf16 decode/encode.
- Updated `ocl/slice.cpp` and `ocl/tile.cpp` implementation registration.

**CPU fallback:**
- Added bf16 case to `cpu/tile.cpp`.

**Tests:**
- Added bf16 unit tests to `slice_gpu_test.cpp` and `tile_gpu_test.cpp`.

### AI assistance:
> [!NOTE]  
> AI assistance used during analysis and PR description preparation. All code originates from the original BF16 OCL enablement branch.
