### PR TITLE
[GPU] BF16 OCL: softmax kernels support

### DIFF
--- a/src/plugins/intel_gpu/src/graph/registry/softmax_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/softmax_impls.cpp
@@ -32,11 +32,13 @@ static std::vector<format> supported_dynamic_fmts = {
 static std::vector<ov::element::Type_t> supported_in_types = {
     ov::element::f32,
     ov::element::f16,
+    ov::element::bf16,
 };
 
 static std::vector<ov::element::Type_t> supported_out_types = {
     ov::element::f32,
     ov::element::f16,
+    ov::element::bf16,
     ov::element::i8,
     ov::element::u8,
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
@@ -11,24 +11,28 @@
 
 #define BLOCK_READ(ptr, offset) DT_INPUT_BLOCK_READ(ptr, offset)
 #define BLOCK_WRITE(ptr, offset, val) DT_OUTPUT_BLOCK_WRITE(ptr, offset, val)
-#define BLOCK_TYPE INPUT0_TYPE
+#define BLOCK_IN_TYPE INPUT0_TYPE
+#define BLOCK_OUT_TYPE OUTPUT_TYPE
 
 #define OPT_BLOCK_SIZE 8
 
 #define BLOCK_READ_OPT(ptr, offset) CAT(DT_INPUT_BLOCK_READ, OPT_BLOCK_SIZE)(ptr, offset)
 #define BLOCK_WRITE_OPT(ptr, offset, val) CAT(DT_OUTPUT_BLOCK_WRITE, OPT_BLOCK_SIZE)(ptr, offset, val)
-#define BLOCK_TYPE_OPT MAKE_VECTOR_TYPE(INPUT0_TYPE, OPT_BLOCK_SIZE)
+#define BLOCK_IN_TYPE_OPT MAKE_VECTOR_TYPE(INPUT0_TYPE, OPT_BLOCK_SIZE)
+#define BLOCK_OUT_TYPE_OPT MAKE_VECTOR_TYPE(OUTPUT_TYPE, OPT_BLOCK_SIZE)
 
 #else
 
 #if SUBGROUP_BLOCK_SIZE == 1
 #define BLOCK_READ(ptr, offset) DT_INPUT_BLOCK_READ(ptr, offset)
 #define BLOCK_WRITE(ptr, offset, val) DT_OUTPUT_BLOCK_WRITE(ptr, offset, val)
-#define BLOCK_TYPE INPUT0_TYPE
+#define BLOCK_IN_TYPE INPUT0_TYPE
+#define BLOCK_OUT_TYPE OUTPUT_TYPE
 #else
 #define BLOCK_READ(ptr, offset) CAT(DT_INPUT_BLOCK_READ, SUBGROUP_BLOCK_SIZE)(ptr, offset)
 #define BLOCK_WRITE(ptr, offset, val) CAT(DT_OUTPUT_BLOCK_WRITE, SUBGROUP_BLOCK_SIZE)(ptr, offset, val)
-#define BLOCK_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, SUBGROUP_BLOCK_SIZE)
+#define BLOCK_IN_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, SUBGROUP_BLOCK_SIZE)
+#define BLOCK_OUT_TYPE MAKE_VECTOR_TYPE(OUTPUT_TYPE, SUBGROUP_BLOCK_SIZE)
 #endif
 
 #endif
@@ -79,9 +83,9 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     const bool use_output_buffer = false;
 #endif
 
-    INPUT0_TYPE my_chunk[STACK_SIZE];
-    INPUT0_TYPE my_sum = UNIT_VAL_ZERO;
-    INPUT0_TYPE my_maximum = -UNIT_VAL_MAX;
+    INPUT0_COMPUTE_TYPE my_chunk[STACK_SIZE];
+    INPUT0_COMPUTE_TYPE my_sum = UNIT_VAL_ZERO;
+    INPUT0_COMPUTE_TYPE my_maximum = -UNIT_VAL_MAX;
 
     // Read inputs and Get maximum value from data set
     uint input_idx=0;
@@ -97,17 +101,18 @@ KERNEL (softmax_gpu_continuous_bfyx)(
         const uint num_iters = items_num - (items_num % OPT_BLOCK_SIZE);
         for (; input_idx < num_iters; input_idx += OPT_BLOCK_SIZE)
         {
-            BLOCK_TYPE_OPT vec_tmp = BLOCK_READ_OPT(input, aligned_data_offset + input_idx * get_sub_group_size());
+            BLOCK_IN_TYPE_OPT vec_tmp = BLOCK_READ_OPT(input, aligned_data_offset + input_idx * get_sub_group_size());
             unroll_for (int j = 0; j < OPT_BLOCK_SIZE; j++)
             {
-                my_chunk[input_idx+j] = vec_tmp[j];
-                my_maximum = max(my_maximum, vec_tmp[j]);
+				INPUT0_COMPUTE_TYPE tmp = DECODE_INPUT0_COMPUTE_TYPE(vec_tmp[j]);
+                my_chunk[input_idx+j] = tmp;
+                my_maximum = max(my_maximum, tmp);
             }
         }
 
         for (; input_idx < items_num; input_idx++)
         {
-            BLOCK_TYPE vec_tmp = BLOCK_READ(input, aligned_data_offset + input_idx * get_sub_group_size());
+            INPUT0_COMPUTE_TYPE vec_tmp = DECODE_INPUT0_COMPUTE_TYPE(BLOCK_READ(input, aligned_data_offset + input_idx * get_sub_group_size()));
             my_chunk[input_idx] = vec_tmp;
             my_maximum = max(my_maximum, vec_tmp);
         }
@@ -117,14 +122,14 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     {
         for (; input_idx<items_num - (items_num % SUBGROUP_BLOCK_SIZE); input_idx+=SUBGROUP_BLOCK_SIZE)
         {
-            BLOCK_TYPE vec_tmp = BLOCK_READ(input, aligned_data_offset + input_idx * get_sub_group_size());
+            BLOCK_IN_TYPE vec_tmp = BLOCK_READ(input, aligned_data_offset + input_idx * get_sub_group_size());
 #if SUBGROUP_BLOCK_SIZE == 1
-            my_chunk[input_idx] = vec_tmp;
-            my_maximum = max(my_maximum, vec_tmp);
+            my_chunk[input_idx] = DECODE_INPUT0_COMPUTE_TYPE(vec_tmp);
+            my_maximum = max(my_maximum, DECODE_INPUT0_COMPUTE_TYPE(vec_tmp));
 #else
             unroll_for (int j = 0; j < SUBGROUP_BLOCK_SIZE; j++)
             {
-                INPUT0_TYPE tmp = vec_tmp[j];
+                INPUT0_COMPUTE_TYPE tmp = DECODE_INPUT0_COMPUTE_TYPE(vec_tmp[j]);
                 my_chunk[input_idx+j] = tmp;
                 my_maximum = max(my_maximum, tmp);
             }
@@ -135,21 +140,21 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 
     for (; input_idx < items_num; input_idx++)
     {
-        INPUT0_TYPE tmp = input[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()];
+        INPUT0_COMPUTE_TYPE tmp = DECODE_INPUT0_COMPUTE_TYPE(input[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()]);
         my_chunk[input_idx] = tmp;
         my_maximum = max(my_maximum, tmp);
     }
 
     if (in_data_set_idx < aligned_offset)
     {
-        INPUT0_TYPE tmp = input[data_set_offset + in_data_set_idx];
+        INPUT0_COMPUTE_TYPE tmp = DECODE_INPUT0_COMPUTE_TYPE(input[data_set_offset + in_data_set_idx]);
         my_chunk[input_idx++] = tmp;
         my_maximum = max(my_maximum, tmp);
     }
 
     if (in_data_set_idx < actual_leftovers)
     {
-        INPUT0_TYPE tmp = input[leftover_idx];
+        INPUT0_COMPUTE_TYPE tmp = DECODE_INPUT0_COMPUTE_TYPE(input[leftover_idx]);
         my_chunk[input_idx++] = tmp;
         my_maximum = max(my_maximum, tmp);
     }
@@ -168,14 +173,14 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 
     for (uint j=0; j<num_iters; ++j)
     {
-        INPUT0_TYPE tmp = native_exp(my_chunk[j] - my_maximum);
+        INPUT0_COMPUTE_TYPE tmp = native_exp(my_chunk[j] - my_maximum);
         my_sum += tmp;
         my_chunk[j] = tmp;
     }
 
     if (in_data_set_idx < aligned_offset)
     {
-        INPUT0_TYPE tmp = native_exp(my_chunk[num_iters] - my_maximum);
+        INPUT0_COMPUTE_TYPE tmp = native_exp(my_chunk[num_iters] - my_maximum);
         my_sum += tmp;
         my_chunk[num_iters] = tmp;
 
@@ -184,7 +189,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 
     if (in_data_set_idx < actual_leftovers)
     {
-        INPUT0_TYPE tmp = native_exp(my_chunk[num_iters] - my_maximum);
+        INPUT0_COMPUTE_TYPE tmp = native_exp(my_chunk[num_iters] - my_maximum);
         my_sum += tmp;
         my_chunk[num_iters] = tmp;
     }
@@ -208,7 +213,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
         const uint num_iters = items_num - (items_num % OPT_BLOCK_SIZE);
         for (; output_idx < num_iters; output_idx += OPT_BLOCK_SIZE)
         {
-            BLOCK_TYPE_OPT vec_tmp;
+            BLOCK_OUT_TYPE_OPT vec_tmp;
             unroll_for (int j = 0; j < OPT_BLOCK_SIZE; j++) {
                 ACTIVATION_TYPE dequantized = my_chunk[output_idx + j] / my_sum;
                 FUSED_OPS_MAIN;
@@ -219,7 +224,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 
         for (; output_idx<items_num; output_idx++)
         {
-            BLOCK_TYPE vec_tmp;
+            BLOCK_OUT_TYPE vec_tmp;
             ACTIVATION_TYPE dequantized = my_chunk[output_idx] / my_sum;
             FUSED_OPS_MAIN;
             vec_tmp = FUSED_OPS_RESULT_MAIN;
@@ -231,7 +236,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     {
         for (; output_idx < items_num - (items_num % SUBGROUP_BLOCK_SIZE); output_idx+=SUBGROUP_BLOCK_SIZE)
         {
-            BLOCK_TYPE vec_tmp;
+            BLOCK_OUT_TYPE vec_tmp;
 #if SUBGROUP_BLOCK_SIZE == 1
             ACTIVATION_TYPE dequantized = my_chunk[output_idx] / my_sum;
             FUSED_OPS_MAIN;
@@ -275,17 +280,17 @@ KERNEL (softmax_gpu_continuous_bfyx)(
         const uint num_iters = items_num - (items_num % OPT_BLOCK_SIZE);
         for (; output_idx < num_iters; output_idx += OPT_BLOCK_SIZE)
         {
-            BLOCK_TYPE_OPT vec_tmp;
+            BLOCK_OUT_TYPE_OPT vec_tmp;
             unroll_for (int j = 0; j < OPT_BLOCK_SIZE; j++){
-                vec_tmp[j] = ACTIVATION(my_chunk[output_idx + j] / my_sum, ACTIVATION_PARAMS);
+                vec_tmp[j] = TO_OUTPUT_TYPE(ACTIVATION(my_chunk[output_idx + j] / my_sum, ACTIVATION_PARAMS));
             }
             BLOCK_WRITE_OPT(output, aligned_data_offset + output_idx * get_sub_group_size(), vec_tmp);
         }
 
         for (; output_idx < items_num; output_idx++)
         {
-            BLOCK_TYPE vec_tmp;
-            vec_tmp = ACTIVATION(my_chunk[output_idx] / my_sum, ACTIVATION_PARAMS);
+            BLOCK_OUT_TYPE vec_tmp;
+            vec_tmp = TO_OUTPUT_TYPE(ACTIVATION(my_chunk[output_idx] / my_sum, ACTIVATION_PARAMS));
             BLOCK_WRITE(output, aligned_data_offset + output_idx * get_sub_group_size(), vec_tmp);
         }
     }
@@ -294,12 +299,12 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     {
         for (; output_idx<items_num - (items_num % SUBGROUP_BLOCK_SIZE); output_idx+=SUBGROUP_BLOCK_SIZE)
         {
-            BLOCK_TYPE vec_tmp;
+            BLOCK_OUT_TYPE vec_tmp;
 #if SUBGROUP_BLOCK_SIZE == 1
-            vec_tmp = ACTIVATION(my_chunk[output_idx] / my_sum, ACTIVATION_PARAMS);
+            vec_tmp = TO_OUTPUT_TYPE(ACTIVATION(my_chunk[output_idx] / my_sum, ACTIVATION_PARAMS));
 #else
             for (int j = 0; j < SUBGROUP_BLOCK_SIZE; j++)
-                vec_tmp[j] = ACTIVATION(my_chunk[output_idx + j] / my_sum, ACTIVATION_PARAMS);
+                vec_tmp[j] = TO_OUTPUT_TYPE(ACTIVATION(my_chunk[output_idx + j] / my_sum, ACTIVATION_PARAMS));
 #endif
             BLOCK_WRITE(output, aligned_data_offset + output_idx * get_sub_group_size(), vec_tmp);
         }
@@ -307,15 +312,15 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 #endif
     for (; output_idx < items_num; output_idx++)
     {
-        output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] = ACTIVATION(my_chunk[output_idx] / my_sum, ACTIVATION_PARAMS);
+        output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] = TO_OUTPUT_TYPE(ACTIVATION(my_chunk[output_idx] / my_sum, ACTIVATION_PARAMS));
     }
 
     if (in_data_set_idx < aligned_offset) {
-        output[data_set_offset + in_data_set_idx] = ACTIVATION(my_chunk[output_idx++] / my_sum, ACTIVATION_PARAMS);
+        output[data_set_offset + in_data_set_idx] = TO_OUTPUT_TYPE(ACTIVATION(my_chunk[output_idx++] / my_sum, ACTIVATION_PARAMS));
     }
 
     if (in_data_set_idx < actual_leftovers) {
-        output[leftover_idx] = ACTIVATION(my_chunk[output_idx++] / my_sum, ACTIVATION_PARAMS);
+        output[leftover_idx] = TO_OUTPUT_TYPE(ACTIVATION(my_chunk[output_idx++] / my_sum, ACTIVATION_PARAMS));
     }
 #endif
 #if IS_DYNAMIC
@@ -325,19 +330,19 @@ KERNEL (softmax_gpu_continuous_bfyx)(
         const uint num_iters = items_num - (items_num % OPT_BLOCK_SIZE);
         for (; input_idx < num_iters; input_idx += OPT_BLOCK_SIZE)
         {
-            BLOCK_TYPE_OPT vec_tmp = BLOCK_READ_OPT(input, aligned_data_offset + input_idx * get_sub_group_size());
+            BLOCK_IN_TYPE_OPT vec_tmp = BLOCK_READ_OPT(input, aligned_data_offset + input_idx * get_sub_group_size());
             unroll_for (int j = 0; j < OPT_BLOCK_SIZE; j++)
             {
-                output[aligned_data_offset + get_sub_group_local_id() + (input_idx + j) * get_sub_group_size()] = vec_tmp[j];
-                my_maximum = max(my_maximum, vec_tmp[j]);
+                output[aligned_data_offset + get_sub_group_local_id() + (input_idx + j) * get_sub_group_size()] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(vec_tmp[j]));
+                my_maximum = max(my_maximum, DECODE_INPUT0_COMPUTE_TYPE(vec_tmp[j]));
             }
         }
 
         for (; input_idx < items_num; input_idx++)
         {
-            BLOCK_TYPE vec_tmp = BLOCK_READ(input, aligned_data_offset + input_idx * get_sub_group_size());
-            output[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()] = vec_tmp;
-            my_maximum = max(my_maximum, vec_tmp);
+            BLOCK_IN_TYPE vec_tmp = BLOCK_READ(input, aligned_data_offset + input_idx * get_sub_group_size());
+            output[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(vec_tmp));
+            my_maximum = max(my_maximum, DECODE_INPUT0_COMPUTE_TYPE(vec_tmp));
         }
     }
 
@@ -345,20 +350,20 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     {
         INPUT0_TYPE tmp = input[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()];
         output[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()] = tmp;
-        my_maximum = max(my_maximum, tmp);
+        my_maximum = max(my_maximum, DECODE_INPUT0_COMPUTE_TYPE(tmp));
     }
 
     if (in_data_set_idx < aligned_offset)
     {
-        INPUT0_TYPE tmp = input[data_set_offset + in_data_set_idx];
-        output[data_set_offset + in_data_set_idx] = tmp;
+        INPUT0_COMPUTE_TYPE tmp = DECODE_INPUT0_COMPUTE_TYPE(input[data_set_offset + in_data_set_idx]);
+        output[data_set_offset + in_data_set_idx] = TO_OUTPUT_TYPE(tmp);
         my_maximum = max(my_maximum, tmp);
     }
 
     if (in_data_set_idx < actual_leftovers)
     {
-        INPUT0_TYPE tmp = input[leftover_idx];
-        output[leftover_idx] = tmp;
+        INPUT0_COMPUTE_TYPE tmp = DECODE_INPUT0_COMPUTE_TYPE(input[leftover_idx]);
+        output[leftover_idx] = TO_OUTPUT_TYPE(tmp);
         my_maximum = max(my_maximum, tmp);
     }
 
@@ -375,21 +380,21 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     const uint num_iters = input_idx;
 
     for (uint j=0; j<num_iters; ++j) {
-        INPUT0_TYPE tmp = native_exp(output[aligned_data_offset + get_sub_group_local_id() + j * get_sub_group_size()] - my_maximum);
+        INPUT0_COMPUTE_TYPE tmp = native_exp(TO_INPUT0_COMPUTE_TYPE(DECODE_OUTPUT_COMPUTE_TYPE(output[aligned_data_offset + get_sub_group_local_id() + j * get_sub_group_size()])) - my_maximum);
         my_sum += tmp;
-        output[aligned_data_offset + get_sub_group_local_id() + j * get_sub_group_size()] = tmp;
+        output[aligned_data_offset + get_sub_group_local_id() + j * get_sub_group_size()] = TO_OUTPUT_TYPE(tmp);
     }
 
     if (in_data_set_idx < aligned_offset) {
-        INPUT0_TYPE tmp = native_exp(output[data_set_offset + in_data_set_idx] - my_maximum);
+        INPUT0_COMPUTE_TYPE tmp = native_exp(TO_INPUT0_COMPUTE_TYPE(DECODE_OUTPUT_COMPUTE_TYPE(output[data_set_offset + in_data_set_idx])) - my_maximum);
         my_sum += tmp;
-        output[data_set_offset + in_data_set_idx] = tmp;
+        output[data_set_offset + in_data_set_idx] = TO_OUTPUT_TYPE(tmp);
     }
 
     if (in_data_set_idx < actual_leftovers) {
-        INPUT0_TYPE tmp = native_exp(output[leftover_idx] - my_maximum);
+        INPUT0_COMPUTE_TYPE tmp = native_exp(TO_INPUT0_COMPUTE_TYPE(DECODE_OUTPUT_COMPUTE_TYPE(output[leftover_idx])) - my_maximum);
         my_sum += tmp;
-        output[leftover_idx] = tmp;
+        output[leftover_idx] = TO_OUTPUT_TYPE(tmp);
     }
 
 #if !IS_DYNAMIC
@@ -410,9 +415,9 @@ KERNEL (softmax_gpu_continuous_bfyx)(
         const uint num_iters = items_num - (items_num % OPT_BLOCK_SIZE);
         for (; output_idx < num_iters; output_idx += OPT_BLOCK_SIZE)
         {
-            BLOCK_TYPE_OPT vec_tmp;
+            BLOCK_OUT_TYPE_OPT vec_tmp;
             unroll_for (int j = 0; j < OPT_BLOCK_SIZE; j++) {
-                ACTIVATION_TYPE dequantized = output[aligned_data_offset + get_sub_group_local_id() + (output_idx + j) * get_sub_group_size()] / my_sum;
+                ACTIVATION_TYPE dequantized = DECODE_OUTPUT_COMPUTE_TYPE(output[aligned_data_offset + get_sub_group_local_id() + (output_idx + j) * get_sub_group_size()]) / my_sum;
                 FUSED_OPS_MAIN;
                 vec_tmp[j] = FUSED_OPS_RESULT_MAIN;
             }
@@ -421,8 +426,8 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 
         for (; output_idx<items_num; output_idx++)
         {
-            BLOCK_TYPE vec_tmp;
-            ACTIVATION_TYPE dequantized = output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] / my_sum;
+            BLOCK_OUT_TYPE vec_tmp;
+            ACTIVATION_TYPE dequantized = DECODE_OUTPUT_COMPUTE_TYPE(output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()]) / my_sum;
             FUSED_OPS_MAIN;
             vec_tmp = FUSED_OPS_RESULT_MAIN;
             BLOCK_WRITE(output, aligned_data_offset + output_idx * get_sub_group_size(), vec_tmp);
@@ -431,21 +436,21 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 
     for (; output_idx < items_num; output_idx++)
     {
-        ACTIVATION_TYPE dequantized = output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] / my_sum;
+        ACTIVATION_TYPE dequantized = DECODE_OUTPUT_COMPUTE_TYPE(output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()]) / my_sum;
         FUSED_OPS_MAIN;
         output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] = FUSED_OPS_RESULT_MAIN;
     }
 
     if (in_data_set_idx < aligned_offset)
     {
-        ACTIVATION_TYPE dequantized = output[data_set_offset + in_data_set_idx] / my_sum;
+        ACTIVATION_TYPE dequantized = DECODE_OUTPUT_COMPUTE_TYPE(output[data_set_offset + in_data_set_idx]) / my_sum;
         FUSED_OPS_LEFTOVERS;
         output[data_set_offset + in_data_set_idx] = FUSED_OPS_RESULT_LEFTOVERS;
     }
 
     if (in_data_set_idx < actual_leftovers)
     {
-        ACTIVATION_TYPE dequantized = output[leftover_idx] / my_sum;
+        ACTIVATION_TYPE dequantized = DECODE_OUTPUT_COMPUTE_TYPE(output[leftover_idx]) / my_sum;
         FUSED_OPS_LEFTOVERS;
         output[leftover_idx] = FUSED_OPS_RESULT_LEFTOVERS;
     }
@@ -455,17 +460,17 @@ KERNEL (softmax_gpu_continuous_bfyx)(
         const uint num_iters = items_num - (items_num % OPT_BLOCK_SIZE);
         for (; output_idx < num_iters; output_idx += OPT_BLOCK_SIZE)
         {
-            BLOCK_TYPE_OPT vec_tmp;
+            BLOCK_OUT_TYPE_OPT vec_tmp;
             unroll_for (int j = 0; j < OPT_BLOCK_SIZE; j++){
-                vec_tmp[j] = ACTIVATION(output[aligned_data_offset + get_sub_group_local_id() + (output_idx + j) * get_sub_group_size()] / my_sum, ACTIVATION_PARAMS);
+                vec_tmp[j] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_OUTPUT_COMPUTE_TYPE(output[aligned_data_offset + get_sub_group_local_id() + (output_idx + j) * get_sub_group_size()]) / my_sum, ACTIVATION_PARAMS));
             }
             BLOCK_WRITE_OPT(output, aligned_data_offset + output_idx * get_sub_group_size(), vec_tmp);
         }
 
         for (; output_idx < items_num; output_idx++)
         {
-            BLOCK_TYPE vec_tmp;
-            vec_tmp = ACTIVATION(output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] / my_sum, ACTIVATION_PARAMS);
+            BLOCK_OUT_TYPE vec_tmp;
+            vec_tmp = TO_OUTPUT_TYPE(ACTIVATION(DECODE_OUTPUT_COMPUTE_TYPE(output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()]) / my_sum, ACTIVATION_PARAMS));
             BLOCK_WRITE(output, aligned_data_offset + output_idx * get_sub_group_size(), vec_tmp);
         }
     }
@@ -473,15 +478,15 @@ KERNEL (softmax_gpu_continuous_bfyx)(
     for (; output_idx < items_num; output_idx++)
     {
         output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()]
-        = ACTIVATION(output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()] / my_sum, ACTIVATION_PARAMS);
+        = TO_OUTPUT_TYPE(ACTIVATION(DECODE_OUTPUT_COMPUTE_TYPE(output[aligned_data_offset + get_sub_group_local_id() + output_idx * get_sub_group_size()]) / my_sum, ACTIVATION_PARAMS));
     }
 
     if (in_data_set_idx < aligned_offset) {
-        output[data_set_offset + in_data_set_idx] = ACTIVATION(output[data_set_offset + in_data_set_idx] / my_sum, ACTIVATION_PARAMS);
+        output[data_set_offset + in_data_set_idx] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_OUTPUT_COMPUTE_TYPE(output[data_set_offset + in_data_set_idx]) / my_sum, ACTIVATION_PARAMS));
     }
 
     if (in_data_set_idx < actual_leftovers) {
-        output[leftover_idx] = ACTIVATION(output[leftover_idx] / my_sum, ACTIVATION_PARAMS);
+        output[leftover_idx] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_OUTPUT_COMPUTE_TYPE(output[leftover_idx]) / my_sum, ACTIVATION_PARAMS));
     }
 #endif
     }
@@ -489,4 +494,5 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 }
 #undef BLOCK_READ
 #undef BLOCK_WRITE
-#undef BLOCK_TYPE
+#undef BLOCK_IN_TYPE
+#undef BLOCK_OUT_TYPE

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
@@ -496,3 +496,7 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 #undef BLOCK_WRITE
 #undef BLOCK_IN_TYPE
 #undef BLOCK_OUT_TYPE
+#undef BLOCK_READ_OPT
+#undef BLOCK_WRITE_OPT
+#undef BLOCK_IN_TYPE_OPT
+#undef BLOCK_OUT_TYPE_OPT

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_bf.cl
@@ -348,9 +348,9 @@ KERNEL (softmax_gpu_continuous_bfyx)(
 
     for (; input_idx < items_num; input_idx++)
     {
-        INPUT0_TYPE tmp = input[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()];
-        output[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()] = tmp;
-        my_maximum = max(my_maximum, DECODE_INPUT0_COMPUTE_TYPE(tmp));
+        INPUT0_COMPUTE_TYPE tmp = DECODE_INPUT0_COMPUTE_TYPE(input[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()]);
+        output[aligned_data_offset + get_sub_group_local_id() + input_idx * get_sub_group_size()] = TO_OUTPUT_TYPE(tmp);
+        my_maximum = max(my_maximum, tmp);
     }
 
     if (in_data_set_idx < aligned_offset)

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_fb.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_fb.cl
@@ -5,14 +5,14 @@
 #include "include/batch_headers/common.cl"
 
 
-INPUT0_TYPE FUNC(find_max_value)(__local INPUT0_TYPE* partial_max, const int global_id, const int idx, const int batch_offset, const int data_sets_count, const __global INPUT0_TYPE* input)
+INPUT0_COMPUTE_TYPE FUNC(find_max_value)(__local INPUT0_COMPUTE_TYPE* partial_max, const int global_id, const int idx, const int batch_offset, const int data_sets_count, const __global INPUT0_TYPE* input)
 {
-    INPUT0_TYPE value = -UNIT_VAL_MAX;
+    INPUT0_COMPUTE_TYPE value = -INPUT0_VAL_MAX;
     for(int i = 0; i < ITEMS_NUM; i++)
     {
-        value = max(value, input[LWS * i + global_id]);
+        value = max(value, DECODE_INPUT0_COMPUTE_TYPE(input[LWS * i + global_id]));
     }
-    value = max(value, global_id < LEFTOVERS? input[LWS * ITEMS_NUM + global_id] : -UNIT_VAL_MAX);
+    value = max(value, global_id < LEFTOVERS? DECODE_INPUT0_COMPUTE_TYPE(input[LWS * ITEMS_NUM + global_id]) : -INPUT0_VAL_MAX);
     partial_max[global_id] = value;
 
     barrier(CLK_LOCAL_MEM_FENCE);
@@ -28,8 +28,8 @@ INPUT0_TYPE FUNC(find_max_value)(__local INPUT0_TYPE* partial_max, const int glo
 }
 
 KERNEL (softmax_gpu_continuous_yxfb)(
-    const __global UNIT_TYPE* input,
-    __global UNIT_TYPE* output
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output
 #if HAS_FUSED_OPS_DECLS
     , FUSED_OPS_DECLS
 #endif
@@ -41,19 +41,19 @@ KERNEL (softmax_gpu_continuous_yxfb)(
 
     const int batch_offset = global_id % data_sets_count;
 
-    __local INPUT0_TYPE partial_max[LWS];
-    const INPUT0_TYPE max_value = FUNC_CALL(find_max_value)(partial_max, global_id, idx, batch_offset, data_sets_count, input);
+    __local INPUT0_COMPUTE_TYPE partial_max[LWS];
+    const INPUT0_COMPUTE_TYPE max_value = FUNC_CALL(find_max_value)(partial_max, global_id, idx, batch_offset, data_sets_count, input);
 
-    INPUT0_TYPE tmp_vals[ITEMS_NUM + 1];
+    INPUT0_COMPUTE_TYPE tmp_vals[ITEMS_NUM + 1];
     for(int i = 0; i < ITEMS_NUM; i++)
     {
-        tmp_vals[i] = native_exp(input[LWS * i + global_id] - max_value);
+        tmp_vals[i] = native_exp(DECODE_INPUT0_COMPUTE_TYPE(input[LWS * i + global_id]) - max_value);
     }
-    tmp_vals[ITEMS_NUM] = global_id < LEFTOVERS ? native_exp(input[LWS * ITEMS_NUM + global_id] - max_value) : UNIT_VAL_ZERO;
+    tmp_vals[ITEMS_NUM] = global_id < LEFTOVERS ? native_exp(DECODE_INPUT0_COMPUTE_TYPE(input[LWS * ITEMS_NUM + global_id] - max_value)) : INPUT0_VAL_ZERO;
 
     // accumulate all values;
-    __local INPUT0_TYPE partial_acc[LWS]; // all values accumulated;
-    partial_acc[global_id] = UNIT_VAL_ZERO;
+    __local INPUT0_COMPUTE_TYPE partial_acc[LWS]; // all values accumulated;
+    partial_acc[global_id] = INPUT0_VAL_ZERO;
     for(int i = 0; i < ITEMS_NUM + 1; i++)
     {
         partial_acc[global_id] += tmp_vals[i];
@@ -84,9 +84,9 @@ KERNEL (softmax_gpu_continuous_yxfb)(
 #else
     for(int i = 0; i < ITEMS_NUM; i++)
     {
-        output[LWS * i + global_id] = ACTIVATION(tmp_vals[i] / partial_acc[batch_offset], ACTIVATION_PARAMS);
+        output[LWS * i + global_id] = TO_OUTPUT_TYPE(ACTIVATION(tmp_vals[i] / partial_acc[batch_offset], ACTIVATION_PARAMS));
     }
     if(global_id < LEFTOVERS)
-        output[LWS * ITEMS_NUM + global_id] = ACTIVATION(tmp_vals[ITEMS_NUM] / partial_acc[batch_offset], ACTIVATION_PARAMS);
+        output[LWS * ITEMS_NUM + global_id] = TO_OUTPUT_TYPE(ACTIVATION(tmp_vals[ITEMS_NUM] / partial_acc[batch_offset], ACTIVATION_PARAMS));
 #endif
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_fb.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_fb.cl
@@ -49,7 +49,7 @@ KERNEL (softmax_gpu_continuous_yxfb)(
     {
         tmp_vals[i] = native_exp(DECODE_INPUT0_COMPUTE_TYPE(input[LWS * i + global_id]) - max_value);
     }
-    tmp_vals[ITEMS_NUM] = global_id < LEFTOVERS ? native_exp(DECODE_INPUT0_COMPUTE_TYPE(input[LWS * ITEMS_NUM + global_id] - max_value)) : INPUT0_VAL_ZERO;
+    tmp_vals[ITEMS_NUM] = global_id < LEFTOVERS ? native_exp(DECODE_INPUT0_COMPUTE_TYPE(input[LWS * ITEMS_NUM + global_id]) - max_value) : INPUT0_VAL_ZERO;
 
     // accumulate all values;
     __local INPUT0_COMPUTE_TYPE partial_acc[LWS]; // all values accumulated;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_items_class_optimized.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_items_class_optimized.cl
@@ -23,11 +23,13 @@
 #if BLOCK_SIZE == 1
 #define BLOCK_READ(ptr, offset) DT_INPUT_BLOCK_READ(ptr, offset)
 #define BLOCK_WRITE(ptr, offset, val) DT_OUTPUT_BLOCK_WRITE(ptr, offset, val)
-#define BLOCK_TYPE INPUT0_TYPE
+#define BLOCK_IN_TYPE INPUT0_TYPE
+#define BLOCK_OUT_TYPE OUTPUT_TYPE
 #else
 #define BLOCK_READ(ptr, offset) CAT(DT_INPUT_BLOCK_READ, BLOCK_SIZE)(ptr, offset)
 #define BLOCK_WRITE(ptr, offset, val) CAT(DT_OUTPUT_BLOCK_WRITE, BLOCK_SIZE)(ptr, offset, val)
-#define BLOCK_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, BLOCK_SIZE)
+#define BLOCK_IN_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, BLOCK_SIZE)
+#define BLOCK_OUT_TYPE MAKE_VECTOR_TYPE(OUTPUT_TYPE, BLOCK_SIZE)
 #endif
 
 #define SUB_GROUP_SIZE 16
@@ -64,16 +66,16 @@ KERNEL(softmax_items_class_optimized)(
 #if FULL_ITERATIONS_NUM >= SUB_GROUP_SIZE && IS_SUBGROUP_BLOCK_IO_ENABLED
     for (; cls < FULL_ITERATIONS_NUM - (FULL_ITERATIONS_NUM % BLOCK_SIZE); cls += BLOCK_SIZE)
     {
-        BLOCK_TYPE vec = BLOCK_READ(input, input_idx);
+        BLOCK_IN_TYPE vec = BLOCK_READ(input, input_idx);
 #if BLOCK_SIZE > 1
         for (int i = 0; i < BLOCK_SIZE; i++)
         {
-            ACCUMULATOR_TYPE in = vec[i];
+            ACCUMULATOR_TYPE in = DECODE_INPUT0_COMPUTE_TYPE(vec[i]);
             max_value = max(max_value, in);
             data[cls + i] = in;
         }
 #else
-        ACCUMULATOR_TYPE in = vec;
+        ACCUMULATOR_TYPE in = DECODE_INPUT0_COMPUTE_TYPE(vec);
         max_value = max(max_value, in);
         data[cls] = in;
 #endif
@@ -83,7 +85,7 @@ KERNEL(softmax_items_class_optimized)(
     input_idx += simd_lane * INPUT0_CLASS_PITCH;
     for (; cls < FULL_ITERATIONS_NUM; cls++)
     {
-        ACCUMULATOR_TYPE in = input[input_idx];
+        ACCUMULATOR_TYPE in = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx]);
         max_value = max(max_value, in);
         data[cls] = in;
         input_idx += WORKITEMS_PER_CLASSES*INPUT0_CLASS_PITCH;
@@ -91,7 +93,7 @@ KERNEL(softmax_items_class_optimized)(
 
     if(simd_lane < LEFTOVERS)
     {
-        ACCUMULATOR_TYPE in = input[input_idx];
+        ACCUMULATOR_TYPE in = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx]);
         max_value = max(max_value, in);
         data[DATA_PER_WORKITEM-1] = in;
     }
@@ -131,7 +133,7 @@ KERNEL(softmax_items_class_optimized)(
 #if FULL_ITERATIONS_NUM >= SUB_GROUP_SIZE && IS_SUBGROUP_BLOCK_IO_ENABLED
     for (; cls < FULL_ITERATIONS_NUM - (FULL_ITERATIONS_NUM % BLOCK_SIZE); cls += BLOCK_SIZE)
     {
-        BLOCK_TYPE vec;
+        BLOCK_OUT_TYPE vec;
 #if BLOCK_SIZE > 1
         for (int i = 0; i < BLOCK_SIZE; i++)
         {
@@ -140,7 +142,7 @@ KERNEL(softmax_items_class_optimized)(
             FUSED_OPS;
             vec[i] = FUSED_OPS_RESULT;
 #else
-            vec[i] = ACTIVATION(res, ACTIVATION_PARAMS);
+            vec[i] = TO_OUTPUT_TYPE(ACTIVATION(res, ACTIVATION_PARAMS));
 #endif
         }
 #else
@@ -149,7 +151,7 @@ KERNEL(softmax_items_class_optimized)(
         FUSED_OPS;
         vec = FUSED_OPS_RESULT;
 #else
-        vec = ACTIVATION(res, ACTIVATION_PARAMS);
+        vec = TO_OUTPUT_TYPE(ACTIVATION(res, ACTIVATION_PARAMS));
 #endif
 #endif
         BLOCK_WRITE(output, output_idx, vec);
@@ -164,7 +166,7 @@ KERNEL(softmax_items_class_optimized)(
         FUSED_OPS;
         output[output_idx] = FUSED_OPS_RESULT;
 #else
-        output[output_idx] = ACTIVATION(res, ACTIVATION_PARAMS);
+        output[output_idx] = TO_OUTPUT_TYPE(ACTIVATION(res, ACTIVATION_PARAMS));
 #endif
         output_idx += WORKITEMS_PER_CLASSES * OUTPUT_CLASS_PITCH;
     }
@@ -175,7 +177,7 @@ KERNEL(softmax_items_class_optimized)(
         FUSED_OPS;
         output[output_idx] = FUSED_OPS_RESULT;
 #else
-        output[output_idx] = ACTIVATION(res, ACTIVATION_PARAMS);
+        output[output_idx] = TO_OUTPUT_TYPE(ACTIVATION(res, ACTIVATION_PARAMS));
 #endif
     }
 }
@@ -184,5 +186,6 @@ KERNEL(softmax_items_class_optimized)(
 #undef DATA_PER_WORKITEM
 #undef BLOCK_READ
 #undef BLOCK_WRITE
-#undef BLOCK_TYPE
+#undef BLOCK_IN_TYPE
+#undef BLOCK_OUT_TYPE
 #undef SUB_GROUP_SIZE

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/softmax_gpu_ref.cl
@@ -83,7 +83,7 @@ KERNEL(softmax)(
 #endif
 
     const size_t class_num = INPUT0_CLASS_NUM;
-    ACCUMULATOR_TYPE max_value = UNIT_VAL_MIN;
+    ACCUMULATOR_TYPE max_value = TO_ACCUMULATOR_TYPE(INPUT0_VAL_MIN);
 #if IS_DYNAMIC
     #define TMP_CLASS_PITCH INPUT0_CLASS_PITCH
     __global ACCUMULATOR_TYPE* data = tmp_buffer + in_depth_offset;
@@ -102,7 +102,7 @@ KERNEL(softmax)(
         const uint index = INPUT0_GET_INDEX(b + *b_offset, f + *f_offset, y + *y_offset, x + *x_offset);
 #endif
 #endif
-        ACCUMULATOR_TYPE in = input[index];
+        ACCUMULATOR_TYPE in = DECODE_INPUT0_COMPUTE_TYPE(input[index]);
         max_value = max(max_value, in);
         data[cls*TMP_CLASS_PITCH] = in;
     }
@@ -130,7 +130,7 @@ KERNEL(softmax)(
         FUSED_OPS;
         output[output_idx] = FUSED_OPS_RESULT;
 #else
-        output[output_idx] = ACTIVATION(res, ACTIVATION_PARAMS);
+        output[output_idx] = TO_OUTPUT_TYPE(ACTIVATION(res, ACTIVATION_PARAMS));
 #endif
     }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
@@ -11,8 +11,10 @@ static constexpr size_t subgroup_size = 16;
 ParamsKey SoftmaxKernel_bf::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableInputLayout(DataLayout::bf);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.cpp
@@ -4,6 +4,7 @@
 
 #include "softmax_kernel_bf.h"
 #include "kernel_selector_utils.h"
+#include "common_tools.h"
 #include <algorithm>
 
 namespace kernel_selector {
@@ -44,7 +45,7 @@ SoftmaxKernel_bf::Parent::DispatchData SoftmaxKernel_bf::SetDefault(const softma
     dispatchData.normIndex = 0;
 
     // We have two units of data per work item in current implementation.
-    auto local_mem_per_wi = 2 * BytesPerElement(params.inputs[0].GetDType());
+    auto local_mem_per_wi = 2 * BytesPerElement(GetComputeDatatype(params.inputs[0].GetDType()));
     // Combining device execution and local memory restrictions to compute maximum possible LWS.
     auto max_lws = std::min(params.engineInfo.maxWorkGroupSize, params.engineInfo.maxLocalMemSize / local_mem_per_wi);
     if (!params.has_dynamic_tensors()) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_fb.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_fb.cpp
@@ -9,8 +9,10 @@ namespace kernel_selector {
 ParamsKey SoftmaxKernel_fb::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputLayout(DataLayout::yxfb);
     k.EnableInputLayout(DataLayout::fb);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_fb.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_fb.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "softmax_kernel_fb.h"
+#include "common_tools.h"
 #include <algorithm>
 
 namespace kernel_selector {
@@ -35,7 +36,8 @@ SoftmaxKernel_fb::Parent::DispatchData SoftmaxKernel_fb::SetDefault(const softma
     dispatchData.normIndex = 1;
 
     // We have two units of data per work item in current implementation.
-    auto local_mem_per_wi = 2 * BytesPerElement(params.inputs[0].GetDType());
+    // Local arrays use INPUT0_COMPUTE_TYPE (float for bf16), so size per element accordingly.
+    auto local_mem_per_wi = 2 * BytesPerElement(GetComputeDatatype(params.inputs[0].GetDType()));
     // Combining device execution and local memory restrictions to compute maximum possible LWS.
     auto max_lws = static_cast<std::size_t>(
         std::min(params.engineInfo.maxWorkGroupSize, params.engineInfo.maxLocalMemSize / local_mem_per_wi));
@@ -68,7 +70,7 @@ bool kernel_selector::SoftmaxKernel_fb::Validate(const Params& params) const {
 
     const auto& softmax_params = static_cast<const kernel_selector::softmax_params&>(params);
 
-    auto local_mem_per_wi = 2 * BytesPerElement(softmax_params.inputs[0].GetDType());
+    auto local_mem_per_wi = 2 * BytesPerElement(GetComputeDatatype(softmax_params.inputs[0].GetDType()));
     auto max_lws = static_cast<std::size_t>(
         std::min(params.engineInfo.maxWorkGroupSize, params.engineInfo.maxLocalMemSize / local_mem_per_wi));
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_items_class_optimized.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_items_class_optimized.cpp
@@ -49,8 +49,10 @@ inline static size_t GetItemClassCount(const DataTensor& input, SoftmaxDim dim) 
 ParamsKey SoftmaxKerneItemsClassOptimized::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputLayout(DataLayout::byxf);
     k.EnableInputLayout(DataLayout::bfyx);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_ref.cpp
@@ -8,6 +8,8 @@
 namespace kernel_selector {
 ParamsKey SoftmaxKernelRef::GetSupportedKey() const {
     auto k = GetDefaultSupportedKey();
+    k.EnableInputDataType(Datatype::BF16);
+    k.EnableOutputDataType(Datatype::BF16);
 
     k.EnableInputLayout(DataLayout::b_fs_yx_fsv16);
     k.EnableOutputLayout(DataLayout::b_fs_yx_fsv16);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_ref.cpp
@@ -8,9 +8,9 @@
 namespace kernel_selector {
 ParamsKey SoftmaxKernelRef::GetSupportedKey() const {
     auto k = GetDefaultSupportedKey();
+
     k.EnableInputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::BF16);
-
     k.EnableInputLayout(DataLayout::b_fs_yx_fsv16);
     k.EnableOutputLayout(DataLayout::b_fs_yx_fsv16);
     k.EnableInputLayout(DataLayout::b_fs_yx_fsv32);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_ref.cpp
@@ -4,6 +4,7 @@
 
 #include "softmax_kernel_ref.h"
 #include "kernel_selector_utils.h"
+#include "common_tools.h"
 
 namespace kernel_selector {
 ParamsKey SoftmaxKernelRef::GetSupportedKey() const {
@@ -54,9 +55,10 @@ void SoftmaxKernelRef::GetUpdateDispatchDataFunc(KernelData& kd) const {
         kd.kernels[0].params.workGroups.global = dispatchData.gws;
         kd.kernels[0].params.workGroups.local = dispatchData.lws;
         kd.kernels[0].skip_execution = KernelData::SkipKernelExecution(prim_params);
+        auto acc_dt = GetAccumulatorType(prim_params);
         kd.internalBuffers.clear();
-        kd.internalBuffers.push_back(prim_params.inputs[0].PhysicalSizeInBytes());
-        kd.internalBufferDataType = prim_params.inputs[0].GetDType();
+        kd.internalBuffers.push_back(prim_params.inputs[0].PhysicalSize() * BytesPerElement(acc_dt));
+        kd.internalBufferDataType = acc_dt;
     };
 }
 
@@ -76,9 +78,10 @@ KernelsData SoftmaxKernelRef::GetKernelsData(const Params& params) const {
             args.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 0});
             args.push_back({ArgumentDescriptor::Types::OUTPUT, 0});
 
+            auto acc_dt = GetAccumulatorType(orgParams);
             kds[0].internalBuffers.clear();
-            kds[0].internalBuffers.push_back(orgParams.inputs[0].PhysicalSizeInBytes());
-            kds[0].internalBufferDataType = orgParams.inputs[0].GetDType();
+            kds[0].internalBuffers.push_back(orgParams.inputs[0].PhysicalSize() * BytesPerElement(acc_dt));
+            kds[0].internalBufferDataType = acc_dt;
         }
     }
     return kds;

--- a/src/plugins/intel_gpu/tests/unit/fusions/softmax_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/softmax_fusion_test.cpp
@@ -82,6 +82,11 @@ public:
 #define CASE_SOFTMAX_FP16_3 {1, 15, 1, 1}, data_types::f16, format::bfyx, 1, data_types::f16, format::bfyx
 #define CASE_SOFTMAX_FP16_4 {1, 15, 1, 2}, data_types::f16, format::bfyx, 2, data_types::f16, format::bfyx
 
+#define CASE_SOFTMAX_BF16_1 {1, 15, 4, 5}, data_types::bf16, format::bfyx, 1, data_types::bf16, format::bfyx
+#define CASE_SOFTMAX_BF16_2 {1, 15, 4, 5}, data_types::bf16, format::bfyx, 3, data_types::bf16, format::bfyx
+#define CASE_SOFTMAX_BF16_3 {1, 15, 1, 1}, data_types::bf16, format::bfyx, 1, data_types::bf16, format::bfyx
+#define CASE_SOFTMAX_BF16_4 {1, 15, 1, 2}, data_types::bf16, format::bfyx, 2, data_types::bf16, format::bfyx
+
 // Keep batch > 1 and use larger odd feature count to force both packed and tail
 // fused-output write loops in softmax_gpu_bf (the pre-fix bug used wrong index in tail writes).
 #define CASE_SOFTMAX_FP32_BF_FUSED_INDEXING {2, 8193, 1, 1}, data_types::f32, format::bfyx, 1, data_types::f32, format::bfyx
@@ -116,6 +121,10 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_quantize,
                         softmax_test_params{ CASE_SOFTMAX_FP16_1, 2, 3 },
                         softmax_test_params{ CASE_SOFTMAX_FP16_2, 3, 3 },
                         softmax_test_params{ CASE_SOFTMAX_FP16_3, 2, 3 },
+
+                        softmax_test_params{ CASE_SOFTMAX_BF16_1, 2, 3 },
+                        softmax_test_params{ CASE_SOFTMAX_BF16_2, 3, 3 },
+                        softmax_test_params{ CASE_SOFTMAX_BF16_3, 2, 3 },
 }));
 
 class softmax_activation : public SoftmaxPrimitiveFusingTest {};
@@ -148,6 +157,8 @@ TEST_P(softmax_eltwise_activation, basic) {
     );
 
     tolerance = default_tolerance(p.data_type);
+    if (p.default_type == data_types::bf16)
+        tolerance = 1.6e-2f; // Default 1e-2 is too small for this test, but error is still within 1ULP, so it's OK
     execute(p);
 }
 
@@ -186,19 +197,23 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_activation,
                         softmax_test_params{ CASE_SOFTMAX_FP32_4, 2, 3, "softmax_gpu_bf" },
                         softmax_test_params{ CASE_SOFTMAX_FP32_BF_FUSED_INDEXING, 2, 3, "softmax_gpu_bf" },
                         softmax_test_params{ CASE_SOFTMAX_FP16_3, 2, 3, "softmax_gpu_bf" },
-                        softmax_test_params{ CASE_SOFTMAX_FP16_4, 2, 3, "softmax_gpu_bf" }
+                        softmax_test_params{ CASE_SOFTMAX_FP16_4, 2, 3, "softmax_gpu_bf" },
+                        softmax_test_params{ CASE_SOFTMAX_BF16_3, 2, 3, "softmax_gpu_bf" },
+                        softmax_test_params{ CASE_SOFTMAX_BF16_4, 2, 3, "softmax_gpu_bf" }
 }));
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_eltwise_activation,
     ::testing::ValuesIn(std::vector<softmax_test_params>{
                         softmax_test_params{ CASE_SOFTMAX_FP32_BF_FUSED_INDEXING, 3, 4, "softmax_gpu_bf" },
-                        softmax_test_params{ CASE_SOFTMAX_FP16_3, 3, 4, "softmax_gpu_bf" }
+                        softmax_test_params{ CASE_SOFTMAX_FP16_3, 3, 4, "softmax_gpu_bf" },
+                        softmax_test_params{ CASE_SOFTMAX_BF16_3, 3, 4, "softmax_gpu_bf" }
 }));
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_eltwise_per_element,
     ::testing::ValuesIn(std::vector<softmax_test_params>{
                         softmax_test_params{ CASE_SOFTMAX_FP32_BF_FUSED_INDEXING, 3, 3, "softmax_gpu_bf" },
-                        softmax_test_params{ CASE_SOFTMAX_FP16_3, 3, 3, "softmax_gpu_bf" }
+                        softmax_test_params{ CASE_SOFTMAX_FP16_3, 3, 3, "softmax_gpu_bf" },
+                        softmax_test_params{ CASE_SOFTMAX_BF16_3, 3, 3, "softmax_gpu_bf" }
 }));
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_activation_bug_repro,
@@ -277,4 +292,9 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_quantize_fusing_through,
                         // Such fusions not allowed yet
                         // softmax_test_params{ CASE_SOFTMAX_FP16_2, 3, 3 },
                         // softmax_test_params{ CASE_SOFTMAX_FP16_3, 3, 3 },
+
+                        softmax_test_params{ CASE_SOFTMAX_BF16_1, 2, 3 },
+                        // Such fusions not allowed yet
+                        // softmax_test_params{ CASE_SOFTMAX_BF16_2, 3, 3 },
+                        // softmax_test_params{ CASE_SOFTMAX_BF16_3, 3, 3 },
 }));

--- a/src/plugins/intel_gpu/tests/unit/fusions/softmax_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/softmax_fusion_test.cpp
@@ -97,11 +97,13 @@ public:
 class softmax_quantize : public SoftmaxPrimitiveFusingTest {};
 TEST_P(softmax_quantize, basic) {
     auto p = GetParam();
+    auto quant_layout = get_single_element_layout(p);
+    if (p.default_type == data_types::bf16) quant_layout.data_type = data_types::f32;
     create_topologies(input_layout("input", get_input_layout(p)),
-        data("in_lo", get_mem(get_single_element_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_single_element_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), -127)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(quant_layout, min_random, 0)),
+        data("in_hi", get_mem(quant_layout, 1, max_random)),
+        data("out_lo", get_mem(quant_layout, -127)),
+        data("out_hi", get_mem(quant_layout, 127)),
         softmax("softmax", input_info("input"), p.dimension),
         quantize("quantize", input_info("softmax"), input_info("in_lo"), input_info("in_hi"),
                  input_info("out_lo"), input_info("out_hi"), 255, data_types::i8),
@@ -225,11 +227,13 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, softmax_activation_bug_repro,
 class softmax_quantize_fusing_through : public SoftmaxPrimitiveFusingTest {};
 TEST_P(softmax_quantize_fusing_through, reshape) {
     auto p = GetParam();
+    auto quant_layout = get_single_element_layout(p);
+    if (p.default_type == data_types::bf16) quant_layout.data_type = data_types::f32;
     create_topologies(input_layout("input", get_input_layout(p)),
-        data("in_lo", get_mem(get_single_element_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_single_element_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), -127)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(quant_layout, min_random, 0)),
+        data("in_hi", get_mem(quant_layout, 1, max_random)),
+        data("out_lo", get_mem(quant_layout, -127)),
+        data("out_hi", get_mem(quant_layout, 127)),
         softmax("softmax", input_info("input"), p.dimension),
         reshape("reshape", input_info("softmax"), get_reshape_shape(p)),
         quantize("quantize", input_info("reshape"), input_info("in_lo"), input_info("in_hi"),
@@ -244,11 +248,13 @@ TEST_P(softmax_quantize_fusing_through, reshape) {
 TEST_P(softmax_quantize_fusing_through, reorder) {
     auto p = GetParam();
     auto reorder_layout = layout{ p.data_type, p.input_format, get_reshape_shape(p), padding{} };
+    auto quant_layout = get_single_element_layout(p);
+    if (p.default_type == data_types::bf16) quant_layout.data_type = data_types::f32;
     create_topologies(input_layout("input", get_input_layout(p)),
-        data("in_lo", get_mem(get_single_element_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_single_element_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), -127)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(quant_layout, min_random, 0)),
+        data("in_hi", get_mem(quant_layout, 1, max_random)),
+        data("out_lo", get_mem(quant_layout, -127)),
+        data("out_hi", get_mem(quant_layout, 127)),
         softmax("softmax", input_info("input"), p.dimension),
         reorder("reorder", input_info("softmax"), reorder_layout),
         quantize("quantize", input_info("reorder"), input_info("in_lo"), input_info("in_hi"),
@@ -263,11 +269,13 @@ TEST_P(softmax_quantize_fusing_through, reorder) {
 TEST_P(softmax_quantize_fusing_through, chain) {
     auto p = GetParam();
     auto reorder_layout = layout{ p.data_type, p.input_format, get_reshape_shape(p), padding{} };
+    auto quant_layout = get_single_element_layout(p);
+    if (p.default_type == data_types::bf16) quant_layout.data_type = data_types::f32;
     create_topologies(input_layout("input", get_input_layout(p)),
-        data("in_lo", get_mem(get_single_element_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_single_element_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), -127)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(quant_layout, min_random, 0)),
+        data("in_hi", get_mem(quant_layout, 1, max_random)),
+        data("out_lo", get_mem(quant_layout, -127)),
+        data("out_hi", get_mem(quant_layout, 127)),
         softmax("softmax", input_info("input"), p.dimension),
         reshape("reshape_first", input_info("softmax"), get_reshape_shape(p)),
         reorder("reorder", input_info("reshape_first"), reorder_layout),

--- a/src/plugins/intel_gpu/tests/unit/fusions/softmax_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/softmax_fusion_test.cpp
@@ -140,7 +140,7 @@ TEST_P(softmax_activation, basic) {
     );
 
     tolerance = default_tolerance(p.data_type);
-    if (p.default_type == data_types::f16)
+    if (p.default_type == data_types::f16 || p.default_type == data_types::bf16)
         tolerance *= 2; // Issue: 185375
 
     execute(p);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/softmax_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/softmax_gpu_test.cpp
@@ -904,6 +904,11 @@ float getError<ov::float16>() {
     return 0.2;
 }
 
+template<>
+float getError<ov::bfloat16>() {
+    return 0.2;
+}
+
 struct PrintToStringParamName {
     template<class T>
     std::string operator()(const testing::TestParamInfo<SoftmaxParamsWithFormat<T> > &param) {
@@ -959,12 +964,17 @@ public:
 
 using softmax_gpu_formats_test_f32 = softmax_gpu_formats_test<float>;
 using softmax_gpu_formats_test_f16 = softmax_gpu_formats_test<ov::float16>;
+using softmax_gpu_formats_test_bf16 = softmax_gpu_formats_test<ov::bfloat16>;
 
 TEST_P(softmax_gpu_formats_test_f32, softmax_gpu_formats_test_f32) {
     ASSERT_NO_FATAL_FAILURE(test(false));
 }
 
 TEST_P(softmax_gpu_formats_test_f16, softmax_gpu_formats_test_f16) {
+    ASSERT_NO_FATAL_FAILURE(test(false));
+}
+
+TEST_P(softmax_gpu_formats_test_bf16, softmax_gpu_formats_test_bf16) {
     ASSERT_NO_FATAL_FAILURE(test(false));
 }
 
@@ -986,6 +996,15 @@ INSTANTIATE_TEST_SUITE_P(softmax_gpu_formats_test_f16_2d,
                                  ),
                          PrintToStringParamName());
 
+INSTANTIATE_TEST_SUITE_P(softmax_gpu_formats_test_bf16_2d,
+                         softmax_gpu_formats_test_bf16,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(generateSoftmaxParams2D<ov::bfloat16>()),
+                                 ::testing::Values(format::bfyx),
+                                 ::testing::ValuesIn(formats2D)
+                                 ),
+                         PrintToStringParamName());
+
 INSTANTIATE_TEST_SUITE_P(softmax_gpu_formats_test_f32_3d,
                          softmax_gpu_formats_test_f32,
                          ::testing::Combine(
@@ -999,6 +1018,15 @@ INSTANTIATE_TEST_SUITE_P(softmax_gpu_formats_test_f16_3d,
                          softmax_gpu_formats_test_f16,
                          ::testing::Combine(
                                  ::testing::ValuesIn(generateSoftmaxParams3D<ov::float16>()),
+                                 ::testing::Values(format::bfzyx),
+                                 ::testing::ValuesIn(formats3D)
+                                 ),
+                         PrintToStringParamName());
+
+INSTANTIATE_TEST_SUITE_P(softmax_gpu_formats_test_bf16_3d,
+                         softmax_gpu_formats_test_bf16,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(generateSoftmaxParams3D<ov::bfloat16>()),
                                  ::testing::Values(format::bfzyx),
                                  ::testing::ValuesIn(formats3D)
                                  ),
@@ -1116,6 +1144,10 @@ TEST_P(softmax_gpu_formats_test_f32, softmax_gpu_formats_test_f32_cached) {
 TEST_P(softmax_gpu_formats_test_f16, softmax_gpu_formats_test_f16_cached) {
     ASSERT_NO_FATAL_FAILURE(test(true));
 }
+
+TEST_P(softmax_gpu_formats_test_bf16, softmax_gpu_formats_test_bf16_cached) {
+    ASSERT_NO_FATAL_FAILURE(test(true));
+}
 #endif
 
 TEST(softmax_gpu_bfyx_f32, bf_opt_normalize_f_dynamic) {
@@ -1197,6 +1229,7 @@ TEST(softmax_gpu_bfyx_f32, bf_opt_normalize_f_dynamic) {
     }
 }
 
+template <typename T>
 static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t y, const int64_t x, const uint64_t axis) {
     tests::random_generator rg(GET_SUITE_NAME);
     auto& engine = get_test_engine();
@@ -1206,10 +1239,11 @@ static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t
     ov::intel_gpu::ImplementationDesc softmax_bf_kernel = {format::bfyx, "softmax_gpu_bf"};
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"softmax", softmax_bf_kernel}}));
 
+    const auto data_type = ov::element::from<T>();
     const int64_t buf_size = b * f * y * x;
     auto input_layout_dynamic = layout{ov::PartialShape{ov::Dimension::dynamic(), f, ov::Dimension::dynamic(), ov::Dimension::dynamic()},
-                                        data_types::f16, format::bfyx};
-    auto input_layout_static = layout{ov::PartialShape{b, f, y, x}, data_types::f16, format::bfyx};
+                                        data_type, format::bfyx};
+    auto input_layout_static = layout{ov::PartialShape{b, f, y, x}, data_type, format::bfyx};
 
     std::string softmax_id = "softmax";
     topology topology;
@@ -1220,7 +1254,7 @@ static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t
 
     auto input_mem = engine.allocate_memory(input_layout_static);
 
-    auto input_data = rg.generate_random_1d<ov::float16>(buf_size, -20, 20);
+    auto input_data = rg.generate_random_1d<T>(buf_size, -20, 20);
     set_values(input_mem, input_data);
 
     std::map<cldnn::primitive_id, cldnn::network_output> outputs;
@@ -1231,16 +1265,88 @@ static void run_softmax_bfyx_opt(const int64_t b, const int64_t f, const int64_t
     output = outputs.at(softmax_id).get_memory();
     ASSERT_NE(output, nullptr);
 
-    std::vector<ov::float16> output_ref(buf_size);
-    ov::reference::softmax<ov::float16>(input_data.data(), output_ref.data(), input_layout_static.get_shape(), ov::AxisSet{axis});
+    std::vector<T> output_ref(buf_size);
+    ov::reference::softmax<T>(input_data.data(), output_ref.data(), input_layout_static.get_shape(), ov::AxisSet{axis});
     ASSERT_NE(output, nullptr);
-    const float threshold_fp16 = 1e-1;
-    cldnn::mem_lock<ov::float16> output_ptr(output, get_test_stream());
+    const float threshold = 1e-1;
+    cldnn::mem_lock<T> output_ptr(output, get_test_stream());
     for (size_t idx = 0; idx < static_cast<size_t>(buf_size); idx++) {
-        ASSERT_NEAR(float(output_ptr[idx]), float(output_ref[idx]), threshold_fp16) << idx << ", " << std::fixed << setprecision(8) << output_ptr[idx] << " vs " << output_ref[idx];
+        ASSERT_NEAR(float(output_ptr[idx]), float(output_ref[idx]), threshold) << idx << ", " << std::fixed << setprecision(8) << output_ptr[idx] << " vs " << output_ref[idx];
     }
 }
 
 TEST(softmax_gpu_bfyx_f16, opt_softmax_bf_axis_3) {
-    run_softmax_bfyx_opt(1, 4, 2, 3083, 3);
+    run_softmax_bfyx_opt<ov::float16>(1, 4, 2, 3083, 3);
+}
+
+TEST(softmax_gpu_bfyx_bf16, opt_softmax_bf_axis_3) {
+    run_softmax_bfyx_opt<ov::bfloat16>(1, 4, 2, 3083, 3);
+}
+
+// Large data set size (> 32 * max_lws) forces the dynamic softmax_gpu_bf kernel to take the
+// use_output_buffer path, since items_num exceeds the fixed dynamic STACK_SIZE (34).
+TEST(softmax_gpu_bfyx_f16, opt_softmax_bf_use_output_buffer) {
+    run_softmax_bfyx_opt<ov::float16>(1, 1, 1, 40000, 3);
+}
+
+TEST(softmax_gpu_bfyx_bf16, opt_softmax_bf_use_output_buffer) {
+    run_softmax_bfyx_opt<ov::bfloat16>(1, 1, 1, 40000, 3);
+}
+
+// Forces the softmax_gpu_items_class_optimized kernel (splits the class dimension across
+// 16 work-items per output). A feature-axis softmax with >= 32 classes keeps this kernel valid,
+// and force_implementations guarantees it is picked over the higher-priority softmax_gpu_bf.
+template <typename T>
+static void run_softmax_items_class_opt(const int64_t b, const int64_t f, const int64_t y, const int64_t x, const uint64_t axis) {
+    tests::random_generator rg(GET_SUITE_NAME);
+    auto& engine = get_test_engine();
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    ov::intel_gpu::ImplementationDesc softmax_items_class_kernel = {format::bfyx, "softmax_gpu_items_class_optimized"};
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"softmax", softmax_items_class_kernel}}));
+
+    const auto data_type = ov::element::from<T>();
+    const int64_t buf_size = b * f * y * x;
+    auto in_layout = layout{ov::PartialShape{b, f, y, x}, data_type, format::bfyx};
+
+    const std::string softmax_id = "softmax";
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(softmax(softmax_id, input_info("input"), axis));
+
+    cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+
+    auto input_mem = engine.allocate_memory(in_layout);
+    auto input_data = rg.generate_random_1d<T>(buf_size, -20, 20);
+    set_values(input_mem, input_data);
+    network->set_input_data("input", input_mem);
+
+    auto inst = network->get_primitive(softmax_id);
+    auto impl = inst->get_impl();
+    ASSERT_TRUE(impl != nullptr);
+    ASSERT_NE(impl->get_kernel_name().find("softmax_gpu_items_class_optimized"), std::string::npos);
+
+    auto outputs = network->execute();
+    auto output = outputs.at(softmax_id).get_memory();
+    ASSERT_NE(output, nullptr);
+
+    std::vector<T> output_ref(buf_size);
+    ov::reference::softmax<T>(input_data.data(), output_ref.data(), in_layout.get_shape(), ov::AxisSet{axis});
+
+    cldnn::mem_lock<T> output_ptr(output, get_test_stream());
+    for (size_t idx = 0; idx < static_cast<size_t>(buf_size); idx++) {
+        ASSERT_NEAR(float(output_ptr[idx]), float(output_ref[idx]), getError<T>()) << idx;
+    }
+}
+
+TEST(softmax_gpu_bfyx_f32, items_class_opt_normalize_f) {
+    run_softmax_items_class_opt<float>(2, 64, 1, 1, 1);
+}
+
+TEST(softmax_gpu_bfyx_f16, items_class_opt_normalize_f) {
+    run_softmax_items_class_opt<ov::float16>(2, 64, 1, 1, 1);
+}
+
+TEST(softmax_gpu_bfyx_bf16, items_class_opt_normalize_f) {
+    run_softmax_items_class_opt<ov::bfloat16>(2, 64, 1, 1, 1);
 }


### PR DESCRIPTION
This PR adds bf16 data type support to all **softmax** OCL kernels (ref, bf, fb, items_class_optimized) as part of the broader BF16 enablement effort for the Intel GPU plugin ([CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)).

Ticket: [CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)

> [!NOTE]
> This pull request is part of a larger implementation effort for BF16 support in the OpenVINO GPU Plugin.  On its own, this PR may not provide complete user-visible BF16 enablement.

---

### Changes

**Kernel selector / OCL kernels:**
- Registered `Datatype::BF16` in `softmax_kernel_ref.cpp`, `softmax_kernel_bf.cpp`, `softmax_kernel_fb.cpp`, and `softmax_kernel_items_class_optimized.cpp`.
- Updated `softmax_gpu_ref.cl`, `softmax_gpu_bf.cl`, `softmax_gpu_fb.cl`, and `softmax_gpu_items_class_optimized.cl` to use compute-type macros for bf16→f32 decode at input boundaries and f32→bf16 encode at output.
- Registered bf16 in `softmax_impls.cpp` implementation registry.

**Tests:**
- Added bf16 unit tests to `softmax_gpu_test.cpp`.
- Added bf16 fusion tests to `softmax_fusion_test.cpp`.

### AI assistance:
> [!NOTE]  
> AI assistance used during analysis and PR description preparation. All code originates from the original BF16 OCL enablement branch.
