### PR TITLE
[GPU] BF16 OCL: broadcast and strided_slice support

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cpu/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/broadcast.cpp
@@ -138,6 +138,7 @@ attach_broadcast_impl::attach_broadcast_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i32,
         data_types::i64,
         data_types::i8,

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/strided_slice.cpp
@@ -194,6 +194,7 @@ attach_strided_slice_impl::attach_strided_slice_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i32,
         data_types::i64,
         data_types::i8,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -145,6 +145,7 @@ attach_broadcast_impl::attach_broadcast_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i8,
         data_types::u8,
         data_types::i32,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -147,6 +147,7 @@ attach_broadcast_impl::attach_broadcast_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i8,
         data_types::u8,
         data_types::i32,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -258,6 +258,7 @@ attach_strided_slice_impl::attach_strided_slice_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i8,
         data_types::u8,
         data_types::i32,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -255,6 +255,7 @@ attach_strided_slice_impl::attach_strided_slice_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i8,
         data_types::u8,
         data_types::i32,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/broadcast_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/broadcast_gpu_ref.cl
@@ -335,7 +335,7 @@ KERNEL(broadcast_gpu_ref)(
                         FUSED_OPS
                         output[output_idx + offset] = FUSED_OPS_RESULT;
                     #else
-                        output[output_idx + offset] = TO_OUTPUT_TYPE(input[idx_pos + offset]);
+                        output[output_idx + offset] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(input[idx_pos + offset]));
                     #endif
                 }
                 output_idx += OUTPUT_SIZE_X;
@@ -351,7 +351,7 @@ KERNEL(broadcast_gpu_ref)(
                         FUSED_OPS
                         out_v[offset] = FUSED_OPS_RESULT;
                     #else
-                        out_v[offset] = TO_OUTPUT_TYPE(input_vec[offset]);
+                        out_v[offset] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(input_vec[offset]));
                     #endif
                 }
                 VSTORE(out_v, 0, &output[output_idx]);
@@ -371,7 +371,7 @@ KERNEL(broadcast_gpu_ref)(
                         output[out_pos + offset] = FUSED_OPS_RESULT;
                         offset += OUTPUT_SIZE_X;
                     #else
-                        output[out_pos + offset] = TO_OUTPUT_TYPE(input_val);
+                        output[out_pos + offset] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(input_val));
                         offset += OUTPUT_SIZE_X;
                     #endif
                 }
@@ -415,7 +415,7 @@ KERNEL(broadcast_gpu_ref)(
             FUSED_OPS
             output[out_pos] = FUSED_OPS_RESULT;
         #else
-            output[out_pos] = TO_OUTPUT_TYPE(input[idx_pos]);
+            output[out_pos] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(input[idx_pos]));
         #endif
     }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/strided_slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/strided_slice_ref.cl
@@ -347,7 +347,13 @@ KERNEL(strided_slice_ref)(OPTIONAL_SHAPE_INFO_ARG
     const uint output_index = OUTPUT_GET_INDEX(batch, feature, w, z, y, x);
 #endif
 
-    output[output_index] = input[input_index];
+#if HAS_FUSED_OPS
+    INPUT0_TYPE input_data = input[input_index];
+    FUSED_OPS;
+    output[output_index] = FUSED_OPS_RESULT;
+#else
+    output[output_index] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(input[input_index]), ACTIVATION_PARAMS));
+#endif
 
 #else // NEW_AXIS_MODE
 #ifdef OUTPUT_LAYOUT_BFYX
@@ -420,7 +426,7 @@ KERNEL(strided_slice_ref)(OPTIONAL_SHAPE_INFO_ARG
     FUSED_OPS;
     output[output_index] = FUSED_OPS_RESULT;
 #else
-    output[output_index] = ACTIVATION(input[input_index], ACTIVATION_PARAMS);
+    output[output_index] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(input[input_index]), ACTIVATION_PARAMS));
 #endif
 #endif // NEW_AXIS_MODE
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/broadcast/broadcast_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/broadcast/broadcast_kernel_base.cpp
@@ -35,7 +35,7 @@ JitConstants BroadcastKernelBase::GetJitConstants(const broadcast_params& params
 
     // Fused post_ops
     if (!params.fused_ops.empty()) {
-        kernel_selector::Datatype input_dt = params.outputs[0].GetDType();
+        kernel_selector::Datatype input_dt = params.inputs[0].GetDType();
         std::vector<std::string> idx_order;
         if (DataTensor::ChannelsCount(params.outputs[0].GetLayout()) == 4) {
             idx_order = {"out_b", "out_f", "out_y + i", "out_x + offset"};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/broadcast/broadcast_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/broadcast/broadcast_kernel_ref.cpp
@@ -9,6 +9,7 @@ ParamsKey BroadcastKernelRef::GetSupportedKey() const {
     ParamsKey k;
 
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::UINT8);
@@ -17,6 +18,7 @@ ParamsKey BroadcastKernelRef::GetSupportedKey() const {
 
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT32);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_ref.cpp
@@ -47,12 +47,14 @@ static size_t GetUsedOutDimsCount(const strided_slice_params& params) {
 ParamsKey StridedSliceKernelRef::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT64);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT8);

--- a/src/plugins/intel_gpu/tests/unit/fusions/broadcast_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/broadcast_fusion_test.cpp
@@ -72,6 +72,17 @@ public:
 #define CASE_BROADCAST_FP16_OPT_1     { 21, 2, 1, 5 }, { 21, 2, 13, 5 },       data_types::f16, data_types::f16, format::bfyx,           data_types::f16,  format::bfyx
 #define CASE_BROADCAST_FP16_OPT_2     { 21, 2, 1, 1 }, { 21, 2, 13, 1 },       data_types::f16, data_types::f16, format::bfyx,           data_types::f16,  format::bfyx
 
+#define CASE_BROADCAST_BF16_1         { 1, 16, 4, 4 }, { 2, 16, 4, 4 },        data_types::bf16, data_types::bf16, format::bfyx,          data_types::bf16, format::bfyx
+#define CASE_BROADCAST_BF16_2         { 2, 1,  4, 4, 4 }, { 2, 16, 4, 4, 4 },  data_types::bf16, data_types::bf16, format::bfzyx,         data_types::bf16, format::bfzyx
+#define CASE_BROADCAST_BF16_3         { 2, 16, 4, 4, 1 }, { 2, 16, 4, 4, 8 },  data_types::bf16, data_types::bf16, format::bfzyx,         data_types::bf16, format::bfzyx
+
+#define CASE_BROADCAST_BF16_1_BLK     { 2, 16, 4, 1 }, { 2, 16, 4, 4 },        data_types::bf16, data_types::bf16, format::b_fs_yx_fsv16, data_types::bf16, format::bfyx
+#define CASE_BROADCAST_BF16_2_BLK     { 1, 16, 4, 4 }, { 2, 16, 4, 4 },        data_types::bf16, data_types::bf16, format::b_fs_yx_fsv16, data_types::bf16, format::bfyx
+#define CASE_BROADCAST_BF16_3_BLK     { 2, 16, 4, 1 }, { 2, 16, 4, 4 },        data_types::u8,   data_types::i8,   format::b_fs_yx_fsv32, data_types::bf16, format::bfyx
+
+#define CASE_BROADCAST_BF16_OPT_1     { 21, 2, 1, 5 }, { 21, 2, 13, 5 },       data_types::bf16, data_types::bf16, format::bfyx,          data_types::bf16, format::bfyx
+#define CASE_BROADCAST_BF16_OPT_2     { 21, 2, 1, 1 }, { 21, 2, 13, 1 },       data_types::bf16, data_types::bf16, format::bfyx,          data_types::bf16, format::bfyx
+
 class broadcast_fused_prims : public BroadcastFusingTest {};
 TEST_P(broadcast_fused_prims, broadcast_activation_with_broadcast) {
     auto p = GetParam();
@@ -104,4 +115,15 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, broadcast_fused_prims, ::testing::ValuesIn
 
     broadcast_test_params{ CASE_BROADCAST_FP16_OPT_1, 4, 6 },
     broadcast_test_params{ CASE_BROADCAST_FP16_OPT_2, 4, 6 },
+
+    broadcast_test_params{ CASE_BROADCAST_BF16_1, 4, 6 },
+    broadcast_test_params{ CASE_BROADCAST_BF16_2, 4, 6 },
+    broadcast_test_params{ CASE_BROADCAST_BF16_3, 4, 6 },
+
+    broadcast_test_params{ CASE_BROADCAST_BF16_1_BLK, 4, 6 },
+    broadcast_test_params{ CASE_BROADCAST_BF16_2_BLK, 4, 6 },
+    broadcast_test_params{ CASE_BROADCAST_BF16_3_BLK, 4, 6 },
+
+    broadcast_test_params{ CASE_BROADCAST_BF16_OPT_1, 4, 6 },
+    broadcast_test_params{ CASE_BROADCAST_BF16_OPT_2, 4, 6 },
 }));

--- a/src/plugins/intel_gpu/tests/unit/fusions/broadcast_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/broadcast_fusion_test.cpp
@@ -87,15 +87,17 @@ class broadcast_fused_prims : public BroadcastFusingTest {};
 TEST_P(broadcast_fused_prims, broadcast_activation_with_broadcast) {
     auto p = GetParam();
     const auto quantize_dt = data_types::i8;
+    auto quant_layout = get_single_element_layout(p);
+    if (p.default_type == data_types::bf16) quant_layout.data_type = data_types::f32;
     create_topologies(
         input_layout("input", get_input_layout1(p)),
         input_layout("input2", get_input_layout2(p)),
         broadcast("broadcast", input_info("input"), get_input_layout2(p).get_shape(), ov::AxisSet({}), ov::op::BroadcastType::NUMPY),
         eltwise("eltwise", {input_info("broadcast"), input_info("input2")}, eltwise_mode::sum, p.default_type),
-        data("in_lo", get_mem(get_single_element_layout(p), -1.9)),
-        data("in_hi", get_mem(get_single_element_layout(p), 1.8)),
-        data("out_lo", get_mem(get_single_element_layout(p), -128)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(quant_layout, -1.9)),
+        data("in_hi", get_mem(quant_layout, 1.8)),
+        data("out_lo", get_mem(quant_layout, -128)),
+        data("out_hi", get_mem(quant_layout, 127)),
         quantize("quantize", input_info("eltwise"), input_info("in_lo"), input_info("in_hi"), input_info("out_lo"), input_info("out_hi"), 256, quantize_dt),
         activation("activation", input_info("quantize"), activation_func::relu),
         reorder("out", input_info("activation"), p.default_format, data_types::f32));

--- a/src/plugins/intel_gpu/tests/unit/fusions/strided_slice_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/strided_slice_fusion_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2023 Intel Corporation
+// Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -56,6 +56,7 @@ public:
 /* ----------------------------------------------------------------------------------------------------- */
 
 #define CASE_STRIDED_SLICE_F16_1 { 1, 8, 1, 1 },  { 1, 3, 2, 2 }, data_types::f16, format::bfyx
+#define CASE_STRIDED_SLICE_BF16_1 { 1, 8, 1, 1 },  { 1, 3, 2, 2 }, data_types::bf16, format::bfyx
 
 
 class strided_slice_activation : public StridedSliceFusingsTest {};
@@ -80,7 +81,7 @@ TEST_P(strided_slice_activation, basic) {
     }
 
     add_topologies(
-        reorder("reorder_bfyx", input_info(before_name), format::bfyx, data_types::f16));
+        reorder("reorder_bfyx", input_info(before_name), format::bfyx, p.input_type));
 
     tolerance = 1e-5f;
     execute(p);
@@ -90,4 +91,45 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, strided_slice_activation, ::testing::Value
     strided_slice_test_params{ CASE_STRIDED_SLICE_F16_1, 2, 2, 4, {{ activation_func::clamp, { } }, { activation_func::exp, { } }} },
     strided_slice_test_params{ CASE_STRIDED_SLICE_F16_1, 2, 2, 3, {{ activation_func::logistic, { } } } },
     strided_slice_test_params{ CASE_STRIDED_SLICE_F16_1, 2, 3, 3, {{ activation_func::hyperbolic_tan, { } } } },
+    strided_slice_test_params{ CASE_STRIDED_SLICE_BF16_1, 2, 2, 4, {{ activation_func::clamp, { } }, { activation_func::exp, { } }} },
+    strided_slice_test_params{ CASE_STRIDED_SLICE_BF16_1, 2, 2, 3, {{ activation_func::logistic, { } } } },
+    strided_slice_test_params{ CASE_STRIDED_SLICE_BF16_1, 2, 3, 3, {{ activation_func::hyperbolic_tan, { } } } },
+}));
+
+// StridedSlice with new_axis_mask set: a new length-1 dimension is inserted and the kernel
+// takes the NEW_AXIS_MODE path, which copies input to output verbatim. This test verifies that
+// a fused activation is still applied on that path (it must not be silently dropped).
+class strided_slice_new_axis_activation : public StridedSliceFusingsTest {};
+TEST_P(strided_slice_new_axis_activation, basic) {
+    std::vector<int64_t> begin_data = { 0, 0, 0, 0 };
+    std::vector<int64_t> end_data = { 1, 8, 1, 1 };
+    std::vector<int64_t> strides_data = { 1, 1, 1, 1 };
+
+    auto p = GetParam();
+    if (engine.get_device_info().supports_immad)
+        p.expected_fused_primitives = p.expected_fused_primitives_onednn;
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        // new_axis_mask = { 1 } inserts a length-1 axis at position 0, producing a 5D output.
+        strided_slice("strided_slice", input_info("input"), begin_data, end_data, strides_data,
+                      {}, {}, { 1 }, {}, {}, { 1, 1, 8, 1, 1 })
+    );
+
+    std::string before_name = "strided_slice";
+    for (auto& act_item : p.activation_func_list) {
+        std::string act_name = "actv_" + activation_type_to_str(act_item.first);
+        add_topologies(activation(act_name, input_info(before_name), act_item.first, act_item.second));
+        before_name = act_name;
+    }
+
+    add_topologies(
+        reorder("reorder_bfyx", input_info(before_name), format::bfyx, p.input_type));
+
+    tolerance = 1e-5f;
+    execute(p);
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, strided_slice_new_axis_activation, ::testing::ValuesIn(std::vector<strided_slice_test_params>{
+    strided_slice_test_params{ CASE_STRIDED_SLICE_F16_1, 2, 2, 3, {{ activation_func::exp, { } } } },
+    strided_slice_test_params{ CASE_STRIDED_SLICE_BF16_1, 2, 2, 3, {{ activation_func::exp, { } } } },
 }));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
@@ -311,8 +311,16 @@ TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1_dynamic) {
     start_broadcast_test_dynamic<float, ov::float16>(format::bfyx, data_types::f32, data_types::f16, {4, 5}, {1, 1}, {0, 1}, false, impl_types::any, true);
 }
 
+TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1_dynamic_bf16) {
+    start_broadcast_test_dynamic<float, ov::bfloat16>(format::bfyx, data_types::f32, data_types::bf16, {4, 5}, {1, 1}, {0, 1}, false, impl_types::any, true);
+}
+
 TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1_dynamic_with_static_output) {
     start_broadcast_test_dynamic<float, ov::float16>(format::bfyx, data_types::f32, data_types::f16, {4, 5}, {1, 1}, {0, 1}, true);
+}
+
+TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1_dynamic_with_static_output_bf16) {
+    start_broadcast_test_dynamic<float, ov::bfloat16>(format::bfyx, data_types::f32, data_types::bf16, {4, 5}, {1, 1}, {0, 1}, true);
 }
 
 TEST(broadcast_gpu_uint8_t, bfyx_1_to_4x5_w_b_axes_0x1_dynamic) {
@@ -1235,6 +1243,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1x38x1x1_to_1x38x1x5_w_b_axes_0) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {1, 38, 1, 5}, {1, 38, 1, 1}, {0});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1x38x1x1_to_1x38x1x5_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {1, 38, 1, 5}, {1, 38, 1, 1}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1x38x1x1_to_1x38x1x5_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {1, 38, 1, 5}, {1, 38, 1, 1}, {0});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_1_to_4x5_w_b_axes_0x1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {4, 5}, {1}, {0, 1});
@@ -1262,6 +1278,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_1_to_4x5_w_b_axes_0x1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1_to_4x5_w_b_axes_0x1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {4, 5}, {1}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1_to_4x5_w_b_axes_0x1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {4, 5}, {1}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1_to_4x5_w_b_axes_0x1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {4, 5}, {1}, {0, 1});
 }
 
 
@@ -1293,6 +1317,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1_to_3x4x5_w_b_axes_0x1x2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {3, 4, 5}, {1}, {0, 1, 2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1_to_3x4x5_w_b_axes_0x1x2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {3, 4, 5}, {1}, {0, 1, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1_to_3x4x5_w_b_axes_0x1x2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {3, 4, 5}, {1}, {0, 1, 2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {1}, {0, 1, 2, 3});
@@ -1320,6 +1352,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {1}, {0, 1, 2, 3});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {1}, {0, 1, 2, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {1}, {0, 1, 2, 3});
 }
 
 
@@ -1351,6 +1391,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_42x36x1x1_to_42x36x1x5_w_o_b_axes)
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {42, 36, 1, 5}, {42, 36, 1, 1}, {});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_42x36x1x1_to_42x36x1x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {42, 36, 1, 5}, {42, 36, 1, 1}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_42x36x1x1_to_42x36x1x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {42, 36, 1, 5}, {42, 36, 1, 1}, {});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {140, 128, 1, 12}, {35, 32, 1, 3}, {});
@@ -1378,6 +1426,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {140, 128, 1, 12}, {35, 32, 1, 3}, {});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {140, 128, 1, 12}, {35, 32, 1, 3}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {140, 128, 1, 12}, {35, 32, 1, 3}, {});
 }
 
 
@@ -1409,6 +1465,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_42x64x1x1_to_84x128x4x5_w_o_b_axes
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {84, 128, 4, 5}, {42, 64, 1, 1}, {});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_42x64x1x1_to_84x128x4x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {84, 128, 4, 5}, {42, 64, 1, 1}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_42x64x1x1_to_84x128x4x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {84, 128, 4, 5}, {42, 64, 1, 1}, {});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {156, 156, 8, 6}, {156, 78, 2, 3}, {});
@@ -1436,6 +1500,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {156, 156, 8, 6}, {156, 78, 2, 3}, {});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {156, 156, 8, 6}, {156, 78, 2, 3}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {156, 156, 8, 6}, {156, 78, 2, 3}, {});
 }
 
 
@@ -1467,6 +1539,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_42x2x3x4_to_126x6x6x4_w_o_b_axes) 
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {126, 6, 6, 4}, {42, 2, 3, 4}, {});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_42x2x3x4_to_126x6x6x4_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {126, 6, 6, 4}, {42, 2, 3, 4}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_42x2x3x4_to_126x6x6x4_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {126, 6, 6, 4}, {42, 2, 3, 4}, {});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {256, 273, 8, 5}, {256, 91, 4, 5}, {});
@@ -1494,6 +1574,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {256, 273, 8, 5}, {256, 91, 4, 5}, {});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {256, 273, 8, 5}, {256, 91, 4, 5}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {256, 273, 8, 5}, {256, 91, 4, 5}, {});
 }
 
 
@@ -1525,6 +1613,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv166_1x45x1x3_to_1x45x2x3_w_b_axes_0) 
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {1, 45, 2, 3}, {1, 45, 1, 3}, {0});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv166_1x45x1x3_to_1x45x2x3_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {1, 45, 2, 3}, {1, 45, 1, 3}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv166_1x45x1x3_to_1x45x2x3_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {1, 45, 2, 3}, {1, 45, 1, 3}, {0});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {1, 62, 2, 6}, {1, 62, 1, 3}, {0});
@@ -1552,6 +1648,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {1, 62, 2, 6}, {1, 62, 1, 3}, {0});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {1, 62, 2, 6}, {1, 62, 1, 3}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {1, 62, 2, 6}, {1, 62, 1, 3}, {0});
 }
 
 
@@ -1583,6 +1687,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2_to_2x3_w_b_axes_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3}, {2}, {1});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2_to_2x3_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3}, {2}, {1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2_to_2x3_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3}, {2}, {1});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2_to_6x3_w_b_axes_1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {6, 3}, {2}, {1});
@@ -1610,6 +1722,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2_to_6x3_w_b_axes_1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2_to_6x3_w_b_axes_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {6, 3}, {2}, {1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2_to_6x3_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {6, 3}, {2}, {1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2_to_6x3_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {6, 3}, {2}, {1});
 }
 
 
@@ -1641,6 +1761,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1x76x3x4_to_1x152x3x4_w_b_axes_0) 
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {1, 152, 3, 4}, {1, 76, 3, 4}, {0});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1x76x3x4_to_1x152x3x4_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {1, 152, 3, 4}, {1, 76, 3, 4}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1x76x3x4_to_1x152x3x4_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {1, 152, 3, 4}, {1, 76, 3, 4}, {0});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x4_to_2x3x4_w_b_axes_1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4}, {2, 4}, {1});
@@ -1668,6 +1796,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x4_to_2x3x4_w_b_axes_1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x4_to_2x3x4_w_b_axes_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {2, 4}, {1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x4_to_2x3x4_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {2, 4}, {1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x4_to_2x3x4_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {2, 4}, {1});
 }
 
 
@@ -1699,6 +1835,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x3_to_2x3x4_w_b_axes_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {2, 3}, {2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x3_to_2x3x4_w_b_axes_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {2, 3}, {2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x3_to_2x3x4_w_b_axes_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {2, 3}, {2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_4_to_2x3x4_w_b_axes_0_1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4}, {4}, {0, 1});
@@ -1726,6 +1870,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_4_to_2x3x4_w_b_axes_0_1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_4_to_2x3x4_w_b_axes_0_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {4}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_4_to_2x3x4_w_b_axes_0_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {4}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_4_to_2x3x4_w_b_axes_0_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {4}, {0, 1});
 }
 
 
@@ -1757,6 +1909,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_3_to_2x3x4_w_b_axes_0_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {3}, {0, 2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_3_to_2x3x4_w_b_axes_0_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {3}, {0, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_3_to_2x3x4_w_b_axes_0_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {3}, {0, 2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2_to_2x3x4_w_b_axes_1_2) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4}, {2}, {1, 2});
@@ -1784,6 +1944,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2_to_2x3x4_w_b_axes_1_2) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2_to_2x3x4_w_b_axes_1_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {2}, {1, 2});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2_to_2x3x4_w_b_axes_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {2}, {1, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2_to_2x3x4_w_b_axes_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {2}, {1, 2});
 }
 
 
@@ -1815,6 +1983,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1x128x4x5_to_2x256x4x5_w_b_axes_0)
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 256, 4, 5}, {1, 128, 4, 5}, {0});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1x128x4x5_to_2x256x4x5_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 256, 4, 5}, {1, 128, 4, 5}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1x128x4x5_to_2x256x4x5_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 256, 4, 5}, {1, 128, 4, 5}, {0});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2, 4, 5}, {1});
@@ -1842,6 +2018,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 4, 5}, {1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 4, 5}, {1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 4, 5}, {1});
 }
 
 
@@ -1873,6 +2057,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x3x5_to_2x3x4x5_w_b_axes_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 3, 5}, {2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x3x5_to_2x3x4x5_w_b_axes_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3, 5}, {2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x3x5_to_2x3x4x5_w_b_axes_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3, 5}, {2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2, 3, 4}, {3});
@@ -1900,6 +2092,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 3, 4}, {3});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3, 4}, {3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3, 4}, {3});
 }
 
 
@@ -1931,6 +2131,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_4x5_to_2x3x4x5_w_b_axes_0_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {4, 5}, {0, 1});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_4x5_to_2x3x4x5_w_b_axes_0_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {4, 5}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_4x5_to_2x3x4x5_w_b_axes_0_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {4, 5}, {0, 1});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {3, 5}, {0, 2});
@@ -1958,6 +2166,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {3, 5}, {0, 2});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {3, 5}, {0, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {3, 5}, {0, 2});
 }
 
 
@@ -1989,6 +2205,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_3x4_to_2x3x4x5_w_b_axes_0_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {3, 4}, {0, 3});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_3x4_to_2x3x4x5_w_b_axes_0_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {3, 4}, {0, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_3x4_to_2x3x4x5_w_b_axes_0_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {3, 4}, {0, 3});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2, 5}, {1, 2});
@@ -2016,6 +2240,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 5}, {1, 2});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 5}, {1, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 5}, {1, 2});
 }
 
 
@@ -2047,6 +2279,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x4_to_2x3x4x5_w_b_axes_1_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 4}, {1, 3});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x4_to_2x3x4x5_w_b_axes_1_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 4}, {1, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x4_to_2x3x4x5_w_b_axes_1_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 4}, {1, 3});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2, 3}, {2, 3});
@@ -2074,6 +2314,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 3}, {2, 3});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3}, {2, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3}, {2, 3});
 }
 
 
@@ -2105,6 +2353,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_5_to_2x3x4x5_w_b_axes_0_1_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {5}, {0, 1, 2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_5_to_2x3x4x5_w_b_axes_0_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {5}, {0, 1, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_5_to_2x3x4x5_w_b_axes_0_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {5}, {0, 1, 2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {4}, {0, 1, 3});
@@ -2132,6 +2388,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {4}, {0, 1, 3});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {4}, {0, 1, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {4}, {0, 1, 3});
 }
 
 
@@ -2163,6 +2427,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_3_to_2x3x4x5_w_b_axes_0_2_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {3}, {0, 2, 3});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_3_to_2x3x4x5_w_b_axes_0_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {3}, {0, 2, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_3_to_2x3x4x5_w_b_axes_0_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {3}, {0, 2, 3});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2_to_2x3x4x5_w_b_axes_1_2_3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2}, {1, 2, 3});
@@ -2192,6 +2464,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2_to_2x3x4x5_w_b_axes_1_2_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2}, {1, 2, 3});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2_to_2x3x4x5_w_b_axes_1_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2}, {1, 2, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2_to_2x3x4x5_w_b_axes_1_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2}, {1, 2, 3});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_zyx_fsv16_1x48x1x1_to_1x48x1x5_w_b_axes_0) {
     start_broadcast_test_5d<float>(format::b_fs_zyx_fsv16, data_types::f32, { 1, 48, 1, 5 }, { 1, 48, 1, 1 }, { 0 });
@@ -2207,6 +2487,10 @@ TEST(broadcast_gpu_int8_t, b_fs_zyx_fsv32_1x48x1x1_to_1x48x1x5_w_b_axes_0) {
 
 TEST(broadcast_gpu_fp16, b_fs_zyx_fsv16_1x48x1x1_to_1x48x1x5_w_b_axes_0) {
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 1, 48, 1, 5 }, { 1, 48, 1, 1 }, { 0 });
+}
+
+TEST(broadcast_gpu_bf16, b_fs_zyx_fsv16_1x48x1x1_to_1x48x1x5_w_b_axes_0) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 1, 48, 1, 5 }, { 1, 48, 1, 1 }, { 0 });
 }
 
 
@@ -2226,6 +2510,10 @@ TEST(broadcast_gpu_fp16, b_fs_zyx_fsv16_64x256x2x1_to_128x256x4x5_w_b_axes_0x1) 
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 128, 256, 4, 5 }, { 64, 256, 2, 1}, {});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_zyx_fsv16_64x256x2x1_to_128x256x4x5_w_b_axes_0x1) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 128, 256, 4, 5 }, { 64, 256, 2, 1}, {});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_zyx_fsv16_1_to_4x5_w_b_axes_0x1) {
     start_broadcast_test_5d<float>(format::b_fs_zyx_fsv16, data_types::f32, { 4, 5 }, { 1 }, { 0, 1 });
@@ -2241,6 +2529,10 @@ TEST(broadcast_gpu_int8_t, b_fs_zyx_fsv32_1_to_4x5_w_b_axes_0x1) {
 
 TEST(broadcast_gpu_fp16, b_fs_zyx_fsv16_1_to_4x5_w_b_axes_0x1) {
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 4, 5 }, { 1 }, { 0, 1 });
+}
+
+TEST(broadcast_gpu_bf16, b_fs_zyx_fsv16_1_to_4x5_w_b_axes_0x1) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 4, 5 }, { 1 }, { 0, 1 });
 }
 
 
@@ -2260,10 +2552,19 @@ TEST(broadcast_gpu_fp16, b_fs_zyx_fsv16_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 });
 }
 
+TEST(broadcast_gpu_bf16, b_fs_zyx_fsv16_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 });
+}
+
 TEST(export_import_broadcast_gpu_fp16, b_fs_zyx_fsv16_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 }, true);
 }
 
+TEST(export_import_broadcast_gpu_bf16, b_fs_zyx_fsv16_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 }, true);
+}
+
+template <typename T>
 static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> in_static_shape,
                                     std::vector<ov::Dimension::value_type> in_dynamic_shape,
                                     std::vector<ov::Dimension::value_type> output_shape,
@@ -2274,8 +2575,9 @@ static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> 
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
-    auto input_static_layout = cldnn::layout{ov::PartialShape{in_static_shape}, data_types::f16, format::bfzyx};
-    auto input_dynamic_layout = cldnn::layout{ov::PartialShape{in_dynamic_shape}, data_types::f16, format::bfzyx};
+    const auto data_type = ov::element::from<T>();
+    auto input_static_layout = cldnn::layout{ov::PartialShape{in_static_shape}, data_type, format::bfzyx};
+    auto input_dynamic_layout = cldnn::layout{ov::PartialShape{in_dynamic_shape}, data_type, format::bfzyx};
     auto target_shape_layout = cldnn::layout{ov::PartialShape{static_cast<ov::Dimension::value_type>(target_shape.size())},
                                                                 data_types::i32, format::bfyx};
 
@@ -2294,15 +2596,15 @@ static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> 
         broadcast_prim.output_pshape = ov::PartialShape({-1, -1, output_shape[2], output_shape[3]});
     }
     topology.add(broadcast_prim);
-    topology.add(reorder("output", input_info("broadcast"), format::bfzyx, data_types::f16));
+    topology.add(reorder("output", input_info("broadcast"), format::bfzyx, data_type));
 
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
 
     size_t input_data_size = accumulate(in_static_shape.rbegin(), in_static_shape.rend(), (size_t)1, std::multiplies<size_t>());
     ASSERT_GE(input_data_size, (size_t)1);
-    std::vector<ov::float16> input_data = {};
+    std::vector<T> input_data = {};
     for (size_t i = 1; i <= input_data_size; ++i) {
-        input_data.push_back((ov::float16)i);
+        input_data.push_back((T)i);
     }
     auto input_mem = engine.allocate_memory(input_static_layout);
     set_values(input_mem, input_data);
@@ -2316,17 +2618,17 @@ static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> 
     auto output = outputs.at("output").get_memory();
 
     ASSERT_NE(output, nullptr);
-    cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
     size_t output_data_size = accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>());
     ASSERT_GE(output_data_size, (size_t)1);
-    std::vector<ov::float16> output_ref(output_data_size);
+    std::vector<T> output_ref(output_data_size);
     ov::reference::broadcast(reinterpret_cast<const char*>(input_data.data()),
                              reinterpret_cast<char*>(output_ref.data()),
                              ov::Shape(in_static_shape.begin(), in_static_shape.end()),
                              ov::Shape(output_shape.begin(), output_shape.end()),
                              ov::AxisSet({}),
-                             sizeof(ov::float16));
+                             sizeof(T));
 
     ASSERT_EQ(output_ref.size(), accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>()));
 
@@ -2373,41 +2675,81 @@ static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> 
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x128_to_21x1x2x16x128_axis_Y_16) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,16,128},{1,1,1,16,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,16,128},{1,1,1,16,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x128_to_21x1x2x17x128_axis_Y_17) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,17,128},{1,1,1,17,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,17,128},{1,1,1,17,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x129_to_21x1x2x19x129_axis_Y_19) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,129},{-1,-1,2,1,129},{21,1,2,19,129},{1,1,1,19,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,129},{-1,-1,2,1,129},{21,1,2,19,129},{1,1,1,19,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x1_to_21x1x2x19x1_axis_Y_19) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,19,1},{1,1,1,19,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,19,1},{1,1,1,19,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x1_to_21x1x2x3x1_axis_Y_3) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,3,1},{1,1,1,3,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,3,1},{1,1,1,3,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfwzyx_21x1x2x1x1_to_21x1x2x19x1_axis_F_14_Z_12) {
-    run_broadcast_gpu_opt_y_axis({21,14,12,1,1},{-1,14,12,1,1},{21,14,12,1,1},{1,14,12,1,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,14,12,1,1},{-1,14,12,1,1},{21,14,12,1,1},{1,14,12,1,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfyx_21x2x1x1_to_21x2x3x1_axis_Y_13) {
-    run_broadcast_gpu_opt_y_axis({21,2,1,5},{-1,2,1,5},{21,2,13,5},{1,1,13,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,2,1,5},{-1,2,1,5},{21,2,13,5},{1,1,13,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x5_to_21x1x2x15x5_axis_Y_15) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,5},{-1,-1,2,1,5},{21,1,2,15,5},{1,1,1,15,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,5},{-1,-1,2,1,5},{21,1,2,15,5},{1,1,1,15,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfyx_4x5x1x1_to_4x5x6x1_axis_Y_6) {
-    run_broadcast_gpu_opt_y_axis({4,5,1,1},{-1,-1,1,1},{4,5,6,1},{1,1,6,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({4,5,1,1},{-1,-1,1,1},{4,5,6,1},{1,1,6,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfyx_4x5x1x1_to_4x5x11x1_axis_Y_11) {
-    run_broadcast_gpu_opt_y_axis({4,5,1,1},{-1,-1,1,1},{4,5,11,1},{1,1,11,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({4,5,1,1},{-1,-1,1,1},{4,5,11,1},{1,1,11,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x128_to_21x1x2x16x128_axis_Y_16) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,16,128},{1,1,1,16,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x128_to_21x1x2x17x128_axis_Y_17) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,17,128},{1,1,1,17,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x129_to_21x1x2x19x129_axis_Y_19) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,129},{-1,-1,2,1,129},{21,1,2,19,129},{1,1,1,19,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x1_to_21x1x2x19x1_axis_Y_19) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,19,1},{1,1,1,19,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x1_to_21x1x2x3x1_axis_Y_3) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,3,1},{1,1,1,3,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfwzyx_21x1x2x1x1_to_21x1x2x19x1_axis_F_14_Z_12) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,14,12,1,1},{-1,14,12,1,1},{21,14,12,1,1},{1,14,12,1,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfyx_21x2x1x1_to_21x2x3x1_axis_Y_13) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,2,1,5},{-1,2,1,5},{21,2,13,5},{1,1,13,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x5_to_21x1x2x15x5_axis_Y_15) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,5},{-1,-1,2,1,5},{21,1,2,15,5},{1,1,1,15,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfyx_4x5x1x1_to_4x5x6x1_axis_Y_6) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({4,5,1,1},{-1,-1,1,1},{4,5,6,1},{1,1,6,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfyx_4x5x1x1_to_4x5x11x1_axis_Y_11) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({4,5,1,1},{-1,-1,1,1},{4,5,11,1},{1,1,11,1});
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
@@ -371,6 +371,18 @@ TEST(broadcast_cpu_impl_int64_t, bfyx_1_to_4x5_w_b_axes_0x1x2x3_dynamic_with_sta
     start_broadcast_test_dynamic<int64_t, int32_t>(format::bfyx, data_types::i64, data_types::i32, {4, 5, 2, 3}, {1, 1, 1, 1}, {0, 1, 2, 3}, false, impl_types::cpu);
 }
 
+TEST(broadcast_cpu_impl_bf16, bfyx_1_to_4x5_w_b_axes_0x1_dynamic) {
+    start_broadcast_test_dynamic<ov::bfloat16, ov::bfloat16>(format::bfyx, data_types::bf16, data_types::bf16, {4, 5}, {1, 1}, {0, 1}, false, impl_types::cpu);
+}
+
+TEST(broadcast_cpu_impl_bf16, bfyx_1_to_4x5_w_b_axes_0x1_dynamic_with_static_output) {
+    start_broadcast_test_dynamic<ov::bfloat16, ov::bfloat16>(format::bfyx, data_types::bf16, data_types::bf16, {4, 5}, {1, 1}, {0, 1}, true, impl_types::cpu);
+}
+
+TEST(broadcast_cpu_impl_bf16, bfyx_1_to_4x5_w_b_axes_0x1x2x3_dynamic) {
+    start_broadcast_test_dynamic<ov::bfloat16, ov::bfloat16>(format::bfyx, data_types::bf16, data_types::bf16, {4, 5, 2, 3}, {1, 1, 1, 1}, {0, 1, 2, 3}, false, impl_types::cpu);
+}
+
 /* Expected golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
@@ -326,8 +326,16 @@ TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1_dynamic) {
     start_broadcast_test_dynamic<float, ov::float16>(format::bfyx, data_types::f32, data_types::f16, {4, 5}, {1, 1}, {0, 1}, false, impl_types::any, true);
 }
 
+TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1_dynamic_bf16) {
+    start_broadcast_test_dynamic<float, ov::bfloat16>(format::bfyx, data_types::f32, data_types::bf16, {4, 5}, {1, 1}, {0, 1}, false, impl_types::any, true);
+}
+
 TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1_dynamic_with_static_output) {
     start_broadcast_test_dynamic<float, ov::float16>(format::bfyx, data_types::f32, data_types::f16, {4, 5}, {1, 1}, {0, 1}, true);
+}
+
+TEST(broadcast_gpu_float, bfyx_1_to_4x5_w_b_axes_0x1_dynamic_with_static_output_bf16) {
+    start_broadcast_test_dynamic<float, ov::bfloat16>(format::bfyx, data_types::f32, data_types::bf16, {4, 5}, {1, 1}, {0, 1}, true);
 }
 
 TEST(broadcast_gpu_uint8_t, bfyx_1_to_4x5_w_b_axes_0x1_dynamic) {
@@ -1250,6 +1258,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1x38x1x1_to_1x38x1x5_w_b_axes_0) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {1, 38, 1, 5}, {1, 38, 1, 1}, {0});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1x38x1x1_to_1x38x1x5_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {1, 38, 1, 5}, {1, 38, 1, 1}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1x38x1x1_to_1x38x1x5_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {1, 38, 1, 5}, {1, 38, 1, 1}, {0});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_1_to_4x5_w_b_axes_0x1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {4, 5}, {1}, {0, 1});
@@ -1277,6 +1293,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_1_to_4x5_w_b_axes_0x1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1_to_4x5_w_b_axes_0x1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {4, 5}, {1}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1_to_4x5_w_b_axes_0x1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {4, 5}, {1}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1_to_4x5_w_b_axes_0x1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {4, 5}, {1}, {0, 1});
 }
 
 
@@ -1308,6 +1332,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1_to_3x4x5_w_b_axes_0x1x2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {3, 4, 5}, {1}, {0, 1, 2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1_to_3x4x5_w_b_axes_0x1x2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {3, 4, 5}, {1}, {0, 1, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1_to_3x4x5_w_b_axes_0x1x2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {3, 4, 5}, {1}, {0, 1, 2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {1}, {0, 1, 2, 3});
@@ -1335,6 +1367,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {1}, {0, 1, 2, 3});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {1}, {0, 1, 2, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1_to_2x3x4x5_w_b_axes_0x1x2x3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {1}, {0, 1, 2, 3});
 }
 
 
@@ -1366,6 +1406,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_42x36x1x1_to_42x36x1x5_w_o_b_axes)
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {42, 36, 1, 5}, {42, 36, 1, 1}, {});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_42x36x1x1_to_42x36x1x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {42, 36, 1, 5}, {42, 36, 1, 1}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_42x36x1x1_to_42x36x1x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {42, 36, 1, 5}, {42, 36, 1, 1}, {});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {140, 128, 1, 12}, {35, 32, 1, 3}, {});
@@ -1393,6 +1441,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {140, 128, 1, 12}, {35, 32, 1, 3}, {});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {140, 128, 1, 12}, {35, 32, 1, 3}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_35x32x1x3_to_140x128x1x12_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {140, 128, 1, 12}, {35, 32, 1, 3}, {});
 }
 
 
@@ -1424,6 +1480,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_42x64x1x1_to_84x128x4x5_w_o_b_axes
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {84, 128, 4, 5}, {42, 64, 1, 1}, {});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_42x64x1x1_to_84x128x4x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {84, 128, 4, 5}, {42, 64, 1, 1}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_42x64x1x1_to_84x128x4x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {84, 128, 4, 5}, {42, 64, 1, 1}, {});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {156, 156, 8, 6}, {156, 78, 2, 3}, {});
@@ -1451,6 +1515,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {156, 156, 8, 6}, {156, 78, 2, 3}, {});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {156, 156, 8, 6}, {156, 78, 2, 3}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_156x78x2x3_to_156x156x8x6_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {156, 156, 8, 6}, {156, 78, 2, 3}, {});
 }
 
 
@@ -1482,6 +1554,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_42x2x3x4_to_126x6x6x4_w_o_b_axes) 
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {126, 6, 6, 4}, {42, 2, 3, 4}, {});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_42x2x3x4_to_126x6x6x4_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {126, 6, 6, 4}, {42, 2, 3, 4}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_42x2x3x4_to_126x6x6x4_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {126, 6, 6, 4}, {42, 2, 3, 4}, {});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {256, 273, 8, 5}, {256, 91, 4, 5}, {});
@@ -1509,6 +1589,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {256, 273, 8, 5}, {256, 91, 4, 5}, {});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {256, 273, 8, 5}, {256, 91, 4, 5}, {});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_256x91x4x5_to_256x273x8x5_w_o_b_axes) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {256, 273, 8, 5}, {256, 91, 4, 5}, {});
 }
 
 
@@ -1540,6 +1628,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv166_1x45x1x3_to_1x45x2x3_w_b_axes_0) 
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {1, 45, 2, 3}, {1, 45, 1, 3}, {0});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv166_1x45x1x3_to_1x45x2x3_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {1, 45, 2, 3}, {1, 45, 1, 3}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv166_1x45x1x3_to_1x45x2x3_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {1, 45, 2, 3}, {1, 45, 1, 3}, {0});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {1, 62, 2, 6}, {1, 62, 1, 3}, {0});
@@ -1567,6 +1663,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {1, 62, 2, 6}, {1, 62, 1, 3}, {0});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {1, 62, 2, 6}, {1, 62, 1, 3}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1x62x1x3_to_1x62x2x6_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {1, 62, 2, 6}, {1, 62, 1, 3}, {0});
 }
 
 
@@ -1598,6 +1702,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2_to_2x3_w_b_axes_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3}, {2}, {1});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2_to_2x3_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3}, {2}, {1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2_to_2x3_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3}, {2}, {1});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2_to_6x3_w_b_axes_1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {6, 3}, {2}, {1});
@@ -1625,6 +1737,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2_to_6x3_w_b_axes_1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2_to_6x3_w_b_axes_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {6, 3}, {2}, {1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2_to_6x3_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {6, 3}, {2}, {1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2_to_6x3_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {6, 3}, {2}, {1});
 }
 
 
@@ -1656,6 +1776,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1x76x3x4_to_1x152x3x4_w_b_axes_0) 
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {1, 152, 3, 4}, {1, 76, 3, 4}, {0});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1x76x3x4_to_1x152x3x4_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {1, 152, 3, 4}, {1, 76, 3, 4}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1x76x3x4_to_1x152x3x4_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {1, 152, 3, 4}, {1, 76, 3, 4}, {0});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x4_to_2x3x4_w_b_axes_1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4}, {2, 4}, {1});
@@ -1683,6 +1811,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x4_to_2x3x4_w_b_axes_1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x4_to_2x3x4_w_b_axes_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {2, 4}, {1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x4_to_2x3x4_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {2, 4}, {1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x4_to_2x3x4_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {2, 4}, {1});
 }
 
 
@@ -1714,6 +1850,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x3_to_2x3x4_w_b_axes_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {2, 3}, {2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x3_to_2x3x4_w_b_axes_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {2, 3}, {2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x3_to_2x3x4_w_b_axes_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {2, 3}, {2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_4_to_2x3x4_w_b_axes_0_1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4}, {4}, {0, 1});
@@ -1741,6 +1885,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_4_to_2x3x4_w_b_axes_0_1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_4_to_2x3x4_w_b_axes_0_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {4}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_4_to_2x3x4_w_b_axes_0_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {4}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_4_to_2x3x4_w_b_axes_0_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {4}, {0, 1});
 }
 
 
@@ -1772,6 +1924,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_3_to_2x3x4_w_b_axes_0_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {3}, {0, 2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_3_to_2x3x4_w_b_axes_0_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {3}, {0, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_3_to_2x3x4_w_b_axes_0_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {3}, {0, 2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2_to_2x3x4_w_b_axes_1_2) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4}, {2}, {1, 2});
@@ -1799,6 +1959,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2_to_2x3x4_w_b_axes_1_2) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2_to_2x3x4_w_b_axes_1_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4}, {2}, {1, 2});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2_to_2x3x4_w_b_axes_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4}, {2}, {1, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2_to_2x3x4_w_b_axes_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4}, {2}, {1, 2});
 }
 
 
@@ -1830,6 +1998,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_1x128x4x5_to_2x256x4x5_w_b_axes_0)
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 256, 4, 5}, {1, 128, 4, 5}, {0});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_1x128x4x5_to_2x256x4x5_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 256, 4, 5}, {1, 128, 4, 5}, {0});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_1x128x4x5_to_2x256x4x5_w_b_axes_0) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 256, 4, 5}, {1, 128, 4, 5}, {0});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2, 4, 5}, {1});
@@ -1857,6 +2033,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 4, 5}, {1});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 4, 5}, {1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x4x5_to_2x3x4x5_w_b_axes_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 4, 5}, {1});
 }
 
 
@@ -1888,6 +2072,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x3x5_to_2x3x4x5_w_b_axes_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 3, 5}, {2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x3x5_to_2x3x4x5_w_b_axes_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3, 5}, {2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x3x5_to_2x3x4x5_w_b_axes_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3, 5}, {2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2, 3, 4}, {3});
@@ -1915,6 +2107,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 3, 4}, {3});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3, 4}, {3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x3x4_to_2x3x4x5_w_b_axes_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3, 4}, {3});
 }
 
 
@@ -1946,6 +2146,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_4x5_to_2x3x4x5_w_b_axes_0_1) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {4, 5}, {0, 1});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_4x5_to_2x3x4x5_w_b_axes_0_1) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {4, 5}, {0, 1});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_4x5_to_2x3x4x5_w_b_axes_0_1) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {4, 5}, {0, 1});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {3, 5}, {0, 2});
@@ -1973,6 +2181,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {3, 5}, {0, 2});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {3, 5}, {0, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_3x5_to_2x3x4x5_w_b_axes_0_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {3, 5}, {0, 2});
 }
 
 
@@ -2004,6 +2220,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_3x4_to_2x3x4x5_w_b_axes_0_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {3, 4}, {0, 3});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_3x4_to_2x3x4x5_w_b_axes_0_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {3, 4}, {0, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_3x4_to_2x3x4x5_w_b_axes_0_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {3, 4}, {0, 3});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2, 5}, {1, 2});
@@ -2031,6 +2255,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 5}, {1, 2});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 5}, {1, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x5_to_2x3x4x5_w_b_axes_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 5}, {1, 2});
 }
 
 
@@ -2062,6 +2294,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x4_to_2x3x4x5_w_b_axes_1_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 4}, {1, 3});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x4_to_2x3x4x5_w_b_axes_1_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 4}, {1, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x4_to_2x3x4x5_w_b_axes_1_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 4}, {1, 3});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2, 3}, {2, 3});
@@ -2089,6 +2329,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2, 3}, {2, 3});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3}, {2, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2x3_to_2x3x4x5_w_b_axes_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2, 3}, {2, 3});
 }
 
 
@@ -2120,6 +2368,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_5_to_2x3x4x5_w_b_axes_0_1_2) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {5}, {0, 1, 2});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_5_to_2x3x4x5_w_b_axes_0_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {5}, {0, 1, 2});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_5_to_2x3x4x5_w_b_axes_0_1_2) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {5}, {0, 1, 2});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {4}, {0, 1, 3});
@@ -2147,6 +2403,14 @@ TEST(broadcast_gpu_fp16, b_fs_yx_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
 
 TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {4}, {0, 1, 3});
+}
+
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {4}, {0, 1, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_4_to_2x3x4x5_w_b_axes_0_1_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {4}, {0, 1, 3});
 }
 
 
@@ -2178,6 +2442,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_3_to_2x3x4x5_w_b_axes_0_2_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {3}, {0, 2, 3});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_3_to_2x3x4x5_w_b_axes_0_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {3}, {0, 2, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_3_to_2x3x4x5_w_b_axes_0_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {3}, {0, 2, 3});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_yx_fsv16_2_to_2x3x4x5_w_b_axes_1_2_3) {
     start_broadcast_test<float>(format::b_fs_yx_fsv16, data_types::f32, {2, 3, 4, 5}, {2}, {1, 2, 3});
@@ -2207,6 +2479,14 @@ TEST(broadcast_gpu_fp16, bs_fs_yx_bsv32_fsv16_2_to_2x3x4x5_w_b_axes_1_2_3) {
     start_broadcast_test<ov::float16>(format::bs_fs_yx_bsv32_fsv16, data_types::f16, {2, 3, 4, 5}, {2}, {1, 2, 3});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_yx_fsv16_2_to_2x3x4x5_w_b_axes_1_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::b_fs_yx_fsv16, data_types::bf16, {2, 3, 4, 5}, {2}, {1, 2, 3});
+}
+
+TEST(broadcast_gpu_bf16, bs_fs_yx_bsv32_fsv16_2_to_2x3x4x5_w_b_axes_1_2_3) {
+    start_broadcast_test<ov::bfloat16>(format::bs_fs_yx_bsv32_fsv16, data_types::bf16, {2, 3, 4, 5}, {2}, {1, 2, 3});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_zyx_fsv16_1x48x1x1_to_1x48x1x5_w_b_axes_0) {
     start_broadcast_test_5d<float>(format::b_fs_zyx_fsv16, data_types::f32, { 1, 48, 1, 5 }, { 1, 48, 1, 1 }, { 0 });
@@ -2222,6 +2502,10 @@ TEST(broadcast_gpu_int8_t, b_fs_zyx_fsv32_1x48x1x1_to_1x48x1x5_w_b_axes_0) {
 
 TEST(broadcast_gpu_fp16, b_fs_zyx_fsv16_1x48x1x1_to_1x48x1x5_w_b_axes_0) {
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 1, 48, 1, 5 }, { 1, 48, 1, 1 }, { 0 });
+}
+
+TEST(broadcast_gpu_bf16, b_fs_zyx_fsv16_1x48x1x1_to_1x48x1x5_w_b_axes_0) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 1, 48, 1, 5 }, { 1, 48, 1, 1 }, { 0 });
 }
 
 
@@ -2241,6 +2525,10 @@ TEST(broadcast_gpu_fp16, b_fs_zyx_fsv16_64x256x2x1_to_128x256x4x5_w_b_axes_0x1) 
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 128, 256, 4, 5 }, { 64, 256, 2, 1}, {});
 }
 
+TEST(broadcast_gpu_bf16, b_fs_zyx_fsv16_64x256x2x1_to_128x256x4x5_w_b_axes_0x1) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 128, 256, 4, 5 }, { 64, 256, 2, 1}, {});
+}
+
 
 TEST(broadcast_gpu_float, b_fs_zyx_fsv16_1_to_4x5_w_b_axes_0x1) {
     start_broadcast_test_5d<float>(format::b_fs_zyx_fsv16, data_types::f32, { 4, 5 }, { 1 }, { 0, 1 });
@@ -2256,6 +2544,10 @@ TEST(broadcast_gpu_int8_t, b_fs_zyx_fsv32_1_to_4x5_w_b_axes_0x1) {
 
 TEST(broadcast_gpu_fp16, b_fs_zyx_fsv16_1_to_4x5_w_b_axes_0x1) {
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 4, 5 }, { 1 }, { 0, 1 });
+}
+
+TEST(broadcast_gpu_bf16, b_fs_zyx_fsv16_1_to_4x5_w_b_axes_0x1) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 4, 5 }, { 1 }, { 0, 1 });
 }
 
 
@@ -2275,10 +2567,19 @@ TEST(broadcast_gpu_fp16, b_fs_zyx_fsv16_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 });
 }
 
+TEST(broadcast_gpu_bf16, b_fs_zyx_fsv16_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 });
+}
+
 TEST(export_import_broadcast_gpu_fp16, b_fs_zyx_fsv16_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
     start_broadcast_test_5d<ov::float16>(format::b_fs_zyx_fsv16, data_types::f16, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 }, true);
 }
 
+TEST(export_import_broadcast_gpu_bf16, b_fs_zyx_fsv16_1_to_2x3x4x5x2_w_b_axes_0x1x2x3x4) {
+    start_broadcast_test_5d<ov::bfloat16>(format::b_fs_zyx_fsv16, data_types::bf16, { 2, 3, 4, 5, 2 }, { 1 }, { 0, 1, 2, 3, 4 }, true);
+}
+
+template <typename T>
 static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> in_static_shape,
                                     std::vector<ov::Dimension::value_type> in_dynamic_shape,
                                     std::vector<ov::Dimension::value_type> output_shape,
@@ -2289,8 +2590,9 @@ static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> 
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
-    auto input_static_layout = cldnn::layout{ov::PartialShape{in_static_shape}, data_types::f16, format::bfzyx};
-    auto input_dynamic_layout = cldnn::layout{ov::PartialShape{in_dynamic_shape}, data_types::f16, format::bfzyx};
+    const auto data_type = ov::element::from<T>();
+    auto input_static_layout = cldnn::layout{ov::PartialShape{in_static_shape}, data_type, format::bfzyx};
+    auto input_dynamic_layout = cldnn::layout{ov::PartialShape{in_dynamic_shape}, data_type, format::bfzyx};
     auto target_shape_layout = cldnn::layout{ov::PartialShape{static_cast<ov::Dimension::value_type>(target_shape.size())},
                                                                 data_types::i32, format::bfyx};
 
@@ -2309,15 +2611,15 @@ static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> 
         broadcast_prim.output_pshape = ov::PartialShape({-1, -1, output_shape[2], output_shape[3]});
     }
     topology.add(broadcast_prim);
-    topology.add(reorder("output", input_info("broadcast"), format::bfzyx, data_types::f16));
+    topology.add(reorder("output", input_info("broadcast"), format::bfzyx, data_type));
 
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), false);
 
     size_t input_data_size = accumulate(in_static_shape.rbegin(), in_static_shape.rend(), (size_t)1, std::multiplies<size_t>());
     ASSERT_GE(input_data_size, (size_t)1);
-    std::vector<ov::float16> input_data = {};
+    std::vector<T> input_data = {};
     for (size_t i = 1; i <= input_data_size; ++i) {
-        input_data.push_back((ov::float16)i);
+        input_data.push_back((T)i);
     }
     auto input_mem = engine.allocate_memory(input_static_layout);
     set_values(input_mem, input_data);
@@ -2331,17 +2633,17 @@ static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> 
     auto output = outputs.at("output").get_memory();
 
     ASSERT_NE(output, nullptr);
-    cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
     size_t output_data_size = accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>());
     ASSERT_GE(output_data_size, (size_t)1);
-    std::vector<ov::float16> output_ref(output_data_size);
+    std::vector<T> output_ref(output_data_size);
     ov::reference::broadcast(reinterpret_cast<const char*>(input_data.data()),
                              reinterpret_cast<char*>(output_ref.data()),
                              ov::Shape(in_static_shape.begin(), in_static_shape.end()),
                              ov::Shape(output_shape.begin(), output_shape.end()),
                              ov::AxisSet({}),
-                             sizeof(ov::float16));
+                             sizeof(T));
 
     ASSERT_EQ(output_ref.size(), accumulate(output_shape.rbegin(), output_shape.rend(), (size_t)1, std::multiplies<size_t>()));
 
@@ -2388,43 +2690,83 @@ static void run_broadcast_gpu_opt_y_axis(std::vector<ov::Dimension::value_type> 
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x128_to_21x1x2x16x128_axis_Y_16) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,16,128},{1,1,1,16,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,16,128},{1,1,1,16,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x128_to_21x1x2x17x128_axis_Y_17) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,17,128},{1,1,1,17,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,17,128},{1,1,1,17,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x129_to_21x1x2x19x129_axis_Y_19) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,129},{-1,-1,2,1,129},{21,1,2,19,129},{1,1,1,19,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,129},{-1,-1,2,1,129},{21,1,2,19,129},{1,1,1,19,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x1_to_21x1x2x19x1_axis_Y_19) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,19,1},{1,1,1,19,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,19,1},{1,1,1,19,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x1_to_21x1x2x3x1_axis_Y_3) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,3,1},{1,1,1,3,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,3,1},{1,1,1,3,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfwzyx_21x1x2x1x1_to_21x1x2x19x1_axis_F_14_Z_12) {
-    run_broadcast_gpu_opt_y_axis({21,14,12,1,1},{-1,14,12,1,1},{21,14,12,1,1},{1,14,12,1,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,14,12,1,1},{-1,14,12,1,1},{21,14,12,1,1},{1,14,12,1,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfyx_21x2x1x1_to_21x2x3x1_axis_Y_13) {
-    run_broadcast_gpu_opt_y_axis({21,2,1,5},{-1,2,1,5},{21,2,13,5},{1,1,13,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,2,1,5},{-1,2,1,5},{21,2,13,5},{1,1,13,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfzyx_21x1x2x1x5_to_21x1x2x15x5_axis_Y_15) {
-    run_broadcast_gpu_opt_y_axis({21,1,2,1,5},{-1,-1,2,1,5},{21,1,2,15,5},{1,1,1,15,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({21,1,2,1,5},{-1,-1,2,1,5},{21,1,2,15,5},{1,1,1,15,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfyx_4x5x1x1_to_4x5x6x1_axis_Y_6) {
-    run_broadcast_gpu_opt_y_axis({4,5,1,1},{-1,-1,1,1},{4,5,6,1},{1,1,6,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({4,5,1,1},{-1,-1,1,1},{4,5,6,1},{1,1,6,1});
 }
 
 TEST(broadcast_gpu_opt_fp16, bfyx_4x5x1x1_to_4x5x11x1_axis_Y_11) {
-    run_broadcast_gpu_opt_y_axis({4,5,1,1},{-1,-1,1,1},{4,5,11,1},{1,1,11,1});
+    run_broadcast_gpu_opt_y_axis<ov::float16>({4,5,1,1},{-1,-1,1,1},{4,5,11,1},{1,1,11,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x128_to_21x1x2x16x128_axis_Y_16) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,16,128},{1,1,1,16,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x128_to_21x1x2x17x128_axis_Y_17) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,128},{-1,-1,2,1,128},{21,1,2,17,128},{1,1,1,17,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x129_to_21x1x2x19x129_axis_Y_19) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,129},{-1,-1,2,1,129},{21,1,2,19,129},{1,1,1,19,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x1_to_21x1x2x19x1_axis_Y_19) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,19,1},{1,1,1,19,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x1_to_21x1x2x3x1_axis_Y_3) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,1},{-1,-1,2,1,1},{21,1,2,3,1},{1,1,1,3,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfwzyx_21x1x2x1x1_to_21x1x2x19x1_axis_F_14_Z_12) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,14,12,1,1},{-1,14,12,1,1},{21,14,12,1,1},{1,14,12,1,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfyx_21x2x1x1_to_21x2x3x1_axis_Y_13) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,2,1,5},{-1,2,1,5},{21,2,13,5},{1,1,13,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfzyx_21x1x2x1x5_to_21x1x2x15x5_axis_Y_15) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({21,1,2,1,5},{-1,-1,2,1,5},{21,1,2,15,5},{1,1,1,15,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfyx_4x5x1x1_to_4x5x6x1_axis_Y_6) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({4,5,1,1},{-1,-1,1,1},{4,5,6,1},{1,1,6,1});
+}
+
+TEST(broadcast_gpu_opt_bf16, bfyx_4x5x1x1_to_4x5x11x1_axis_Y_11) {
+    run_broadcast_gpu_opt_y_axis<ov::bfloat16>({4,5,1,1},{-1,-1,1,1},{4,5,11,1},{1,1,11,1});
 }
 
 // ===== Tests targeting broadcast_gpu_opt kernel (batch-repeat path) =====

--- a/src/plugins/intel_gpu/tests/unit/test_cases/strided_slice_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/strided_slice_gpu_test.cpp
@@ -15,6 +15,26 @@
 using namespace cldnn;
 using namespace ::tests;
 
+namespace {
+// Floating-point data types the strided_slice tests are parametrized over.
+using slice_data_types = ::testing::Types<float, ov::float16, ov::bfloat16>;
+
+// Produces readable type suffixes (f32/f16/bf16) for the generated typed tests.
+struct slice_type_names {
+    template <typename T>
+    static std::string GetName(int) {
+        if (std::is_same<T, float>::value)
+            return "f32";
+        if (std::is_same<T, ov::float16>::value)
+            return "f16";
+        if (std::is_same<T, ov::bfloat16>::value)
+            return "bf16";
+        return "unknown";
+    }
+};
+}  // namespace
+
+template <typename T>
 class strided_slice_gpu: public ::testing::Test {
 public:
     void test_2x2x2x2_full_legacy_activation(bool is_caching_test) {
@@ -25,12 +45,12 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, data_types::f32, format::bfyx });
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, ov::element::from<T>(), format::bfyx });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 -0.2f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.8f
         });
@@ -46,7 +66,7 @@ public:
         topology.add(data("input4", strides));
         topology.add(strided_slice("strided_slice", input_info("input"), input_info("input2"), input_info("input3"), input_info("input4"), {}, {}, {}, {}, {}, {2, 2, 2, 2}));
         topology.add(activation("out", input_info("strided_slice"), activation_func::clamp, {0.f, 15.0f}));
-        topology.add(reorder("out_reorder", input_info("out"), format::bfyx, data_types::f32));
+        topology.add(reorder("out_reorder", input_info("out"), format::bfyx, ov::element::from<T>()));
 
         auto config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
@@ -66,7 +86,7 @@ public:
         std::vector<float> answers = {
                 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -83,9 +103,9 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, data_types::f32, format::bfyx });
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, ov::element::from<T>(), format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -111,7 +131,7 @@ public:
         std::vector<float> answers = {
                 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -128,9 +148,9 @@ public:
         // Output (BFZYX): 2x2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2, 2 }, data_types::f32, format::bfzyx });
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2, 2 }, ov::element::from<T>(), format::bfzyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f,
                 16.0f, 17.0f, 18.0f, 19.0f, 20.0f, 21.0f, 22.0f,
@@ -162,7 +182,7 @@ public:
             23.0f, 24.0f, 25.0f, 26.0f, 27.0f, 28.0f, 29.0f, 30.0f, 31.0f,
         };
 
-        cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -180,9 +200,9 @@ public:
         // Output (BFWZYX): 2x2x2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2, 2, 2 }, data_types::f32, format::bfwzyx });
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2, 2, 2 }, ov::element::from<T>(), format::bfwzyx });
 
-        set_values(input, {
+        set_values<T>(input, {
             0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
             8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f,
             16.0f, 17.0f, 18.0f, 19.0f, 20.0f, 21.0f, 22.0f, 23.0f,
@@ -225,7 +245,7 @@ public:
             56.0f, 57.0f, 58.0f, 59.0f, 60.0f, 61.0f, 62.0f, 63.0f,
         };
 
-        cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -242,9 +262,9 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, data_types::f32, format::bfyx });
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, ov::element::from<T>(), format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -274,7 +294,7 @@ public:
         std::vector<float> answers = {
                 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -291,9 +311,9 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 2, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -321,7 +341,7 @@ public:
             9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -338,9 +358,9 @@ public:
         // Output (BFYX): 1x1x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 2, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -369,7 +389,7 @@ public:
 
         std::vector<float> answers = { 15.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -386,9 +406,9 @@ public:
         // Output (BFYX): 2x2x2x3
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 3, 4 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 3, 4 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f,
                 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f,
                 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f,
@@ -420,7 +440,7 @@ public:
                 24.f, 25.f, 26.f, 30.f, 31.f, 32.f, 36.f, 37.f, 38.f, 42.f, 43.f, 44.f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -437,9 +457,9 @@ public:
         // Output (BFYX): 1x2x4x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 4, 4 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 4, 4 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f,
                 4.0f, 5.0f, 6.0f, 7.0f,
                 8.0f, 9.0f, 10.0f, 11.0f,
@@ -491,7 +511,7 @@ public:
                 61.0f, 63.0f
         };
 
-        cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -506,9 +526,9 @@ public:
         // Output (BFYX): 1x2x2x4
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 1, 4 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 1, 4 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
                 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -536,7 +556,7 @@ public:
                 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -550,9 +570,9 @@ public:
         // Output (BFYX): 1x2x1x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 1, 1 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 1, 1 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f
         });
         std::vector<int64_t> begin_data = { 1, 0, 1, 0 };
@@ -578,7 +598,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -591,9 +611,9 @@ public:
         // Output (BFYX): 2x2x1x1
 
         auto engine = create_test_engine(engine_types::ocl, runtime_types::ocl, !disable_usm);
-        auto input = engine->allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 1, 1 } });
+        auto input = engine->allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 1, 1 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f
         });
         std::vector<int64_t> begin_data = { 0, 0 };
@@ -623,7 +643,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -636,9 +656,9 @@ public:
         // Output (BFZYX): 1x2x2x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfzyx, { 2, 2, 1, 1, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
         });
         std::vector<int64_t> begin_data = { 0, 0, 0 };
@@ -664,7 +684,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -677,9 +697,9 @@ public:
         // Output (BFZYX): 2x1x1x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfzyx, { 2, 2, 1, 1, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
         });
         std::vector<int64_t> begin_data = { 0, 0, 0 };
@@ -709,7 +729,7 @@ public:
                 0.0f, 4.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -722,9 +742,9 @@ public:
         // Output (BFWZYX): 1x2x2x2x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfwzyx, { 2, 2, 1, 1, 2, 2 }});
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfwzyx, { 2, 2, 1, 1, 2, 2 }});
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
                 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f,
         });
@@ -751,7 +771,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -764,9 +784,9 @@ public:
         // Output (BFWZYX): 2x1x1x1x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfwzyx, { 2, 2, 1, 1, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfwzyx, { 2, 2, 1, 1, 2, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
                 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f,
         });
@@ -797,7 +817,7 @@ public:
                 0.0f, 8.0f,
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -813,9 +833,9 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, data_types::f32, format::bfyx });
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, ov::element::from<T>(), format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -841,7 +861,7 @@ public:
         std::vector<float> answers = {
                 12.f, 13.f, 14.f, 15.f, 8.f, 9.f, 10.f, 11.f, 4.f, 5.f, 6.f, 7.f, 0.f, 1.f, 2.f, 3.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -858,9 +878,9 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, data_types::f32, format::bfyx });
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2, 2 }, ov::element::from<T>(), format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -890,7 +910,7 @@ public:
         std::vector<float> answers = {
                 12.f, 13.f, 14.f, 15.f, 8.f, 9.f, 10.f, 11.f, 4.f, 5.f, 6.f, 7.f, 0.f, 1.f, 2.f, 3.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -903,9 +923,9 @@ public:
         // Output (BFZYX): 2x1x1x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfzyx, { 2, 2, 1, 1, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
         });
         std::vector<int64_t> begin_data = { 0, 0, 0 };
@@ -931,7 +951,7 @@ public:
                 0.0f, 4.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -944,13 +964,13 @@ public:
         // Output (BFZYX): 2x1x1x1x1
 
         auto& engine = get_test_engine();
-        auto input_lay = layout{ ov::PartialShape::dynamic(3), data_types::f32, format::bfyx };
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2 }, data_types::f32, format::bfyx });
+        auto input_lay = layout{ ov::PartialShape::dynamic(3), ov::element::from<T>(), format::bfyx };
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2 }, ov::element::from<T>(), format::bfyx });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 3 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 3 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 3 }, data_types::i64, format::bfyx });
 
-        set_values(input, {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f});
+        set_values<T>(input, {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f});
         set_values<int64_t>(begin, {0, 0, 0});
         set_values<int64_t>(end, {2, 2, 2});
         set_values<int64_t>(strides, {1, 2, 2});
@@ -987,7 +1007,7 @@ public:
                 0.0f, 4.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -997,13 +1017,13 @@ public:
 
     void test_2x2x2_all_dynamic_bcast(impl_types impl_type = impl_types::any) {
         auto& engine = get_test_engine();
-        auto input_lay = layout{ ov::PartialShape::dynamic(3), data_types::f32, format::bfyx };
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2 }, data_types::f32, format::bfyx });
+        auto input_lay = layout{ ov::PartialShape::dynamic(3), ov::element::from<T>(), format::bfyx };
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2 }, ov::element::from<T>(), format::bfyx });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 1 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 1 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 1 }, data_types::i64, format::bfyx });
 
-        set_values(input, {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f});
+        set_values<T>(input, {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f});
         set_values<int64_t>(begin, {1});
         set_values<int64_t>(end, {2});
         set_values<int64_t>(strides, {1});
@@ -1044,7 +1064,7 @@ public:
                 4.0f, 5.0f, 6.0f, 7.0f
         };
 
-        cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)         {
             ASSERT_EQ(answers[i], output_ptr[i]) << " i = " << i;
@@ -1053,12 +1073,12 @@ public:
 
     void test_2x2x2x1x1_2_negative_all_dynamic_begin(impl_types impl_type = impl_types::any) {
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2 }, data_types::f32, format::bfyx });
+        auto input = engine.allocate_memory({ ov::PartialShape{ 2, 2, 2 }, ov::element::from<T>(), format::bfyx });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 3 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 3 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 3 }, data_types::i64, format::bfyx });
 
-        set_values(input, {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f});
+        set_values<T>(input, {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f});
         set_values<int64_t>(begin, {0, 0, 0});
         set_values<int64_t>(end, {2, 2, 2});
         set_values<int64_t>(strides, {1, 2, 2});
@@ -1095,7 +1115,7 @@ public:
                 0.0f, 4.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -1105,7 +1125,7 @@ public:
 
     void test_3d_all_dynamic_with_new_axis() {
         auto& engine = get_test_engine();
-        auto l_input = layout{ ov::PartialShape::dynamic(3), data_types::f32, format::bfyx };
+        auto l_input = layout{ ov::PartialShape::dynamic(3), ov::element::from<T>(), format::bfyx };
         auto l_begin = layout{ ov::PartialShape{ 3 }, data_types::i64, format::bfyx };
         auto l_end = layout{ ov::PartialShape{ 3 }, data_types::i64, format::bfyx };
 
@@ -1139,7 +1159,7 @@ public:
     void test_3d_all_dynamic_with_shrink_axis() {
         auto& engine = get_test_engine();
 
-        auto l_input = layout{ ov::PartialShape::dynamic(3), data_types::f32, format::bfyx };
+        auto l_input = layout{ ov::PartialShape::dynamic(3), ov::element::from<T>(), format::bfyx };
         auto l_begin = layout{ ov::PartialShape{ 3 }, data_types::i64, format::bfyx };
         auto l_end = layout{ ov::PartialShape{ 3 }, data_types::i64, format::bfyx };
 
@@ -1171,6 +1191,9 @@ public:
     }
 };
 
+TYPED_TEST_SUITE(strided_slice_gpu, slice_data_types, slice_type_names);
+
+template <typename T>
 class strided_slice_gpu_constants: public ::testing::Test {
 public:
     void test_2x2x2x2_full(bool is_caching_test, impl_types impl_type = impl_types::any) {
@@ -1181,12 +1204,12 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 2, 2 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -1225,7 +1248,7 @@ public:
         std::vector<float> answers = {
                 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1242,12 +1265,12 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 2, 2 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -1284,7 +1307,7 @@ public:
             9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1301,12 +1324,12 @@ public:
         // Output (BFYX): 1x1x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 2, 2 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
                 });
@@ -1344,7 +1367,7 @@ public:
 
         std::vector<float> answers = { 15.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1361,12 +1384,12 @@ public:
         // Output (BFYX): 2x2x2x3
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 3, 4 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 3, 4 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f,
                 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f,
                 18.f, 19.f, 20.f, 21.f, 22.f, 23.f, 24.f, 25.f, 26.f,
@@ -1411,7 +1434,7 @@ public:
                 24.f, 25.f, 26.f, 30.f, 31.f, 32.f, 36.f, 37.f, 38.f, 42.f, 43.f, 44.f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1428,12 +1451,12 @@ public:
         // Output (BFYX): 1x2x4x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 4, 4 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 4, 4 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f,
                 4.0f, 5.0f, 6.0f, 7.0f,
                 8.0f, 9.0f, 10.0f, 11.0f,
@@ -1497,7 +1520,7 @@ public:
                 61.0f, 63.0f
         };
 
-        cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1512,12 +1535,12 @@ public:
         // Output (BFYX): 1x2x2x4
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 1, 4 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 1, 4 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
                 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -1558,7 +1581,7 @@ public:
                 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -1572,12 +1595,12 @@ public:
         // Output (BFYX): 1x2x1x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 1, 1 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 1, 1 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f
         });
         set_values<int64_t>(begin, {
@@ -1612,7 +1635,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -1625,12 +1648,12 @@ public:
         // Output (BFYX): 2x2x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 1, 1 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 1, 1 } });
         auto begin = engine.allocate_memory({ data_types::i64, format::bfyx, { 2, 1, 1, 1 } });
         auto end = engine.allocate_memory({ data_types::i64, format::bfyx, { 2, 1, 1, 1 } });
         auto strides = engine.allocate_memory({ data_types::i64, format::bfyx, { 2, 1, 1, 1 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f
         });
 
@@ -1666,7 +1689,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -1679,12 +1702,12 @@ public:
         // Output (BFZYX): 1x2x2x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfzyx, { 2, 2, 1, 1, 2 } });
         auto begin = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
         auto end = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
         auto strides = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
         });
         set_values<int64_t>(begin, {
@@ -1719,7 +1742,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -1732,12 +1755,12 @@ public:
         // Output (BFZYX): 2x1x1x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfzyx, { 2, 2, 1, 1, 2 } });
         auto begin = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
         auto end = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
         auto strides = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
         });
         set_values<int64_t>(begin, {
@@ -1772,7 +1795,7 @@ public:
                 0.0f, 4.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -1788,12 +1811,12 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 2, 2 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f,
                 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -1828,7 +1851,7 @@ public:
         std::vector<float> answers = {
                 12.f, 13.f, 14.f, 15.f, 8.f, 9.f, 10.f, 11.f, 4.f, 5.f, 6.f, 7.f, 0.f, 1.f, 2.f, 3.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1845,9 +1868,9 @@ public:
         // Output (BFYX): 1x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 1, 2, 2, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f,
                 4.0f, 5.0f, 6.0f, 7.0f
         });
@@ -1879,7 +1902,7 @@ public:
         std::vector<float> answers = {
                 4.f, 5.f, 6.f, 7.f, 0.f, 1.f, 2.f, 3.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1896,9 +1919,9 @@ public:
         // Output (BFYX): 1x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 1, 2, 2, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f,
                 4.0f, 5.0f, 6.0f, 7.0f
         });
@@ -1930,7 +1953,7 @@ public:
         std::vector<float> answers = {
                 4.f, 5.f, 6.f, 7.f, 0.f, 1.f, 2.f, 3.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1947,9 +1970,9 @@ public:
         // Output (BFYX): 1x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 1, 2, 2, 2 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f,
                 4.0f, 5.0f, 6.0f, 7.0f
         });
@@ -1981,7 +2004,7 @@ public:
         std::vector<float> answers = {
                 4.f, 5.f, 6.f, 7.f, 0.f, 1.f, 2.f, 3.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -1995,12 +2018,12 @@ public:
         // Output (BFZYX): 2x1x1x1x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfzyx, { 2, 2, 1, 1, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfzyx, { 2, 2, 1, 1, 2 } });
         auto begin = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
         auto end = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
         auto strides = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
         });
         set_values<int64_t>(begin, {
@@ -2035,7 +2058,7 @@ public:
                 0.0f, 4.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -2047,12 +2070,12 @@ public:
         // Input (BFZYX):  1x3x1x3
         // Output (BFZYX): 1x1x1x3
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 3, 1, 3} });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 1, 3, 1, 3} });
         auto begin = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
         auto end = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1 } });
         auto strides = engine.allocate_memory({ data_types::i64, format::bfyx, { 3, 1, 1, 1} });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f,
                 3.0f, 4.0f, 5.0f,
                 6.0f, 7.0f, 8.0f,
@@ -2090,7 +2113,7 @@ public:
                 6.0f, 7.0f, 8.0f,
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -2102,12 +2125,12 @@ public:
         // Input (BFZYX):  1x1x1x3
         // Output (BFZYX): 1x1x1x3
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 3, 1} });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 1, 1, 3, 1} });
         auto begin = engine.allocate_memory({ data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
         auto end = engine.allocate_memory({ data_types::i64, format::bfyx, { 4, 1, 1, 1 } });
         auto strides = engine.allocate_memory({ data_types::i64, format::bfyx, { 4, 1, 1, 1} });
 
-        set_values(input, {
+        set_values<T>(input, {
                 6.0f, 7.0f, 8.0f,
         });
 
@@ -2143,7 +2166,7 @@ public:
                 6.0f, 7.0f, 8.0f,
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -2159,12 +2182,12 @@ public:
         // Output (BFYX): 2x2x2x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 2, 2 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 2, 2 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
                 8.0f, 9.0f, 10.0f, 11.0f,
                 12.0f, 13.0f, 14.0f, 15.0f
@@ -2200,7 +2223,7 @@ public:
         std::vector<float> answers = {
                 12.f, 13.f, 14.f, 15.f, 8.f, 9.f, 10.f, 11.f, 4.f, 5.f, 6.f, 7.f, 0.f, 1.f, 2.f, 3.f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -2217,12 +2240,12 @@ public:
         // Output (BFYX): 1x1x1x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 10, 1 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 1, 1, 10, 1 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f
         });
         set_values<int64_t>(begin, {
@@ -2255,7 +2278,7 @@ public:
 
         std::vector<float> answers = { 5.0f, 3.0f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -2272,12 +2295,12 @@ public:
         // Output (BFYX): 1x1x1x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 10, 1 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 1, 1, 10, 1 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f
         });
         set_values<int64_t>(begin, {
@@ -2310,7 +2333,7 @@ public:
 
         std::vector<float> answers = { 5.0f, 3.0f };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), answers.size());
         for (size_t i = 0; i < answers.size(); ++i)
@@ -2320,6 +2343,9 @@ public:
     }
 };
 
+TYPED_TEST_SUITE(strided_slice_gpu_constants, slice_data_types, slice_type_names);
+
+template <typename T>
 class strided_slice_gpu_four_inputs: public ::testing::Test {
 public:
     void test_2x2x4x1_new_axis_mask(bool is_caching_test) {
@@ -2328,12 +2354,12 @@ public:
         // Output (BFYX): 1x2x2x4
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 1, 4 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 1, 4 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f,
                 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         });
@@ -2373,7 +2399,7 @@ public:
                 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -2387,12 +2413,12 @@ public:
         // Output (BFYX): 1x2x1x2
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 2, 2, 1, 1 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 2, 2, 1, 1 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 4 }, data_types::i64, format::bfyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f
         });
         set_values<int64_t>(begin, {
@@ -2430,7 +2456,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -2438,6 +2464,8 @@ public:
         }
     }
 };
+
+TYPED_TEST_SUITE(strided_slice_gpu_four_inputs, slice_data_types, slice_type_names);
 
 class strided_slice_gpu_i8: public ::testing::Test {
 public:
@@ -2523,19 +2551,20 @@ public:
     }
 };
 
-class strided_slice_gpu_f32_i32: public ::testing::Test {
+template <typename T>
+class strided_slice_gpu_i32_indices: public ::testing::Test {
 public:
     void test_1x1x1x8x1_new_axis_5d(bool is_caching_test) {
         // Input (BFYX): 1x8x1x1
         // Output (BFZYX): 1x1x1x8x1
 
         auto& engine = get_test_engine();
-        auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 8, 1, 1 } });
+        auto input = engine.allocate_memory({ ov::element::from<T>(), format::bfyx, { 1, 8, 1, 1 } });
         auto begin = engine.allocate_memory({ ov::PartialShape{ 5 }, data_types::i32, format::bfzyx });
         auto end = engine.allocate_memory({ ov::PartialShape{ 5 }, data_types::i32, format::bfzyx });
         auto strides = engine.allocate_memory({ ov::PartialShape{ 5 }, data_types::i32, format::bfzyx });
 
-        set_values(input, {
+        set_values<T>(input, {
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
         });
         set_values(begin, {
@@ -2570,7 +2599,7 @@ public:
                 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f
         };
 
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         for (size_t i = 0; i < answers.size(); ++i)
         {
@@ -2579,95 +2608,97 @@ public:
     }
 };
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_full) {
+TYPED_TEST_SUITE(strided_slice_gpu_i32_indices, slice_data_types, slice_type_names);
+
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full) {
     this->test_2x2x2x2_full(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full) {
     this->test_2x2x2x2_full(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2x2_full) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2x2_full) {
     this->test_2x2x2x2x2_full(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2x2x2_full) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2x2x2_full) {
     this->test_2x2x2x2x2x2_full(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_full_pad) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full_pad) {
     this->test_2x2x2x2_full_pad(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_ignore) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_ignore) {
     this->test_2x2x2x2_ignore(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_ignore) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_ignore) {
     this->test_2x2x2x2_ignore(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_single) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_single) {
     this->test_2x2x2x2_single(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_single) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_single) {
     this->test_2x2x2x2_single(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x4x3_stride) {
+TYPED_TEST(strided_slice_gpu, test_2x2x4x3_stride) {
     this->test_2x2x4x3_stride(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x4x3_stride) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x4x3_stride) {
     this->test_2x2x4x3_stride(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x4x4_part_stride) {
+TYPED_TEST(strided_slice_gpu, test_2x2x4x4_part_stride) {
     this->test_2x2x4x4_part_stride(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x4x4_part_stride) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x4x4_part_stride) {
     this->test_2x2x4x4_part_stride(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x4x1_new_axis_mask) {
+TYPED_TEST(strided_slice_gpu, test_2x2x4x1_new_axis_mask) {
     this->test_2x2x4x1_new_axis_mask(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x4x1_new_axis_mask) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x4x1_new_axis_mask) {
     this->test_2x2x4x1_new_axis_mask(false);
 }
 
-TEST_F(strided_slice_gpu_four_inputs, test_2x2x4x1_new_axis_mask) {
+TYPED_TEST(strided_slice_gpu_four_inputs, test_2x2x4x1_new_axis_mask) {
     this->test_2x2x4x1_new_axis_mask(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x1x1_new_axis_mask_2) {
+TYPED_TEST(strided_slice_gpu, test_2x2x1x1_new_axis_mask_2) {
     this->test_2x2x1x1_new_axis_mask_2(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x1x1_new_axis_mask_2) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x1x1_new_axis_mask_2) {
     this->test_2x2x1x1_new_axis_mask_2(false);
 }
 
-TEST_F(strided_slice_gpu_four_inputs, test_2x2x1x1_new_axis_mask_2) {
+TYPED_TEST(strided_slice_gpu_four_inputs, test_2x2x1x1_new_axis_mask_2) {
     this->test_2x2x1x1_new_axis_mask_2(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x1x1) {
+TYPED_TEST(strided_slice_gpu, test_2x2x1x1) {
     this->test_2x2x1x1(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x1x1) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x1x1) {
     this->test_2x2x1x1(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x1x1) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x1x1) {
     this->test_2x2x2x1x1(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x1x1) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x1x1) {
     this->test_2x2x2x1x1(false);
 }
 
@@ -2675,19 +2706,19 @@ TEST_F(strided_slice_gpu_i8, test_2x2x2x1x1) {
     this->test_2x2x2x1x1(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x1x1_2) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x1x1_2) {
     this->test_2x2x2x1x1_2(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x1x1_2) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x1x1_2) {
     this->test_2x2x2x1x1_2(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2x1x1) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2x1x1) {
     this->test_2x2x2x2x1x1(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2x1x1_2) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2x1x1_2) {
     this->test_2x2x2x2x1x1_2(false);
 }
 
@@ -2695,182 +2726,186 @@ TEST_F(strided_slice_gpu_i8, test_2x2x2x2x1x1) {
     this->test_2x2x2x2x1x1(false);
 }
 
-TEST_F(strided_slice_gpu_f32_i32, test_1x1x1x8x1_new_axis_5d) {
+TYPED_TEST(strided_slice_gpu_i32_indices, test_1x1x1x8x1_new_axis_5d) {
     this->test_1x1x1x8x1_new_axis_5d(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_full_negative_stride) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full_negative_stride) {
     this->test_2x2x2x2_full_negative_stride(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride) {
     this->test_2x2x2x2_full_negative_stride(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_full_negative_stride_pad) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full_negative_stride_pad) {
     this->test_2x2x2x2_full_negative_stride_pad(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_f_axis) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_f_axis) {
     this->test_2x2x2x2_full_negative_stride_f_axis(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_negative_begin_f_axis) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_negative_begin_f_axis) {
     this->test_2x2x2x2_full_negative_stride_negative_begin_f_axis(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_f_axis_clamp) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_f_axis_clamp) {
     this->test_2x2x2x2_full_negative_stride_f_axis_clamp(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x1x1_2_negative_all) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x1x1_2_negative_all) {
     this->test_2x2x2x1x1_2_negative_all(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x1x1_2_negative_all) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x1x1_2_negative_all) {
     this->test_2x2x2x1x1_2_negative_all(false);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x1x1_2_negative_all_dynamic) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x1x1_2_negative_all_dynamic) {
     this->test_2x2x2x1x1_2_negative_all_dynamic();
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x1x1_2_negative_all_dynamic_begin) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x1x1_2_negative_all_dynamic_begin) {
     this->test_2x2x2x1x1_2_negative_all_dynamic_begin();
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2_all_dynamic_bcast) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2_all_dynamic_bcast) {
     this->test_2x2x2_all_dynamic_bcast();
 }
 
-class strided_slice_cpu_impl : public strided_slice_gpu {};
-TEST_F(strided_slice_cpu_impl, test_2x2x2x1x1_2_negative_all_dynamic) {
+template <typename T>
+class strided_slice_cpu_impl : public strided_slice_gpu<T> {};
+TYPED_TEST_SUITE(strided_slice_cpu_impl, slice_data_types, slice_type_names);
+TYPED_TEST(strided_slice_cpu_impl, test_2x2x2x1x1_2_negative_all_dynamic) {
     this->test_2x2x2x1x1_2_negative_all_dynamic(impl_types::cpu);
 }
 
-TEST_F(strided_slice_cpu_impl, test_2x2x2x1x1_2_negative_all_dynamic_begin) {
+TYPED_TEST(strided_slice_cpu_impl, test_2x2x2x1x1_2_negative_all_dynamic_begin) {
     this->test_2x2x2x1x1_2_negative_all_dynamic_begin(impl_types::cpu);
 }
 
-TEST_F(strided_slice_cpu_impl, test_2x2x2_all_dynamic_bcast) {
+TYPED_TEST(strided_slice_cpu_impl, test_2x2x2_all_dynamic_bcast) {
     this->test_2x2x2_all_dynamic_bcast(impl_types::cpu);
 }
 
-TEST_F(strided_slice_cpu_impl, test_2x2x1x1) {
+TYPED_TEST(strided_slice_cpu_impl, test_2x2x1x1) {
     this->test_2x2x1x1(false, impl_types::cpu);
 }
 
-TEST_F(strided_slice_cpu_impl, test_2x2x1x1_disable_usm) {
+TYPED_TEST(strided_slice_cpu_impl, test_2x2x1x1_disable_usm) {
     this->test_2x2x1x1(false, impl_types::cpu, true);
 }
 
-TEST_F(strided_slice_cpu_impl, test_2x2x2x1x1_2) {
+TYPED_TEST(strided_slice_cpu_impl, test_2x2x2x1x1_2) {
     this->test_2x2x2x1x1_2(false, impl_types::cpu);
 }
 
-TEST_F(strided_slice_cpu_impl, test_2x2x2x2_single) {
+TYPED_TEST(strided_slice_cpu_impl, test_2x2x2x2_single) {
     this->test_2x2x2x2_single(false, impl_types::cpu);
 }
 
-class strided_slice_cpu_impl_constants : public strided_slice_gpu_constants {};
-TEST_F(strided_slice_cpu_impl_constants, test_2x2x2x2_full) {
+template <typename T>
+class strided_slice_cpu_impl_constants : public strided_slice_gpu_constants<T> {};
+TYPED_TEST_SUITE(strided_slice_cpu_impl_constants, slice_data_types, slice_type_names);
+TYPED_TEST(strided_slice_cpu_impl_constants, test_2x2x2x2_full) {
     this->test_2x2x2x2_full(false, impl_types::cpu);
 }
 
-TEST_F(strided_slice_cpu_impl_constants, test_2x2x2x2_single) {
+TYPED_TEST(strided_slice_cpu_impl_constants, test_2x2x2x2_single) {
     this->test_2x2x2x2_single(false, impl_types::cpu);
 }
 
-TEST_F(strided_slice_cpu_impl_constants, test_2x2x4x3_stride) {
+TYPED_TEST(strided_slice_cpu_impl_constants, test_2x2x4x3_stride) {
     this->test_2x2x4x3_stride(false, impl_types::cpu);
 }
 
-TEST_F(strided_slice_cpu_impl_constants, DISABLED_test_2x2x4x1_new_axis_mask) { // Issue 129991
+TYPED_TEST(strided_slice_cpu_impl_constants, DISABLED_test_2x2x4x1_new_axis_mask) { // Issue 129991
     this->test_2x2x4x1_new_axis_mask(false, impl_types::cpu);
 }
 
 #ifdef RUN_ALL_MODEL_CACHING_TESTS
-TEST_F(strided_slice_gpu, test_2x2x2x2_full_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full_cached) {
     this->test_2x2x2x2_full(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_cached) {
     this->test_2x2x2x2_full(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_full_pad_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full_pad_cached) {
     this->test_2x2x2x2_full_pad(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_ignore_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_ignore_cached) {
     this->test_2x2x2x2_ignore(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_ignore_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_ignore_cached) {
     this->test_2x2x2x2_ignore(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_single_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_single_cached) {
     this->test_2x2x2x2_single(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_single_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_single_cached) {
     this->test_2x2x2x2_single(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x4x3_stride_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x4x3_stride_cached) {
     this->test_2x2x4x3_stride(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x4x3_stride_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x4x3_stride_cached) {
     this->test_2x2x4x3_stride(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x4x4_part_stride_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x4x4_part_stride_cached) {
     this->test_2x2x4x4_part_stride(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x4x4_part_stride_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x4x4_part_stride_cached) {
     this->test_2x2x4x4_part_stride(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x4x1_new_axis_mask_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x4x1_new_axis_mask_cached) {
     this->test_2x2x4x1_new_axis_mask(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x4x1_new_axis_mask_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x4x1_new_axis_mask_cached) {
     this->test_2x2x4x1_new_axis_mask(true);
 }
 
-TEST_F(strided_slice_gpu_four_inputs, test_2x2x4x1_new_axis_mask_cached) {
+TYPED_TEST(strided_slice_gpu_four_inputs, test_2x2x4x1_new_axis_mask_cached) {
     this->test_2x2x4x1_new_axis_mask(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x1x1_new_axis_mask_2_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x1x1_new_axis_mask_2_cached) {
     this->test_2x2x1x1_new_axis_mask_2(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x1x1_new_axis_mask_2_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x1x1_new_axis_mask_2_cached) {
     this->test_2x2x1x1_new_axis_mask_2(true);
 }
 
-TEST_F(strided_slice_gpu_four_inputs, test_2x2x1x1_new_axis_mask_2_cached) {
+TYPED_TEST(strided_slice_gpu_four_inputs, test_2x2x1x1_new_axis_mask_2_cached) {
     this->test_2x2x1x1_new_axis_mask_2(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x1x1_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x1x1_cached) {
     this->test_2x2x1x1(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x1x1_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x1x1_cached) {
     this->test_2x2x1x1(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x1x1_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x1x1_cached) {
     this->test_2x2x2x1x1(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x1x1_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x1x1_cached) {
     this->test_2x2x2x1x1(true);
 }
 
@@ -2878,81 +2913,81 @@ TEST_F(strided_slice_gpu_i8, test_2x2x2x1x1_cached) {
     this->test_2x2x2x1x1(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x1x1_2_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x1x1_2_cached) {
     this->test_2x2x2x1x1_2(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x1x1_2_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x1x1_2_cached) {
     this->test_2x2x2x1x1_2(true);
 }
 
-TEST_F(strided_slice_gpu_f32_i32, test_1x1x1x8x1_new_axis_5d_cached) {
+TYPED_TEST(strided_slice_gpu_i32_indices, test_1x1x1x8x1_new_axis_5d_cached) {
     this->test_1x1x1x8x1_new_axis_5d(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_full_negative_stride_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full_negative_stride_cached) {
     this->test_2x2x2x2_full_negative_stride(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_cached) {
     this->test_2x2x2x2_full_negative_stride(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x2_full_negative_stride_pad_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full_negative_stride_pad_cached) {
     this->test_2x2x2x2_full_negative_stride_pad(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_f_axis_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_f_axis_cached) {
     this->test_2x2x2x2_full_negative_stride_f_axis(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_negative_begin_f_axis_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_negative_begin_f_axis_cached) {
     this->test_2x2x2x2_full_negative_stride_negative_begin_f_axis(true);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_f_axis_clamp_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_full_negative_stride_f_axis_clamp_cached) {
     this->test_2x2x2x2_full_negative_stride_f_axis_clamp(true);
 }
 
-TEST_F(strided_slice_gpu, test_2x2x2x1x1_2_negative_all_cached) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x1x1_2_negative_all_cached) {
     this->test_2x2x2x1x1_2_negative_all(true);
 }
 #endif
-TEST_F(strided_slice_gpu_constants, test_2x2x2x1x1_2_negative_all_cached) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x1x1_2_negative_all_cached) {
     this->test_2x2x2x1x1_2_negative_all(true);
 }
 
 // test_2x2x2x2_full_activation
-TEST_F(strided_slice_gpu, test_2x2x2x2_full_legacy_activation) {
+TYPED_TEST(strided_slice_gpu, test_2x2x2x2_full_legacy_activation) {
     this->test_2x2x2x2_full_legacy_activation(true);
 }
 
 
-TEST_F(strided_slice_gpu, test_3d_all_dynamic_with_new_axis) {
+TYPED_TEST(strided_slice_gpu, test_3d_all_dynamic_with_new_axis) {
     this->test_3d_all_dynamic_with_new_axis();
 }
 
-TEST_F(strided_slice_gpu, test_3d_all_dynamic_with_shrink_axis) {
+TYPED_TEST(strided_slice_gpu, test_3d_all_dynamic_with_shrink_axis) {
     this->test_3d_all_dynamic_with_shrink_axis();
 }
 
-TEST_F(strided_slice_gpu_constants, test_1x3x1x3_negative) {
+TYPED_TEST(strided_slice_gpu_constants, test_1x3x1x3_negative) {
     this->test_1x3x1x3_negative(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_1x1x1x3_negative) {
+TYPED_TEST(strided_slice_gpu_constants, test_1x1x1x3_negative) {
     this->test_1x1x1x3_negative(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_2x2x2x2_negative_begin_end_positive_stride) {
+TYPED_TEST(strided_slice_gpu_constants, test_2x2x2x2_negative_begin_end_positive_stride) {
     this->test_2x2x2x2_negative_begin_end_positive_stride(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_1x1x1x10_pos_begin_end_neg_stride2) {
+TYPED_TEST(strided_slice_gpu_constants, test_1x1x1x10_pos_begin_end_neg_stride2) {
     this->test_1x1x1x10_pos_begin_end_neg_stride2(false);
 }
 
-TEST_F(strided_slice_gpu_constants, test_1x1x1x10_neg_begin_end_neg_stride2) {
+TYPED_TEST(strided_slice_gpu_constants, test_1x1x1x10_neg_begin_end_neg_stride2) {
     this->test_1x1x1x10_neg_begin_end_neg_stride2(false);
 }
 


### PR DESCRIPTION
This PR adds bf16 data type support to the **broadcast** and **strided_slice** OCL kernels as part of the broader BF16 enablement effort for the Intel GPU plugin ([CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)).

Ticket: [CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)

> [!NOTE]
> This pull request is part of a larger implementation effort for BF16 support in the OpenVINO GPU Plugin.  On its own, this PR may not provide complete user-visible BF16 enablement.

---

### Changes

**Kernel selector / OCL kernels:**
- Registered `Datatype::BF16` in `broadcast_kernel_ref.cpp` and `strided_slice_kernel_ref.cpp`.
- Updated `broadcast_gpu_ref.cl` and `strided_slice_ref.cl` to use compute-type macros for bf16 decode/encode.
- Fixed fused-ops input dtype in `broadcast_kernel_base.cpp` (use `inputs[0]` instead of `outputs[0]`).

**CPU fallback:**
- Added bf16 case to `cpu/broadcast.cpp` and `cpu/strided_slice.cpp`.

**OCL implementations:**
- Added bf16 registration in `ocl/broadcast.cpp` and `ocl/strided_slice.cpp`.

**Tests:**
- Added bf16 unit tests to `broadcast_gpu_test.cpp` and `strided_slice_gpu_test.cpp`.
- Added bf16 fusion tests to `broadcast_fusion_test.cpp` and `strided_slice_fusion_test.cpp`.
- Parametrized existing f32 strided_slice tests to also run with f16 and bf16.

### AI assistance:
> [!NOTE]  
> AI assistance used during analysis and PR description preparation. All code originates from the original BF16 OCL enablement branch.
