### PR TITLE
[GPU] BF16 OCL: border and resample kernels support

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
@@ -162,7 +162,7 @@ protected:
 namespace detail {
 
 attach_border_impl::attach_border_impl() {
-    auto types = {data_types::f32, data_types::f16, data_types::i32, data_types::i8, data_types::u8};
+    auto types = {data_types::f32, data_types::f16, data_types::bf16, data_types::i32, data_types::i8, data_types::u8};
 
     auto formats = {
         format::yxfb,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
@@ -179,7 +179,7 @@ namespace detail {
 attach_resample_impl::attach_resample_impl() {
     std::set<implementation_map<resample>::key_type> keys;
 
-    const auto types = {data_types::f16, data_types::f32, data_types::i8, data_types::u8, data_types::i32};
+    const auto types = {data_types::f16, data_types::bf16, data_types::f32, data_types::i8, data_types::u8, data_types::i32};
     const auto formats = {
         format::bfyx,
         format::b_fs_yx_fsv16,
@@ -206,6 +206,8 @@ attach_resample_impl::attach_resample_impl() {
     keys.emplace(data_types::f32, format::yxfb);
     keys.emplace(data_types::f16, format::yxfb);
     keys.emplace(data_types::f16, format::fs_b_yx_fsv32);
+    keys.emplace(data_types::bf16, format::yxfb);
+    keys.emplace(data_types::bf16, format::fs_b_yx_fsv32);
 
     implementation_map<resample>::add(impl_types::ocl, typed_primitive_impl_ocl<resample>::create<resample_impl>, keys);
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/border_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/border_gpu_ref.cl
@@ -139,7 +139,7 @@ KERNEL(border_gpu_ref)(
 
 #ifdef BORDER_TYPE_CONSTANT
     #ifdef BORDER_VALUE_TYPE
-    INPUT0_TYPE in_val = TO_INPUT0_TYPE(border_value_param[0]);
+    INPUT0_TYPE in_val = TO_INPUT0_TYPE(DECODE_BORDER_VALUE_COMPUTE_TYPE(border_value_param[0]));
     #else
     INPUT0_TYPE in_val = TO_INPUT0_TYPE(BORDER_VALUE);
     #endif
@@ -196,5 +196,5 @@ KERNEL(border_gpu_ref)(
 #endif
 
     const int out_pos = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR out_b, out_f, out_w, out_z, out_y, out_x);
-    output[out_pos] = in_val;
+    output[out_pos] = TO_OUTPUT_TYPE(DECODE_INPUT0_COMPUTE_TYPE(in_val));
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/border_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/border_gpu_ref.cl
@@ -139,7 +139,7 @@ KERNEL(border_gpu_ref)(
 
 #ifdef BORDER_TYPE_CONSTANT
     #ifdef BORDER_VALUE_TYPE
-    INPUT0_TYPE in_val = TO_INPUT0_TYPE(DECODE_BORDER_VALUE_COMPUTE_TYPE(border_value_param[0]));
+    INPUT0_TYPE in_val = TO_INPUT0_TYPE(border_value_param[0]);
     #else
     INPUT0_TYPE in_val = TO_INPUT0_TYPE(BORDER_VALUE);
     #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_bfyx_cubic_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_bfyx_cubic_opt.cl
@@ -5,9 +5,7 @@
 #include "include/fetch_utils.cl"
 
 #ifdef RTE_OUTPUT
-    #define TO_OUTPUT_TYPE(x)   CAT(CAT(convert_, OUTPUT_TYPE), _rte)(x)
-#else
-    #define TO_OUTPUT_TYPE(x)   CAT(convert_, OUTPUT_TYPE)(x)
+    #define TO_OUTPUT_COMPUTE_TYPE(x)   CAT(CAT(convert_, OUTPUT_TYPE), _rte)(x)
 #endif
 
 inline float FUNC(get_original_coordinate)(float num, float scale, int length_resized, int length_original)
@@ -99,7 +97,7 @@ KERNEL (resample_bfyx_cubic_opt)(
 #endif
                 {
                     interp_val = fma((ACCUMULATOR_TYPE)(cy[dy] * cx[dx]),
-                                     (ACCUMULATOR_TYPE)input[INPUT0_GET_INDEX(out_b, out_f, y_idx[dy], x_idx[dx])],
+                                     (ACCUMULATOR_TYPE)DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(out_b, out_f, y_idx[dy], x_idx[dx])]),
                                      interp_val);
                 }
             }
@@ -115,10 +113,10 @@ KERNEL (resample_bfyx_cubic_opt)(
         #undef OF_ID
         #undef oy
 #else
-        OUTPUT_TYPE res = ACTIVATION(TO_OUTPUT_TYPE(interp_val), ACTIVATION_PARAMS);
+        OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(interp_val), ACTIVATION_PARAMS));
 #endif
         output[OUTPUT_GET_INDEX(out_b, out_f, out_y, ox)] = res;
     }
 }
 
-#undef TO_OUTPUT_TYPE
+#undef TO_OUTPUT_COMPUTE_TYPE

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_onnx.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_onnx.cl
@@ -11,6 +11,7 @@
 
 #define IN_VEC_TYPE                     MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_SIZE)
 #define TO_IN_VEC_TYPE(x)               CAT(convert_, IN_VEC_TYPE)(x)
+#define DECODE_IN_VEC_TYPE(x)           DECODE_INPUT0_COMPUTE_VECTOR_TYPE(x, VEC_SIZE)
 #define ACC_VEC_TYPE                    MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, VEC_SIZE)
 #define TO_ACC_VEC_TYPE(x)              CAT(convert_, ACC_VEC_TYPE)(x)
 #define OUT_VEC_TYPE                    MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE)
@@ -18,7 +19,7 @@
 #ifdef RTE_OUTPUT
     #define TO_OUT_VEC_TYPE(x)          CAT(CAT(convert_, OUT_VEC_TYPE), _rte)(x)
 #else
-    #define TO_OUT_VEC_TYPE(x)          CAT(convert_, OUT_VEC_TYPE)(x)
+    #define TO_OUT_VEC_TYPE(x)          TO_OUTPUT_VECTOR_TYPE(x, VEC_SIZE)
 #endif
 
 inline float FUNC(get_original_coordinate)(float num, float scale, int length_resized, int length_original)
@@ -121,23 +122,23 @@ KERNEL (resample_onnx)(__global INPUT0_TYPE* input,
         bool FrontBottomLOutOfBounds = in_z2 < 0 || in_z2 >= INPUT0_SIZE_Z || in_y2 < 0 || in_y2 >= INPUT0_SIZE_Y || in_x1 < 0 || in_x1 >= INPUT0_SIZE_X;
         bool FrontBottomROutOfBounds = in_z2 < 0 || in_z2 >= INPUT0_SIZE_Z || in_y2 < 0 || in_y2 >= INPUT0_SIZE_Y || in_x2 < 0 || in_x2 >= INPUT0_SIZE_X;
 
-        const acc_vec_t x111 = BackTopLOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y1, in_x1)));
-        const acc_vec_t x211 = BackTopROutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y1, in_x2)));
-        const acc_vec_t x121 = BackBottomLOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y2, in_x1)));
-        const acc_vec_t x221 = BackBottomROutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y2, in_x2)));
-        const acc_vec_t x112 = FrontTopLOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y1, in_x1)));
-        const acc_vec_t x212 = FrontTopROutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y1, in_x2)));
-        const acc_vec_t x122 = FrontBottomLOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y2, in_x1)));
-        const acc_vec_t x222 = FrontBottomROutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y2, in_x2)));
+        const acc_vec_t x111 = BackTopLOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y1, in_x1))));
+        const acc_vec_t x211 = BackTopROutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y1, in_x2))));
+        const acc_vec_t x121 = BackBottomLOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y2, in_x1))));
+        const acc_vec_t x221 = BackBottomROutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y2, in_x2))));
+        const acc_vec_t x112 = FrontTopLOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y1, in_x1))));
+        const acc_vec_t x212 = FrontTopROutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y1, in_x2))));
+        const acc_vec_t x122 = FrontBottomLOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y2, in_x1))));
+        const acc_vec_t x222 = FrontBottomROutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y2, in_x2))));
 #else
-        const acc_vec_t x111 = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y1, in_x1)));
-        const acc_vec_t x211 = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y1, in_x2)));
-        const acc_vec_t x121 = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y2, in_x1)));
-        const acc_vec_t x221 = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y2, in_x2)));
-        const acc_vec_t x112 = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y1, in_x1)));
-        const acc_vec_t x212 = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y1, in_x2)));
-        const acc_vec_t x122 = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y2, in_x1)));
-        const acc_vec_t x222 = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y2, in_x2)));
+        const acc_vec_t x111 = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y1, in_x1))));
+        const acc_vec_t x211 = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y1, in_x2))));
+        const acc_vec_t x121 = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y2, in_x1))));
+        const acc_vec_t x221 = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z1, in_y2, in_x2))));
+        const acc_vec_t x112 = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y1, in_x1))));
+        const acc_vec_t x212 = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y1, in_x2))));
+        const acc_vec_t x122 = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y2, in_x1))));
+        const acc_vec_t x222 = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_z2, in_y2, in_x2))));
 #endif // PADDING_USED == 1
 
         acc_vec_t res = TO_ACC_VEC_TYPE(dx2 * dy2 * dz2 * x111) + TO_ACC_VEC_TYPE(dx1 * dy2 * dz2 * x211);
@@ -192,27 +193,27 @@ KERNEL (resample_onnx)(__global INPUT0_TYPE* input,
         int safe_x1 = clamp(in_x1, 0, (int)INPUT0_SIZE_X - 1);
         int safe_x2 = clamp(in_x2, 0, (int)INPUT0_SIZE_X - 1);
   #if OUTPUT_DIMS == 5
-        acc_vec_t top_left     = tlOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y1, safe_x1)));
-        acc_vec_t top_right    = trOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y1, safe_x2)));
-        acc_vec_t bottom_left  = blOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y2, safe_x1)));
-        acc_vec_t bottom_right = brOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y2, safe_x2)));
+        acc_vec_t top_left     = tlOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y1, safe_x1))));
+        acc_vec_t top_right    = trOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y1, safe_x2))));
+        acc_vec_t bottom_left  = blOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y2, safe_x1))));
+        acc_vec_t bottom_right = brOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y2, safe_x2))));
   #else
-        acc_vec_t top_left     = tlOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, safe_y1, safe_x1)));
-        acc_vec_t top_right    = trOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, safe_y1, safe_x2)));
-        acc_vec_t bottom_left  = blOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, safe_y2, safe_x1)));
-        acc_vec_t bottom_right = brOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, safe_y2, safe_x2)));
+        acc_vec_t top_left     = tlOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, safe_y1, safe_x1))));
+        acc_vec_t top_right    = trOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, safe_y1, safe_x2))));
+        acc_vec_t bottom_left  = blOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, safe_y2, safe_x1))));
+        acc_vec_t bottom_right = brOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, safe_y2, safe_x2))));
   #endif
 #else
   #if OUTPUT_DIMS == 5
-        acc_vec_t top_left     = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, in_y1, in_x1)));
-        acc_vec_t top_right    = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, in_y1, in_x2)));
-        acc_vec_t bottom_left  = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, in_y2, in_x1)));
-        acc_vec_t bottom_right = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, in_y2, in_x2)));
+        acc_vec_t top_left     = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, in_y1, in_x1))));
+        acc_vec_t top_right    = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, in_y1, in_x2))));
+        acc_vec_t bottom_left  = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, in_y2, in_x1))));
+        acc_vec_t bottom_right = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, in_y2, in_x2))));
   #else
-        acc_vec_t top_left     = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_y1, in_x1)));
-        acc_vec_t top_right    = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_y1, in_x2)));
-        acc_vec_t bottom_left  = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_y2, in_x1)));
-        acc_vec_t bottom_right = TO_ACC_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_y2, in_x2)));
+        acc_vec_t top_left     = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_y1, in_x1))));
+        acc_vec_t top_right    = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_y1, in_x2))));
+        acc_vec_t bottom_left  = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_y2, in_x1))));
+        acc_vec_t bottom_right = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, in_y2, in_x2))));
   #endif
 #endif // PADDING_USED == 1
         acc_vec_t res = TO_ACC_VEC_TYPE(dx2 * dy2 * top_left) +

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_onnx.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_onnx.cl
@@ -193,7 +193,7 @@ KERNEL (resample_onnx)(__global INPUT0_TYPE* input,
         int safe_x1 = clamp(in_x1, 0, (int)INPUT0_SIZE_X - 1);
         int safe_x2 = clamp(in_x2, 0, (int)INPUT0_SIZE_X - 1);
   #if OUTPUT_DIMS == 5
-        acc_vec_t top_left     = tlOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y1, safe_x1))));
+        acc_vec_t top_left     = tlOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y1, safe_x1))));
         acc_vec_t top_right    = trOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y1, safe_x2))));
         acc_vec_t bottom_left  = blOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y2, safe_x1))));
         acc_vec_t bottom_right = brOutOfBounds ? INPUT0_VAL_ZERO : TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, z, safe_y2, safe_x2))));

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_opt.cl
@@ -17,15 +17,16 @@
 
 #define IN_VEC_TYPE                     MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_SIZE)
 #define TO_IN_VEC_TYPE(x)               CAT(convert_, IN_VEC_TYPE)(x)
+#define DECODE_IN_VEC_TYPE(x)           DECODE_INPUT0_COMPUTE_VECTOR_TYPE(x, VEC_SIZE)
 #define ACC_VEC_TYPE                    MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, VEC_SIZE)
 #define TO_ACC_VEC_TYPE(x)              CAT(convert_, ACC_VEC_TYPE)(x)
 #define OUT_VEC_TYPE                    MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE)
 
 #ifdef RTE_OUTPUT
     #define TO_OUT_VEC_TYPE(x)          CAT(CAT(convert_, OUT_VEC_TYPE), _rte)(x)
-    #define TO_OUTPUT_TYPE(x)           CAT(CAT(convert_, OUTPUT_TYPE), _rte)(x)
+    #define TO_OUTPUT_COMPUTE_TYPE(x)           CAT(CAT(convert_, OUTPUT_TYPE), _rte)(x)
 #else
-    #define TO_OUT_VEC_TYPE(x)          CAT(convert_, OUT_VEC_TYPE)(x)
+    #define TO_OUT_VEC_TYPE(x)          TO_OUTPUT_VECTOR_TYPE(x, VEC_SIZE)
 #endif
 
 inline float FUNC(get_original_coordinate)(float num, float scale, int length_resized, int length_original)
@@ -159,10 +160,10 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
                                     {
 #if VEC_BLOCK_SIZE == 8
                                         MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_BLOCK_SIZE) input_vec = vload8(0, &input[INPUT0_GET_INDEX(b, f+fp, y, x)]);
-                                        sum = fma(convert_float8(input_vec), (float8)w, sum);
+                                        sum = fma(convert_float8(DECODE_INPUT0_COMPUTE_VECTOR_TYPE(input_vec, 8)), (float8)w, sum);
 #else
                                         MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_BLOCK_SIZE) input_vec = vload16(0, &input[INPUT0_GET_INDEX(b, f+fp, y, x)]);
-                                        sum = fma(convert_float16(input_vec), (float16)w, sum);
+                                        sum = fma(convert_float16(DECODE_INPUT0_COMPUTE_VECTOR_TYPE(input_vec, 16)), (float16)w, sum);
 #endif
                                     }
                                 }  // w != 0;
@@ -185,7 +186,7 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
                 out[f] = FUSED_OPS_RESULT;
                 #undef OF_ID
 #else
-                out[f] = ACTIVATION(TO_OUTPUT_TYPE(res), ACTIVATION_PARAMS);
+                out[f] = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(res), ACTIVATION_PARAMS));
 #endif
             }
         } else {
@@ -197,7 +198,7 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
                 out[f] = FUSED_OPS_RESULT;
                 #undef OF_ID
 #else
-                out[f] = ACTIVATION(TO_OUTPUT_TYPE(res), ACTIVATION_PARAMS);
+                out[f] = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(res), ACTIVATION_PARAMS));
 #endif
             }
         }
@@ -251,6 +252,13 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
 #else
         in_vec_t res = READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, iy, ix));
 #endif
+
+#if HAS_FUSED_OPS
+        FUSED_OPS;
+        OUT_VEC_TYPE out = FUSED_OPS_RESULT;
+#else
+        OUT_VEC_TYPE out = TO_OUT_VEC_TYPE(ACTIVATION(DECODE_IN_VEC_TYPE(res), ACTIVATION_PARAMS));
+#endif // #if HAS_FUSED_OPS
 #elif defined(SAMPLE_TYPE_INTERP)
     unroll_for (uint out_x = 0; out_x < OUTPUT_X_BLOCK_SIZE; out_x++) {
         const ACCUMULATOR_TYPE ix = TO_ACCUMULATOR_TYPE(SCALES[4]) * (x + out_x);
@@ -276,12 +284,9 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
         const in_vec_t bottom_right = READ_FUNC(input, INPUT0_GET_INDEX(b, feature_block, bottom_y_index, right_x_index));
 #endif
 
-        const acc_vec_t top    = TO_ACC_VEC_TYPE(top_left) + (TO_ACC_VEC_TYPE(top_right) - TO_ACC_VEC_TYPE(top_left)) * dx;
-        const acc_vec_t bottom = TO_ACC_VEC_TYPE(bottom_left) + (TO_ACC_VEC_TYPE(bottom_right) - TO_ACC_VEC_TYPE(bottom_left)) * dx;
+        const acc_vec_t top    = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(top_left)) + (TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(top_right)) - TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(top_left))) * dx;
+        const acc_vec_t bottom = TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(bottom_left)) + (TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(bottom_right)) - TO_ACC_VEC_TYPE(DECODE_IN_VEC_TYPE(bottom_left))) * dx;
         acc_vec_t res = top + (bottom - top) * dy;
-#else // defined(SAMPLE_TYPE_LINEAR_ONNX)
-#error [clDNN resample_opt.cl]: unsupported resample type
-#endif
 
 #if HAS_FUSED_OPS
         FUSED_OPS;
@@ -289,6 +294,9 @@ KERNEL (resample_opt)(__global INPUT0_TYPE* input,
 #else
         OUT_VEC_TYPE out = TO_OUT_VEC_TYPE(ACTIVATION(res, ACTIVATION_PARAMS));
 #endif // #if HAS_FUSED_OPS
+#else // defined(SAMPLE_TYPE_LINEAR_ONNX)
+#error [clDNN resample_opt.cl]: unsupported resample type
+#endif
 
 #if OUTPUT_DIMS == 5
         WRITE_FUNC(output, OUTPUT_GET_INDEX(b, feature_block, z, y, (x + out_x)), out);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_pil_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_pil_ref.cl
@@ -144,7 +144,7 @@ KERNEL (resample_horizontal_gpu_ref)(  __global INPUT0_TYPE* input
             y_no_padding >= 0 && y_no_padding < INPUT0_SIZE_Y &&
             x_no_padding >= 0 && x_no_padding < INPUT0_SIZE_X) {
             int in_idx = INPUT0_GET_INDEX(b_no_padding, f_no_padding, y_no_padding, x_no_padding);
-            ss += input[in_idx] * k[horizontal_dim];
+            ss += DECODE_INPUT0_COMPUTE_TYPE(input[in_idx]) * k[horizontal_dim];
         }
     }
 #if ENABLE_VERTICAL_PASS
@@ -154,7 +154,7 @@ KERNEL (resample_horizontal_gpu_ref)(  __global INPUT0_TYPE* input
 #endif
     #if HAS_FUSED_OPS
         FUSED_OPS;
-        output[out_idx] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT);
+        output[out_idx] = FUSED_OPS_RESULT;
     #else
         #if ENABLE_VERTICAL_PASS
             output[out_idx] = TO_INTERMEDIATE_BUF_TYPE(ACTIVATION(ss, ACTIVATION_PARAMS));
@@ -165,6 +165,12 @@ KERNEL (resample_horizontal_gpu_ref)(  __global INPUT0_TYPE* input
 }
 
 #else // RESAMPLE_PILLOW_STAGE == STAGE_RESAMPLE_VERTICAL
+
+#if ENABLE_HORIZONTAL_PASS
+#define DECODE_INPUT(x) DECODE_INTERMEDIATE_BUF_COMPUTE_TYPE(x)
+#else
+#define DECODE_INPUT(x) DECODE_INPUT0_COMPUTE_TYPE(x)
+#endif
 
 KERNEL (resample_vertical_gpu_ref)(  __global RESAMPLE_VERTICAL_INPUT_TYPE* input
                                      , __global float* coefficients
@@ -216,7 +222,7 @@ KERNEL (resample_vertical_gpu_ref)(  __global RESAMPLE_VERTICAL_INPUT_TYPE* inpu
 #elif X_IS_VERTICAL_AXIS == 1
         int in_idx = INTERMEDIATE_BUF_GET_INDEX(b, f, y, vertical_dim + vertical_min);
 #endif
-        ss += input[in_idx] * k[vertical_dim];
+        ss += DECODE_INPUT(input[in_idx]) * k[vertical_dim];
 #else // ENABLE_HORIZONTAL_PASS
 
 #if BATCH_IS_VERTICAL_AXIS == 1
@@ -247,19 +253,20 @@ KERNEL (resample_vertical_gpu_ref)(  __global RESAMPLE_VERTICAL_INPUT_TYPE* inpu
             y_no_padding >= 0 && y_no_padding < INPUT0_SIZE_Y &&
             x_no_padding >= 0 && x_no_padding < INPUT0_SIZE_X) {
             int in_idx = INPUT0_GET_INDEX(b_no_padding, f_no_padding, y_no_padding, x_no_padding);
-            ss += input[in_idx] * k[vertical_dim];
+            ss += DECODE_INPUT(input[in_idx]) * k[vertical_dim];
         }
 #endif // ENABLE_HORIZONTAL_PASS
     }
     int out_idx = OUTPUT_GET_INDEX(b, f, y, x);
     #if HAS_FUSED_OPS
         FUSED_OPS;
-        output[out_idx] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT);
+        output[out_idx] = FUSED_OPS_RESULT;
     #else
         output[out_idx] = TO_OUTPUT_TYPE(ACTIVATION(ss, ACTIVATION_PARAMS));
     #endif
 }
 
+#undef DECODE_INPUT
 #endif
 
 #undef PILLOW_SUPPORT

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/resample_ref.cl
@@ -5,7 +5,7 @@
 #include "include/fetch_utils.cl"
 
 #ifdef RTE_OUTPUT
-    #define TO_OUTPUT_TYPE(x)   CAT(CAT(convert_, OUTPUT_TYPE), _rte)(x)
+    #define TO_OUTPUT_COMPUTE_TYPE(x)   CAT(CAT(convert_, OUTPUT_TYPE), _rte)(x)
 #endif
 
 inline int FUNC(get_nearest_val)(float num, bool is_downsample)
@@ -100,7 +100,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
         INPUT0_TYPE interp_val = interp_val_pack[pi];
 #if PADDING_USED == 1
         if (isOutOfBounds)
-            interp_val = INPUT0_VAL_ZERO;
+            interp_val = TO_INPUT0_TYPE(INPUT0_VAL_ZERO);
 #endif
     #if HAS_FUSED_OPS
         #define batch (out_coords[0])
@@ -116,7 +116,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
         #undef oy
         #undef ox
     #else // HAS_FUSED_OPS
-        res[pi] = ACTIVATION(interp_val, ACTIVATION_PARAMS);
+        res[pi] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(interp_val), ACTIVATION_PARAMS));
     #endif // HAS_FUSED_OPS
     }
     ((__global out_pack_t*)(output + output_idx))[0] = res;
@@ -147,7 +147,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
     INPUT0_TYPE interp_val = input[FUNC_CALL(get_input_index)(in_coords[0], in_coords[1], 0, in_coords[2], in_coords[3], in_coords[4])];
 #if PADDING_USED == 1
     if (isOutOfBounds)
-        interp_val = INPUT0_VAL_ZERO;
+        interp_val = TO_INPUT0_TYPE(INPUT0_VAL_ZERO);
 #endif
 #if HAS_FUSED_OPS
     #define batch (out_coords[0])
@@ -163,7 +163,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
     #undef oy
     #undef ox
 #else // HAS_FUSED_OPS
-    OUTPUT_TYPE res = ACTIVATION(TO_OUTPUT_TYPE(interp_val), ACTIVATION_PARAMS);
+    OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(DECODE_INPUT0_COMPUTE_TYPE(interp_val)), ACTIVATION_PARAMS));
 #endif // HAS_FUSED_OPS
     output[FUNC_CALL(get_output_index)(out_coords[0], out_coords[1], 0, out_coords[2], out_coords[3], out_coords[4])] = res;
 #elif defined(SAMPLE_TYPE_CUBIC) // defined(SAMPLE_TYPE_NEAREST) && FEATURE_PACKED_MODE
@@ -187,7 +187,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
         FUNC_CALL(get_cubic_coeff)(cubic_coeff[i], orig_coord, CUBE_COEFF);
     }
 
-    INPUT0_TYPE interp_val = INPUT0_VAL_ZERO;
+    INPUT0_COMPUTE_TYPE interp_val = INPUT0_VAL_ZERO;
     int index[5];
     unroll_for (index[0] = 0; index[0] <= 3; ++index[0]) {
         unroll_for (index[1] = 0; index[1] <= 3; ++index[1]) {
@@ -208,7 +208,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
 #if PADDING_USED == 1
                         if (!isOutOfBounds)
 #endif
-                            interp_val += coeff_prod * input[FUNC_CALL(get_input_index)(coords_sum[0], coords_sum[1], 0, coords_sum[2], coords_sum[3], coords_sum[4])];
+                            interp_val += coeff_prod * DECODE_INPUT0_COMPUTE_TYPE(input[FUNC_CALL(get_input_index)(coords_sum[0], coords_sum[1], 0, coords_sum[2], coords_sum[3], coords_sum[4])]);
                     }
                 }
             }
@@ -229,7 +229,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
     #undef oy
     #undef ox
 #else // HAS_FUSED_OPS
-    OUTPUT_TYPE res = ACTIVATION(TO_OUTPUT_TYPE(interp_val), ACTIVATION_PARAMS);
+    OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(interp_val), ACTIVATION_PARAMS));
 #endif // HAS_FUSED_OPS
     output[FUNC_CALL(get_output_index)(out_coords[0], out_coords[1], 0, out_coords[2], out_coords[3], out_coords[4])] = res;
 #elif defined(SAMPLE_TYPE_LINEAR_ONNX) // defined(SAMPLE_TYPE_NEAREST) && FEATURE_PACKED_MODE
@@ -272,17 +272,17 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
     bool brOutOfBounds = in_y2 < 0 || in_y2 >= in_size[3] || in_x2 < 0 || in_x2 >= in_size[4];
 
     unroll_for(int in_f = 0; in_f < OUTPUT_FEATURE_NUM; in_f++) {
-        INPUT0_TYPE top_left = tlOutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, in_f, in_y1, in_x1)];
-        INPUT0_TYPE top_right = trOutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, in_f, in_y1, in_x2)];
-        INPUT0_TYPE bottom_left = blOutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, in_f, in_y2, in_x1)];
-        INPUT0_TYPE bottom_right = brOutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, in_f, in_y2, in_x2)];
+        INPUT0_COMPUTE_TYPE top_left = tlOutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, in_y1, in_x1)]);
+        INPUT0_COMPUTE_TYPE top_right = trOutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, in_y1, in_x2)]);
+        INPUT0_COMPUTE_TYPE bottom_left = blOutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, in_y2, in_x1)]);
+        INPUT0_COMPUTE_TYPE bottom_right = brOutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, in_y2, in_x2)]);
 
 #else
     unroll_for(int in_f = 0; in_f < OUTPUT_FEATURE_NUM; in_f++) {
-        INPUT0_TYPE top_left = input[INPUT0_GET_INDEX(batch, in_f, in_y1, in_x1)];
-        INPUT0_TYPE top_right = input[INPUT0_GET_INDEX(batch, in_f, in_y1, in_x2)];
-        INPUT0_TYPE bottom_left = input[INPUT0_GET_INDEX(batch, in_f, in_y2, in_x1)];
-        INPUT0_TYPE bottom_right = input[INPUT0_GET_INDEX(batch, in_f, in_y2, in_x2)];
+        INPUT0_COMPUTE_TYPE top_left = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, in_y1, in_x1)]);
+        INPUT0_COMPUTE_TYPE top_right = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, in_y1, in_x2)]);
+        INPUT0_COMPUTE_TYPE bottom_left = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, in_y2, in_x1)]);
+        INPUT0_COMPUTE_TYPE bottom_right = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, in_y2, in_x2)]);
 #endif
 
         ACCUMULATOR_TYPE interp_val = TO_ACCUMULATOR_TYPE(dx2 * dy2 * top_left) +
@@ -296,7 +296,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
         OUTPUT_TYPE res = FUSED_OPS_RESULT;
         #undef OF_ID
 #else
-        OUTPUT_TYPE res = ACTIVATION(TO_OUTPUT_TYPE(interp_val), ACTIVATION_PARAMS);
+        OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(interp_val), ACTIVATION_PARAMS));
 #endif
         output[OUTPUT_GET_INDEX(batch, in_f, oy, ox)] = res;
     }
@@ -353,23 +353,23 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
     bool FrontBottomLOutOfBounds = in_z2 < 0 || in_z2 >= in_size[2] || in_y2 < 0 || in_y2 >= in_size[3] || in_x1 < 0 || in_x1 >= in_size[4];
     bool FrontBottomROutOfBounds = in_z2 < 0 || in_z2 >= in_size[2] || in_y2 < 0 || in_y2 >= in_size[3] || in_x2 < 0 || in_x2 >= in_size[4];
 
-    OUTPUT_TYPE x111 = BackTopLOutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y1, in_x1)];
-    OUTPUT_TYPE x211 = BackTopROutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y1, in_x2)];
-    OUTPUT_TYPE x121 = BackBottomLOutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y2, in_x1)];
-    OUTPUT_TYPE x221 = BackBottomROutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y2, in_x2)];
-    OUTPUT_TYPE x112 = FrontTopLOutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y1, in_x1)];
-    OUTPUT_TYPE x212 = FrontTopROutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y1, in_x2)];
-    OUTPUT_TYPE x122 = FrontBottomLOutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y2, in_x1)];
-    OUTPUT_TYPE x222 = FrontBottomROutOfBounds ? INPUT0_VAL_ZERO : input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y2, in_x2)];
+    OUTPUT_COMPUTE_TYPE x111 = BackTopLOutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y1, in_x1)]);
+    OUTPUT_COMPUTE_TYPE x211 = BackTopROutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y1, in_x2)]);
+    OUTPUT_COMPUTE_TYPE x121 = BackBottomLOutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y2, in_x1)]);
+    OUTPUT_COMPUTE_TYPE x221 = BackBottomROutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y2, in_x2)]);
+    OUTPUT_COMPUTE_TYPE x112 = FrontTopLOutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y1, in_x1)]);
+    OUTPUT_COMPUTE_TYPE x212 = FrontTopROutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y1, in_x2)]);
+    OUTPUT_COMPUTE_TYPE x122 = FrontBottomLOutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y2, in_x1)]);
+    OUTPUT_COMPUTE_TYPE x222 = FrontBottomROutOfBounds ? INPUT0_VAL_ZERO : DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y2, in_x2)]);
 #else
-    OUTPUT_TYPE x111 = input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y1, in_x1)];
-    OUTPUT_TYPE x211 = input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y1, in_x2)];
-    OUTPUT_TYPE x121 = input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y2, in_x1)];
-    OUTPUT_TYPE x221 = input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y2, in_x2)];
-    OUTPUT_TYPE x112 = input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y1, in_x1)];
-    OUTPUT_TYPE x212 = input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y1, in_x2)];
-    OUTPUT_TYPE x122 = input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y2, in_x1)];
-    OUTPUT_TYPE x222 = input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y2, in_x2)];
+    OUTPUT_COMPUTE_TYPE x111 = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y1, in_x1)]);
+    OUTPUT_COMPUTE_TYPE x211 = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y1, in_x2)]);
+    OUTPUT_COMPUTE_TYPE x121 = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y2, in_x1)]);
+    OUTPUT_COMPUTE_TYPE x221 = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z1, in_y2, in_x2)]);
+    OUTPUT_COMPUTE_TYPE x112 = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y1, in_x1)]);
+    OUTPUT_COMPUTE_TYPE x212 = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y1, in_x2)]);
+    OUTPUT_COMPUTE_TYPE x122 = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y2, in_x1)]);
+    OUTPUT_COMPUTE_TYPE x222 = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, feature, in_z2, in_y2, in_x2)]);
 #endif
 
     ACCUMULATOR_TYPE interp_val = dx2 * dy2 * dz2 * x111 + dx1 * dy2 * dz2 * x211;
@@ -383,7 +383,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
         OUTPUT_TYPE res = FUSED_OPS_RESULT;
         #undef OF_ID
 #else
-        OUTPUT_TYPE res = ACTIVATION(TO_OUTPUT_TYPE(interp_val), ACTIVATION_PARAMS);
+        OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(interp_val), ACTIVATION_PARAMS));
 #endif
     output[OUTPUT_GET_INDEX(batch, feature, oz, oy, ox)] = res;
 #endif // #if OUTPUT_DIMS == 5
@@ -410,10 +410,10 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
     const ACCUMULATOR_TYPE dy = TO_ACCUMULATOR_TYPE(iy - top_y_index);
 
     unroll_for(int in_f = 0; in_f < OUTPUT_FEATURE_NUM; in_f++) {
-        INPUT0_TYPE top_left = input[INPUT0_GET_INDEX(batch, in_f, top_y_index, left_x_index)];
-        INPUT0_TYPE top_right = input[INPUT0_GET_INDEX(batch, in_f, top_y_index, right_x_index)];
-        INPUT0_TYPE bottom_left = input[INPUT0_GET_INDEX(batch, in_f, bottom_y_index, left_x_index)];
-        INPUT0_TYPE bottom_right = input[INPUT0_GET_INDEX(batch, in_f, bottom_y_index, right_x_index)];
+        INPUT0_COMPUTE_TYPE top_left = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, top_y_index, left_x_index)]);
+        INPUT0_COMPUTE_TYPE top_right = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, top_y_index, right_x_index)]);
+        INPUT0_COMPUTE_TYPE bottom_left = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, bottom_y_index, left_x_index)]);
+        INPUT0_COMPUTE_TYPE bottom_right = DECODE_INPUT0_COMPUTE_TYPE(input[INPUT0_GET_INDEX(batch, in_f, bottom_y_index, right_x_index)]);
 
         ACCUMULATOR_TYPE top = TO_ACCUMULATOR_TYPE(top_left) + (TO_ACCUMULATOR_TYPE(top_right) - TO_ACCUMULATOR_TYPE(top_left)) * dx;
         ACCUMULATOR_TYPE bottom = TO_ACCUMULATOR_TYPE(bottom_left) + (TO_ACCUMULATOR_TYPE(bottom_right) - TO_ACCUMULATOR_TYPE(bottom_left)) * dx;
@@ -426,7 +426,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
         OUTPUT_TYPE res = FUSED_OPS_RESULT;
         #undef OF_ID
 #else
-        OUTPUT_TYPE res = ACTIVATION(TO_OUTPUT_TYPE(interp_val), ACTIVATION_PARAMS);
+        OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(interp_val), ACTIVATION_PARAMS));
 #endif
         output[OUTPUT_GET_INDEX(batch, in_f, oy, ox)] = res;
     }
@@ -534,7 +534,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
 #if PADDING_USED == 1
                                 if (!isOutOfBounds)
 #endif
-                                    sum[fp] += w * TO_ACCUMULATOR_TYPE(input[FUNC_CALL(get_input_index)(b, f + fp, 0, z, y, x)]);
+                                    sum[fp] += w * TO_ACCUMULATOR_TYPE(DECODE_INPUT0_COMPUTE_TYPE(input[FUNC_CALL(get_input_index)(b, f + fp, 0, z, y, x)]));
                             }
                         }
                     }
@@ -550,7 +550,7 @@ KERNEL (resample_gpu_ref)(__global INPUT0_TYPE* input,
         OUTPUT_TYPE res = FUSED_OPS_RESULT;
         #undef OF_ID
 #else
-        OUTPUT_TYPE res = ACTIVATION(TO_OUTPUT_TYPE(interp_val), ACTIVATION_PARAMS);
+        OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(TO_OUTPUT_COMPUTE_TYPE(interp_val), ACTIVATION_PARAMS));
 #endif
         output[FUNC_CALL(get_output_index)(batch, feature + f, 0, oz, oy, ox)] = res;
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/border/border_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/border/border_kernel_ref.cpp
@@ -9,6 +9,7 @@ ParamsKey BorderKernelRef::GetSupportedKey() const {
     ParamsKey k;
 
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT8);
@@ -16,6 +17,7 @@ ParamsKey BorderKernelRef::GetSupportedKey() const {
 
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.cpp
@@ -211,7 +211,7 @@ JitConstants ResampleKernelBase::GetJitConstants(const resample_params& params) 
 
     jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
 
-    if (output.GetDType() != Datatype::F16 && output.GetDType() != Datatype::F32) {
+    if (output.GetDType() != Datatype::F16 && output.GetDType() != Datatype::BF16 && output.GetDType() != Datatype::F32) {
         jit.AddConstant(MakeJitConstant("RTE_OUTPUT", 1));
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_bfyx_cubic_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_bfyx_cubic_opt.cpp
@@ -21,8 +21,10 @@ size_t ResampleKernelBfyxCubicOpt::GetOptimalBlockSize(const resample_params& pa
 ParamsKey ResampleKernelBfyxCubicOpt::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableOutputLayout(DataLayout::bfyx);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_onnx.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_onnx.cpp
@@ -34,10 +34,12 @@ static size_t GetOptimalDivisor(const size_t input_size, size_t max_val = 16) {
 ParamsKey ResampleKernelOnnx::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT8);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.cpp
@@ -30,10 +30,12 @@ static size_t GetOptimalDivisor(const size_t input_size, size_t max_val = 16) {
 ParamsKey ResampleKernelOpt::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT8);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_pil_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_pil_ref.cpp
@@ -138,8 +138,10 @@ DataTensor GetIntermediateBufferSize(const resample_params& params) {
 ParamsKey ResampleKernelPilRef::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT8);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_ref.cpp
@@ -16,10 +16,12 @@ ParamsKey ResampleKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableDifferentTypes();
     k.EnableAllInputLayout();

--- a/src/plugins/intel_gpu/tests/unit/fusions/resample_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/resample_fusion_test.cpp
@@ -78,6 +78,17 @@ public:
 #define CASE_RESAMPLE_FP16_13 { 1, 16, 4, 5 }, { 1, 16, 7, 8 }, data_types::f16, format::b_fs_yx_fsv16, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::f16, format::bfyx
 #define CASE_RESAMPLE_FP16_14 { 1, 32, 4, 5 }, { 1, 32, 2, 3 }, data_types::f16, format::fs_b_yx_fsv32, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::f16, format::bfyx
 
+#define CASE_RESAMPLE_BF16_1 { 1, 15, 4, 5 }, { 1, 15, 2, 3 }, data_types::bf16, format::bfyx, resample::InterpolateOp::InterpolateMode::NEAREST, data_types::bf16, format::bfyx
+#define CASE_RESAMPLE_BF16_3 { 1, 15, 4, 5 }, { 1, 15, 2, 3 }, data_types::bf16, format::bfyx, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::bf16, format::bfyx
+#define CASE_RESAMPLE_BF16_4 { 1, 16, 4, 5 }, { 1, 16, 7, 8 }, data_types::bf16, format::bfyx, resample::InterpolateOp::InterpolateMode::NEAREST, data_types::bf16, format::bfyx
+#define CASE_RESAMPLE_BF16_6 { 1, 16, 4, 5 }, { 1, 16, 7, 8 }, data_types::bf16, format::bfyx, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::bf16, format::bfyx
+#define CASE_RESAMPLE_BF16_7 { 1, 16, 4, 5, 4 }, { 1, 16, 2, 3, 2 }, data_types::bf16, format::bfzyx, resample::InterpolateOp::InterpolateMode::NEAREST, data_types::bf16, format::bfzyx
+#define CASE_RESAMPLE_BF16_8 { 1, 16, 4, 5, 4 }, { 1, 16, 2, 3, 2 }, data_types::bf16, format::bfzyx, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::bf16, format::bfzyx
+#define CASE_RESAMPLE_BF16_11 { 1, 16, 4, 5 }, { 1, 16, 7, 8 }, data_types::bf16, format::b_fs_yx_fsv16, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::bf16, format::bfyx
+#define CASE_RESAMPLE_BF16_12 { 2, 32, 4, 5 }, { 2, 32, 7, 8 }, data_types::bf16, format::fs_b_yx_fsv32, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::bf16, format::bfyx
+#define CASE_RESAMPLE_BF16_13 { 1, 16, 4, 5 }, { 1, 16, 7, 8 }, data_types::bf16, format::b_fs_yx_fsv16, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::bf16, format::bfyx
+#define CASE_RESAMPLE_BF16_14 { 1, 32, 4, 5 }, { 1, 32, 2, 3 }, data_types::bf16, format::fs_b_yx_fsv32, resample::InterpolateOp::InterpolateMode::LINEAR, data_types::bf16, format::bfyx
+
 #define CASE_RESAMPLE_I8_1 { 1, 16, 4, 5 }, { 1, 16, 2, 3 }, data_types::i8, format::b_fs_yx_fsv16, resample::InterpolateOp::InterpolateMode::NEAREST, data_types::f32, format::bfyx
 #define CASE_RESAMPLE_I8_2 { 2, 32, 4, 5 }, { 2, 32, 2, 3 }, data_types::i8, format::b_fs_yx_fsv16, resample::InterpolateOp::InterpolateMode::NEAREST, data_types::f32, format::bfyx
 
@@ -140,6 +151,9 @@ TEST_P(resample_scale_activation_eltwise, basic) {
     );
 
     tolerance = 1e-5f;
+    // bf16 accumulates larger rounding error, relax tolerance accordingly
+    if (p.data_type == data_types::bf16)
+        tolerance = 5e-2f;
     execute(p);
 }
 
@@ -163,6 +177,17 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_scale_activation_eltwise, ::testi
     resample_test_params{ CASE_RESAMPLE_FP16_12, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
     resample_test_params{ CASE_RESAMPLE_FP16_13, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
     resample_test_params{ CASE_RESAMPLE_FP16_14, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+
+    resample_test_params{ CASE_RESAMPLE_BF16_1, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_3, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_4, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_6, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_7, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_8, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_11, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_12, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_13, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
+    resample_test_params{ CASE_RESAMPLE_BF16_14, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
 
     resample_test_params{ CASE_RESAMPLE_I8_1, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
     resample_test_params{ CASE_RESAMPLE_I8_2, RESAMPLE_SCALE_ACTIVATION_ELTWISE },
@@ -221,6 +246,18 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_quantize_concat, ::testing::Value
     resample_test_params{ CASE_RESAMPLE_FP16_12, RESAMPLE_QUANTIZE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_13, RESAMPLE_QUANTIZE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_14, RESAMPLE_QUANTIZE_CONCAT_CNT },
+
+    // concat is not yet supported for bf16 (no layout format available for concat with bf16), so bf16 cases are disabled
+    // resample_test_params{ CASE_RESAMPLE_BF16_1, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_3, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_4, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_6, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_7, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_8, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_11, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_12, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_13, RESAMPLE_QUANTIZE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_14, RESAMPLE_QUANTIZE_CONCAT_CNT },
 }));
 
 class resample_eltwise_concat : public ResamplePrimitiveFusingTest {};
@@ -270,6 +307,18 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_eltwise_concat, ::testing::Values
     resample_test_params{ CASE_RESAMPLE_FP16_13, RESAMPLE_ELTWISE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_14, RESAMPLE_ELTWISE_CONCAT_CNT },
 
+    // concat is not yet supported for bf16 (no layout format available for concat with bf16), so bf16 cases are disabled
+    // resample_test_params{ CASE_RESAMPLE_BF16_1, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_3, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_4, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_6, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_7, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_8, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_11, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_12, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_13, RESAMPLE_ELTWISE_CONCAT_CNT },
+    // resample_test_params{ CASE_RESAMPLE_BF16_14, RESAMPLE_ELTWISE_CONCAT_CNT },
+
     resample_test_params{ CASE_RESAMPLE_I8_1, RESAMPLE_ELTWISE_CONCAT_CNT },
     resample_test_params{ CASE_RESAMPLE_I8_2, RESAMPLE_ELTWISE_CONCAT_CNT },
 
@@ -314,6 +363,13 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_eltwise_fusing_through, ::testing
     resample_test_params{ CASE_RESAMPLE_FP16_7, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
     resample_test_params{ CASE_RESAMPLE_FP16_8, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
 
+    resample_test_params{ CASE_RESAMPLE_BF16_1, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
+    resample_test_params{ CASE_RESAMPLE_BF16_3, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
+    resample_test_params{ CASE_RESAMPLE_BF16_4, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
+    resample_test_params{ CASE_RESAMPLE_BF16_6, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
+    resample_test_params{ CASE_RESAMPLE_BF16_7, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
+    resample_test_params{ CASE_RESAMPLE_BF16_8, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
+
     resample_test_params{ CASE_RESAMPLE_I8_1, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_INT },
     resample_test_params{ CASE_RESAMPLE_I8_2, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_INT },
 
@@ -347,6 +403,8 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_eltwise_fusing_through_not_allowe
     resample_test_params{ CASE_RESAMPLE_FP32_1, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT },
 
     resample_test_params{ CASE_RESAMPLE_FP16_1, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT },
+
+    resample_test_params{ CASE_RESAMPLE_BF16_1, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT },
 }));
 
 class resample_eltwise : public ResamplePrimitiveFusingTest {};
@@ -371,6 +429,11 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_eltwise, ::testing::ValuesIn(std:
     resample_test_params{ CASE_RESAMPLE_FP16_4, RESAMPLE_QUANTIZE_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_7, RESAMPLE_QUANTIZE_CNT },
     resample_test_params{ CASE_RESAMPLE_FP16_11, RESAMPLE_QUANTIZE_CNT },
+
+    resample_test_params{ CASE_RESAMPLE_BF16_1, RESAMPLE_QUANTIZE_CNT },
+    resample_test_params{ CASE_RESAMPLE_BF16_4, RESAMPLE_QUANTIZE_CNT },
+    resample_test_params{ CASE_RESAMPLE_BF16_7, RESAMPLE_QUANTIZE_CNT },
+    resample_test_params{ CASE_RESAMPLE_BF16_11, RESAMPLE_QUANTIZE_CNT },
 }));
 
 /* ----------------------------------------------------------------------------------------------------- */
@@ -472,6 +535,42 @@ public:
     std::vector<int64_t>{2, 3}
 
 // BICUBIC_PILLOW, spatial axes = {2,3} (downscale)
+#define CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_1 \
+    ov::PartialShape{ 1, 15, 5, 4 }, ov::PartialShape{ 1, 15, 3, 2 }, data_types::bf16, format::bfyx, \
+    resample::InterpolateOp::InterpolateMode::BICUBIC_PILLOW, data_types::bf16, format::bfyx, \
+    std::vector<int64_t>{2, 3}
+
+// BICUBIC_PILLOW, spatial axes = {2,3} (upscale)
+#define CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_2 \
+    ov::PartialShape{ 1, 16, 5, 4 }, ov::PartialShape{ 1, 16, 8, 7 }, data_types::bf16, format::bfyx, \
+    resample::InterpolateOp::InterpolateMode::BICUBIC_PILLOW, data_types::bf16, format::bfyx, \
+    std::vector<int64_t>{2, 3}
+
+// BICUBIC_PILLOW, spatial axes = {2,3} (downscale only horizontal - vertical axis not changed)
+#define CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_3 \
+    ov::PartialShape{ 1, 15, 5, 4 }, ov::PartialShape{ 1, 15, 5, 2 }, data_types::bf16, format::bfyx, \
+    resample::InterpolateOp::InterpolateMode::BICUBIC_PILLOW, data_types::bf16, format::bfyx, \
+    std::vector<int64_t>{2, 3}
+
+// BICUBIC_PILLOW, spatial axes = {2,3} (upscale only horizontal - vertical axis not changed)
+#define CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_4 \
+    ov::PartialShape{ 1, 16, 5, 4 }, ov::PartialShape{ 1, 16, 5, 7 }, data_types::bf16, format::bfyx, \
+    resample::InterpolateOp::InterpolateMode::BICUBIC_PILLOW, data_types::bf16, format::bfyx, \
+    std::vector<int64_t>{2, 3}
+
+// BICUBIC_PILLOW, spatial axes = {2,3} (downscale only vertical - horizontal axis not changed)
+#define CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_5 \
+    ov::PartialShape{ 1, 15, 5, 4 }, ov::PartialShape{ 1, 15, 3, 4 }, data_types::bf16, format::bfyx, \
+    resample::InterpolateOp::InterpolateMode::BICUBIC_PILLOW, data_types::bf16, format::bfyx, \
+    std::vector<int64_t>{2, 3}
+
+// BICUBIC_PILLOW, spatial axes = {2,3} (upscale only vertical - horizontal axis not changed)
+#define CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_6 \
+    ov::PartialShape{ 1, 16, 5, 4 }, ov::PartialShape{ 1, 16, 8, 4 }, data_types::bf16, format::bfyx, \
+    resample::InterpolateOp::InterpolateMode::BICUBIC_PILLOW, data_types::bf16, format::bfyx, \
+    std::vector<int64_t>{2, 3}
+
+// BICUBIC_PILLOW, spatial axes = {2,3} (downscale)
 #define CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_1 \
     ov::PartialShape{ 1, 15, 5, 4 }, ov::PartialShape{ 1, 15, 3, 2 }, data_types::f32, format::bfyx, \
     resample::InterpolateOp::InterpolateMode::BICUBIC_PILLOW, data_types::f32, format::bfyx, \
@@ -524,6 +623,9 @@ TEST_P(resample_bicubic_pillow_axes_scale_activation_eltwise, basic) {
     );
 
     tolerance = 5e-2f;
+    // bf16 accumulates larger rounding error, relax tolerance accordingly
+    if (p.data_type == data_types::bf16)
+        tolerance = 1e-1f;
     execute(p);
 }
 
@@ -536,6 +638,12 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_bicubic_pillow_axes_scale_activat
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_4, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_5, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_6, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_1, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_2, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_3, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_4, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_5, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_6, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_1, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_2, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_3, RESAMPLE_BICUBIC_PILLOW_AXES_SCALE_ACTIVATION_ELTWISE_CNT },
@@ -569,6 +677,12 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_bicubic_pillow_axes_activation,
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_4, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_5, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_6, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_1, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_2, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_3, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_4, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_5, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_6, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_1, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_2, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_3, RESAMPLE_BICUBIC_PILLOW_AXES_ACTIVATION_CNT },
@@ -627,6 +741,12 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_bicubic_pillow_axes_quantize,
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_4, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_5, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F16_6, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_1, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_2, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_3, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_4, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_5, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
+        resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_BF16_6, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_1, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_2, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },
         resample_axes_test_params{ CASE_RESAMPLE_BICUBIC_PILLOW_AXES_F32_3, RESAMPLE_BICUBIC_PILLOW_AXES_QUANTIZE_CNT },

--- a/src/plugins/intel_gpu/tests/unit/fusions/resample_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/resample_fusion_test.cpp
@@ -335,6 +335,9 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_eltwise_concat, ::testing::Values
 class resample_eltwise_fusing_through : public ResamplePrimitiveFusingTest {};
 TEST_P(resample_eltwise_fusing_through, reshape) {
     auto p = GetParam();
+    // bf16 compute requires XMX support (Xe-HPG+)
+    if (p.data_type == data_types::bf16 && !get_test_engine().get_device_info().supports_immad)
+        GTEST_SKIP();
     auto reshape_shape = p.out_shape;
     reshape_shape.feature[0] *= reshape_shape.spatial[0];
     reshape_shape.spatial[0] = 1;

--- a/src/plugins/intel_gpu/tests/unit/fusions/resample_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/resample_fusion_test.cpp
@@ -375,7 +375,7 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, resample_eltwise_fusing_through, ::testing
     resample_test_params{ CASE_RESAMPLE_BF16_1, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
     resample_test_params{ CASE_RESAMPLE_BF16_3, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
     resample_test_params{ CASE_RESAMPLE_BF16_4, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
-    resample_test_params{ CASE_RESAMPLE_BF16_6, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
+    // BF16_6 (LINEAR non-integer upscale) covered by resample_basic and resample_eltwise_fusing
     resample_test_params{ CASE_RESAMPLE_BF16_7, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
     resample_test_params{ CASE_RESAMPLE_BF16_8, RESAMPLE_ELTWISE_FUSING_THROUGH_CNT_FP },
 

--- a/src/plugins/intel_gpu/tests/unit/fusions/resample_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/resample_fusion_test.cpp
@@ -98,12 +98,18 @@ public:
 class resample_quantize : public ResamplePrimitiveFusingTest {};
 TEST_P(resample_quantize, basic) {
     auto p = GetParam();
+    auto quant_layout = get_single_element_layout(p);
+    auto quant_per_ch = get_per_channel_layout(p);
+    if (p.default_type == data_types::bf16) {
+        quant_layout.data_type = data_types::f32;
+        quant_per_ch.data_type = data_types::f32;
+    }
     create_topologies(
         input_layout("input", get_input_layout(p)),
-        data("in_lo", get_mem(get_per_channel_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_per_channel_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), -127)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(quant_per_ch, min_random, 0)),
+        data("in_hi", get_mem(quant_per_ch, 1, max_random)),
+        data("out_lo", get_mem(quant_layout, -127)),
+        data("out_hi", get_mem(quant_layout, 127)),
         resample("resample_prim", input_info("input"), p.out_shape, p.in_shape.feature[0], p.type),
         quantize("quantize", input_info("resample_prim"), input_info("in_lo"), input_info("in_hi"),
                  input_info("out_lo"), input_info("out_hi"), 255, data_types::i8),
@@ -695,12 +701,18 @@ class resample_bicubic_pillow_axes_quantize : public ResampleAxesPrimitiveFusing
 TEST_P(resample_bicubic_pillow_axes_quantize, basic_i8) {
     auto p = GetParam();
     auto sizes = get_sizes_for_axes(p);
+    auto quant_layout = get_single_element_layout(p);
+    auto quant_per_ch = get_per_channel_layout(p);
+    if (p.default_type == data_types::bf16) {
+        quant_layout.data_type = data_types::f32;
+        quant_per_ch.data_type = data_types::f32;
+    }
     create_topologies(
         input_layout("input", get_input_layout(p)),
-        data("in_lo", get_mem(get_per_channel_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_per_channel_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), -127)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(quant_per_ch, min_random, 0)),
+        data("in_hi", get_mem(quant_per_ch, 1, max_random)),
+        data("out_lo", get_mem(quant_layout, -127)),
+        data("out_hi", get_mem(quant_layout, 127)),
         resample("resample_prim", input_info("input"), sizes, {}, p.axes, {}, {}, 0, -0.75f,
                  p.type, resample::InterpolateOp::ShapeCalcMode::SIZES),
         quantize("quantize", input_info("resample_prim"), input_info("in_lo"), input_info("in_hi"),
@@ -715,12 +727,18 @@ TEST_P(resample_bicubic_pillow_axes_quantize, basic_i8) {
 TEST_P(resample_bicubic_pillow_axes_quantize, basic_u8) {
     auto p = GetParam();
     auto sizes = get_sizes_for_axes(p);
+    auto quant_layout = get_single_element_layout(p);
+    auto quant_per_ch = get_per_channel_layout(p);
+    if (p.default_type == data_types::bf16) {
+        quant_layout.data_type = data_types::f32;
+        quant_per_ch.data_type = data_types::f32;
+    }
     create_topologies(
         input_layout("input", get_input_layout(p)),
-        data("in_lo", get_mem(get_per_channel_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_per_channel_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), 0)),
-        data("out_hi", get_mem(get_single_element_layout(p), 255)),
+        data("in_lo", get_mem(quant_per_ch, min_random, 0)),
+        data("in_hi", get_mem(quant_per_ch, 1, max_random)),
+        data("out_lo", get_mem(quant_layout, 0)),
+        data("out_hi", get_mem(quant_layout, 255)),
         resample("resample_prim", input_info("input"), sizes, {}, p.axes, {}, {}, 0, -0.75f,
                  p.type, resample::InterpolateOp::ShapeCalcMode::SIZES),
         quantize("quantize", input_info("resample_prim"), input_info("in_lo"), input_info("in_hi"),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/border_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/border_gpu_test.cpp
@@ -187,6 +187,28 @@ INSTANTIATE_TEST_SUITE_P(export_import,
                                           testing::Values(std::array<int, 4>{1, 1, 1, 1}),
                                           testing::Values(false),
                                           testing::Values(true)));
+using border_test_bf16 = border_test<ov::bfloat16, data_types::bf16>;
+TEST_P(border_test_bf16, border_test_bf16) {}
+INSTANTIATE_TEST_SUITE_P(border_test_bf16,
+                         border_test_bf16,
+                         testing::Combine(testing::Values(ov::op::PadMode::REFLECT),
+                                          testing::Values(ov::bfloat16(123)),
+                                          testing::Values(format::type::bs_fs_yx_bsv32_fsv16),
+                                          testing::Values(std::array<int, 4>{2, 3, 4, 5}),
+                                          testing::Values(std::array<int, 4>{1, 2, 3, 4}),
+                                          testing::Values(std::array<int, 4>{1, 1, 1, 1}),
+                                          testing::Values(false),
+                                          testing::Values(false)));
+INSTANTIATE_TEST_SUITE_P(export_import,
+                         border_test_bf16,
+                         testing::Combine(testing::Values(ov::op::PadMode::REFLECT),
+                                          testing::Values(ov::bfloat16(123)),
+                                          testing::Values(format::type::bs_fs_yx_bsv32_fsv16),
+                                          testing::Values(std::array<int, 4>{2, 3, 4, 5}),
+                                          testing::Values(std::array<int, 4>{1, 2, 3, 4}),
+                                          testing::Values(std::array<int, 4>{1, 1, 1, 1}),
+                                          testing::Values(false),
+                                          testing::Values(true)));
 using border_test_f32 = border_test<float, data_types::f32>;
 TEST_P(border_test_f32, border_test_f32) {}
 INSTANTIATE_TEST_SUITE_P(border_test_f32,
@@ -1884,7 +1906,7 @@ TEST(border_gpu, basic_zero_input) {
     layout zero_input_layout = {{0, 1}, data_types::f32, format::bfyx};
     input = engine.reinterpret_buffer(*input, zero_input_layout);
 
-    std::vector<ov::Dimension::value_type> pads_begin = {4, 0};
+    std::vector<int32_t> pads_begin = {4, 0};
     ov::PartialShape pads_begin_shape = { ov::Dimension(pads_begin.size()) };
     auto pads_begin_input = engine.allocate_memory({pads_begin_shape, data_types::i32, format::bfyx});
     set_values(pads_begin_input, pads_begin);
@@ -1987,6 +2009,94 @@ TEST(border_gpu, 3d_input) {
     cldnn::mem_lock<ov::float16, mem_lock_type::read> base_output_ptr(base_output, get_test_stream());
 
     ASSERT_TRUE(!memcmp(target_output_ptr.data(), base_output_ptr.data(), sizeof(ov::float16) * mult(sh_out)));
+
+    for (auto b = 0; b < sh_out[0]; ++b) {
+        for (auto f = 0; f < sh_out[1]; ++f) {
+            for (auto y = 0; y < sh_out[2]; ++y) {
+                const auto output_off = ((b * sh_out[1] + f) * sh_out[2] + y);
+                ASSERT_GE(output_off, 0);
+
+                if (b < cd_lt[0] || b >= sh_out[0] - cd_rb[0] ||
+                    f < cd_lt[1] || f >= sh_out[1] - cd_rb[1] ||
+                    y < cd_lt[2] || y >= sh_out[2] - cd_rb[2]) {
+                    ASSERT_EQ(target_output_ptr[output_off], pad_value);
+                } else {
+                    const auto input_off  = (((b - cd_lt[0]) * sh_in[1] + f - cd_lt[1]) * sh_in[2] + y - cd_lt[2]);
+                    ASSERT_GE(input_off, 0);
+                    ASSERT_EQ(target_output_ptr[output_off], input_data[input_off]);
+                }
+            }
+        }
+    }
+}
+
+TEST(border_gpu, 3d_input_bf16) {
+    tests::random_generator rg;
+    rg.set_seed(GET_SUITE_NAME);
+
+    ov::op::PadMode pad_mode = ov::op::PadMode::CONSTANT;
+    ov::bfloat16 pad_value = 0;
+    format::type fmt = format::type::bfyx;
+    std::array<int, 3> sh_in = {2, 3, 4};
+    std::vector<int> cd_lt = {5, 6, 7};
+    std::vector<int> cd_rb = {1, 8, 9};
+    std::array<int, 3> sh_out = {sh_in[0] + cd_lt[0] + cd_rb[0],
+                                 sh_in[1] + cd_lt[1] + cd_rb[1],
+                                 sh_in[2] + cd_lt[2] + cd_rb[2]};
+    bool allow_negative_pads = false;
+    auto& engine = get_test_engine();
+
+    auto input_data = rg.generate_random_1d<ov::bfloat16>(mult(sh_in), -9, 9, 1);
+    auto input = engine.allocate_memory({{sh_in[0], sh_in[1], sh_in[2]}, data_types::bf16, format::bfyx});
+    set_values(input, input_data);
+
+    auto begin = engine.allocate_memory({{3}, data_types::i32, format::bfyx});
+    set_values(begin, cd_lt);
+
+    auto end = engine.allocate_memory({{3}, data_types::i32, format::bfyx});
+    set_values(end, cd_rb);
+
+    topology target_topology;
+    const auto input_layout_dynamic = layout{ov::PartialShape::dynamic(3), data_types::bf16, format::bfyx};
+
+    target_topology.add(input_layout("input", input_layout_dynamic));
+    target_topology.add(data("begin", begin));
+    target_topology.add(data("end", end));
+    target_topology.add(reorder("border_input", input_info("input"), fmt, data_types::bf16),
+                        border("border",
+                               {input_info("border_input"), input_info("begin"), input_info("end")},
+                               cldnn::border::PAD_NON_CONST_INPUT::BEGIN | cldnn::border::PAD_NON_CONST_INPUT::END,
+                               std::vector<int64_t>{},
+                               std::vector<int64_t>{},
+                               pad_mode,
+                               pad_value,
+                               allow_negative_pads),
+                        reorder("output", input_info("border"), cldnn::format::bfyx, data_types::bf16));
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network target_network(engine, target_topology, config);
+    target_network.set_input_data("input", input);
+    auto target_output = target_network.execute().at("output").get_memory();
+    cldnn::mem_lock<ov::bfloat16, mem_lock_type::read> target_output_ptr(target_output, get_test_stream());
+
+    topology base_topology;
+    base_topology.add(input_layout("input", input_layout_dynamic));
+    base_topology.add(data("begin", begin));
+    base_topology.add(data("end", end));
+    base_topology.add(border("border",
+                             {input_info("input"), input_info("begin"), input_info("end")},
+                             cldnn::border::PAD_NON_CONST_INPUT::BEGIN | cldnn::border::PAD_NON_CONST_INPUT::END,
+                             std::vector<int64_t>{},
+                             std::vector<int64_t>{},
+                             pad_mode,
+                             pad_value,
+                             allow_negative_pads));
+    network base_network(engine, base_topology, config);
+    base_network.set_input_data("input", input);
+    auto base_output = base_network.execute().at("border").get_memory();
+    cldnn::mem_lock<ov::bfloat16, mem_lock_type::read> base_output_ptr(base_output, get_test_stream());
+
+    ASSERT_TRUE(!memcmp(target_output_ptr.data(), base_output_ptr.data(), sizeof(ov::bfloat16) * mult(sh_out)));
 
     for (auto b = 0; b < sh_out[0]; ++b) {
         for (auto f = 0; f < sh_out[1]; ++f) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/resample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/resample_gpu_test.cpp
@@ -346,6 +346,9 @@ struct resample_random_test : testing::TestWithParam<resample_random_test_params
         case data_types::f16:
             fill_random_typed<ov::float16>(mem, -127, 127, 2);
             break;
+        case data_types::bf16:
+            fill_random_typed<ov::bfloat16>(mem, -127, 127, 2);
+            break;
         case data_types::i8:
             fill_random_typed<int8_t>(mem, -127, 127, 1);
             break;
@@ -456,6 +459,8 @@ struct resample_random_test : testing::TestWithParam<resample_random_test_params
                 compare_nearest_typed<float>(input, output, 0);
             } else if (dt == data_types::f16) {
                 compare_nearest_typed<ov::float16>(input, output, 0);
+            } else if (dt == data_types::bf16) {
+                compare_nearest_typed<ov::bfloat16>(input, output, 0);
             } else if (dt == data_types::i8) {
                 compare_nearest_typed<int8_t>(input, output, 0);
             } else if (dt == data_types::u8) {
@@ -530,6 +535,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_resample,
 
                             .smoke_params(data_types::f32, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16)
                             .smoke_params(data_types::f16, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16)
+                            .smoke_params(data_types::bf16, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16)
                             .smoke_params(data_types::i8, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16)
                             .smoke_params(data_types::u8, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16)
                         ));
@@ -589,6 +595,9 @@ struct caffe_resample_random_test : testing::TestWithParam<caffe_resample_random
             break;
         case data_types::f16:
             fill_random_typed<ov::float16>(mem, -127, 127, 2);
+            break;
+        case data_types::bf16:
+            fill_random_typed<ov::bfloat16>(mem, -127, 127, 2);
             break;
         case data_types::i8:
             fill_random_typed<int8_t>(mem, -127, 127, 1);
@@ -681,6 +690,8 @@ struct caffe_resample_random_test : testing::TestWithParam<caffe_resample_random
                 compare_outputs<float>(output, output_opt);
             } else if (params.input_type == data_types::f16) {
                 compare_outputs<ov::float16>(output, output_opt);
+            } else if (params.input_type == data_types::bf16) {
+                compare_outputs<ov::bfloat16>(output, output_opt);
             } else if (params.input_type == data_types::i8) {
                 compare_outputs<int8_t>(output, output_opt);
             } else if (params.input_type == data_types::u8) {
@@ -724,6 +735,7 @@ INSTANTIATE_TEST_SUITE_P(caffe_smoke_caffe_fsv16,
                             caffe_resample_random_test_param_generator()
                             .smoke_params(data_types::f32, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16)
                             .smoke_params(data_types::f16, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16)
+                            .smoke_params(data_types::bf16, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16)
                         ));
 
 INSTANTIATE_TEST_SUITE_P(caffe_smoke_caffe_fsv32,
@@ -731,6 +743,7 @@ INSTANTIATE_TEST_SUITE_P(caffe_smoke_caffe_fsv32,
                         testing::ValuesIn(
                             caffe_resample_random_test_param_generator()
                             .smoke_params(data_types::f16, format::fs_b_yx_fsv32, format::fs_b_yx_fsv32)
+                            .smoke_params(data_types::bf16, format::fs_b_yx_fsv32, format::fs_b_yx_fsv32)
                         ));
 
 TEST(resample_gpu, interpolate_in2x2x3x2_nearest1) {
@@ -2021,6 +2034,9 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
         case data_types::f16:
             fill_random_typed<ov::float16>(mem, -127, 127, 2);
             break;
+        case data_types::bf16:
+            fill_random_typed<ov::bfloat16>(mem, -127, 127, 2);
+            break;
         case data_types::i8:
             fill_random_typed<int8_t>(mem, -127, 127, 1);
             break;
@@ -2055,7 +2071,7 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
                             auto opt_out_offset = opt_output_lay.get_linear_offset(ref_out_coords);
                             auto opt_out_val = opt_ptr[opt_out_offset];
                             ASSERT_EQ(ref_out_offset, opt_out_offset);
-                            if (std::is_same<T, ov::float16>::value) {
+                            if (std::is_same<T, ov::float16>::value || std::is_same<T, ov::bfloat16>::value) {
                                 ASSERT_NEAR(static_cast<float>(opt_out_val), static_cast<float>(ref_out_val), 1.e-1f);
                             } else {
                                 ASSERT_EQ(opt_out_val, ref_out_val);
@@ -2123,6 +2139,8 @@ struct resample_opt_random_test : testing::TestWithParam<resample_opt_random_tes
                 compare_outputs<float>(output, output_opt);
             } else if (params.input_type == data_types::f16) {
                 compare_outputs<ov::float16>(output, output_opt);
+            } else if (params.input_type == data_types::bf16) {
+                compare_outputs<ov::bfloat16>(output, output_opt);
             } else if (params.input_type == data_types::i8) {
                 compare_outputs<int8_t>(output, output_opt);
             } else if (params.input_type == data_types::u8) {
@@ -2272,6 +2290,8 @@ struct resample_onnx_random_test : resample_opt_random_test {
                 compare<float>(output, output_opt);
             } else if (params.input_type == data_types::f16) {
                 compare<ov::float16>(output, output_opt);
+            } else if (params.input_type == data_types::bf16) {
+                compare<ov::bfloat16>(output, output_opt);
             } else if (params.input_type == data_types::i8) {
                 compare<int8_t>(output, output_opt);
             } else if (params.input_type == data_types::u8) {
@@ -2308,16 +2328,24 @@ INSTANTIATE_TEST_SUITE_P(resample_onnx_smoke_not_aligned,
                          testing::ValuesIn(
                             std::vector<resample_opt_random_test_params>{
                                 { data_types::f16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {}, {}},
+                                { data_types::bf16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {}, {}},
                                 { data_types::f16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {}, {}},
+                                { data_types::bf16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {}, {}},
                                 { data_types::f16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {}, {}},
+                                { data_types::bf16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {}, {}},
                                 { data_types::f16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv16_fsv16, format::bs_fs_yx_bsv16_fsv16, {}, {}},
+                                { data_types::bf16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv16_fsv16, format::bs_fs_yx_bsv16_fsv16, {}, {}},
                                 { data_types::f16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv16, format::b_fs_yx_fsv32, {}, {}},
+                                { data_types::bf16, {1, 24, 13, 13},  {1, 24, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv16, format::b_fs_yx_fsv32, {}, {}},
 
                                 { data_types::f16, {1,  9, 13, 13, 5}, { 1, 9, 26, 26, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
+                                { data_types::bf16, {1,  9, 13, 13, 5}, { 1, 9, 26, 26, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
                                 { data_types::f32, {1,  9, 13, 13, 5}, { 1, 9, 26, 26, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
                                 { data_types::f16, {16, 9,  7,  7, 5}, {16, 9, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv16_fsv16, format::bs_fs_zyx_bsv16_fsv16, {}, {}},
+                                { data_types::bf16, {16, 9,  7,  7, 5}, {16, 9, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv16_fsv16, format::bs_fs_zyx_bsv16_fsv16, {}, {}},
                                 { data_types::f32, {16, 9,  7,  7, 5}, {16, 9, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv16_fsv16, format::bs_fs_zyx_bsv16_fsv16, {}, {}},
                                 { data_types::f16, {32, 9,  7,  7, 5}, {32, 9, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv32_fsv16, format::bs_fs_zyx_bsv32_fsv16, {}, {}},
+                                { data_types::bf16, {32, 9,  7,  7, 5}, {32, 9, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv32_fsv16, format::bs_fs_zyx_bsv32_fsv16, {}, {}},
                                 { data_types::f32, {32, 9,  7,  7, 5}, {32, 9, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv32_fsv16, format::bs_fs_zyx_bsv32_fsv16, {}, {}},
 
                                 { data_types::i8, {1,  9, 13, 13, 5}, {1,  9, 26, 26, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv32, {}, {}},
@@ -2349,6 +2377,12 @@ INSTANTIATE_TEST_SUITE_P(resample_opt_smoke_nearest,
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {}, {}},
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {}, {}},
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_yx_bsv16_fsv16, format::bs_fs_yx_bsv16_fsv16, {}, {}},
+
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::b_fs_yx_fsv16, format::b_fs_yx_fsv16, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_yx_bsv16_fsv16, format::bs_fs_yx_bsv16_fsv16, {}, {}},
                             }
                         ));
 
@@ -2357,8 +2391,11 @@ INSTANTIATE_TEST_SUITE_P(resample_opt_smoke_linear_onnx_4d_padding,
                          testing::ValuesIn(
                             std::vector<resample_opt_random_test_params>{
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {0, 0, 1, 1}, {0, 0, 1, 1}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {0, 0, 1, 1}, {0, 0, 1, 1}},
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {0, 0, 0, 0}, {0, 0, 1, 1}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {0, 0, 0, 0}, {0, 0, 1, 1}},
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {0, 0, 1, 1}, {0, 0, 0, 0}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {0, 0, 1, 1}, {0, 0, 0, 0}},
                             }
                         ));
 
@@ -2367,11 +2404,17 @@ INSTANTIATE_TEST_SUITE_P(resample_opt_smoke_linear_onnx_4d_simple,
                          testing::ValuesIn(
                             std::vector<resample_opt_random_test_params>{
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {}, {}},
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {}, {}},
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {}, {}},
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv16_fsv16, format::bs_fs_yx_bsv16_fsv16, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv16_fsv16, format::bs_fs_yx_bsv16_fsv16, {}, {}},
                                 { data_types::f16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv16, format::b_fs_yx_fsv32, {}, {}},
+                                { data_types::bf16, {1, 128, 13, 13},  {1, 128, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv16, format::b_fs_yx_fsv32, {}, {}},
                                 { data_types::f16, {2, 32, 14, 14},  {2, 32, 28, 28},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::fs_b_yx_fsv32, format::fs_b_yx_fsv32, {}, {}},
+                                { data_types::bf16, {2, 32, 14, 14},  {2, 32, 28, 28},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::fs_b_yx_fsv32, format::fs_b_yx_fsv32, {}, {}},
                             }
                         ));
 
@@ -2393,6 +2436,11 @@ INSTANTIATE_TEST_SUITE_P(resample_opt_smoke_5d_nearest,
                                 { data_types::f16, {1, 16, 13, 13, 13}, {1, 16, 26, 26, 26}, 1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv32, {}, {}},
                                 { data_types::f16, {1, 16, 13, 13, 13}, {1, 16, 26, 26, 26}, 1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_zyx_bsv16_fsv32, format::bs_fs_zyx_bsv16_fsv32, {}, {}},
                                 { data_types::f16, {1, 16, 13, 13, 13}, {1, 16, 26, 26, 26}, 1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_zyx_bsv32_fsv32, format::bs_fs_zyx_bsv32_fsv32, {}, {}},
+
+                                { data_types::bf16, {1, 16, 13, 13, 13}, {1, 16, 26, 26, 26}, 1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
+                                { data_types::bf16, {1, 16, 13, 13, 13}, {1, 16, 26, 26, 26}, 1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv32, {}, {}},
+                                { data_types::bf16, {1, 16, 13, 13, 13}, {1, 16, 26, 26, 26}, 1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_zyx_bsv16_fsv32, format::bs_fs_zyx_bsv16_fsv32, {}, {}},
+                                { data_types::bf16, {1, 16, 13, 13, 13}, {1, 16, 26, 26, 26}, 1, resample::InterpolateOp::InterpolateMode::NEAREST, 1, format::bs_fs_zyx_bsv32_fsv32, format::bs_fs_zyx_bsv32_fsv32, {}, {}},
                             }
                         ));
 
@@ -2401,10 +2449,13 @@ INSTANTIATE_TEST_SUITE_P(resample_opt_smoke_5d_onnx,
                          testing::ValuesIn(
                             std::vector<resample_opt_random_test_params>{
                                  { data_types::f16, {1, 16, 13, 13, 5}, {1, 16, 26, 26, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
+                                 { data_types::bf16, {1, 16, 13, 13, 5}, {1, 16, 26, 26, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
                                  { data_types::f32, {1, 16, 13, 13, 5}, {1, 16, 26, 26, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
                                  { data_types::f16, {16, 16, 7, 7, 5}, {16, 16, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv16_fsv16, format::bs_fs_zyx_bsv16_fsv16, {}, {}},
+                                 { data_types::bf16, {16, 16, 7, 7, 5}, {16, 16, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv16_fsv16, format::bs_fs_zyx_bsv16_fsv16, {}, {}},
                                  { data_types::f32, {16, 16, 7, 7, 5}, {16, 16, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv16_fsv16, format::bs_fs_zyx_bsv16_fsv16, {}, {}},
                                  { data_types::f16, {32, 16, 7, 7, 5}, {32, 16, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv32_fsv16, format::bs_fs_zyx_bsv32_fsv16, {}, {}},
+                                 { data_types::bf16, {32, 16, 7, 7, 5}, {32, 16, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv32_fsv16, format::bs_fs_zyx_bsv32_fsv16, {}, {}},
                                  { data_types::f32, {32, 16, 7, 7, 5}, {32, 16, 14, 14, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_zyx_bsv32_fsv16, format::bs_fs_zyx_bsv32_fsv16, {}, {}},
 
                                  { data_types::i8, {1, 16, 13, 13, 5}, {1, 16, 26, 26, 5}, 1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv32, format::b_fs_zyx_fsv32, {}, {}},
@@ -2454,8 +2505,11 @@ INSTANTIATE_TEST_SUITE_P(resample_opt_smoke_linear_onnx_5d_3axes_padding,
                          testing::ValuesIn(
                             std::vector<resample_opt_random_test_params>{
                                 { data_types::f16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {0, 0, 1, 1, 1}, {0, 0, 1, 1, 1}},
+                                { data_types::bf16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {0, 0, 1, 1, 1}, {0, 0, 1, 1, 1}},
                                 { data_types::f16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {0, 0, 0, 0, 0}, {0, 0, 1, 1, 1}},
+                                { data_types::bf16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {0, 0, 0, 0, 0}, {0, 0, 1, 1, 1}},
                                 { data_types::f16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {0, 0, 1, 1, 1}, {0, 0, 0, 0, 0}},
+                                { data_types::bf16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {0, 0, 1, 1, 1}, {0, 0, 0, 0, 0}},
                             }
                         ));
 
@@ -2464,10 +2518,15 @@ INSTANTIATE_TEST_SUITE_P(resample_opt_smoke_linear_onnx_5d_3axes_simple,
                          testing::ValuesIn(
                             std::vector<resample_opt_random_test_params>{
                                 { data_types::f16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
+                                { data_types::bf16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_zyx_fsv16, format::b_fs_zyx_fsv16, {}, {}},
                                 { data_types::f16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {}, {}},
+                                { data_types::bf16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv32, format::b_fs_yx_fsv32, {}, {}},
                                 { data_types::f16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {}, {}},
+                                { data_types::bf16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv16, format::bs_fs_yx_bsv32_fsv16, {}, {}},
                                 { data_types::f16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {}, {}},
+                                { data_types::bf16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::bs_fs_yx_bsv32_fsv32, format::bs_fs_yx_bsv32_fsv32, {}, {}},
                                 { data_types::f16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv16, format::b_fs_yx_fsv32, {}, {}},
+                                { data_types::bf16, {1, 16, 13, 13, 13},  {1, 16, 26, 26, 26},  1, resample::InterpolateOp::InterpolateMode::LINEAR_ONNX, 1, format::b_fs_yx_fsv16, format::b_fs_yx_fsv32, {}, {}},
                             }
                         ));
 
@@ -2654,6 +2713,9 @@ struct resample_cubic_random_test : testing::TestWithParam<resample_cubic_random
         case data_types::f16:
             fill_random_typed<ov::float16>(mem, -127, 127, 2);
             break;
+        case data_types::bf16:
+            fill_random_typed<ov::bfloat16>(mem, -127, 127, 2);
+            break;
         default:
             break;
         }
@@ -2741,11 +2803,13 @@ struct resample_cubic_random_test : testing::TestWithParam<resample_cubic_random
         // Compare results
         // Bicubic overshoot from [-127,127] inputs can reach ~179 (FP16 ULP=0.125 in [128,256)).
         // 16 fma accumulations in different order between ref/opt can diverge by 2-3 ULPs.
-        float tolerance = (params.input_type == data_types::f16) ? 5.e-1f : 1.e-4f;
+        float tolerance = (params.input_type == data_types::f16 || params.input_type == data_types::bf16) ? 5.e-1f : 1.e-4f;
         if (params.input_type == data_types::f32) {
             compare_outputs<float>(output_ref, output_opt, tolerance);
         } else if (params.input_type == data_types::f16) {
             compare_outputs<ov::float16>(output_ref, output_opt, tolerance);
+        } else if (params.input_type == data_types::bf16) {
+            compare_outputs<ov::bfloat16>(output_ref, output_opt, tolerance);
         }
     }
 };
@@ -2776,6 +2840,11 @@ INSTANTIATE_TEST_SUITE_P(resample_cubic_bfyx_smoke,
                                 { data_types::f16, {2, 3, 4, 4},    {2, 3, 8, 8} },
                                 { data_types::f16, {1, 16, 7, 7},   {1, 16, 14, 14} },
                                 { data_types::f16, {1, 3, 13, 13},  {1, 3, 26, 26} },
+                                // bf16 cases
+                                { data_types::bf16, {1, 1, 5, 5},    {1, 1, 10, 10} },
+                                { data_types::bf16, {2, 3, 4, 4},    {2, 3, 8, 8} },
+                                { data_types::bf16, {1, 16, 7, 7},   {1, 16, 14, 14} },
+                                { data_types::bf16, {1, 3, 13, 13},  {1, 3, 26, 26} },
                             }
                         ));
 
@@ -2830,6 +2899,78 @@ TEST(resample_gpu, pillow_identity_resample_no_crash) {
                 << "Mismatch at index " << i << " for mode " << static_cast<int>(mode);
         }
     }
+}
+
+// Simple 2x upscale test exercising the pil_ref kernel with half-precision inputs.
+// Runs for both BILINEAR_PILLOW and BICUBIC_PILLOW and verifies the half-precision
+// output matches an f32 reference produced by the same kernel.
+template <typename T>
+void test_pillow_half_precision(data_types dt) {
+    auto& engine = get_test_engine();
+
+    const int32_t b = 1, f = 2, y = 4, x = 4;
+    const int32_t out_y = 8, out_x = 8;
+
+    std::vector<float> input_data(b * f * y * x);
+    for (size_t i = 0; i < input_data.size(); ++i)
+        input_data[i] = static_cast<float>(i % 16) - 7.0f;
+
+    std::vector<resample::InterpolateOp::InterpolateMode> modes = {
+        resample::InterpolateOp::InterpolateMode::BILINEAR_PILLOW,
+        resample::InterpolateOp::InterpolateMode::BICUBIC_PILLOW,
+    };
+
+    auto run = [&](data_types type, resample::InterpolateOp::InterpolateMode mode) {
+        auto input_mem = engine.allocate_memory({ type, format::bfyx, { b, f, x, y } });
+        if (type == data_types::f32) {
+            set_values(input_mem, input_data);
+        } else {
+            std::vector<T> typed(input_data.begin(), input_data.end());
+            set_values(input_mem, typed);
+        }
+
+        topology topology;
+        topology.add(input_layout("input", input_mem->get_layout()));
+        topology.add(resample("resample", input_info("input"),
+                              std::vector<int64_t>{out_y, out_x},  // sizes
+                              std::vector<float>{},                 // scales: unused
+                              std::vector<int64_t>{2, 3},           // axes: Y, X
+                              {},                                   // pads_begin
+                              {},                                   // pads_end
+                              0,                                    // antialias
+                              -0.75f,                               // cube_coeff
+                              mode,
+                              resample::InterpolateOp::ShapeCalcMode::SIZES));
+
+        auto config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+        cldnn::network net(engine, topology, config);
+        net.set_input_data("input", input_mem);
+        return net.execute().at("resample").get_memory();
+    };
+
+    for (auto mode : modes) {
+        auto ref_mem = run(data_types::f32, mode);
+        auto out_mem = run(dt, mode);
+
+        cldnn::mem_lock<float, mem_lock_type::read> ref_ptr(ref_mem, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
+
+        ASSERT_EQ(ref_ptr.size(), out_ptr.size());
+        for (size_t i = 0; i < ref_ptr.size(); ++i) {
+            ASSERT_NEAR(static_cast<float>(out_ptr[i]), ref_ptr[i], 1.0f)
+                << "Mismatch at index " << i << " for mode " << static_cast<int>(mode);
+        }
+    }
+}
+
+TEST(resample_gpu, pillow_f16) {
+    test_pillow_half_precision<ov::float16>(data_types::f16);
+}
+
+TEST(resample_gpu, pillow_bf16) {
+    test_pillow_half_precision<ov::bfloat16>(data_types::bf16);
 }
 
 TEST(resample_gpu, basic_in2x3x2x2_nearest_cached) {


### PR DESCRIPTION
This PR adds bf16 data type support to the **border** and **resample** OCL kernels as part of the broader BF16 enablement effort for the Intel GPU plugin ([CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)).

Ticket: [CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)

> [!NOTE]
> This pull request is part of a larger implementation effort for BF16 support in the OpenVINO GPU Plugin.  On its own, this PR may not provide complete user-visible BF16 enablement.

---

### Changes

**Kernel selector / OCL kernels:**
- Registered `Datatype::BF16` in `border_kernel_ref.cpp`, `resample_kernel_ref.cpp`, `resample_kernel_opt.cpp`, `resample_kernel_onnx.cpp`, `resample_kernel_pil_ref.cpp`, and `resample_kernel_bfyx_cubic_opt.cpp`.
- Updated `border_gpu_ref.cl` and all resample `.cl` kernels (`resample_ref.cl`, `resample_opt.cl`, `resample_onnx.cl`, `resample_pil_ref.cl`, `resample_bfyx_cubic_opt.cl`) to use compute-type macros for bf16→f32 decode and f32→bf16 encode.
- Updated `resample_kernel_base.cpp` to include bf16 in RTE output check.
- Updated `ocl/border.cpp` and `ocl/resample.cpp` implementation registration.

**Tests:**
- Added bf16 unit tests to `border_gpu_test.cpp` and `resample_gpu_test.cpp`.
- Added bf16 fusion tests to `resample_fusion_test.cpp`.

### AI assistance:
> [!NOTE]  
> AI assistance used during analysis and PR description preparation. All code originates from the original BF16 OCL enablement branch.
