### PR TITLE
[GPU] BF16 OCL: random_uniform and benchmark_app fix

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
@@ -61,6 +61,7 @@ attach_random_uniform_impl::attach_random_uniform_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i32,
         data_types::i64
     };

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/random_uniform_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/random_uniform_ref.cl
@@ -3,6 +3,7 @@
 //
 
 #include "include/batch_headers/fetch_data.cl"
+#include "include/batch_headers/bf16_utils.cl"
 
 #define N_ROUNDS 10
 #define STATISTIC_MAXIMIZING_MULTIPLIER_N 0xD2511F53UL
@@ -127,12 +128,33 @@ inline void FUNC(fill_half)(const uint4 res,
     }
 }
 
+inline float FUNC(uint32_to_bfloat16)(uint x) {
+    ushort x_uint16 = (ushort) x;
+    ushort out_val = (ushort)(127 << 7) | (x_uint16 & 0x7fu);
+    return _convert_as_bfloat16_float(out_val) - 1.0f;
+}
+
+inline void FUNC(fill_bf16)(const uint4 res,
+               float min_val,
+               float max_val,
+               __global ushort *output,
+               uint output_index,
+               uint output_size) {
+    float diff = max_val - min_val;
+    for (uint i = 0; i < 4; ++i) {
+        if (output_index + i < output_size) {
+            float val = FUNC_CALL(uint32_to_bfloat16)(res[i]) * diff + min_val;
+            output[output_index + i] = _convert_bfloat16_as_ushort(val);
+        }
+    }
+}
+
 KERNEL(random_uniform_ref)(OPTIONAL_SHAPE_INFO_ARG
                             const __global INPUT0_TYPE* shape, const __global INPUT1_TYPE *min_val,
                             const __global INPUT2_TYPE* max_val, __global OUTPUT_TYPE *output) {
     const uint plain_index = get_global_id(0);
     uint4 result = FUNC_CALL(run_philox)(plain_index);
-    FILL_FUNC(FUNC_NAME(OUTPUT_TYPE), result, *min_val, *max_val, output, plain_index * OUTPUT_STEP, OUTPUT_LENGTH);
+    FILL_FUNC(FUNC_NAME(OUTPUT_TYPE_NAME), result, DECODE_INPUT1_COMPUTE_TYPE(*min_val), DECODE_INPUT2_COMPUTE_TYPE(*max_val), output, plain_index * OUTPUT_STEP, OUTPUT_LENGTH);
 }
 
 #undef FILL_FUNC

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/random_uniform/random_uniform_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/random_uniform/random_uniform_kernel_ref.cpp
@@ -42,6 +42,12 @@ JitConstants RandomUniformKernelRef::GetJitConstants(const random_uniform_params
 
     jit.AddConstant(MakeJitConstant("OP_SEED", params.op_seed));
     jit.AddConstant(MakeJitConstant("OUTPUT_STEP", getStep(params)));
+
+    if (params.outputs[0].GetDType() == Datatype::BF16) {
+        jit.AddConstant(MakeJitConstant("OUTPUT_TYPE_NAME", "bf16"));
+    } else {
+        jit.AddConstant(MakeJitConstant("OUTPUT_TYPE_NAME", "OUTPUT_TYPE"));
+    }
     return jit;
 }
 
@@ -78,12 +84,14 @@ ParamsKey RandomUniformKernelRef::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT64);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F16);
     k.EnableInputDataType(Datatype::F32);
 
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT64);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableDifferentTypes();
     k.EnableInputLayout(DataLayout::bfyx);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/random_uniform_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/random_uniform_gpu_test.cpp
@@ -102,10 +102,22 @@ std::string PrintToStringParamName::operator()(const testing::TestParamInfo<Rand
     return buf.str();
 }
 
+template<>
+std::string PrintToStringParamName::operator()(const testing::TestParamInfo<RandomUniformParams<ov::bfloat16> > &param) {
+    std::stringstream buf;
+    buf << "output_tensor_" << param.param.output_shape
+        << "_min_value_" << static_cast<float>(param.param.min_val)
+        << "_max_value_" << static_cast<float>(param.param.max_val)
+        << "_global_seed_" << param.param.global_seed
+        << "_op_seed_" << param.param.op_seed;
+    return buf.str();
+}
+
 using random_uniform_gpu_test_i32 = random_uniform_gpu_test<int32_t>;
 using random_uniform_gpu_test_i64 = random_uniform_gpu_test<int64_t>;
 using random_uniform_gpu_test_f32 = random_uniform_gpu_test<float>;
 using random_uniform_gpu_test_f16 = random_uniform_gpu_test<ov::float16>;
+using random_uniform_gpu_test_bf16 = random_uniform_gpu_test<ov::bfloat16>;
 
 TEST_P(random_uniform_gpu_test_i32, random_int32) {
     ASSERT_NO_FATAL_FAILURE(test(false));
@@ -121,6 +133,10 @@ TEST_P(random_uniform_gpu_test_f32, random_f32) {
 }
 
 TEST_P(random_uniform_gpu_test_f16, random_f16) {
+    ASSERT_NO_FATAL_FAILURE(test(false));
+}
+
+TEST_P(random_uniform_gpu_test_bf16, random_bf16) {
     ASSERT_NO_FATAL_FAILURE(test(false));
 }
 
@@ -195,6 +211,27 @@ INSTANTIATE_TEST_SUITE_P(smoke_random_uniform_f16,
                          ),
                          PrintToStringParamName());
 
+INSTANTIATE_TEST_SUITE_P(smoke_random_uniform_bf16,
+                         random_uniform_gpu_test_bf16,
+                         ::testing::Values(
+                                 RandomUniformParams<ov::bfloat16>{ov::Shape{1, 1, 4, 2, 3}, ov::bfloat16(-1.5),
+                                                             ov::bfloat16(-1.0), 150, 10,
+                                                             {ov::bfloat16(-1.07812500), ov::bfloat16(-1.27343750),
+                                                              ov::bfloat16(-1.17187500), ov::bfloat16(-1.46875000),
+                                                              ov::bfloat16(-1.35937500), ov::bfloat16(-1.17187500),
+                                                              ov::bfloat16(-1.32812500), ov::bfloat16(-1.16406250),
+                                                              ov::bfloat16(-1.15625000), ov::bfloat16(-1.12500000),
+                                                              ov::bfloat16(-1.38281250), ov::bfloat16(-1.48437500),
+                                                              ov::bfloat16(-1.10937500), ov::bfloat16(-1.02343750),
+                                                              ov::bfloat16(-1.34375000), ov::bfloat16(-1.21093750),
+                                                              ov::bfloat16(-1.20312500), ov::bfloat16(-1.24218750),
+                                                              ov::bfloat16(-1.37500000), ov::bfloat16(-1.21093750),
+                                                              ov::bfloat16(-1.20312500), ov::bfloat16(-1.46875000),
+                                                              ov::bfloat16(-1.42187500), ov::bfloat16(-1.35937500)}
+                                 }
+                         ),
+                         PrintToStringParamName());
+
 #ifdef RUN_ALL_MODEL_CACHING_TESTS
 TEST_P(random_uniform_gpu_test_i32, random_int32_cached) {
     ASSERT_NO_FATAL_FAILURE(test(true));
@@ -209,5 +246,9 @@ TEST_P(random_uniform_gpu_test_f32, random_f32_cached) {
 }
 #endif
 TEST_P(random_uniform_gpu_test_f16, random_f16_cached) {
+    ASSERT_NO_FATAL_FAILURE(test(true));
+}
+
+TEST_P(random_uniform_gpu_test_bf16, random_bf16_cached) {
     ASSERT_NO_FATAL_FAILURE(test(true));
 }

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -351,12 +351,30 @@ def get_random_4bit_tensor(shape, element_type, rs):
     rr = np.packbits(rand_data)
     return Tensor(rr, shape, element_type)
 
+
+def float_to_bf16_bits(values: np.ndarray) -> np.ndarray:
+    """
+    Convert float values to bf16 bit patterns using round-to-nearest-even.
+    Mirrors ov::bfloat16::round_to_nearest_even.
+    """
+    f32 = np.ascontiguousarray(values, dtype=np.float32)
+    bits = f32.view(np.uint32)
+    rounding_bias = (bits & np.uint32(0x00010000)) >> np.uint32(1)
+    return ((bits + rounding_bias) >> np.uint32(16)).astype(np.uint16)
+
+
+def get_random_bf16_tensor(shape, rand_min, rand_max, rs):
+    floats = rs.uniform(rand_min, rand_max, list(shape))
+    bf16_bits = float_to_bf16_bits(floats)
+    return Tensor(bf16_bits, list(shape), Type.bf16)
+
+
 def fill_tensors_with_random(layer):
     is_4bit = layer.element_type.bitwidth == 4
+    is_bf16 = layer.element_type == Type.bf16
     dtype = np.uint8 if is_4bit else get_dtype(layer.element_type)
     rand_min, rand_max = (0, 1) if dtype == bool else (np.iinfo(np.uint8).min, np.iinfo(np.uint8).max)
-    # np.random.uniform excludes high: add 1 to have it generated
-    if np.dtype(dtype).kind in ['i', 'u', 'b']:
+    if not is_bf16 and np.dtype(dtype).kind in ['i', 'u', 'b']:
         rand_max += 1
     rs = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(0)))
     input_tensors = []
@@ -364,11 +382,15 @@ def fill_tensors_with_random(layer):
         if shape:
             if is_4bit:
                 ov_tensor = get_random_4bit_tensor(shape, layer.element_type, rs)
+            elif is_bf16:
+                ov_tensor = get_random_bf16_tensor(shape, rand_min, rand_max, rs)
             else:
                 ov_tensor = Tensor(rs.uniform(rand_min, rand_max, list(shape)).astype(dtype))
         else:
             if is_4bit:
                 ov_tensor = get_random_4bit_tensor([1], layer.element_type, rs)
+            elif is_bf16:
+                ov_tensor = get_random_bf16_tensor([1], rand_min, rand_max, rs)
             else:
                 ov_tensor = Tensor(np.ndarray([], dtype, np.array(rs.uniform(rand_min, rand_max)).astype(dtype)))
         input_tensors.append(ov_tensor)


### PR DESCRIPTION
This PR adds bf16 data type support to the **random_uniform** OCL kernel and fixes a **benchmark_app** issue with bf16 inputs, as part of the broader BF16 enablement effort for the Intel GPU plugin ([CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)).

Ticket: [CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)

> [!NOTE]
> This pull request is part of a larger implementation effort for BF16 support in the OpenVINO GPU Plugin.  On its own, this PR may not provide complete user-visible BF16 enablement.

---

### Changes

**Kernel selector / OCL kernel:**
- Registered `Datatype::BF16` in `random_uniform_kernel_ref.cpp`.
- Updated `random_uniform_ref.cl` to handle bf16 output conversion.
- Updated `ocl/random_uniform.cpp` implementation registration.

**benchmark_app:**
- Fixed `inputs_filling.py` to handle bf16 data type correctly when generating input tensors.

**Tests:**
- Added bf16 unit tests to `random_uniform_gpu_test.cpp`.

### AI assistance:
> [!NOTE]  
> AI assistance used during analysis and PR description preparation. All code originates from the original BF16 OCL enablement branch.
