### PR TITLE
[GPU] reset only part of max_output_layout_count

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -983,7 +983,7 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
             }
         };
         if (can_be_optimized()) {
-            _max_output_layout_count = _deps[0].first->_max_output_layout_count;
+            _max_output_layout_count[0] = _deps[0].first->_max_output_layout_count[_deps[0].second];
             GPU_DEBUG_PROFILED_STAGE_MEMALLOC_INFO("can_be_optimized");
             // If the inst is optimized out but it executed at the previous iteration,
             // reset all output memory of users which was optimized out at the previous iteration.

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -983,7 +983,8 @@ void primitive_inst::realloc_outputs(bool prev_execution_skipped) {
             }
         };
         if (can_be_optimized()) {
-            _max_output_layout_count[0] = _deps[0].first->_max_output_layout_count[_deps[0].second];
+            const auto dep_idx = _deps[0].second;
+            _max_output_layout_count[0] = _deps[0].first->_max_output_layout_count[static_cast<size_t>(dep_idx)];
             GPU_DEBUG_PROFILED_STAGE_MEMALLOC_INFO("can_be_optimized");
             // If the inst is optimized out but it executed at the previous iteration,
             // reset all output memory of users which was optimized out at the previous iteration.


### PR DESCRIPTION
### Details:
 - resetting full max_output_layout_count makes loose information which is needed when primitive is not optimized out

### Tickets:
 - found when debugging 191047 - it not solves it but heal out of bound read
### AI Assistance:
 - *AI assistance used:  yes*