### PR TITLE
[Transformations] Add RestoreReshapeBakedBatch SmartReshape pass

### DIFF
--- a/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
+++ b/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
@@ -19,92 +19,33 @@ class TRANSFORMATIONS_API RestoreReshapeBakedBatch;
 /// \brief Restores a dynamic batch dimension that framework tracing froze into a window-reverse view
 /// shape, so the model can be reshaped along batch.
 ///
-/// When a model is traced with a fixed batch, a window-reverse style view such as `x.view(B, H, W, -1)`
-/// bakes `B` as a literal `Constant` in the leading position of the Reshape's shape `Concat`, while the
-/// channel dimension is the single trailing `-1` (infer) slot. After the model batch is changed (e.g.
-/// `model.reshape({input:[2,...]})`) the leading constant cannot propagate the new batch, so the `-1`
-/// channel silently absorbs it and the data is mis-partitioned.
+/// When a model is traced with a fixed batch, a window-reverse view such as `x.view(B, H, W, -1)` bakes
+/// `B` as a literal leading `Constant` in the Reshape's shape `Concat`, while the channel is the single
+/// trailing `-1` slot. After the batch is changed (`model.reshape(...)`) the baked constant cannot
+/// propagate it, so the `-1` channel silently absorbs it and the data is mis-partitioned. The pass
+/// rewrites the shape `Concat` to relax the leading `Constant(B)` to `Constant(-1)` (batch inferred) and
+/// pin the trailing `-1` to `Constant(channel)` (recovered statically); the interior is kept.
 ///
-/// The pass rewrites the shape `Concat` that feeds the Reshape: the leading baked-batch `Constant`
-/// becomes `Constant(-1)` (the batch is inferred from the real element count) and the trailing `-1`
-/// (infer) slot becomes `Constant(channel)` (the batch-independent channel recovered statically). The
-/// interior dimensions are kept.
-///
-/// Before:
-///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
-///   │  Constant(B)  │ │   <interior> │ │   <interior> │ │ Constant(-1) │  │ data │
-///   │ leading batch │ │   (dynamic)  │ │   (dynamic)  │ │   channel    │  └──┬───┘
-///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
-///           └────────────────┴───────┬────────┴────────────────┘             │
-///                              ┌──────▼──────┐                                │
-///                              │   Concat    │ axis = 0                       │
-///                              │ (view shape)│                                │
-///                              └──────┬──────┘                                │
-///                                     └─────────────────┬─────────────────────┘
-///                                                ┌──────▼──────┐
-///                                                │   Reshape   │ special_zero = false
-///                                                └──────┬──────┘
-///                                                       ▼
-///
-/// After:
-///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
-///   │ Constant(-1)  │ │   <interior> │ │   <interior> │ │Constant(chan)│  │ data │
-///   │ leading batch │ │   (dynamic,  │ │   (dynamic,  │ │   channel    │  └──┬───┘
-///   │   (inferred)  │ │  unchanged)  │ │  unchanged)  │ │  (static)    │     │
-///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
-///           └────────────────┴───────┬────────┴────────────────┘             │
-///                              ┌──────▼──────┐                                │
-///                              │   Concat    │ axis = 0                       │
-///                              │ (view shape)│                                │
-///                              └──────┬──────┘                                │
-///                                     └─────────────────┬─────────────────────┘
-///                                                ┌──────▼──────┐
-///                                                │   Reshape   │ special_zero = false
-///                                                └──────┬──────┘
-///                                                       ▼
+///   Before:  Concat[ Constant(B), <interior...>, Constant(-1) ] ──► Reshape (special_zero=false)
+///   After:   Concat[ Constant(-1), <interior...>, Constant(chan) ] ──► Reshape
 ///
 /// The rewrite is value-preserving ONLY for window-reverse views, where the restored channel provably
-/// equals the data tensor's channel dimension. The pass matches the exact window-reverse structure — a
-/// pair of chained views separated by a last-axis-preserving `Transpose` — and both views must have a
-/// shape `Concat` with a leading positive-int constant, exactly one trailing `-1`, and at least one
-/// dynamic interior dimension. Two value-preservation guards keep it from corrupting ordinary reshapes
-/// that share the structural signature (spatial flatten `view(1, C, -1)`, attention head-merge
-/// `view(1, N, -1)`, merge/split reshapes whose `-1` spans more than the data's last dim):
-///   1. If a reshape's output last dim is statically known, it must equal the recovered channel.
-///   2. Applied whenever a reshape's OWN data last dim is static (independently of guard 1): it requires
-///      the rewrite to merely re-partition the data's leading dimension and keep the data's entire
-///      trailing block, which is exactly the window-reverse semantics and rejects merge/split reshapes.
-///      For the window-reverse chain the output last dim is dynamic, so guard 1 is vacuous there and
-///      guard 2 does the real work.
+/// equals the data's channel dim. Window-reverse emits two chained views separated by a last-axis-
+/// preserving `Transpose`; OV shape inference does NOT propagate the channel through that permute (the
+/// spatial value-bounds collapse the permuted output to fully dynamic), so the matcher keys on the whole
+/// two-view chain and recovers the channel from the INNER view's static data last dim. Both views are
+/// rewritten together in a single match, so no recorded state or traversal order is needed.
 ///
-/// This lives in SmartReshape because it is a reshapeability concern (it runs inside `Model::reshape`),
-/// not a framework-import concern: it operates on the already-built `ov::Model` and is framework-agnostic.
+/// Each view must have a shape `Concat` with a leading positive-int constant, exactly one trailing `-1`,
+/// and at least one dynamic interior dim. Two value-preservation guards keep the pass off ordinary
+/// reshapes that share this signature:
+///   1. If a reshape's output last dim is static, it must equal the recovered channel.
+///   2. If a reshape's own data last dim is static, the rewrite must merely re-partition the data's
+///      leading dim and keep its entire trailing block (the window-reverse semantics). For the chain the
+///      output last dim is dynamic, so guard 1 is vacuous and guard 2 does the work.
 ///
-/// Window-reverse uses two chained views: the second view's data is the permuted output of the first, and
-/// OV shape inference does NOT propagate the channel through the permute (the spatial value-bounds collapse
-/// the permuted output to fully dynamic). The matcher therefore keys on the whole two-view chain and
-/// recovers the channel from the INNER view's static data last dim; both views are rewritten together in a
-/// single match, so no recorded state or traversal order is needed.
-///
-/// Matched chain (the two window-reverse views):
-///
-///        data [?,8,8,180]   (static last dim = 180)
-///              │
-///        ┌─────▼──────┐  Reshape_1 (INNER / 1st view): its channel is the static last dim (180) of
-///        │  Reshape   │  ITS OWN data. Its output last dim is DYNAMIC (out [?,?,?,8,8,?]).
-///        └─────┬──────┘
-///              │
-///        ┌─────▼──────┐  Transpose(order=[0,1,3,2,4,5]): last axis kept last, so the inner view's
-///        │ Transpose  │  channel is also the outer view's channel. out [?,?,?,?,?,?] (bounds collapse).
-///        └─────┬──────┘
-///              │  data last dim is now DYNAMIC
-///        ┌─────▼──────┐  Reshape_2 (OUTER / 2nd view): matched as the chain root; its channel is taken
-///        │  Reshape   │  from the inner view's static data last dim (180). out [?,H,W,-1].
-///        └─────┬──────┘
-///              ▼
-///
-/// Reshape_1 has a static data last dim, so the trailing-block guard applies to it; Reshape_2's data last
-/// dim is dynamic (it comes through the permute), so it is exempt from the trailing-block guard.
+/// It lives in SmartReshape because it is a reshapeability concern (it runs inside `Model::reshape`) on
+/// the already-built framework-agnostic `ov::Model`, not a framework-import concern.
 class ov::pass::RestoreReshapeBakedBatch : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("RestoreReshapeBakedBatch");

--- a/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
+++ b/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
@@ -71,10 +71,11 @@ class TRANSFORMATIONS_API RestoreReshapeBakedBatch;
 /// that share the structural signature (spatial flatten `view(1, C, -1)`, attention head-merge
 /// `view(1, N, -1)`, merge/split reshapes whose `-1` spans more than the data's last dim):
 ///   1. If a reshape's output last dim is statically known, it must equal the recovered channel.
-///   2. (Applied to a reshape whose OWN data last dim is static.) When the output last dim is dynamic,
-///      guard 1 is vacuous; guard 2 requires the rewrite to merely re-partition the data's leading
-///      dimension and keep the data's entire trailing block, which is exactly the window-reverse
-///      semantics and rejects merge/split reshapes.
+///   2. Applied whenever a reshape's OWN data last dim is static (independently of guard 1): it requires
+///      the rewrite to merely re-partition the data's leading dimension and keep the data's entire
+///      trailing block, which is exactly the window-reverse semantics and rejects merge/split reshapes.
+///      For the window-reverse chain the output last dim is dynamic, so guard 1 is vacuous there and
+///      guard 2 does the real work.
 ///
 /// This lives in SmartReshape because it is a reshapeability concern (it runs inside `Model::reshape`),
 /// not a framework-import concern: it operates on the already-built `ov::Model` and is framework-agnostic.

--- a/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
+++ b/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
@@ -26,8 +26,52 @@ class TRANSFORMATIONS_API RestoreReshapeBakedBatch;
 /// rewrites the shape `Concat` to relax the leading `Constant(B)` to `Constant(-1)` (batch inferred) and
 /// pin the trailing `-1` to `Constant(channel)` (recovered statically); the interior is kept.
 ///
-///   Before:  Concat[ Constant(B), <interior...>, Constant(-1) ] ──► Reshape (special_zero=false)
-///   After:   Concat[ Constant(-1), <interior...>, Constant(chan) ] ──► Reshape
+/// Before:
+///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
+///   │  Constant(B)  │ │   <interior> │ │   <interior> │ │ Constant(-1) │  │ data │
+///   │ leading batch │ │   (dynamic)  │ │   (dynamic)  │ │   channel    │  └──┬───┘
+///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
+///           └────────────────┴───────┬────────┴────────────────┘             │
+///                              ┌──────▼──────┐                                │
+///                              │   Concat    │ axis = 0                       │
+///                              │ (view shape)│                                │
+///                              └──────┬──────┘                                │
+///                                     └─────────────────┬─────────────────────┘
+///                                                ┌──────▼──────┐
+///                                                │   Reshape   │ special_zero = false
+///                                                └──────┬──────┘
+///                                                       ▼
+///
+/// After:
+///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
+///   │ Constant(-1)  │ │   <interior> │ │   <interior> │ │Constant(chan)│  │ data │
+///   │ leading batch │ │   (dynamic,  │ │   (dynamic,  │ │   channel    │  └──┬───┘
+///   │   (inferred)  │ │  unchanged)  │ │  unchanged)  │ │  (static)    │     │
+///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
+///           └────────────────┴───────┬────────┴────────────────┘             │
+///                              ┌──────▼──────┐                                │
+///                              │   Concat    │ axis = 0                       │
+///                              │ (view shape)│                                │
+///                              └──────┬──────┘                                │
+///                                     └─────────────────┬─────────────────────┘
+///                                                ┌──────▼──────┐
+///                                                │   Reshape   │ special_zero = false
+///                                                └──────┬──────┘
+///                                                       ▼
+///
+/// Per Concat input position (window-reverse example: window size 8, channel 180) -- only the leading
+/// batch slot and the trailing channel slot change; every interior element is reused as-is:
+///
+///   input position:  0            1        2        3          4          last
+///                    ┌────────┐   ┌──────┐ ┌──────┐ ┌────────┐ ┌────────┐ ┌──────────┐
+///   old Concat:      Const(1)     interior interior Const(8)   Const(8)   Const(-1)
+///                       ▲                                                     ▲
+///                       │ changed                                    changed │
+///                       ▼                                                     ▼
+///   new Concat:      Const(-1)    interior interior Const(8)   Const(8)   Const(180)
+///                    └────────┘   └──────┘ └──────┘ └────────┘ └────────┘ └──────────┘
+///                     DIFFERENT    SAME     SAME     SAME       SAME       DIFFERENT
+///                     source       sources (reused)                       source
 ///
 /// The rewrite is value-preserving ONLY for window-reverse views, where the restored channel provably
 /// equals the data's channel dim. Window-reverse emits two chained views separated by a last-axis-

--- a/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
+++ b/src/common/transformations/include/transformations/smart_reshape/restore_reshape_baked_batch.hpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov {
+namespace pass {
+
+class TRANSFORMATIONS_API RestoreReshapeBakedBatch;
+
+}  // namespace pass
+}  // namespace ov
+
+/// \ingroup ov_transformation_common_api
+/// \brief Restores a dynamic batch dimension that framework tracing froze into a window-reverse view
+/// shape, so the model can be reshaped along batch.
+///
+/// When a model is traced with a fixed batch, a window-reverse style view such as `x.view(B, H, W, -1)`
+/// bakes `B` as a literal `Constant` in the leading position of the Reshape's shape `Concat`, while the
+/// channel dimension is the single trailing `-1` (infer) slot. After the model batch is changed (e.g.
+/// `model.reshape({input:[2,...]})`) the leading constant cannot propagate the new batch, so the `-1`
+/// channel silently absorbs it and the data is mis-partitioned.
+///
+/// The pass rewrites the shape `Concat` that feeds the Reshape: the leading baked-batch `Constant`
+/// becomes `Constant(-1)` (the batch is inferred from the real element count) and the trailing `-1`
+/// (infer) slot becomes `Constant(channel)` (the batch-independent channel recovered statically). The
+/// interior dimensions are kept.
+///
+/// Before:
+///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
+///   │  Constant(B)  │ │   <interior> │ │   <interior> │ │ Constant(-1) │  │ data │
+///   │ leading batch │ │   (dynamic)  │ │   (dynamic)  │ │   channel    │  └──┬───┘
+///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
+///           └────────────────┴───────┬────────┴────────────────┘             │
+///                              ┌──────▼──────┐                                │
+///                              │   Concat    │ axis = 0                       │
+///                              │ (view shape)│                                │
+///                              └──────┬──────┘                                │
+///                                     └─────────────────┬─────────────────────┘
+///                                                ┌──────▼──────┐
+///                                                │   Reshape   │ special_zero = false
+///                                                └──────┬──────┘
+///                                                       ▼
+///
+/// After:
+///   ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐  ┌──────┐
+///   │ Constant(-1)  │ │   <interior> │ │   <interior> │ │Constant(chan)│  │ data │
+///   │ leading batch │ │   (dynamic,  │ │   (dynamic,  │ │   channel    │  └──┬───┘
+///   │   (inferred)  │ │  unchanged)  │ │  unchanged)  │ │  (static)    │     │
+///   └───────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘     │
+///           └────────────────┴───────┬────────┴────────────────┘             │
+///                              ┌──────▼──────┐                                │
+///                              │   Concat    │ axis = 0                       │
+///                              │ (view shape)│                                │
+///                              └──────┬──────┘                                │
+///                                     └─────────────────┬─────────────────────┘
+///                                                ┌──────▼──────┐
+///                                                │   Reshape   │ special_zero = false
+///                                                └──────┬──────┘
+///                                                       ▼
+///
+/// The rewrite is value-preserving ONLY for window-reverse views, where the restored channel provably
+/// equals the data tensor's channel dimension. The pass matches the exact window-reverse structure — a
+/// pair of chained views separated by a last-axis-preserving `Transpose` — and both views must have a
+/// shape `Concat` with a leading positive-int constant, exactly one trailing `-1`, and at least one
+/// dynamic interior dimension. Two value-preservation guards keep it from corrupting ordinary reshapes
+/// that share the structural signature (spatial flatten `view(1, C, -1)`, attention head-merge
+/// `view(1, N, -1)`, merge/split reshapes whose `-1` spans more than the data's last dim):
+///   1. If a reshape's output last dim is statically known, it must equal the recovered channel.
+///   2. (Applied to a reshape whose OWN data last dim is static.) When the output last dim is dynamic,
+///      guard 1 is vacuous; guard 2 requires the rewrite to merely re-partition the data's leading
+///      dimension and keep the data's entire trailing block, which is exactly the window-reverse
+///      semantics and rejects merge/split reshapes.
+///
+/// This lives in SmartReshape because it is a reshapeability concern (it runs inside `Model::reshape`),
+/// not a framework-import concern: it operates on the already-built `ov::Model` and is framework-agnostic.
+///
+/// Window-reverse uses two chained views: the second view's data is the permuted output of the first, and
+/// OV shape inference does NOT propagate the channel through the permute (the spatial value-bounds collapse
+/// the permuted output to fully dynamic). The matcher therefore keys on the whole two-view chain and
+/// recovers the channel from the INNER view's static data last dim; both views are rewritten together in a
+/// single match, so no recorded state or traversal order is needed.
+///
+/// Matched chain (the two window-reverse views):
+///
+///        data [?,8,8,180]   (static last dim = 180)
+///              │
+///        ┌─────▼──────┐  Reshape_1 (INNER / 1st view): its channel is the static last dim (180) of
+///        │  Reshape   │  ITS OWN data. Its output last dim is DYNAMIC (out [?,?,?,8,8,?]).
+///        └─────┬──────┘
+///              │
+///        ┌─────▼──────┐  Transpose(order=[0,1,3,2,4,5]): last axis kept last, so the inner view's
+///        │ Transpose  │  channel is also the outer view's channel. out [?,?,?,?,?,?] (bounds collapse).
+///        └─────┬──────┘
+///              │  data last dim is now DYNAMIC
+///        ┌─────▼──────┐  Reshape_2 (OUTER / 2nd view): matched as the chain root; its channel is taken
+///        │  Reshape   │  from the inner view's static data last dim (180). out [?,H,W,-1].
+///        └─────┬──────┘
+///              ▼
+///
+/// Reshape_1 has a static data last dim, so the trailing-block guard applies to it; Reshape_2's data last
+/// dim is dynamic (it comes through the permute), so it is exempt from the trailing-block guard.
+class ov::pass::RestoreReshapeBakedBatch : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("RestoreReshapeBakedBatch");
+    RestoreReshapeBakedBatch();
+};

--- a/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
@@ -76,9 +76,8 @@ bool passes_structural_gates(const std::shared_ptr<v1::Reshape>& reshape, const 
 }
 
 // True if `transpose` has a constant, full-rank order whose last element is rank-1, i.e. it keeps the
-// last axis in the last position (e.g. [0,1,3,2,4,5]). Transpose's own validation already guarantees the
-// order is a true permutation, so checking size and the last element is enough. Such a permute preserves
-// the channel dimension, so the two chained window-reverse views share the same (static) channel.
+// last axis last (e.g. [0,1,3,2,4,5]) -- so the two chained views share the same channel. Transpose's
+// own validation guarantees the order is a true permutation, so size + last element is enough to check.
 bool is_last_axis_preserving_transpose(const std::shared_ptr<v1::Transpose>& transpose) {
     auto order = ov::as_type_ptr<v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
     const auto& in_ps = transpose->input_value(0).get_partial_shape();
@@ -202,8 +201,8 @@ ov::pass::RestoreReshapeBakedBatch::RestoreReshapeBakedBatch() {
         if (!is_last_axis_preserving_transpose(transpose_node))
             return false;
 
-        // The channel is the inner view's static data last dim (e.g. 180); it is batch-independent and,
-        // through the last-axis-preserving permute, is also the outer view's channel.
+        // The channel is the inner view's static data last dim; through the permute it is also the outer
+        // view's channel, and it is batch-independent.
         const auto channel = static_last_dim(r_in->input_value(0).get_partial_shape());
         if (!channel)
             return false;

--- a/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
@@ -1,0 +1,222 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/smart_reshape/restore_reshape_baked_batch.hpp"
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/pass/node_registry.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+
+namespace {
+
+// True if `out` is a Constant holding a single element equal to `value`.
+bool is_scalar_constant_with_value(const ov::Output<ov::Node>& out, int64_t value) {
+    return ov::op::util::has_constant_value<int64_t>(out.get_node_shared_ptr(), value);
+}
+
+// True if `out` is a Constant holding a single positive integer.
+bool is_scalar_positive_constant(const ov::Output<ov::Node>& out) {
+    int64_t value = 0;
+    return ov::op::util::get_constant_value<int64_t>(out.get_node_shared_ptr(), value) && value > 0;
+}
+
+// The statically-known last dimension of `ps`, or nullopt when the rank is dynamic, the shape is a
+// scalar, or the last dimension itself is dynamic.
+std::optional<int64_t> static_last_dim(const ov::PartialShape& ps) {
+    if (ps.rank().is_dynamic() || ps.size() == 0)
+        return std::nullopt;
+    const auto& last = ps[static_cast<std::ptrdiff_t>(ps.size()) - 1];
+    if (last.is_static())
+        return last.get_length();
+    return std::nullopt;
+}
+
+// Structural signature of a window-reverse style view whose leading batch was frozen by tracing.
+bool passes_structural_gates(const std::shared_ptr<v1::Reshape>& reshape, const std::shared_ptr<v0::Concat>& concat) {
+    if (reshape->get_special_zero())
+        return false;
+    if (concat->get_axis() != 0)
+        return false;
+
+    const auto& shape_inputs = concat->input_values();
+    if (shape_inputs.size() < 3)
+        return false;
+
+    if (!is_scalar_positive_constant(shape_inputs.front()))
+        return false;
+
+    const size_t channel_idx = shape_inputs.size() - 1;
+    if (!is_scalar_constant_with_value(shape_inputs.back(), -1))
+        return false;
+    for (size_t i = 0; i + 1 < shape_inputs.size(); ++i) {
+        if (is_scalar_constant_with_value(shape_inputs[i], -1))
+            return false;  // more than one -1 -> ambiguous, not our pattern
+    }
+
+    for (size_t i = 1; i < channel_idx; ++i) {
+        if (!ov::as_type_ptr<v0::Constant>(shape_inputs[i].get_node_shared_ptr()))
+            return true;
+    }
+    return false;
+}
+
+// True if `transpose` has a constant, full-rank permutation order that keeps the last axis in the last
+// position (e.g. [0,1,3,2,4,5]). Such a permute preserves the channel dimension, so the two chained
+// window-reverse views share the same (static) channel.
+bool is_last_axis_preserving_transpose(const std::shared_ptr<v1::Transpose>& transpose) {
+    auto order = ov::as_type_ptr<v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+    const auto& in_ps = transpose->input_value(0).get_partial_shape();
+    if (!order || in_ps.rank().is_dynamic())
+        return false;
+    const auto perm = order->cast_vector<int64_t>();
+    const int64_t rank = in_ps.rank().get_length();
+    return static_cast<int64_t>(perm.size()) == rank && !perm.empty() && perm.back() == rank - 1;
+}
+
+// Value-preservation guard for a reshape whose channel was recovered from its OWN static data last dim.
+// The rewrite must merely re-partition the data's leading dimension and keep the data's entire trailing
+// block intact — exactly the window-reverse semantics.
+bool keeps_data_trailing_block(const std::shared_ptr<v1::Reshape>& reshape,
+                               const std::shared_ptr<v0::Concat>& concat,
+                               int64_t channel) {
+    const auto& data_ps = reshape->input_value(0).get_partial_shape();
+    if (data_ps.rank().is_dynamic())
+        return false;
+    const int64_t rank = data_ps.rank().get_length();
+    if (rank < 2)
+        return false;
+
+    const auto& shape_inputs = concat->input_values();
+    const auto m = static_cast<int64_t>(shape_inputs.size());
+    if (m < rank)
+        return false;
+
+    for (int64_t j = 1; j < rank; ++j) {
+        const auto& data_dim = data_ps[static_cast<std::ptrdiff_t>(j)];
+        if (data_dim.is_dynamic())
+            return false;
+        const auto& shape_elem = shape_inputs[static_cast<size_t>(m - rank + j)];
+        if (j == rank - 1) {
+            if (channel != data_dim.get_length())
+                return false;
+        } else if (!is_scalar_constant_with_value(shape_elem, data_dim.get_length())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// The two value-preservation guards for a single reshape given the recovered channel. Guard 1 (output last
+// dim, if static, must equal the channel) always applies; guard 2 (trailing-block) applies only when the
+// reshape's own data last dim is static.
+bool guards_hold(const std::shared_ptr<v1::Reshape>& reshape,
+                 const std::shared_ptr<v0::Concat>& concat,
+                 int64_t channel) {
+    const auto out_last = static_last_dim(reshape->get_output_partial_shape(0));
+    if (out_last && *out_last != channel)
+        return false;
+    const bool direct_path = static_last_dim(reshape->input_value(0).get_partial_shape()).has_value();
+    if (direct_path && !keeps_data_trailing_block(reshape, concat, channel))
+        return false;
+    return true;
+}
+
+// Rebuild the shape vector for THIS reshape's own data (the concat may be shared between blocks, so we
+// must not edit it in place): leading batch -> -1; channel (-1) -> Constant(channel).
+void rewrite_reshape(const std::shared_ptr<v1::Reshape>& reshape,
+                     const std::shared_ptr<v0::Concat>& concat,
+                     int64_t channel) {
+    const auto& shape_inputs = concat->input_values();
+    const size_t channel_idx = shape_inputs.size() - 1;
+
+    ov::pass::NodeRegistry rg;
+
+    const auto& channel_et = concat->input_value(channel_idx).get_element_type();
+    const auto channel_out = rg.make<v0::Constant>(channel_et.is_static() ? channel_et : ov::element::i64,
+                                                   ov::Shape{1},
+                                                   std::vector<int64_t>{channel});
+
+    const auto& batch_et = shape_inputs.front().get_element_type();
+    const auto minus_one = rg.make<v0::Constant>(batch_et.is_static() ? batch_et : ov::element::i64,
+                                                 ov::Shape{1},
+                                                 std::vector<int64_t>{-1});
+
+    ov::OutputVector new_shape_inputs;
+    new_shape_inputs.reserve(shape_inputs.size());
+    new_shape_inputs.push_back(minus_one);
+    for (size_t i = 1; i < channel_idx; ++i)
+        new_shape_inputs.push_back(shape_inputs[i]);
+    new_shape_inputs.push_back(channel_out);
+
+    const auto new_concat = rg.make<v0::Concat>(new_shape_inputs, 0);
+    reshape->input(1).replace_source_output(new_concat);
+    ov::copy_runtime_info(concat, rg.get());
+}
+
+}  // namespace
+
+ov::pass::RestoreReshapeBakedBatch::RestoreReshapeBakedBatch() {
+    MATCHER_SCOPE(RestoreReshapeBakedBatch);
+
+    // Match the exact window-reverse chain: two views separated by a last-axis-preserving Transpose. The
+    // shape input of each view is a Concat (ordinary reshapes feed a Constant here). The precise value/
+    // arity checks — leading positive-int const, single trailing -1, dynamic interior, and the permute
+    // being a full last-axis-preserving order — are done in the callback (wrap_type cannot express them).
+    auto inner_concat = pattern::wrap_type<v0::Concat>();
+    auto inner_reshape = pattern::wrap_type<v1::Reshape>({pattern::any_input(), inner_concat});
+    auto transpose = pattern::wrap_type<v1::Transpose>({inner_reshape, pattern::wrap_type<v0::Constant>()});
+    auto outer_concat = pattern::wrap_type<v0::Concat>();
+    auto outer_reshape = pattern::wrap_type<v1::Reshape>({transpose, outer_concat});
+
+    matcher_pass_callback callback = [=](pattern::Matcher& m) -> bool {
+        const auto& pm = m.get_pattern_map();
+        auto r_in = ov::as_type_ptr<v1::Reshape>(pm.at(inner_reshape));
+        auto r_out = ov::as_type_ptr<v1::Reshape>(pm.at(outer_reshape));
+        auto c_in = ov::as_type_ptr<v0::Concat>(pm.at(inner_concat));
+        auto c_out = ov::as_type_ptr<v0::Concat>(pm.at(outer_concat));
+        auto transpose_node = ov::as_type_ptr<v1::Transpose>(pm.at(transpose));
+        if (!r_in || !r_out || !c_in || !c_out || !transpose_node)
+            return false;
+
+        // Both views must carry the frozen-batch signature.
+        if (!passes_structural_gates(r_in, c_in) || !passes_structural_gates(r_out, c_out))
+            return false;
+
+        // The permute keeps the last (channel) axis last, so the inner and outer channels are the same.
+        if (!is_last_axis_preserving_transpose(transpose_node))
+            return false;
+
+        // The channel is the inner view's static data last dim (e.g. 180); it is batch-independent and,
+        // through the last-axis-preserving permute, is also the outer view's channel.
+        const auto channel = static_last_dim(r_in->input_value(0).get_partial_shape());
+        if (!channel)
+            return false;
+
+        // Value-preservation guards on both views before any rewrite.
+        if (!guards_hold(r_in, c_in, *channel) || !guards_hold(r_out, c_out, *channel))
+            return false;
+
+        rewrite_reshape(r_in, c_in, *channel);
+        rewrite_reshape(r_out, c_out, *channel);
+        return true;
+    };
+
+    auto m = std::make_shared<pattern::Matcher>(outer_reshape, matcher_name);
+    register_matcher(m, callback);
+}

--- a/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/restore_reshape_baked_batch.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "itt.hpp"
-#include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
@@ -76,9 +75,10 @@ bool passes_structural_gates(const std::shared_ptr<v1::Reshape>& reshape, const 
     return false;
 }
 
-// True if `transpose` has a constant, full-rank permutation order that keeps the last axis in the last
-// position (e.g. [0,1,3,2,4,5]). Such a permute preserves the channel dimension, so the two chained
-// window-reverse views share the same (static) channel.
+// True if `transpose` has a constant, full-rank order whose last element is rank-1, i.e. it keeps the
+// last axis in the last position (e.g. [0,1,3,2,4,5]). Transpose's own validation already guarantees the
+// order is a true permutation, so checking size and the last element is enough. Such a permute preserves
+// the channel dimension, so the two chained window-reverse views share the same (static) channel.
 bool is_last_axis_preserving_transpose(const std::shared_ptr<v1::Transpose>& transpose) {
     auto order = ov::as_type_ptr<v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
     const auto& in_ps = transpose->input_value(0).get_partial_shape();

--- a/src/common/transformations/src/transformations/smart_reshape/smart_reshape.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/smart_reshape.cpp
@@ -16,6 +16,7 @@
 #include "transformations/smart_reshape/proposal_scales_stridedslice.hpp"
 #include "transformations/smart_reshape/reshape_sinking.hpp"
 #include "transformations/smart_reshape/reshape_to_1D.hpp"
+#include "transformations/smart_reshape/restore_reshape_baked_batch.hpp"
 #include "transformations/smart_reshape/shape_of_const_folding.hpp"
 #include "transformations/smart_reshape/strided_slice_squeeze.hpp"
 
@@ -35,6 +36,7 @@ bool ov::pass::SmartReshape::run_on_model(const std::shared_ptr<ov::Model>& f) {
     static_manager.register_pass<ov::pass::BroadcastConstRangeReplacement>();
     static_manager.register_pass<ov::pass::LSTMStatesBroadcast>();
     static_manager.register_pass<ov::pass::ReshapeSinkingMatMul>();
+    static_manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
     static_manager.run_passes(f);
 
     ov::pass::Manager dynamic_manager("SmartReshape:dynamic");

--- a/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
@@ -29,6 +29,21 @@ std::shared_ptr<v0::Constant> dim_const(int64_t value) {
     return v0::Constant::create(element::i64, Shape{1}, {value});
 }
 
+// n dynamic i64 shape-vector inputs (each PartialShape{1}).
+ParameterVector make_dyn_dims(size_t n) {
+    ParameterVector dims(n);
+    for (auto& d : dims)
+        d = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    return dims;
+}
+
+// {data, dims...} in consumption order.
+ParameterVector params_of(const std::shared_ptr<v0::Parameter>& data, const ParameterVector& dims) {
+    ParameterVector params{data};
+    params.insert(params.end(), dims.begin(), dims.end());
+    return params;
+}
+
 // Wire the window-reverse chain: inner Reshape -> Transpose(order) -> outer Reshape, and return the outer
 // Reshape (the chain root the pass matches on).
 std::shared_ptr<v1::Reshape> wire_chain(const Output<Node>& data,
@@ -45,73 +60,55 @@ std::shared_ptr<v1::Reshape> wire_chain(const Output<Node>& data,
 
 }  // namespace
 
-// Positive. The exact window-reverse chain: an inner view [?,ws,ws,C] -> [?,H//ws,W//ws,ws,ws,C] whose
-// channel resolves DIRECTLY from its data's static last dim C, a last-axis-preserving
-// Transpose(order=[0,1,3,2,4,5]) whose output is fully dynamic, then the outer view [B,H,W,-1] whose data
-// last dim is now DYNAMIC (it comes through the permute). Tracing froze the leading batch into Constant(1)
-// and left the channel as the trailing -1 in BOTH views. The pass matches the chain on the outer reshape
-// and rewrites BOTH shape Concats: leading Constant(1) -> Constant(-1) (batch inferred) and trailing -1 ->
-// Constant(C) (channel taken from the inner view's static data last dim), keeping the interior intact.
+// Positive. The window-reverse chain: inner view [?,ws,ws,C] -> [?,H//ws,W//ws,ws,ws,C] (channel from its
+// static data last dim C), a last-axis-preserving Transpose, then the outer view [B,H,W,-1] whose data
+// last dim is now dynamic. Tracing froze the leading batch into Constant(1) and left the channel as the
+// trailing -1 in both views; the pass relaxes both leading constants to -1 and pins both channels to C.
 TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_chain_positive) {
     constexpr int64_t WS = 8, C = 16;
     {
         auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-        // Dynamic spatial split (H//ws, W//ws) and (H, W) -- non-constant shape elements.
-        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-
-        auto shape1 =
-            std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)},
-                                         0);
-        auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+        auto dims = make_dyn_dims(4);  // h, w, H, W
+        auto shape1 = std::make_shared<v0::Concat>(
+            OutputVector{dim_const(1), dims[0], dims[1], dim_const(WS), dim_const(WS), dim_const(-1)},
+            0);
+        auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[2], dims[3], dim_const(-1)}, 0);
         auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
-        model = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+        model = std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 
         manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
-        // The rewrite only flips scalar Constants (1 -> -1, -1 -> C); the default comparator does not
-        // inspect Constant values, so enable that explicitly to actually assert the rewrite.
+        // The rewrite only flips scalar Constants, which the default comparator ignores.
         comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     }
     {
         auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-        auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-
-        auto shape1 =
-            std::make_shared<v0::Concat>(OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)},
-                                         0);
-        auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(-1), H, W, dim_const(C)}, 0);
+        auto dims = make_dyn_dims(4);
+        auto shape1 = std::make_shared<v0::Concat>(
+            OutputVector{dim_const(-1), dims[0], dims[1], dim_const(WS), dim_const(WS), dim_const(C)},
+            0);
+        auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(-1), dims[2], dims[3], dim_const(C)}, 0);
         auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
-        model_ref = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+        model_ref = std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
     }
 }
 
-// End-to-end: SmartReshape runs inside Model::reshape, so re-batching the windows tensor must drive the
-// pass over the whole model. We assert the rewrite happened through that full path: BOTH shape Concats
-// (inner and outer view) have their leading baked-batch Constant relaxed to -1 (batch inferred) and their
-// trailing -1 channel pinned to Constant(C). (The Reshape's inferred partial shape stays dynamic here
-// because the interior spatial dims are dynamic Parameters and the leading -1 cannot be folded -- the
-// rewrite is nonetheless value-correct, which the real-model A/B verifies; here we pin the graph effect.)
+// End-to-end: SmartReshape runs inside Model::reshape, so re-batching drives the pass over the whole
+// model. We assert on the graph (both leading constants relaxed to -1, both channels pinned to C) rather
+// than the output shape: the interior spatial dims are dynamic Parameters and the leading -1 cannot fold,
+// so the inferred shape stays dynamic although the rewrite is value-correct.
 TEST(SmartReshapeTests, RestoreReshapeBakedBatch_reshape) {
     constexpr int64_t WS = 2, C = 16;
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{4, WS, WS, C});
-    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-
-    auto shape1 =
-        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto dims = make_dyn_dims(4);  // h, w, H, W
+    auto shape1 = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(1), dims[0], dims[1], dim_const(WS), dim_const(WS), dim_const(-1)},
+        0);
     auto reshape1 = std::make_shared<v1::Reshape>(data, shape1, false);
     auto order = v0::Constant::create(element::i64, Shape{6}, {0, 1, 3, 2, 4, 5});
     auto transpose = std::make_shared<v1::Transpose>(reshape1, order);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[2], dims[3], dim_const(-1)}, 0);
     auto reshape2 = std::make_shared<v1::Reshape>(transpose, shape2, false);
-    auto model = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+    auto model = std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 
     // RestoreReshapeBakedBatch is called as a part of SmartReshape.
     OV_ASSERT_NO_THROW(model->reshape({{data->output(0), PartialShape{8, WS, WS, C}}}));
@@ -133,181 +130,147 @@ TEST(SmartReshapeTests, RestoreReshapeBakedBatch_reshape) {
 }
 
 // --------------------------------------------------------------------------------------------------
-// Negative cases. The pass runs inside every Model::reshape, so it must never fire on a graph it cannot
-// prove value-preserving. Each builder produces a graph the pass must leave untouched; the TEST_P body
-// sets only `model` (no model_ref), so TransformationTestsF::TearDown clones `model` BEFORE running the
-// pass and compares against the clone. The pass's only mutation flips scalar Constant values (leading
-// batch -> -1, trailing -1 -> channel) without changing topology, so the TEST_P body enables CONST_VALUES
-// -- otherwise a spurious value-only fire would go undetected by the default comparator.
-//
-// Two families:
-//   (A) A structurally valid two-view chain in which ONE gate/guard is violated -- the chain matches the
-//       pattern, the callback runs, and it bails at the named check. These prove the gate/guard logic.
-//   (B) Graphs that do not form the chain at all -- these prove the matcher is narrow (a lone view or an
-//       ordinary reshape is never touched).
+// Negative cases -- the pass must never fire where it cannot prove value preservation. Two families:
+//   (A) a valid two-view chain in which one gate/guard is violated (the callback runs and bails);
+//   (B) graphs that do not form the chain at all (the matcher is narrow).
+// The TEST_P body sets only `model`, so TransformationTestsF::TearDown compares against a pre-pass clone.
 // --------------------------------------------------------------------------------------------------
 
 namespace {
 
 // ---- family (A): valid chain with a single violated gate/guard -------------------------------------
 
-// special_zero == true is a different reshape semantics; the inner view's structural gate must reject it.
+// special_zero=true on the inner view: the structural gate rejects.
 std::shared_ptr<Model> build_neg_special_zero() {
     constexpr int64_t WS = 8, C = 16;
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto shape1 =
-        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto dims = make_dyn_dims(4);  // h, w, H, W
+    auto shape1 = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(1), dims[0], dims[1], dim_const(WS), dim_const(WS), dim_const(-1)},
+        0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[2], dims[3], dim_const(-1)}, 0);
     auto reshape2 = wire_chain(data, shape1, /*sz1=*/true, {0, 1, 3, 2, 4, 5}, shape2, false);
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
-// A non-constant (already symbolic) leading element means the batch already propagates -- there is
-// nothing baked to relax, so the inner view's structural gate must reject.
+// Non-constant leading element: batch already propagates, nothing baked to relax -- the gate rejects.
 std::shared_ptr<Model> build_neg_dynamic_leading() {
     constexpr int64_t WS = 8, C = 16;
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-    auto b = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic leading
-    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto shape1 =
-        std::make_shared<v0::Concat>(OutputVector{b, h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto dims = make_dyn_dims(5);  // b (dynamic leading), h, w, H, W
+    auto shape1 = std::make_shared<v0::Concat>(
+        OutputVector{dims[0], dims[1], dims[2], dim_const(WS), dim_const(WS), dim_const(-1)},
+        0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[3], dims[4], dim_const(-1)}, 0);
     auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, b, h, w, H, W});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
-// A fully baked shape (no dynamic interior) is an ordinary fixed reshape, not the window-reverse
-// signature -- the inner view's structural gate must reject.
+// Fully baked shape (no dynamic interior): an ordinary fixed reshape -- the gate rejects.
 std::shared_ptr<Model> build_neg_no_dynamic_interior() {
     constexpr int64_t WS = 8, C = 16;
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto dims = make_dyn_dims(2);  // H, W
     auto shape1 = std::make_shared<v0::Concat>(
         OutputVector{dim_const(1), dim_const(2), dim_const(2), dim_const(WS), dim_const(WS), dim_const(-1)},
         0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[0], dims[1], dim_const(-1)}, 0);
     auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, H, W});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
-// A middle Transpose that MOVES the last axis (order.back() != rank-1) breaks the guarantee that the two
-// views share a channel; is_last_axis_preserving_transpose must reject.
+// Transpose moves the last axis (order.back() != rank-1): is_last_axis_preserving_transpose rejects.
 std::shared_ptr<Model> build_neg_transpose_moves_last_axis() {
     constexpr int64_t WS = 8, C = 16;
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto shape1 =
-        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto dims = make_dyn_dims(4);  // h, w, H, W
+    auto shape1 = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(1), dims[0], dims[1], dim_const(WS), dim_const(WS), dim_const(-1)},
+        0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[2], dims[3], dim_const(-1)}, 0);
     auto reshape2 = wire_chain(data, shape1, false, {0, 1, 2, 3, 5, 4}, shape2, false);  // last axis moved
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
-// Window-reverse with a DYNAMIC channel (no projection to a fixed width). Structural gates pass, but the
-// channel cannot be recovered from the inner view's data static last dim (it is dynamic), so the callback
-// bails at the channel-resolution step.
+// Dynamic channel (no projection to a fixed width): the channel cannot be recovered from the inner
+// view's data static last dim, so the callback bails at channel resolution.
 std::shared_ptr<Model> build_neg_dyn_channel() {
     constexpr int64_t WS = 8;
     auto data =
         std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, Dimension::dynamic()});
-    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto shape1 =
-        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto dims = make_dyn_dims(4);  // h, w, H, W
+    auto shape1 = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(1), dims[0], dims[1], dim_const(WS), dim_const(WS), dim_const(-1)},
+        0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[2], dims[3], dim_const(-1)}, 0);
     auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
-// Spatial flatten view(1, C, -1) as the inner (direct-path) view: the shape vector is shorter than the
-// data rank, so the trailing-block guard rejects it (the -1 would span more than data's last dim -- here
-// H*W, not W). A valid outer view completes the chain so the callback reaches the inner guard.
+// Spatial flatten view(1, C, -1) as the inner view: the shape vector is shorter than the data rank, so
+// the trailing-block guard rejects (the -1 spans more than data's last dim).
 std::shared_ptr<Model> build_neg_spatial_flatten() {
-    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{2, 3, 4, 5});  // last dim 5
-    auto c = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});              // dynamic C slot
-    auto s = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});              // outer interior
-    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), c, dim_const(-1)}, 0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), s, dim_const(-1)}, 0);
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{2, 3, 4, 5});
+    auto dims = make_dyn_dims(2);  // c (channel slot), s (outer interior)
+    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[0], dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[1], dim_const(-1)}, 0);
     auto reshape2 = wire_chain(data, shape1, false, {0, 1, 2}, shape2, false);
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, c, s});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
-// Head-merge view(1, T//2, -1) as the inner view: data has a STATIC last dim (D) but a DYNAMIC interior,
-// so the trailing -1 spans more than D. Guard 1 is vacuous (output last dim dynamic); the trailing-block
-// guard rejects at its data_dim.is_dynamic() branch (the kept interior dim is dynamic).
+// Head-merge view(1, T//2, -1) as the inner view: static data last dim but dynamic interior, so the
+// trailing -1 spans more than the last dim -- the trailing-block guard rejects at its is_dynamic branch.
 std::shared_ptr<Model> build_neg_head_merge() {
     constexpr int64_t D = 8;
     auto data =
         std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), Dimension::dynamic(), D});
-    auto t = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic T//2
-    auto s = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // outer interior
-    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), t, dim_const(-1)}, 0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), s, dim_const(-1)}, 0);
+    auto dims = make_dyn_dims(2);  // t (T//2), s (outer interior)
+    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[0], dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[1], dim_const(-1)}, 0);
     auto reshape2 = wire_chain(data, shape1, false, {0, 1, 2}, shape2, false);
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, t, s});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
-// Head-split view(1, T*2, -1) as the inner view: data has a STATIC last dim (D) AND a static interior dim,
-// but the kept interior shape element is dynamic (T*2) and cannot be proven equal to data's static
-// interior dim, so the trailing-block guard rejects at its non-constant-interior branch (distinct from
-// head_merge).
+// Head-split view(1, T*2, -1) as the inner view: static data interior dim but the kept shape element is
+// dynamic and cannot be proven equal to it -- the trailing-block guard rejects at its non-constant branch.
 std::shared_ptr<Model> build_neg_head_split() {
     constexpr int64_t D = 8, T = 4;
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), T, D});
-    auto t = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic T*2
-    auto s = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // outer interior
-    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), t, dim_const(-1)}, 0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), s, dim_const(-1)}, 0);
+    auto dims = make_dyn_dims(2);  // t (T*2), s (outer interior)
+    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[0], dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), dims[1], dim_const(-1)}, 0);
     auto reshape2 = wire_chain(data, shape1, false, {0, 1, 2}, shape2, false);
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, t, s});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
-// Idempotency: the already-rewritten chain (leading Constant(-1), trailing Constant(C) in both views).
-// Re-running the pass must not re-fire -- a Constant(-1) leading element fails the positive-int leading
-// gate, so the rewrite is a fixed point.
+// Idempotency: an already-rewritten chain (leading Constant(-1)) fails the positive-int leading gate.
 std::shared_ptr<Model> build_neg_already_rewritten() {
     constexpr int64_t WS = 8, C = 16;
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto shape1 =
-        std::make_shared<v0::Concat>(OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)}, 0);
-    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(-1), H, W, dim_const(C)}, 0);
+    auto dims = make_dyn_dims(4);  // h, w, H, W
+    auto shape1 = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(-1), dims[0], dims[1], dim_const(WS), dim_const(WS), dim_const(C)},
+        0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(-1), dims[2], dims[3], dim_const(C)}, 0);
     auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
-    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+    return std::make_shared<Model>(OutputVector{reshape2}, params_of(data, dims));
 }
 
 // ---- family (B): no chain -> matcher is narrow -----------------------------------------------------
 
-// A single window-reverse view with NO following Transpose+second view. The pass matches only the full
-// two-view chain, so a lone view is deliberately left untouched (the ticket model always emits the pair).
+// A lone view with no following Transpose+second view: the pass matches only the full chain.
 std::shared_ptr<Model> build_neg_lone_view() {
     constexpr int64_t WS = 8, C = 16;
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
-    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
-    auto shape =
-        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto dims = make_dyn_dims(2);  // h, w
+    auto shape = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(1), dims[0], dims[1], dim_const(WS), dim_const(WS), dim_const(-1)},
+        0);
     auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
-    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
+    return std::make_shared<Model>(OutputVector{reshape}, params_of(data, dims));
 }
 
-// An ordinary reshape with a constant target shape (not a Concat) -- the common case -- is never matched.
+// An ordinary reshape with a constant target shape (not a Concat) is never matched.
 std::shared_ptr<Model> build_neg_ordinary_reshape() {
     auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), 3, 4, 5});
     auto shape = v0::Constant::create(element::i64, Shape{2}, {-1, 60});
@@ -328,9 +291,8 @@ TEST_P(RestoreReshapeBakedBatchNeg, PassDoesNotFire) {
     const auto& p = GetParam();
     model = p.build();
     manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
-    // model_ref left null on purpose: TearDown clones `model` before running the pass and compares,
-    // so the test asserts the pass made no change. The pass only rewrites scalar Constant values, which
-    // the default comparator ignores, so enable CONST_VALUES to make this a true "did not fire" assertion.
+    // The pass rewrites only scalar Constant values, which the default comparator ignores, so enable
+    // CONST_VALUES to make the clone comparison a true "did not fire" assertion.
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
 

--- a/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
@@ -136,7 +136,9 @@ TEST(SmartReshapeTests, RestoreReshapeBakedBatch_reshape) {
 // Negative cases. The pass runs inside every Model::reshape, so it must never fire on a graph it cannot
 // prove value-preserving. Each builder produces a graph the pass must leave untouched; the TEST_P body
 // sets only `model` (no model_ref), so TransformationTestsF::TearDown clones `model` BEFORE running the
-// pass and compares against the clone -- an exact "did not fire" assertion.
+// pass and compares against the clone. The pass's only mutation flips scalar Constant values (leading
+// batch -> -1, trailing -1 -> channel) without changing topology, so the TEST_P body enables CONST_VALUES
+// -- otherwise a spurious value-only fire would go undetected by the default comparator.
 //
 // Two families:
 //   (A) A structurally valid two-view chain in which ONE gate/guard is violated -- the chain matches the
@@ -327,7 +329,9 @@ TEST_P(RestoreReshapeBakedBatchNeg, PassDoesNotFire) {
     model = p.build();
     manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
     // model_ref left null on purpose: TearDown clones `model` before running the pass and compares,
-    // so the test asserts the pass made no change.
+    // so the test asserts the pass made no change. The pass only rewrites scalar Constant values, which
+    // the default comparator ignores, so enable CONST_VALUES to make this a true "did not fire" assertion.
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
 
 INSTANTIATE_TEST_SUITE_P(SmartReshapeTests,

--- a/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
+++ b/src/common/transformations/tests/smart_reshape/restore_reshape_baked_batch.cpp
@@ -1,0 +1,350 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/smart_reshape/restore_reshape_baked_batch.hpp"
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/transpose.hpp"
+
+using namespace ov;
+using namespace ov::op;
+
+namespace {
+
+// Build a 1-element i64 Constant (a shape-vector element).
+std::shared_ptr<v0::Constant> dim_const(int64_t value) {
+    return v0::Constant::create(element::i64, Shape{1}, {value});
+}
+
+// Wire the window-reverse chain: inner Reshape -> Transpose(order) -> outer Reshape, and return the outer
+// Reshape (the chain root the pass matches on).
+std::shared_ptr<v1::Reshape> wire_chain(const Output<Node>& data,
+                                        const std::shared_ptr<Node>& shape1,
+                                        bool sz1,
+                                        const std::vector<int64_t>& order,
+                                        const std::shared_ptr<Node>& shape2,
+                                        bool sz2) {
+    auto reshape1 = std::make_shared<v1::Reshape>(data, shape1, sz1);
+    auto ord = v0::Constant::create(element::i64, Shape{order.size()}, order);
+    auto transpose = std::make_shared<v1::Transpose>(reshape1, ord);
+    return std::make_shared<v1::Reshape>(transpose, shape2, sz2);
+}
+
+}  // namespace
+
+// Positive. The exact window-reverse chain: an inner view [?,ws,ws,C] -> [?,H//ws,W//ws,ws,ws,C] whose
+// channel resolves DIRECTLY from its data's static last dim C, a last-axis-preserving
+// Transpose(order=[0,1,3,2,4,5]) whose output is fully dynamic, then the outer view [B,H,W,-1] whose data
+// last dim is now DYNAMIC (it comes through the permute). Tracing froze the leading batch into Constant(1)
+// and left the channel as the trailing -1 in BOTH views. The pass matches the chain on the outer reshape
+// and rewrites BOTH shape Concats: leading Constant(1) -> Constant(-1) (batch inferred) and trailing -1 ->
+// Constant(C) (channel taken from the inner view's static data last dim), keeping the interior intact.
+TEST_F(TransformationTestsF, RestoreReshapeBakedBatch_chain_positive) {
+    constexpr int64_t WS = 8, C = 16;
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+        // Dynamic spatial split (H//ws, W//ws) and (H, W) -- non-constant shape elements.
+        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+
+        auto shape1 =
+            std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)},
+                                         0);
+        auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+        auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
+        model = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+
+        manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+        // The rewrite only flips scalar Constants (1 -> -1, -1 -> C); the default comparator does not
+        // inspect Constant values, so enable that explicitly to actually assert the rewrite.
+        comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    }
+    {
+        auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+        auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+        auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+
+        auto shape1 =
+            std::make_shared<v0::Concat>(OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)},
+                                         0);
+        auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(-1), H, W, dim_const(C)}, 0);
+        auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
+        model_ref = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+    }
+}
+
+// End-to-end: SmartReshape runs inside Model::reshape, so re-batching the windows tensor must drive the
+// pass over the whole model. We assert the rewrite happened through that full path: BOTH shape Concats
+// (inner and outer view) have their leading baked-batch Constant relaxed to -1 (batch inferred) and their
+// trailing -1 channel pinned to Constant(C). (The Reshape's inferred partial shape stays dynamic here
+// because the interior spatial dims are dynamic Parameters and the leading -1 cannot be folded -- the
+// rewrite is nonetheless value-correct, which the real-model A/B verifies; here we pin the graph effect.)
+TEST(SmartReshapeTests, RestoreReshapeBakedBatch_reshape) {
+    constexpr int64_t WS = 2, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{4, WS, WS, C});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+
+    auto shape1 =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto reshape1 = std::make_shared<v1::Reshape>(data, shape1, false);
+    auto order = v0::Constant::create(element::i64, Shape{6}, {0, 1, 3, 2, 4, 5});
+    auto transpose = std::make_shared<v1::Transpose>(reshape1, order);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto reshape2 = std::make_shared<v1::Reshape>(transpose, shape2, false);
+    auto model = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+
+    // RestoreReshapeBakedBatch is called as a part of SmartReshape.
+    OV_ASSERT_NO_THROW(model->reshape({{data->output(0), PartialShape{8, WS, WS, C}}}));
+
+    for (const auto& reshape : {reshape1, reshape2}) {
+        auto concat = ov::as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
+        ASSERT_NE(concat, nullptr);
+        const auto& elems = concat->input_values();
+        ASSERT_GE(elems.size(), 3u);
+
+        auto leading = ov::as_type_ptr<v0::Constant>(elems.front().get_node_shared_ptr());
+        ASSERT_NE(leading, nullptr) << "leading element must be the inferred -1 Constant";
+        EXPECT_EQ(leading->cast_vector<int64_t>().at(0), -1) << "baked batch not relaxed to -1";
+
+        auto channel = ov::as_type_ptr<v0::Constant>(elems.back().get_node_shared_ptr());
+        ASSERT_NE(channel, nullptr) << "channel must be pinned to a static Constant";
+        EXPECT_EQ(channel->cast_vector<int64_t>().at(0), C) << "channel not pinned to data's last dim";
+    }
+}
+
+// --------------------------------------------------------------------------------------------------
+// Negative cases. The pass runs inside every Model::reshape, so it must never fire on a graph it cannot
+// prove value-preserving. Each builder produces a graph the pass must leave untouched; the TEST_P body
+// sets only `model` (no model_ref), so TransformationTestsF::TearDown clones `model` BEFORE running the
+// pass and compares against the clone -- an exact "did not fire" assertion.
+//
+// Two families:
+//   (A) A structurally valid two-view chain in which ONE gate/guard is violated -- the chain matches the
+//       pattern, the callback runs, and it bails at the named check. These prove the gate/guard logic.
+//   (B) Graphs that do not form the chain at all -- these prove the matcher is narrow (a lone view or an
+//       ordinary reshape is never touched).
+// --------------------------------------------------------------------------------------------------
+
+namespace {
+
+// ---- family (A): valid chain with a single violated gate/guard -------------------------------------
+
+// special_zero == true is a different reshape semantics; the inner view's structural gate must reject it.
+std::shared_ptr<Model> build_neg_special_zero() {
+    constexpr int64_t WS = 8, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape1 =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto reshape2 = wire_chain(data, shape1, /*sz1=*/true, {0, 1, 3, 2, 4, 5}, shape2, false);
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+}
+
+// A non-constant (already symbolic) leading element means the batch already propagates -- there is
+// nothing baked to relax, so the inner view's structural gate must reject.
+std::shared_ptr<Model> build_neg_dynamic_leading() {
+    constexpr int64_t WS = 8, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto b = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic leading
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape1 =
+        std::make_shared<v0::Concat>(OutputVector{b, h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, b, h, w, H, W});
+}
+
+// A fully baked shape (no dynamic interior) is an ordinary fixed reshape, not the window-reverse
+// signature -- the inner view's structural gate must reject.
+std::shared_ptr<Model> build_neg_no_dynamic_interior() {
+    constexpr int64_t WS = 8, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape1 = std::make_shared<v0::Concat>(
+        OutputVector{dim_const(1), dim_const(2), dim_const(2), dim_const(WS), dim_const(WS), dim_const(-1)},
+        0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, H, W});
+}
+
+// A middle Transpose that MOVES the last axis (order.back() != rank-1) breaks the guarantee that the two
+// views share a channel; is_last_axis_preserving_transpose must reject.
+std::shared_ptr<Model> build_neg_transpose_moves_last_axis() {
+    constexpr int64_t WS = 8, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape1 =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto reshape2 = wire_chain(data, shape1, false, {0, 1, 2, 3, 5, 4}, shape2, false);  // last axis moved
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+}
+
+// Window-reverse with a DYNAMIC channel (no projection to a fixed width). Structural gates pass, but the
+// channel cannot be recovered from the inner view's data static last dim (it is dynamic), so the callback
+// bails at the channel-resolution step.
+std::shared_ptr<Model> build_neg_dyn_channel() {
+    constexpr int64_t WS = 8;
+    auto data =
+        std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, Dimension::dynamic()});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape1 =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), H, W, dim_const(-1)}, 0);
+    auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+}
+
+// Spatial flatten view(1, C, -1) as the inner (direct-path) view: the shape vector is shorter than the
+// data rank, so the trailing-block guard rejects it (the -1 would span more than data's last dim -- here
+// H*W, not W). A valid outer view completes the chain so the callback reaches the inner guard.
+std::shared_ptr<Model> build_neg_spatial_flatten() {
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{2, 3, 4, 5});  // last dim 5
+    auto c = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});              // dynamic C slot
+    auto s = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});              // outer interior
+    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), c, dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), s, dim_const(-1)}, 0);
+    auto reshape2 = wire_chain(data, shape1, false, {0, 1, 2}, shape2, false);
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, c, s});
+}
+
+// Head-merge view(1, T//2, -1) as the inner view: data has a STATIC last dim (D) but a DYNAMIC interior,
+// so the trailing -1 spans more than D. Guard 1 is vacuous (output last dim dynamic); the trailing-block
+// guard rejects at its data_dim.is_dynamic() branch (the kept interior dim is dynamic).
+std::shared_ptr<Model> build_neg_head_merge() {
+    constexpr int64_t D = 8;
+    auto data =
+        std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), Dimension::dynamic(), D});
+    auto t = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic T//2
+    auto s = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // outer interior
+    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), t, dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), s, dim_const(-1)}, 0);
+    auto reshape2 = wire_chain(data, shape1, false, {0, 1, 2}, shape2, false);
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, t, s});
+}
+
+// Head-split view(1, T*2, -1) as the inner view: data has a STATIC last dim (D) AND a static interior dim,
+// but the kept interior shape element is dynamic (T*2) and cannot be proven equal to data's static
+// interior dim, so the trailing-block guard rejects at its non-constant-interior branch (distinct from
+// head_merge).
+std::shared_ptr<Model> build_neg_head_split() {
+    constexpr int64_t D = 8, T = 4;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), T, D});
+    auto t = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // dynamic T*2
+    auto s = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});  // outer interior
+    auto shape1 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), t, dim_const(-1)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(1), s, dim_const(-1)}, 0);
+    auto reshape2 = wire_chain(data, shape1, false, {0, 1, 2}, shape2, false);
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, t, s});
+}
+
+// Idempotency: the already-rewritten chain (leading Constant(-1), trailing Constant(C) in both views).
+// Re-running the pass must not re-fire -- a Constant(-1) leading element fails the positive-int leading
+// gate, so the rewrite is a fixed point.
+std::shared_ptr<Model> build_neg_already_rewritten() {
+    constexpr int64_t WS = 8, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto H = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto W = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape1 =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(-1), h, w, dim_const(WS), dim_const(WS), dim_const(C)}, 0);
+    auto shape2 = std::make_shared<v0::Concat>(OutputVector{dim_const(-1), H, W, dim_const(C)}, 0);
+    auto reshape2 = wire_chain(data, shape1, false, {0, 1, 3, 2, 4, 5}, shape2, false);
+    return std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data, h, w, H, W});
+}
+
+// ---- family (B): no chain -> matcher is narrow -----------------------------------------------------
+
+// A single window-reverse view with NO following Transpose+second view. The pass matches only the full
+// two-view chain, so a lone view is deliberately left untouched (the ticket model always emits the pair).
+std::shared_ptr<Model> build_neg_lone_view() {
+    constexpr int64_t WS = 8, C = 16;
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), WS, WS, C});
+    auto h = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto w = std::make_shared<v0::Parameter>(element::i64, PartialShape{1});
+    auto shape =
+        std::make_shared<v0::Concat>(OutputVector{dim_const(1), h, w, dim_const(WS), dim_const(WS), dim_const(-1)}, 0);
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, h, w});
+}
+
+// An ordinary reshape with a constant target shape (not a Concat) -- the common case -- is never matched.
+std::shared_ptr<Model> build_neg_ordinary_reshape() {
+    auto data = std::make_shared<v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), 3, 4, 5});
+    auto shape = v0::Constant::create(element::i64, Shape{2}, {-1, 60});
+    auto reshape = std::make_shared<v1::Reshape>(data, shape, false);
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
+}
+
+struct NegParams {
+    std::string name;
+    std::function<std::shared_ptr<Model>()> build;
+};
+
+}  // namespace
+
+class RestoreReshapeBakedBatchNeg : public testing::WithParamInterface<NegParams>, public TransformationTestsF {};
+
+TEST_P(RestoreReshapeBakedBatchNeg, PassDoesNotFire) {
+    const auto& p = GetParam();
+    model = p.build();
+    manager.register_pass<ov::pass::RestoreReshapeBakedBatch>();
+    // model_ref left null on purpose: TearDown clones `model` before running the pass and compares,
+    // so the test asserts the pass made no change.
+}
+
+INSTANTIATE_TEST_SUITE_P(SmartReshapeTests,
+                         RestoreReshapeBakedBatchNeg,
+                         testing::ValuesIn(std::vector<NegParams>{
+                             {"special_zero", build_neg_special_zero},
+                             {"dynamic_leading", build_neg_dynamic_leading},
+                             {"no_dynamic_interior", build_neg_no_dynamic_interior},
+                             {"transpose_moves_last_axis", build_neg_transpose_moves_last_axis},
+                             {"dyn_channel", build_neg_dyn_channel},
+                             {"spatial_flatten", build_neg_spatial_flatten},
+                             {"head_merge", build_neg_head_merge},
+                             {"head_split", build_neg_head_split},
+                             {"already_rewritten", build_neg_already_rewritten},
+                             {"lone_view", build_neg_lone_view},
+                             {"ordinary_reshape", build_neg_ordinary_reshape},
+                         }),
+                         [](const testing::TestParamInfo<NegParams>& info) {
+                             return info.param.name;
+                         });


### PR DESCRIPTION
### Details:
A SwinIR-style `window_reverse` computes the batch as plain Python arithmetic:

```python
B = int(windows.shape[0] / (H * W / ws / ws))
x = windows.view(B, H // ws, W // ws, ws, ws, -1)
```

Under `torch.jit.trace` the `int(...)` collapses to a literal, so the view shape becomes a
`Concat` where the spatial dims stay live (`aten::size`) but the leading batch is a baked
`Constant(1)` and the channel is the trailing `-1`. At the traced batch=1 this is correct.

After `model.reshape(batch=2)` the leading `1` stays `1` (a literal with nothing to rewrite)
and the spatial dims do not depend on batch, so the known product is unchanged while the
element count doubles. The only free axis (`-1`) absorbs the extra factor: the batch leaks
into the channel (180 -> 360) and the window grid is scrambled. Shapes still infer and
inference runs, so the corruption is silent -- only the values are wrong (`max_abs_diff ~3.47`
on SwinIR_Classical at batch=2).

### Fix

Add `ov::pass::RestoreReshapeBakedBatch`, a `MatcherPass` registered in SmartReshape. For a
view with the window-reverse signature (leading positive-int constant, one trailing `-1`, a
dynamic interior dim) it frees the leading dim to `-1` and pins the channel to a `Constant`,
so batch is inferred from the real element count instead of leaking into the channel.

The channel cannot be read off the second view: `window_reverse` chains two views through a
permute whose output stays dynamic, so OV shape inference does not propagate the channel. The
matcher keys on the whole `Reshape -> Transpose -> Reshape` chain, recovers the channel from
the inner view's static data last dim, and rewrites both views in one match. Requiring the
Transpose to be last-axis-preserving guarantees the two views share that channel. The pass is
stateless -- no recorded state, no traversal-order dependency.

Two guards keep it off ordinary reshapes that share the structure:
- if a view's output last dim is static, it must equal the recovered channel;
- if a view's data last dim is static, the rewrite must only re-partition the leading dim and
  keep the entire trailing block, rejecting merge/split reshapes like `view(1, T//2, -1)`.

It lives in SmartReshape, not the PyTorch frontend: reshapeability is handled on the built
`ov::Model`, so it runs both at convert time and inside `Model::reshape`, for any framework.

### Tickets:
 - 172206