### PR TITLE
[CPU][ARM] Skip `smoke_MatMulCompressedWeightsGrp_Kleidiai` on non-dotprod machines

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -685,7 +685,7 @@ const std::vector<std::regex>& disabled_test_patterns() {
         }
 #elif defined(OPENVINO_ARCH_ARM64) || defined(OPENVINO_ARCH_ARM)
         if (!ov::intel_cpu::hasArmISASupport(ov::intel_cpu::ArmISA::DOTPROD)) {
-            patterns.emplace_back(std::regex(R"(.*smoke_MatMulCompressedWeights_Kleidiai.*)"));
+            patterns.emplace_back(std::regex(R"(.*smoke_MatMulCompressedWeights(Grp)?_Kleidiai.*)"));
         }
         if (!ov::with_cpu_arm_dotprod() && !ov::with_cpu_arm_i8mm()) {
             patterns.emplace_back(std::regex(R"(.*smoke_GroupedMatMul_Compressed.*)"));


### PR DESCRIPTION
### Details:
 - KleidiAI compressed FC requires DOTPROD. Without DOTPROD the FullyConnectedCompressed op is never created and the i4 weights stay decompressed as an ordinary f32 subgraph.
 - `smoke_MatMulCompressedWeightsGrp_Kleidiai` tests brought by https://github.com/openvinotoolkit/openvino/pull/36476 should be skipped on non-dotprod machines

### Tickets:
 - CVS-191445
 - CVS-191444
