### PR TITLE
[Reference] Fix potential OOB write in ScatterNDUpdate OP

### DIFF
--- a/src/core/reference/include/openvino/reference/scatter_nd_update.hpp
+++ b/src/core/reference/include/openvino/reference/scatter_nd_update.hpp
@@ -99,7 +99,7 @@ void scatterNdUpdate(
             if (c < 0) {
                 c += static_cast<indicesType>(dataShape[j]);
             }
-            OPENVINO_ASSERT(c > 0 && static_cast<size_t>(c) < dataShape[j], "Index is out of bounds");
+            OPENVINO_ASSERT(c >= 0 && static_cast<size_t>(c) < dataShape[j], "Index is out of bounds");
             j++;
         }
 

--- a/src/core/reference/include/openvino/reference/scatter_nd_update.hpp
+++ b/src/core/reference/include/openvino/reference/scatter_nd_update.hpp
@@ -99,6 +99,7 @@ void scatterNdUpdate(
             if (c < 0) {
                 c += static_cast<indicesType>(dataShape[j]);
             }
+            OPENVINO_ASSERT(c > 0 && static_cast<size_t>(c) < dataShape[j], "Index is out of bounds");
             j++;
         }
 

--- a/src/plugins/template/tests/functional/op_reference/scatter_nd_update.cpp
+++ b/src/plugins/template/tests/functional/op_reference/scatter_nd_update.cpp
@@ -657,6 +657,16 @@ std::vector<ScatterNDUpdateParams> generateScatterNDUpdateNegativeParams() {
                               reference_tests::Tensor({1}, IN_ET, std::vector<T>{10}),
                               reference_tests::Tensor({2, 2}, IN_ET, std::vector<T>{1, 2, 3, 4, 5, 6}),
                               "scatter_nd_update_2x3_with_out_of_bounds_index"),
+        // scatter_nd_update_4x4_with_out_of_range_negative_index
+        // Regression test for CWE-190 -> CWE-787: an index whose magnitude exceeds
+        // its dimension (dim=4, idx=-5) stays negative after the single-pass negative
+        // index fixup. Casting it to the unsigned accumulator used to wrap the bounds
+        // check and allow an out-of-bounds write; it must now be rejected.
+        ScatterNDUpdateParams(reference_tests::Tensor({4, 4}, IN_ET, std::vector<T>(16, static_cast<T>(0))),
+                              reference_tests::Tensor({1, 2}, IU_ET, std::vector<U>{0, -5}),
+                              reference_tests::Tensor({1}, IN_ET, std::vector<T>{1}),
+                              reference_tests::Tensor({4, 4}, IN_ET, std::vector<T>(16, static_cast<T>(0))),
+                              "scatter_nd_update_4x4_with_out_of_range_negative_index"),
     };
     return scatterParams;
 }


### PR DESCRIPTION
### Details:
 - Adds signed validation to offset calculation when using negative indices. The fix ensures that the unsigned offset will remain with the bounds of the tensor.

### Tickets:
 - [CVS-191818](https://jira.devtools.intel.com/browse/CVS-191818)

### AI Assistance:
 - AI assistance used: yes
 - Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
