### PR TITLE
[Snippets][CPU][ARM] Spill only live registers around calls

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_copy_b_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_copy_b_emitter.cpp
@@ -12,7 +12,6 @@
 #include <cstdint>
 #include <memory>
 #include <set>
-#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -100,8 +99,8 @@ void jit_gemm_copy_b_emitter::emit_call(const std::shared_ptr<ExecutorT>& kernel
                                         const std::vector<size_t>& mem_ptrs_idxs) const {
     OV_CPU_JIT_EMITTER_ASSERT(kernel_executor, "GemmCopyB executor is not initialized");
 
-    std::unordered_set<size_t> exclude_spill = {};
-    store_context(exclude_spill);
+    EmitABIRegSpills spill(h);
+    spill.preamble(get_regs_to_spill());
 
     Xbyak_aarch64::XReg x0(0);
     Xbyak_aarch64::XReg x1(1);
@@ -132,7 +131,7 @@ void jit_gemm_copy_b_emitter::emit_call(const std::shared_ptr<ExecutorT>& kernel
     h->mov(call_address_reg, reinterpret_cast<uintptr_t>(ExecutorT::execute));
     h->blr(call_address_reg);
 
-    restore_context(exclude_spill);
+    spill.postamble();
 }
 
 bool jit_gemm_copy_b_emitter::is_f16_executor() const {

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
@@ -10,7 +10,6 @@
 #include <cstdint>
 #include <memory>
 #include <set>
-#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -101,8 +100,8 @@ void jit_gemm_emitter::emit_call(const std::shared_ptr<ExecutorT>& kernel_execut
     OV_CPU_JIT_EMITTER_ASSERT(kernel_executor, "GemmKai executor is not initialized");
 
     const auto& call_address_reg = get_call_address_reg();
-    std::unordered_set<size_t> exclude_spill = {};
-    store_context(exclude_spill);
+    EmitABIRegSpills spill(h);
+    spill.preamble(get_regs_to_spill());
 
     auto reserved_stack_size = ov::intel_cpu::rnd_up(sizeof(typename ExecutorT::call_args), sp_alignment);
     emit_stack_preserve(reserved_stack_size);
@@ -139,7 +138,7 @@ void jit_gemm_emitter::emit_call(const std::shared_ptr<ExecutorT>& kernel_execut
 
     emit_stack_restore(reserved_stack_size);
 
-    restore_context(exclude_spill);
+    spill.postamble();
 }
 
 bool jit_gemm_emitter::is_f16_executor() const {

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_perf_count_chrono_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_perf_count_chrono_emitters.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "jit_binary_call_emitter.hpp"
+#include "emitters/snippets/aarch64/utils.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type.hpp"
 #include "snippets/lowered/expression.hpp"
@@ -48,12 +49,12 @@ void jit_perf_count_chrono_start_emitter::emit_impl([[maybe_unused]] const std::
     const auto& fn_ptr =
         reinterpret_cast<uint64_t>(static_cast<void (*)(ov::snippets::op::PerfCountBegin*)>(set_start_time));
 
-    // Conservatively preserve full JIT context across external call
-    store_context({});
+    EmitABIRegSpills spill(h);
+    spill.preamble(get_regs_to_spill());
     h->mov(func_reg, fn_ptr);
     h->mov(XReg(0), reinterpret_cast<uint64_t>(m_start_node.get()));
     h->blr(func_reg);
-    restore_context({});
+    spill.postamble();
 }
 
 jit_perf_count_chrono_end_emitter::jit_perf_count_chrono_end_emitter(dnnl::impl::cpu::aarch64::jit_generator_t* host,
@@ -75,11 +76,12 @@ void jit_perf_count_chrono_end_emitter::emit_impl([[maybe_unused]] const std::ve
     const auto& fn_ptr =
         reinterpret_cast<uint64_t>(static_cast<void (*)(ov::snippets::op::PerfCountEnd*)>(set_accumulated_time));
 
-    store_context({});
+    EmitABIRegSpills spill(h);
+    spill.preamble(get_regs_to_spill());
     h->mov(func_reg, fn_ptr);
     h->mov(XReg(0), reinterpret_cast<uint64_t>(m_end_node.get()));
     h->blr(func_reg);
-    restore_context({});
+    spill.postamble();
 }
 
 }  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_perf_count_chrono_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_perf_count_chrono_emitters.cpp
@@ -12,8 +12,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "jit_binary_call_emitter.hpp"
 #include "emitters/snippets/aarch64/utils.hpp"
+#include "jit_binary_call_emitter.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type.hpp"
 #include "snippets/lowered/expression.hpp"


### PR DESCRIPTION
### Details:
Use expression liveness to avoid saving the full JIT context around KAI GEMM and perf-count calls mirroring x64

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
 - Implementation is assisted and after that manually tested and reviewed
