### PR TITLE
[NPU] guard weightless constant byte-size overflow and add regression…

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_utils.cpp
@@ -65,8 +65,12 @@ std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> get_all_consta
             OPENVINO_ASSERT(opt.has_value(), "Failed to parse id for constant: ", descriptor.nameFromCompiler);
 
             const size_t id = opt.value();
-            const size_t byte_size =
-                ov::util::get_memory_size(descriptor.precision, shape_size(descriptor.shapeFromCompiler.to_shape()));
+            const auto byte_size_opt =
+                ov::util::get_memory_size_safe(descriptor.precision, descriptor.shapeFromCompiler.to_shape());
+            OPENVINO_ASSERT(byte_size_opt.has_value(),
+                            "Overflow computing byte size for constant: ",
+                            descriptor.nameFromCompiler);
+            const size_t byte_size = *byte_size_opt;
             OPENVINO_ASSERT(id <= mapped_memory->size() && byte_size <= mapped_memory->size() - id,
                             "Constant offset/size is out of bounds for mapped weights file: offset=",
                             id,

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ set(MANDATORY_UNIT_TESTS_LIBS
         "openvino::npu_al"
         "openvino::npu_logger_utils"
         "openvino_npu_common"
+        "openvino_npu_compiler_adapter"
         "openvino::npu_ops"
         "openvino_npu_vm_utils"
 )
@@ -29,6 +30,8 @@ ov_add_test_target(
         INCLUDES
             ${CMAKE_CURRENT_SOURCE_DIR}
             ${CMAKE_CURRENT_SOURCE_DIR}/npuw
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/common/include
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/compiler_adapter/include
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/pipelines
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/utils/include
@@ -147,6 +150,7 @@ install(TARGETS ${TARGET_NAME}
 
 target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/executor_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npu/weightless_utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_compiled_model_graph_options_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/stored_tokens_state_test.cpp

--- a/src/plugins/intel_npu/tests/unit/npu/weightless_utils.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/weightless_utils.cpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "weightless_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include "intel_npu/common/network_metadata.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+using namespace intel_npu;
+
+TEST(WeightlessUtilsOverflow, CraftedShapeSizeOverflowIsRejected) {
+    // Write a tiny weights file so mapped_memory->size() is small.
+    const std::string weightsPath = "crafted_overflow_weights.bin";
+    struct TempFileCleanup final {
+        explicit TempFileCleanup(const char* file_path) : path{file_path} {}
+        ~TempFileCleanup() {
+            std::remove(path);
+        }
+        const char* path;
+    } cleanup{weightsPath.c_str()};
+
+    {
+        std::ofstream ofs(weightsPath, std::ios::binary);
+        const std::vector<char> bytes(16, 0);  // 16-byte mmap-able file
+        ofs.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    }
+
+    IODescriptor descriptor;
+    // id must parse from nameFromCompiler (view_to_number<size_t>) and be within file.
+    descriptor.nameFromCompiler = "0";
+    descriptor.precision = ov::element::f32;
+    // This shape is chosen to overflow unchecked byte-size calculations.
+    descriptor.shapeFromCompiler = ov::PartialShape({1ll << 32, 1ll << 32, 4});
+    descriptor.isInitInputWeights = true;
+    descriptor.indexUsedByDriver = 0;
+
+    NetworkMetadata meta;
+    meta.name = "init_schedule";
+    meta.inputs.push_back(descriptor);
+
+    std::vector<NetworkMetadata> initNetworkMetadata{meta};
+
+    // Overflow should be detected and rejected.
+    EXPECT_THROW(get_all_constants_memory_mapped(weightsPath, initNetworkMetadata), ov::Exception);
+}


### PR DESCRIPTION
… test

### Tickets:
 - [CVS-191885](https://jira.devtools.intel.com/browse/CVS-191885)

### Details:
Replace unchecked memory-size computation in weightless constant mapping with get_memory_size_safe and assert on overflow before using the value.

Add a unit test that crafts an oversized shape and verifies overflow is rejected with an exception.

### AI Assistance:
- AI assistance used: yes
- Bug root cause was found by AI and a unit test was added.