### PR TITLE
[TRANSFORMATIONS] Fix NCHW/NHWC layout mismatch in ConvertWeightCompressedConv1x1ToMatmul

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
@@ -340,9 +340,32 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
             ov::copy_runtime_info(m.get_matched_nodes(), final_out);
             ov::replace_node(consumer_transpose, final_out);
         } else if (consumer_reshape) {
-            // Reshape consumer found - clone reshape with matmul output
+            // final_out is NHWC (channel last), but Reshape does not reorder elements, so
+            // consumer_reshape (built for the Convolution's NCHW output) needs NCHW input too.
+            // Group as [N, H, W, Cout] (N inferred, element order already matches final_out) then
+            // permute to NCHW.
+            const auto& conv_out_pshape = conv1x1->get_output_partial_shape(0);
+            if (conv_out_pshape.rank() != 4 || conv_out_pshape[1].is_dynamic() ||
+                conv_out_pshape[2].is_dynamic() || conv_out_pshape[3].is_dynamic()) {
+                return false;
+            }
+            auto nhwc_shape_const = std::make_shared<ov::op::v0::Constant>(
+                ov::element::i32,
+                ov::Shape{4},
+                std::vector<int64_t>{-1,
+                                      conv_out_pshape[2].get_length(),
+                                      conv_out_pshape[3].get_length(),
+                                      conv_out_pshape[1].get_length()});
+            auto final_out_nhwc = std::make_shared<ov::op::v1::Reshape>(final_out, nhwc_shape_const, false);
+            ov::copy_runtime_info(conv1x1, final_out_nhwc);
+            auto nhwc_to_nchw_order = std::make_shared<ov::op::v0::Constant>(ov::element::i32,
+                                                                             ov::Shape{4},
+                                                                             std::vector<int64_t>{0, 3, 1, 2});
+            auto final_out_nchw = std::make_shared<ov::op::v1::Transpose>(final_out_nhwc, nhwc_to_nchw_order);
+            ov::copy_runtime_info(conv1x1, final_out_nchw);
+
             auto reshape_order = consumer_reshape->get_input_node_shared_ptr(1);
-            auto reshape_final = consumer_reshape->clone_with_new_inputs({final_out, reshape_order});
+            auto reshape_final = consumer_reshape->clone_with_new_inputs({final_out_nchw, reshape_order});
             reshape_final->set_friendly_name(consumer_reshape->get_friendly_name());
             ov::copy_runtime_info(m.get_matched_nodes(), reshape_final);
             ov::replace_node(consumer_reshape, reshape_final);

--- a/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
@@ -208,6 +208,16 @@ std::shared_ptr<ov::Model> gen_model_ref(const Conv1x1ToMatmulTestParams& p) {
 
     std::shared_ptr<ov::Node> out_node = current_node;
     if (p.activation_op_type == "Reshape" || p.activation_op_type == "None_Reshape") {
+        // The transformation always restores NCHW order (Reshape to [N, H, W, Cout] + Transpose)
+        // before feeding a matched output Reshape, since Reshape never reorders elements and the
+        // matched Reshape was built against the original Convolution's NCHW output. Here H = W = 1,
+        // so the NCHW/NHWC shapes coincide, but the nodes are still inserted.
+        auto nhwc_shape_const =
+            ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {(int)input_batch, 1, 1, 15});
+        out_node = std::make_shared<ov::opset1::Reshape>(out_node, nhwc_shape_const, false);
+        auto nhwc_to_nchw_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
+        out_node = std::make_shared<ov::opset1::Transpose>(out_node, nhwc_to_nchw_const);
+
         auto reshape_const = ov::opset1::Constant::create(ov::element::i32, ov::Shape{4}, {(int)input_batch, 1, 1, 15});
         out_node = std::make_shared<ov::opset1::Reshape>(out_node, reshape_const, false);
     }


### PR DESCRIPTION
### Details:
 - `MatMul` (transpose_b=true) produces output with the channel dimension last (e.g. `[N, H, W, Cout]`), while the `Convolution` it replaces always produces channel dimension second (NCHW: `[N, Cout, H, W]`).
 - When the matched output consumer is a `Transpose`, this is harmless - the `Transpose` is dropped and the channel-last `MatMul` output is reused directly, since it already matches what that `Transpose` would have produced.
 - But when the output consumer is a `Reshape`, the code fed the channel-last `MatMul` output straight into it. `Reshape` never reorders elements, and the matched `Reshape` was built assuming NCHW element order (like the original `Convolution`'s output) - so this silently scrambled the channel/spatial ordering of the data whenever H*W > 1.
 - This PR restores NCHW order (`Reshape` to `[N, H, W, Cout]` + `Transpose`) before handing off to the matched `Reshape`, mirroring what the "no consumer" branch already does. It also bails out gracefully (rather than asserting) if the `Convolution`'s output shape isn't statically known.
 - Updates the existing parameterized unit test's reference model, which otherwise would no longer structurally match pass output for the "Reshape" `activation_op_type` cases.

### Tickets:
 - *N/A*

### AI Assistance:
 - AI assistance used: yes
 - Used an AI coding assistant to help bisect the regression, trace tensor shapes/types via debug instrumentation, draft the fix and the updated test reference model, and write this description. The root cause, fix design, and correctness of the NCHW restoration logic were manually reviewed and verified by running the affected unit tests and by reproducing/validating the original accuracy regression scenario end-to-end (accuracy restored from failing to passing) before submission.
