### PR TITLE
[GPU] Allow scatter_*_update kernel to skip stage1 copy.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/scatter_elements_update_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/scatter_elements_update_inst.h
@@ -9,6 +9,18 @@
 
 namespace cldnn {
 
+template <>
+struct typed_program_node<scatter_elements_update> : public typed_program_node_base<scatter_elements_update> {
+private:
+    using parent = typed_program_node_base<scatter_elements_update>;
+
+public:
+    using parent::parent;
+    program_node& input(std::size_t i = 0) const { return get_dependency(i); }
+
+    std::vector<size_t> get_shape_infer_dependencies() const override { return {0}; }
+};
+
 using scatter_elements_update_node = typed_program_node<scatter_elements_update>;
 
 template <>

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.cpp
@@ -244,6 +244,10 @@ bool ScatterElementsUpdateKernelRef::SkipKernelExecution(const scatter_elements_
         if (params.outputs[0].LogicalSize() != 0 && params.outputs[0] != params.inputs[0]) {
             return false;
         }
+        GPU_DEBUG_TRACE_DETAIL << "[scatter_elements_update_ref] check init stage with inplace[" << params.is_inplace << "]" << std::endl;
+        if (params.is_inplace) {
+            return true;
+        }
     }
     return KernelData::SkipKernelExecution(params);
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.h
@@ -16,6 +16,7 @@ struct scatter_elements_update_params : public base_params {
     ScatterUpdateAxis axis{ScatterUpdateAxis::BATCH};
     ScatterUpdateReduction mode{ScatterUpdateReduction::NONE};
     bool use_init_val{true};
+    bool is_inplace{false};
 };
 
 class ScatterElementsUpdateKernelRef : public KernelBaseOpenCL {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.cpp
@@ -280,6 +280,10 @@ void ScatterUpdateKernelRef::GetUpdateDispatchDataFunc(KernelData& kd) const {
             kd.kernels[i].params.workGroups.global = dispatchData.gws;
             kd.kernels[i].params.workGroups.local = dispatchData.lws;
             kd.kernels[i].skip_execution = KernelData::SkipKernelExecution(prim_params);
+            if (i == 0 && !kd.kernels[i].skip_execution) {
+                GPU_DEBUG_TRACE_DETAIL << "[scatter_update_ref] check init stage with inplace[" << prim_params.is_inplace << "]" << std::endl;
+                kd.kernels[i].skip_execution = prim_params.is_inplace;
+            }
         }
     };
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.h
@@ -14,6 +14,7 @@ struct scatter_update_params : public base_params {
     scatter_update_params() : base_params(KernelType::SCATTER_UPDATE), axis(ScatterUpdateAxis::BATCH) {}
 
     ScatterUpdateAxis axis;
+    bool is_inplace{false};
 };
 
 class ScatterUpdateKernelRef : public KernelBaseOpenCL {


### PR DESCRIPTION
### Details:

Current scatter_update/scatter_element_update kernel is always doing a full copy at stage1.
For our later enabling, we would like to conditionally skip this stage (when input&output are the same tensor).

This PR adds a flag to indicate stage1 should be skipped. It's not used in actual primitive yet, but could be a future optimization.

### Tickets:
 - *CVS-191894*

### AI Assistance:
 - *AI assistance used: no
