### PR TITLE
[CPU] Add native LTX-Video RoPE kernel and enable the fusion

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -267,18 +267,11 @@ struct RoPE::RoPEExecutorLtxVideo : public RoPE::Executor {
         auto seq_len = t_src.size(1);
         auto rotary_dims = m_config.rotary_ndims;
 
-        OPENVINO_ASSERT(
-            (t_cos.size(0) == 1 || t_cos.size(0) == batch_size) && (t_cos.size(1) == 1 || t_cos.size(1) == seq_len) &&
-                (t_sin.size(0) == 1 || t_sin.size(0) == batch_size) && (t_sin.size(1) == 1 || t_sin.size(1) == seq_len),
-            "RoPE LTX: cos/sin batch/seq must be 1 or match the input");
-
         cpu_parallel->parallel_for2d(batch_size, seq_len, [&](size_t b, size_t p) {
             auto* x = t_src.ptr<T>(b, p);
-            // cos/sin tables may broadcast over batch/seq
-            auto cb = b < t_cos.size(0) ? b : 0;
-            auto cp = p < t_cos.size(1) ? p : 0;
-            const float* cos = t_cos.ptr<float>(cb, cp);
-            const float* sin = t_sin.ptr<float>(cb, cp);
+            // allow_broadcast handles size-1 cos/sin batch/seq natively
+            const float* cos = &t_cos.at<float>({b, p, 0}, true);
+            const float* sin = &t_sin.at<float>({b, p, 0}, true);
             auto* dst = t_dst.ptr<T>(b, p);
 
             for (size_t r = 0; r < rotary_dims; r += 2) {

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -245,8 +245,9 @@ struct RoPE::RoPEExecutorInterleaved : public RoPE::Executor {
 };
 
 // LTX-Video 3D spatial-temporal RoPE: x [batch, seq, rotary_ndims] with separate full-width cos/sin
-// tables. Interleaved complex pairs, rotation accumulated in f32 (cos/sin ports are f32) and rounded
-// once on store, so bf16 stays as precise as PyTorch.
+// tables. Interleaved complex pairs; each element keeps its own cos/sin (the two halves of a pair
+// need not share an angle). Accumulated in f32 (cos/sin ports are f32) and rounded once on store,
+// so bf16 stays as precise as PyTorch.
 template <typename T>
 struct RoPE::RoPEExecutorLtxVideo : public RoPE::Executor {
     const op::internal::RoPE::Config& m_config;
@@ -279,7 +280,7 @@ struct RoPE::RoPEExecutorLtxVideo : public RoPE::Executor {
                 auto real = static_cast<float>(x[r]);
                 auto imag = static_cast<float>(x[r + 1]);
                 dst[r] = static_cast<T>(cos[r] * real - sin[r] * imag);
-                dst[r + 1] = static_cast<T>(sin[r] * real + cos[r] * imag);
+                dst[r + 1] = static_cast<T>(sin[r + 1] * real + cos[r + 1] * imag);
             }
         });
     }

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -267,6 +267,11 @@ struct RoPE::RoPEExecutorLtxVideo : public RoPE::Executor {
         auto seq_len = t_src.size(1);
         auto rotary_dims = m_config.rotary_ndims;
 
+        OPENVINO_ASSERT(
+            (t_cos.size(0) == 1 || t_cos.size(0) == batch_size) && (t_cos.size(1) == 1 || t_cos.size(1) == seq_len) &&
+                (t_sin.size(0) == 1 || t_sin.size(0) == batch_size) && (t_sin.size(1) == 1 || t_sin.size(1) == seq_len),
+            "RoPE LTX: cos/sin batch/seq must be 1 or match the input");
+
         cpu_parallel->parallel_for2d(batch_size, seq_len, [&](size_t b, size_t p) {
             auto* x = t_src.ptr<T>(b, p);
             // cos/sin tables may broadcast over batch/seq
@@ -513,6 +518,7 @@ void RoPE::initSupportedPrimitiveDescriptors() {
             rtPrecision = ov::element::f32;
         }
     } else if (m_config.is_ltx_video) {
+        CPU_NODE_ASSERT(m_config.rotary_ndims % 2 == 0, "rotary_ndims must be even for LTX RoPE");
         // LTX sets both is_interleaved and is_ltx_video, so this must be checked first
         if (rtPrecision == ov::element::f16) {
             m_executor = std::make_shared<RoPEExecutorLtxVideo<ov::float16>>(m_config);

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -244,6 +244,47 @@ struct RoPE::RoPEExecutorInterleaved : public RoPE::Executor {
     }
 };
 
+// LTX-Video 3D spatial-temporal RoPE: x [batch, seq, rotary_ndims] with separate full-width cos/sin
+// tables. Interleaved complex pairs, rotation accumulated in f32 (cos/sin ports are f32) and rounded
+// once on store, so bf16 stays as precise as PyTorch.
+template <typename T>
+struct RoPE::RoPEExecutorLtxVideo : public RoPE::Executor {
+    const op::internal::RoPE::Config& m_config;
+
+    explicit RoPEExecutorLtxVideo(const op::internal::RoPE::Config& config) : m_config(config) {}
+
+    void execute([[maybe_unused]] const dnnl::stream& strm,
+                 const std::vector<MemoryPtr>& inputs,
+                 const std::vector<MemoryPtr>& outputs,
+                 const CpuParallelPtr& cpu_parallel) override {
+        ov::intel_cpu::PlainTensor t_src(inputs[0]);
+        ov::intel_cpu::PlainTensor t_cos(inputs[1]);
+        ov::intel_cpu::PlainTensor t_sin(inputs[2]);
+        ov::intel_cpu::PlainTensor t_dst(outputs[0]);
+
+        auto batch_size = t_src.size(0);
+        auto seq_len = t_src.size(1);
+        auto rotary_dims = m_config.rotary_ndims;
+
+        cpu_parallel->parallel_for2d(batch_size, seq_len, [&](size_t b, size_t p) {
+            auto* x = t_src.ptr<T>(b, p);
+            // cos/sin tables may broadcast over batch/seq
+            auto cb = b < t_cos.size(0) ? b : 0;
+            auto cp = p < t_cos.size(1) ? p : 0;
+            const float* cos = t_cos.ptr<float>(cb, cp);
+            const float* sin = t_sin.ptr<float>(cb, cp);
+            auto* dst = t_dst.ptr<T>(b, p);
+
+            for (size_t r = 0; r < rotary_dims; r += 2) {
+                auto real = static_cast<float>(x[r]);
+                auto imag = static_cast<float>(x[r + 1]);
+                dst[r] = static_cast<T>(cos[r] * real - sin[r] * imag);
+                dst[r + 1] = static_cast<T>(sin[r] * real + cos[r] * imag);
+            }
+        });
+    }
+};
+
 template <typename T>
 struct RoPE::RoPEExecutorChatGLM : public RoPE::Executor {
     const op::internal::RoPE::Config& m_config;
@@ -468,6 +509,16 @@ void RoPE::initSupportedPrimitiveDescriptors() {
             m_executor = std::make_shared<RoPEExecutorChatGLM<ov::bfloat16>>(m_config);
         } else {
             m_executor = std::make_shared<RoPEExecutorChatGLM<float>>(m_config);
+            rtPrecision = ov::element::f32;
+        }
+    } else if (m_config.is_ltx_video) {
+        // LTX sets both is_interleaved and is_ltx_video, so this must be checked first
+        if (rtPrecision == ov::element::f16) {
+            m_executor = std::make_shared<RoPEExecutorLtxVideo<ov::float16>>(m_config);
+        } else if (rtPrecision == ov::element::bf16) {
+            m_executor = std::make_shared<RoPEExecutorLtxVideo<ov::bfloat16>>(m_config);
+        } else {
+            m_executor = std::make_shared<RoPEExecutorLtxVideo<float>>(m_config);
             rtPrecision = ov::element::f32;
         }
     } else if (m_config.is_interleaved) {

--- a/src/plugins/intel_cpu/src/nodes/rope.h
+++ b/src/plugins/intel_cpu/src/nodes/rope.h
@@ -49,6 +49,8 @@ private:
     template <typename T>
     struct RoPEExecutorInterleaved;
     template <typename T>
+    struct RoPEExecutorLtxVideo;
+    template <typename T>
     struct RoPEExecutorChatGLM;
     template <typename T>
     struct RoPEExecutorQwen;

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1140,7 +1140,6 @@ void Transformations::PostLpt() {
     CPU_REGISTER_PASS_X64(postLPTPassManager, ov::pass::RoPEFusion, true);
     CPU_REGISTER_PASS_ARM64(postLPTPassManager, ov::pass::RoPEFusion, true);
     CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionFlux);
-    CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionLtxVideo);
     CPU_REGISTER_PASS_X64(postLPTPassManager, CausalMaskPreprocessFusion);
 
 #if defined(OPENVINO_ARCH_X86_64)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
@@ -93,5 +93,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_RoPETestGPTOSS,
                             ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          RoPETestGPTOSS::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_RoPETestLtxVideo,
+                         RoPETestLtxVideo,
+                         ::testing::Combine(::testing::Values(ov::element::f32),
+                                            ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                         RoPETestLtxVideo::getTestCaseName);
+
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details
LTX-Video's 3-axis RoPE was left decomposed on CPU because the fusion was disabled, the existing interleaved executor can't handle LTX's 3D layout with separate full-width cos/sin tables.

This PR adds a native RoPEExecutorLtxVideo that computes the rotation in f32 and rounds once to the output type, enables RoPEFusionLtxVideo on CPU (same fused op as GPU), and instantiates the shared RoPETestLtxVideo test for CPU.

RoPE subgraph, seq 2520 × 2048, median CPU latency, fused vs decomposed:

| precision | decomposed | fused | speedup |
|-----------|------------|--------|---------|
| f32       | 23.05 ms   | 11.26 ms | **2.05×** |
| bf16      | 23.19 ms   | 14.69 ms | **1.58×** |

f16 stays on the decomposed path for now. unlike bf16, its pipeline runs ConvertPrecision before RoPEFusion, so the fusion doesn't fire. Enabling f16 fusion is a follow-up. and is anyways producing NaN as of now (ref #37039).
```mermaid
flowchart LR
  subgraph Before["Before — decomposed (~8 ops)"]
    direction LR
    x1[x] --> R1[Reshape]
    R1 --> SP[Split]
    SP -->|imag| NEG["Multiply(-1)"]
    NEG --> CC[Concat]
    SP -->|real| CC
    CC --> R2[Reshape]
    x1 --> MC["Multiply · cos"]
    cos1[cos] --> MC
    R2 --> MS["Multiply · sin"]
    sin1[sin] --> MS
    MC --> ADD[Add]
    MS --> ADD
    ADD --> o1[out]
  end
  subgraph After["After — fused"]
    direction LR
    x2[x] --> ROPE["RoPE(is_ltx_video)"]
    cos2[cos] --> ROPE
    sin2[sin] --> ROPE
    ROPE --> o2[out]
  end
```

### AI Assistance:
 - *AI assistance used: no / yes* yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
