### PR TITLE
[NPU] Add ZE_MEMORY_TYPE_HOST_IMPORTED as supported memory type

### DIFF
--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -175,8 +175,8 @@ static inline uint64_t get_l0_context_memory_allocation_id(ze_context_handle_t h
     desc.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
     auto res = intel_npu::zeMemGetAllocProperties(handle, ptr, &desc, nullptr);
     if (res == ZE_RESULT_SUCCESS && desc.id > 0 &&
-        ((desc.type == ZE_MEMORY_TYPE_HOST) || (desc.type == ZE_MEMORY_TYPE_DEVICE) ||
-         (desc.type == ZE_MEMORY_TYPE_SHARED))) {
+        ((desc.type == ZE_MEMORY_TYPE_HOST) || (desc.type == ZE_MEMORY_TYPE_HOST_IMPORTED) ||
+         (desc.type == ZE_MEMORY_TYPE_DEVICE) || (desc.type == ZE_MEMORY_TYPE_SHARED))) {
         return desc.id;
     }
 


### PR DESCRIPTION
### Details:
 - *Add ZE_MEMORY_TYPE_HOST_IMPORTED as supported memory type*

### Tickets:
 - *EISW-223542*

### AI Assistance:
 - *AI assistance used: no*
