### PR TITLE
fix(inference): log warning when user-provided compiled_blob fails to import

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -244,7 +244,12 @@ ov::SoPtr<ov::ICompiledModel> import_compiled_model(const ov::Plugin& plugin,
             const auto& compiled_blob = blob_hint->second.as<ov::Tensor>();
             compiled_model = context ? plugin.import_model(compiled_blob, context, config)
                                      : plugin.import_model(compiled_blob, config);
+        } catch (const std::exception& ex) {
+            OPENVINO_WARN("Failed to import model from compiled blob hint: ", ex.what(),
+                          ". Falling back to compilation.");
         } catch (...) {
+            OPENVINO_WARN("Failed to import model from compiled blob hint: unknown exception. ",
+                          "Falling back to compilation.");
         }
     }
     return compiled_model;


### PR DESCRIPTION
## Description

Fix silent exception swallowing in `import_compiled_model()` when a user-provided `compiled_blob` fails to import.

### Problem

In `src/inference/src/dev/core_impl.cpp`, the `import_compiled_model()` function catches all exceptions with `catch (...) {}` and silently discards them. When a user explicitly provides a `compiled_blob` hint but the import fails, the failure is completely hidden — the code silently falls back to compilation, ignoring the user's intent. This makes debugging extremely difficult.

### Fix

Replace the empty `catch (...) {}` with two catch blocks that emit `OPENVINO_WARN` log messages:

- `catch (const std::exception& ex)` — logs the exception message via `ex.what()`
- `catch (...)` — logs an unknown exception warning

Both cases still fall back to compilation, preserving the original behavior, but now the user is informed about the failure.

### Changes

- `src/inference/src/dev/core_impl.cpp`: Added `OPENVINO_WARN` logging in `import_compiled_model()` catch blocks
