### PR TITLE
[NPUW] Add KVCacheBlockManager::truncate_allocated

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
@@ -178,6 +178,36 @@ void KVCacheBlockManager::clear_all() {
     release(0);
 }
 
+void KVCacheBlockManager::truncate_allocated(uint32_t keep_count) {
+    const auto allocated = get_allocated_blocks();
+    OPENVINO_ASSERT(keep_count <= allocated.size(),
+                    "KVCacheBlockManager: cannot truncate to ",
+                    keep_count,
+                    " blocks, only ",
+                    allocated.size(),
+                    " are allocated");
+
+    // Deallocate the suffix, keeping device tensors warm for quick reuse.
+    for (size_t i = keep_count; i < allocated.size(); ++i) {
+        auto& block = blocks_[allocated[i]];
+        block.is_allocated = false;
+        block.num_tokens = 0;
+    }
+
+    // Rebuild the free stack so the smallest free ID is allocated first. This keeps
+    // logical append order intact when the freed suffix IDs are reacquired.
+    std::stack<uint32_t> empty;
+    free_block_ids_.swap(empty);
+    for (uint32_t i = max_blocks_; i > 0; --i) {
+        if (!blocks_[i - 1].is_allocated) {
+            free_block_ids_.push(i - 1);
+        }
+    }
+
+    LOG_DEBUG("KVCacheBlockManager: truncated to " << keep_count << " blocks, " << (allocated.size() - keep_count)
+                                                   << " suffix block(s) freed");
+}
+
 void KVCacheBlockManager::validate_block_id(uint32_t block_id) const {
     if (block_id >= max_blocks_) {
         OPENVINO_THROW("KVCacheBlockManager: Invalid block ID ", block_id, " (valid range: 0-", max_blocks_ - 1, ")");

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
@@ -166,16 +166,24 @@ void KVCacheBlockManager::release(uint32_t keep_warm_count) {
                                                    << keep_warm_count << " warm");
     }
 
-    // Rebuild free stack (push in reverse order so block 0 is on top)
-    std::stack<uint32_t> empty;
-    free_block_ids_.swap(empty);
-    for (uint32_t i = max_blocks_; i > 0; --i) {
-        free_block_ids_.push(i - 1);
-    }
+    rebuild_free_block_ids();
 }
 
 void KVCacheBlockManager::clear_all() {
     release(0);
+}
+
+void KVCacheBlockManager::rebuild_free_block_ids() {
+    // Push in descending ID order so the smallest free ID ends up on top of the stack
+    // and is handed out first. Allocation order then follows block ID order, which is
+    // what keeps a truncated prefix contiguous when the freed suffix is reacquired.
+    std::stack<uint32_t> empty;
+    free_block_ids_.swap(empty);
+    for (uint32_t i = max_blocks_; i > 0; --i) {
+        if (!blocks_[i - 1].is_allocated) {
+            free_block_ids_.push(i - 1);
+        }
+    }
 }
 
 void KVCacheBlockManager::truncate_allocated(uint32_t keep_count) {
@@ -194,15 +202,7 @@ void KVCacheBlockManager::truncate_allocated(uint32_t keep_count) {
         block.num_tokens = 0;
     }
 
-    // Rebuild the free stack so the smallest free ID is allocated first. This keeps
-    // logical append order intact when the freed suffix IDs are reacquired.
-    std::stack<uint32_t> empty;
-    free_block_ids_.swap(empty);
-    for (uint32_t i = max_blocks_; i > 0; --i) {
-        if (!blocks_[i - 1].is_allocated) {
-            free_block_ids_.push(i - 1);
-        }
-    }
+    rebuild_free_block_ids();
 
     LOG_DEBUG("KVCacheBlockManager: truncated to " << keep_count << " blocks, " << (allocated.size() - keep_count)
                                                    << " suffix block(s) freed");

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
@@ -183,6 +183,16 @@ private:
     std::shared_ptr<const ov::IPlugin> plugin_;  ///< Plugin for memory allocation
 
     /**
+     * @brief Rebuild the free block ID stack from the current allocation flags.
+     *
+     * Pushes in descending ID order so the smallest free ID is handed out first,
+     * keeping allocation order aligned with block ID order. Shared by every path
+     * that changes allocation state, since the ordering is what keeps a retained
+     * prefix contiguous once freed IDs are reacquired.
+     */
+    void rebuild_free_block_ids();
+
+    /**
      * @brief Validate block ID
      */
     void validate_block_id(uint32_t block_id) const;

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
@@ -128,6 +128,20 @@ public:
     void clear_all();
 
     /**
+     * @brief Truncate the allocated block list to its first keep_count blocks.
+     *
+     * Used by continuous prefill to discard the suffix of a previous turn while
+     * retaining the shared prefix. Retained blocks keep their IDs, order, token
+     * counts and tensors. Suffix blocks are deallocated with token counts zeroed
+     * and their device tensors kept warm, and subsequent allocations return the
+     * freed IDs in ascending order so logical append order is preserved.
+     *
+     * @param keep_count Number of leading allocated blocks to retain. Must not
+     *                   exceed the current allocated count.
+     */
+    void truncate_allocated(uint32_t keep_count);
+
+    /**
      * @brief Get block size (tokens per block)
      */
     uint32_t get_block_size() const {

--- a/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
@@ -248,6 +248,57 @@ TEST_F(KVCacheBlockManagerTest, InvalidBlockID) {
         << "Updating invalid block ID should throw";
 }
 
+// Truncation for continuous prefill keeps the leading blocks and frees the suffix.
+TEST_F(KVCacheBlockManagerTest, TruncateAllocatedKeepsPrefix) {
+    std::vector<uint32_t> ids;
+    for (int i = 0; i < 5; ++i) {
+        auto id = manager->allocate_block();
+        ASSERT_TRUE(id.has_value());
+        manager->update_block_tokens(id.value(), block_size);
+        ids.push_back(id.value());
+    }
+
+    manager->truncate_allocated(2);
+
+    auto allocated = manager->get_allocated_blocks();
+    ASSERT_EQ(allocated.size(), 2u);
+    EXPECT_EQ(allocated[0], ids[0]);
+    EXPECT_EQ(allocated[1], ids[1]);
+    // Retained blocks keep their token counts and tensors.
+    EXPECT_EQ(manager->get_block_tokens(ids[0]), block_size);
+    EXPECT_EQ(manager->get_block_tokens(ids[1]), block_size);
+    EXPECT_NE(manager->get_block_tensor(ids[0]), nullptr);
+    EXPECT_EQ(manager->num_free_blocks(), max_blocks - 2);
+}
+
+TEST_F(KVCacheBlockManagerTest, TruncateAllocatedPreservesAppendOrder) {
+    std::vector<uint32_t> ids;
+    for (int i = 0; i < 4; ++i) {
+        auto id = manager->allocate_block();
+        ASSERT_TRUE(id.has_value());
+        ids.push_back(id.value());
+    }
+
+    manager->truncate_allocated(1);
+
+    // Freed suffix IDs come back in ascending order so logical append order holds.
+    auto first = manager->allocate_block();
+    auto second = manager->allocate_block();
+    ASSERT_TRUE(first.has_value() && second.has_value());
+    EXPECT_EQ(first.value(), ids[1]);
+    EXPECT_EQ(second.value(), ids[2]);
+    // Reacquired blocks start empty.
+    EXPECT_EQ(manager->get_block_tokens(first.value()), 0u);
+}
+
+TEST_F(KVCacheBlockManagerTest, TruncateAllocatedRejectsOverKeep) {
+    ASSERT_TRUE(manager->allocate_block().has_value());
+    EXPECT_THROW(manager->truncate_allocated(2), ov::Exception);
+    // Truncating to the full allocated count is a no-op.
+    manager->truncate_allocated(1);
+    EXPECT_EQ(manager->get_allocated_blocks().size(), 1u);
+}
+
 // Test 11: Get Tensor After Clear (memory kept, state reset)
 TEST_F(KVCacheBlockManagerTest, GetTensorAfterClear) {
     auto block_id = manager->allocate_block();

--- a/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
@@ -291,6 +291,31 @@ TEST_F(KVCacheBlockManagerTest, TruncateAllocatedPreservesAppendOrder) {
     EXPECT_EQ(manager->get_block_tokens(first.value()), 0u);
 }
 
+TEST_F(KVCacheBlockManagerTest, TruncateAllocatedKeepsSuffixTensorsWarm) {
+    std::vector<uint32_t> ids;
+    std::vector<void*> data_before;
+    for (int i = 0; i < 3; ++i) {
+        auto id = manager->allocate_block();
+        ASSERT_TRUE(id.has_value());
+        ids.push_back(id.value());
+        data_before.push_back(manager->get_block_tensor(id.value())->data());
+    }
+
+    manager->truncate_allocated(1);
+
+    // Retained prefix keeps its tensor untouched.
+    EXPECT_EQ(manager->get_block_tensor(ids[0])->data(), data_before[0]);
+
+    // Suffix tensors are kept warm, so reacquiring those IDs must not re-allocate.
+    // Without this the first prefill chunk of a continuation pays allocation latency.
+    for (size_t i = 1; i < ids.size(); ++i) {
+        auto reacquired = manager->allocate_block();
+        ASSERT_TRUE(reacquired.has_value());
+        EXPECT_EQ(reacquired.value(), ids[i]);
+        EXPECT_EQ(manager->get_block_tensor(reacquired.value())->data(), data_before[i]);
+    }
+}
+
 TEST_F(KVCacheBlockManagerTest, TruncateAllocatedRejectsOverKeep) {
     ASSERT_TRUE(manager->allocate_block().has_value());
     EXPECT_THROW(manager->truncate_allocated(2), ov::Exception);


### PR DESCRIPTION
### Details
Adds `KVCacheBlockManager::truncate_allocated(keep_count)`, which truncates the allocated block list to its first `keep_count` blocks.

Postconditions: retained blocks keep their IDs, order, token counts and tensors; suffix blocks are deallocated with token counts zeroed and their device tensors kept warm; the free structure is rebuilt so subsequent allocations return freed IDs in ascending order, preserving logical append order.

This is the primitive continuous prefill needs to discard the suffix of a previous chat turn while retaining the shared prefix. There are no callers in this PR.

**PR 1 of 4** for EISW-227938 (continuous prefill). Independent of the rest of the series and safe to merge on its own.
- PR 2: propose/grant protocol and capability property
- PR 3: contiguous KV strategy and delta prefill path
- PR 4: block-based KV cache continuation
- Companion GenAI PR: openvinotoolkit/openvino.genai#4237

### Validation
3 new unit tests in `kv_cache_block_manager_test.cpp` (prefix retention, append order after reacquisition, over-keep rejection). Full `*BlockManager*` suite green (17 tests) with this branch built standalone.

### Tickets
- EISW-227938