### PR TITLE
[CPU] Remove x64 `cpu_isa_traits.hpp` / `xbyak` dependency from architecture-common files

### DIFF
--- a/src/inference/dev_api/openvino/runtime/system_conf.hpp
+++ b/src/inference/dev_api/openvino/runtime/system_conf.hpp
@@ -126,6 +126,13 @@ OPENVINO_RUNTIME_API bool with_cpu_x86_avx2();
 OPENVINO_RUNTIME_API bool with_cpu_x86_avx2_vnni();
 
 /**
+ * @brief      Checks whether CPU supports AVX2_VNNI_2 capability
+ * @ingroup    ov_dev_api_system_conf
+ * @return     `True` is AVX2_VNNI_2 instructions are available, `false` otherwise
+ */
+OPENVINO_RUNTIME_API bool with_cpu_x86_avx2_vnni_2();
+
+/**
  * @brief      Checks whether CPU supports AVX 512 capability
  * @ingroup    ov_dev_api_system_conf
  * @return     `True` is AVX512F (foundation) instructions are available, `false` otherwise

--- a/src/inference/src/system_conf.cpp
+++ b/src/inference/src/system_conf.cpp
@@ -76,6 +76,11 @@ bool with_cpu_x86_avx2_vnni() {
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI);
 }
 
+bool with_cpu_x86_avx2_vnni_2() {
+    return get_cpu_info().has(Xbyak::util::Cpu::tAVX2 | Xbyak::util::Cpu::tAVX_VNNI | Xbyak::util::Cpu::tAVX_VNNI_INT8 |
+                              Xbyak::util::Cpu::tAVX_NE_CONVERT);
+}
+
 bool with_cpu_x86_avx512f() {
     return get_cpu_info().has(Xbyak::util::Cpu::tAVX512F);
 }
@@ -140,6 +145,9 @@ bool with_cpu_x86_avx2() {
     return false;
 }
 bool with_cpu_x86_avx2_vnni() {
+    return false;
+}
+bool with_cpu_x86_avx2_vnni_2() {
     return false;
 }
 bool with_cpu_x86_avx512f() {

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "internal_properties.hpp"
 #include "openvino/core/any.hpp"
 #include "openvino/core/except.hpp"
@@ -21,6 +20,7 @@
 #include "openvino/runtime/intel_cpu/properties.hpp"
 #include "openvino/runtime/internal_properties.hpp"
 #include "openvino/runtime/properties.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "openvino/runtime/weightless_properties_utils.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
@@ -33,7 +33,6 @@
 namespace ov::intel_cpu {
 
 using namespace ov::threading;
-using namespace dnnl::impl::cpu::x64;
 
 Config::Config() {
     CPU_DEBUG_CAP_ENABLE(applyDebugCapsProperties());
@@ -524,7 +523,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             }
 #    endif
 #endif
-            if (mayiuse(avx512_core_bf16)) {
+            if (ov::with_cpu_x86_bfloat16()) {
                 inferencePrecision = ov::element::bf16;
             }
         } else {

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -11,8 +11,11 @@
 #include <common/utils.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
+#include <string>
+#include <vector>
 
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -11,11 +11,8 @@
 #include <common/utils.hpp>
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
-#include <string>
-#include <vector>
 
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"
@@ -43,6 +40,7 @@
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 #    include <xbyak/xbyak.h>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/injectors/jit_uni_depthwise_injector.hpp"
 #    include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #    include "cpu/x64/jit_generator.hpp"

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -17,7 +17,6 @@
 #include <string>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"
 #include "eltwise.h"
@@ -36,6 +35,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/binary_convolution.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
 #include "utils/ngraph_utils.hpp"
@@ -62,9 +62,11 @@
 using namespace dnnl;
 using namespace dnnl::impl;
 using namespace dnnl::impl::cpu;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 namespace ov::intel_cpu::node {
 #if defined(OPENVINO_ARCH_X86_64)
@@ -1009,11 +1011,11 @@ BinaryConvolution::BinaryConvolution(const std::shared_ptr<ov::Node>& op, const 
         paddingL = binConv->get_pads_begin();
         paddingR = binConv->get_pads_end();
 
-        if (mayiuse(x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             implType = impl_desc_type::jit_avx512;
-        } else if (mayiuse(x64::avx2)) {
+        } else if (ov::with_cpu_x86_avx2()) {
             implType = impl_desc_type::jit_avx2;
-        } else if (mayiuse(x64::sse41)) {
+        } else if (ov::with_cpu_x86_sse42()) {
             implType = impl_desc_type::jit_sse42;
         } else {
             implType = impl_desc_type::ref;

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -37,6 +37,7 @@
 
 #    include <array>
 #    include <common/c_types_map.hpp>
+#    include <cpu/x64/cpu_isa_traits.hpp>
 #    include <cpu/x64/jit_generator.hpp>
 
 #    include "kernels/x64/jit_kernel.hpp"

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -30,6 +29,7 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/custom/color_convert.hpp"
 
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
@@ -44,8 +44,10 @@
 
 using namespace dnnl::impl;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 namespace ov::intel_cpu::node {
 namespace {
@@ -312,7 +314,7 @@ ColorConvert::Converter::PrimitiveDescs supportedPrimitiveDescs(Node* node) {
 
     descs.emplace_back(std::vector<PortConfigurator>{node->getOriginalInputsNumber(), {layout, precision}},
                        std::vector<PortConfigurator>{{layout, precision}},
-                       mayiuse(cpu_isa_t::sse41) ? impl_desc_type::jit_uni : impl_desc_type::ref,
+                       ov::with_cpu_x86_sse42() ? impl_desc_type::jit_uni : impl_desc_type::ref,
                        true);
 
     return descs;
@@ -643,7 +645,7 @@ ColorConvert::Converter::PrimitiveDescs supportedPrimitiveDescs(Node* node) {
 
     descs.emplace_back(std::vector<PortConfigurator>{node->getOriginalInputsNumber(), {layout, precision}},
                        std::vector<PortConfigurator>{{layout, precision}},
-                       mayiuse(cpu_isa_t::sse41) ? impl_desc_type::jit_uni : impl_desc_type::ref,
+                       ov::with_cpu_x86_sse42() ? impl_desc_type::jit_uni : impl_desc_type::ref,
                        true);
 
     return descs;

--- a/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
@@ -4,6 +4,7 @@
 #include "softmax.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 
@@ -327,7 +328,7 @@ void SoftmaxGeneric::calculate(const in_data_t* src_data,
 
             float expSum = 0;
             for (int c = 0; c < C; c++) {
-                dst_data[b * C * H * W + c * H * W + offset] = exp(src_data[b * C * H * W + c * H * W + offset] - max);
+                dst_data[b * C * H * W + c * H * W + offset] = std::exp(src_data[b * C * H * W + c * H * W + offset] - max);
                 expSum += dst_data[b * C * H * W + c * H * W + offset];
             }
 

--- a/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
@@ -7,10 +7,10 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_parallel.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "utils/bfloat16.hpp"
 
 #if defined(OPENVINO_ARCH_X86_64)
@@ -27,11 +27,13 @@
 #    include "utils/cpu_utils.hpp"
 #endif
 
+#if defined(OPENVINO_ARCH_X86_64)
 using namespace dnnl;
 using namespace dnnl::impl;
 using namespace dnnl::impl::cpu;
 using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#endif
 
 #define GET_OFF(field) offsetof(jit_args_softmax, field)
 
@@ -257,7 +259,7 @@ SoftmaxGeneric::SoftmaxGeneric(ov::element::Type inpPrc, ov::element::Type outPr
     : input_prec(inpPrc),
       output_prec(outPrc) {
     if (ov::element::bf16 == output_prec) {
-        if (!mayiuse(avx512_core)) {
+        if (!ov::with_cpu_x86_avx512_core()) {
             OPENVINO_THROW("SoftmaxGeneric doesn't support BF16 precision on this target.");
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
@@ -328,7 +328,8 @@ void SoftmaxGeneric::calculate(const in_data_t* src_data,
 
             float expSum = 0;
             for (int c = 0; c < C; c++) {
-                dst_data[b * C * H * W + c * H * W + offset] = std::exp(src_data[b * C * H * W + c * H * W + offset] - max);
+                dst_data[b * C * H * W + c * H * W + offset] =
+                    std::exp(src_data[b * C * H * W + c * H * W + offset] - max);
                 expSum += dst_data[b * C * H * W + c * H * W + offset];
             }
 

--- a/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
@@ -22,6 +22,7 @@
 
 #    include "common/c_types_map.hpp"
 #    include "common/utils.hpp"
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #    include "emitters/plugin/x64/jit_bf16_emitters.hpp"

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "allocation_context.hpp"
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_memory.h"
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"
@@ -50,6 +49,7 @@
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/group_conv.hpp"
 #include "openvino/op/util/attr_types.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "post_ops.hpp"
 #include "shape_inference/custom/convolution.hpp"
 #include "utils/general_utils.h"
@@ -257,8 +257,7 @@ Convolution::Convolution(const std::shared_ptr<ov::Node>& op, const GraphContext
         }
     }
     // Only apply this heuristic logic on FP32 IR. IC=1 ,OC=1 would disable brgconv on avx2.
-    const bool isAvx2FP32 = !dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) &&
-                            dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2) && !context->isGraphQuantized();
+    const bool isAvx2FP32 = !ov::with_cpu_x86_avx512_core() && ov::with_cpu_x86_avx2() && !context->isGraphQuantized();
     useJitPlanar = ((all_of(1U, IC, groupOC * groupNum)) && isAvx2FP32);
 }
 
@@ -323,7 +322,7 @@ const std::vector<impl_desc_type>& Convolution::getDefaultImplPriority() {
         impl_desc_type::ref,
     };
     // WA heuristic to avoid regressions introduced by avx2 brgconv.
-    const bool isBrgConvAvailable = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2) && !useJitPlanar;
+    const bool isBrgConvAvailable = ov::with_cpu_x86_avx2() && !useJitPlanar;
     if (isBrgConvAvailable) {
         return priorities;
     }
@@ -837,9 +836,7 @@ void Convolution::initializeInputZeroPoints(const uint8_t* inputZpData, const si
     // per-channel zp If zero point is pertensor, both legacy zp and stock zp would be passed into conv node. The conv
     // node would determine how to create post-ops attribute and prioritize to choose final onednn kernel.
     if (m_attrs.inputZeroPointsType == ZeroPointsType::PerTensor &&
-        (impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx) ||
-         impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_vnni) ||
-         impl::cpu::x64::mayiuse(impl::cpu::x64::avx2_vnni_2))) {
+        (ov::with_cpu_x86_avx512_core_amx() || ov::with_cpu_x86_avx512_core_vnni() || ov::with_cpu_x86_avx2_vnni_2())) {
         inputZeroPoints.push_back(static_cast<int32_t>(inputZpData[0]));
     } else {
         m_attrs.inputZeroPointsType = ZeroPointsType::PerChannel;

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -66,7 +66,7 @@ public:
         std::unordered_set<NodePtr> nodesSet;
         std::vector<EdgePtr> edges;
 
-        auto addEdge = [&](const NodePtr& parent, const NodePtr& child, size_t parentPort, size_t childPort) -> void {
+        auto addEdge = [&](const NodePtr& parent, const NodePtr& child, int parentPort, int childPort) -> void {
             auto edge = std::make_shared<Edge>(parent, child, parentPort, childPort);
             Node::addEdge(edge);
             edges.push_back(edge);
@@ -109,7 +109,7 @@ public:
                 addEdge(parentNode, currentNode, 0, 0);
                 auto constantsItr = conv.fusedConstNodes.find(currentNode);
                 if (constantsItr != conv.fusedConstNodes.end()) {
-                    size_t inpPort = 1LU;
+                    int inpPort = 1;
                     for (const auto& item : constantsItr->second) {
                         addEdge(item, currentNode, 0, inpPort++);
                     }

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -606,7 +606,7 @@ void Convolution::createPrimitive() {
     for (const auto& entry : m_atoi) {
         const auto argumentId = entry.first;
         const auto inputId = entry.second;
-        m_memory[argumentId] = getSrcMemoryAtPort(inputId);
+        m_memory[static_cast<int>(argumentId)] = getSrcMemoryAtPort(inputId);
     }
 
     if (!m_attrs.withBias) {
@@ -804,12 +804,12 @@ void Convolution::addFusedNode(const NodePtr& fusingNode) {
         // @todo padding should be updated by the graph optimizer / transformation
         for (size_t j = 0; j < m_attrs.paddingR.size(); j++) {
             int with_group = m_attrs.isGrouped ? 1 : 0;
-            int krn = weightDims[with_group + 2 + j];
-            int src = getInputShapeAtPort(0).getStaticDims()[2 + j];
-            int dst = fusingNode->getOutputShapeAtPort(0).getStaticDims()[2 + j];
+            int krn = static_cast<int>(weightDims[with_group + 2 + j]);
+            int src = static_cast<int>(getInputShapeAtPort(0).getStaticDims()[2 + j]);
+            int dst = static_cast<int>(fusingNode->getOutputShapeAtPort(0).getStaticDims()[2 + j]);
 
-            krn = (krn - 1) * (m_attrs.dilation[j] + 1) + 1;
-            int calc_dst = (src - krn + m_attrs.paddingL[j]) / m_attrs.stride[j] + 1;
+            krn = static_cast<int>((krn - 1) * (m_attrs.dilation[j] + 1) + 1);
+            int calc_dst = static_cast<int>((src - krn + m_attrs.paddingL[j]) / m_attrs.stride[j] + 1);
             m_attrs.paddingR[j] = (dst - calc_dst) * m_attrs.stride[j];
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -804,12 +804,12 @@ void Convolution::addFusedNode(const NodePtr& fusingNode) {
         // @todo padding should be updated by the graph optimizer / transformation
         for (size_t j = 0; j < m_attrs.paddingR.size(); j++) {
             int with_group = m_attrs.isGrouped ? 1 : 0;
-            int krn = static_cast<int>(weightDims[with_group + 2 + j]);
-            int src = static_cast<int>(getInputShapeAtPort(0).getStaticDims()[2 + j]);
-            int dst = static_cast<int>(fusingNode->getOutputShapeAtPort(0).getStaticDims()[2 + j]);
+            auto krn = static_cast<int>(weightDims[with_group + 2 + j]);
+            const auto src = static_cast<int>(getInputShapeAtPort(0).getStaticDims()[2 + j]);
+            const auto dst = static_cast<int>(fusingNode->getOutputShapeAtPort(0).getStaticDims()[2 + j]);
 
             krn = static_cast<int>((krn - 1) * (m_attrs.dilation[j] + 1) + 1);
-            int calc_dst = static_cast<int>((src - krn + m_attrs.paddingL[j]) / m_attrs.stride[j] + 1);
+            const auto calc_dst = static_cast<int>((src - krn + m_attrs.paddingL[j]) / m_attrs.stride[j] + 1);
             m_attrs.paddingR[j] = (dst - calc_dst) * m_attrs.stride[j];
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -454,10 +454,10 @@ std::pair<VectorDims, VectorDims> Deconvolution::makeDummyInOutShape() {
                 const auto& maxDims = shape.getMaxDims();
                 const auto& dims = shape.getDims();
                 for (size_t i = 0; i < dims.size() - 2; ++i) {
-                    lastOutputSpatialDims[i] =
+                    lastOutputSpatialDims[i] = static_cast<int32_t>(
                         dims[i + 2] == Shape::UNDEFINED_DIM
                             ? std::min(maxDims[i + 2], std::max(minDims[i + 2], static_cast<Dim>(64)))
-                            : dims[i + 2];
+                            : dims[i + 2]);
                 }
             }
 
@@ -1226,7 +1226,7 @@ std::shared_ptr<MemoryDesc> Deconvolution::getSrcMemDesc(const dnnl::primitive_d
                                                       Shape(getInputShapeAtPort(idx).getStaticDims()));
     }
     // idx =0 case
-    auto desc = prim_desc.src_desc(idx);
+    auto desc = prim_desc.src_desc(static_cast<int>(idx));
     if (getInputShapeAtPort(idx).isDynamic()) {
         return DnnlExtensionUtils::makeUndefinedDesc(desc, getInputShapeAtPort(idx));
     }
@@ -1234,7 +1234,7 @@ std::shared_ptr<MemoryDesc> Deconvolution::getSrcMemDesc(const dnnl::primitive_d
 }
 
 std::shared_ptr<MemoryDesc> Deconvolution::getDstMemDesc(const dnnl::primitive_desc& prim_desc, size_t idx) const {
-    auto desc = prim_desc.dst_desc(idx);
+    auto desc = prim_desc.dst_desc(static_cast<int>(idx));
     if (getOutputShapeAtPort(idx).isDynamic()) {
         return DnnlExtensionUtils::makeUndefinedDesc(desc, getOutputShapeAtPort(idx));
     }

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -22,7 +22,6 @@
 
 #include "common/primitive_attr.hpp"
 #include "common/primitive_hashing_utils.hpp"
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_memory.h"
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"
@@ -52,6 +51,7 @@
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/group_conv.hpp"
 #include "openvino/op/util/attr_types.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "shape_inference/shape_inference_status.hpp"
@@ -357,7 +357,7 @@ bool Deconvolution::canBeExecutedInInt8() const {
     if (!withGroups && deconvAttrs.stride.back() > 3) {
         return false;
     }
-    if (!impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core)) {
+    if (!ov::with_cpu_x86_avx512_core()) {
         const auto& inMaxDims = getOutputShapeAtPort(0).getMaxDims();
         if (std::any_of(inMaxDims.begin(), inMaxDims.end(), [](Dim dim) {
                 return dim == Shape::UNDEFINED_DIM;
@@ -384,10 +384,10 @@ bool Deconvolution::canBeExecutedInInt8() const {
 
     // not supported in oneDNN
     int channelBlock = [&]() {
-        if (impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return 16;
         }
-        if (impl::cpu::x64::mayiuse(impl::cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return 8;
         }
         return 4;
@@ -395,7 +395,7 @@ bool Deconvolution::canBeExecutedInInt8() const {
     if (withGroups && !isDW && (IC % channelBlock != 0 || OC % channelBlock != 0)) {
         return false;
     }
-    if (!impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core) && deconvAttrs.stride.back() > 3) {
+    if (!ov::with_cpu_x86_avx512_core() && deconvAttrs.stride.back() > 3) {
         return false;
     }
 
@@ -526,7 +526,7 @@ std::vector<memory::format_tag> Deconvolution::getAvailableFormatsForDims(const 
         return {memory::format_tag::nc};
     case 3:
         // Ticket 156640
-        if (impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx_fp16)) {
+        if (ov::with_cpu_x86_avx512_core_amx_fp16()) {
             return {memory::format_tag::ncw,
                     memory::format_tag::nCw8c,
                     memory::format_tag::nCw16c,

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -43,6 +43,7 @@
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 #    include <xbyak/xbyak.h>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #    include "utils/cpu_utils.hpp"
 #endif

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -10,7 +10,6 @@
 #include <cmath>
 #include <common/c_types_map.hpp>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -37,6 +36,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/util/attr_types.hpp"
 #include "openvino/op/util/deformable_convolution_base.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "openvino/util/pp.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
@@ -49,9 +49,11 @@
 
 using namespace dnnl;
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 namespace ov::intel_cpu::node {
 #if defined(OPENVINO_ARCH_X86_64)
@@ -879,19 +881,19 @@ void DeformableConvolution::initSupportedPrimitiveDescriptors() {
 
     if (enforceRef) {
         impl_type = impl_desc_type::ref;
-    } else if (mayiuse(cpu::x64::avx512_core)) {
+    } else if (ov::with_cpu_x86_avx512_core()) {
         impl_type = impl_desc_type::jit_avx512;
-    } else if (mayiuse(cpu::x64::avx2)) {
+    } else if (ov::with_cpu_x86_avx2()) {
         impl_type = impl_desc_type::jit_avx2;
-    } else if (mayiuse(cpu::x64::sse41)) {
+    } else if (ov::with_cpu_x86_sse42()) {
         impl_type = impl_desc_type::jit_sse42;
     }
 
-    if (!enforceRef && mayiuse(cpu::x64::sse41)) {
+    if (!enforceRef && ov::with_cpu_x86_sse42()) {
         // optimized implementation
         auto dataFormat = memory::format_tag::nhwc;
         auto offFormat = memory::format_tag::nchw;
-        auto weiFormat = mayiuse(avx512_core) ? memory::format_tag::OIhw16i16o : memory::format_tag::OIhw8i8o;
+        auto weiFormat = ov::with_cpu_x86_avx512_core() ? memory::format_tag::OIhw16i16o : memory::format_tag::OIhw8i8o;
         config.inConfs[DATA_ID].setMemDesc(
             std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(DATA_ID), memory::data_type::f32, dataFormat));
         config.inConfs[OFF_ID].setMemDesc(
@@ -1117,7 +1119,7 @@ DeformableConvolution::DefConvExecutor::DefConvExecutor(
     jcp.with_bias = false;
     jcp.with_bi_pad = defConvAttr.with_bilinear_pad;
     jcp.with_modulation = withModulation;
-    const int simd_w = mayiuse(cpu::x64::avx512_core) ? 16 : 8;
+    const int simd_w = ov::with_cpu_x86_avx512_core() ? 16 : 8;
     jcp.ic_block = simd_w;
     jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
 
@@ -1131,8 +1133,8 @@ DeformableConvolution::DefConvExecutor::DefConvExecutor(
     jcp.typesize_sampled_offsets = sizeof(int);
     jcp.typesize_out = sizeof(float);
 
-    jcp.ur_w = mayiuse(cpu::x64::avx512_core) ? 6 : 3;
-    jcp.nb_oc_blocking = !mayiuse(cpu::x64::avx2) ? 2 : 4;
+    jcp.ur_w = ov::with_cpu_x86_avx512_core() ? 6 : 3;
+    jcp.nb_oc_blocking = !ov::with_cpu_x86_avx2() ? 2 : 4;
 
     jcp.nthr = parallel_get_max_threads();
 }

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -168,8 +168,9 @@ void DepthToSpace::initSupportedPrimitiveDescriptors() {
     }
     supportedTypes.push_back(LayoutType::ncsp);
     auto creators = BlockedDescCreator::getCommonCreators();
-    auto range =
-        BlockedDescCreator::makeFilteredRange(creators, static_cast<unsigned>(inputDataShape.getRank()), supportedTypes);
+    auto range = BlockedDescCreator::makeFilteredRange(creators,
+                                                       static_cast<unsigned>(inputDataShape.getRank()),
+                                                       supportedTypes);
 
     for (auto itr = range.first; itr != range.second; ++itr) {
         config.inConfs[0].setMemDesc(itr->second->createSharedDesc(precision, inputDataShape));

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -168,7 +168,8 @@ void DepthToSpace::initSupportedPrimitiveDescriptors() {
     }
     supportedTypes.push_back(LayoutType::ncsp);
     auto creators = BlockedDescCreator::getCommonCreators();
-    auto range = BlockedDescCreator::makeFilteredRange(creators, inputDataShape.getRank(), supportedTypes);
+    auto range =
+        BlockedDescCreator::makeFilteredRange(creators, static_cast<unsigned>(inputDataShape.getRank()), supportedTypes);
 
     for (auto itr = range.first; itr != range.second; ++itr) {
         config.inConfs[0].setMemDesc(itr->second->createSharedDesc(precision, inputDataShape));

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -6,7 +6,6 @@
 
 #include <cmath>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -34,6 +33,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/depth_to_space.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "openvino/util/pp.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
@@ -130,11 +130,11 @@ void DepthToSpace::initSupportedPrimitiveDescriptors() {
     ov::element::Type precision = getOriginalInputPrecisionAtPort(0);
 
     impl_desc_type impl_type = impl_desc_type::ref;
-    if (cpu::x64::mayiuse(cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         impl_type = impl_desc_type::jit_avx512;
-    } else if (cpu::x64::mayiuse(cpu::x64::avx2)) {
+    } else if (ov::with_cpu_x86_avx2()) {
         impl_type = impl_desc_type::jit_avx2;
-    } else if (cpu::x64::mayiuse(cpu::x64::sse41)) {
+    } else if (ov::with_cpu_x86_sse42()) {
         impl_type = impl_desc_type::jit_sse42;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -38,6 +38,10 @@
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
 
+#if defined(OPENVINO_ARCH_X86_64)
+#    include "cpu/x64/cpu_isa_traits.hpp"
+#endif
+
 using namespace dnnl::impl;
 
 namespace ov::intel_cpu::node {

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -35,11 +34,11 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/dft.hpp"
 #include "openvino/op/idft.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
 
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 
 namespace ov::intel_cpu::node {
 
@@ -581,11 +580,11 @@ std::vector<int32_t> DFT::getAxes() const {
 void DFT::createJITKernels(bool hasDFT, bool hasFFT) {
 #if defined(OPENVINO_ARCH_X86_64)
     if (hasDFT && dftKernel == nullptr) {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             dftKernel = std::make_unique<jit_uni_dft_kernel_f32<cpu::x64::avx512_core>>();
-        } else if (mayiuse(cpu::x64::avx2)) {
+        } else if (ov::with_cpu_x86_avx2()) {
             dftKernel = std::make_unique<jit_uni_dft_kernel_f32<cpu::x64::avx2>>();
-        } else if (mayiuse(cpu::x64::sse41)) {
+        } else if (ov::with_cpu_x86_sse42()) {
             dftKernel = std::make_unique<jit_uni_dft_kernel_f32<cpu::x64::sse41>>();
         } else {
             CPU_NODE_THROW("Can't create jit DFT kernel");
@@ -597,11 +596,11 @@ void DFT::createJITKernels(bool hasDFT, bool hasFFT) {
     }
 
     if (hasFFT && fftKernel == nullptr) {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             fftKernel = std::make_unique<jit_uni_fft_kernel_f32<cpu::x64::avx512_core>>();
-        } else if (mayiuse(cpu::x64::avx2)) {
+        } else if (ov::with_cpu_x86_avx2()) {
             fftKernel = std::make_unique<jit_uni_fft_kernel_f32<cpu::x64::avx2>>();
-        } else if (mayiuse(cpu::x64::sse41)) {
+        } else if (ov::with_cpu_x86_sse42()) {
             fftKernel = std::make_unique<jit_uni_fft_kernel_f32<cpu::x64::sse41>>();
         } else {
             CPU_NODE_THROW("Can't create jit FFT kernel");
@@ -637,7 +636,7 @@ void DFT::createPrimitive() {
             }
         }
     }
-    if (mayiuse(cpu::x64::sse41)) {
+    if (ov::with_cpu_x86_sse42()) {
         createJITKernels(hasDFT, hasFFT);
     }
     Node::createPrimitive();

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
@@ -24,7 +24,6 @@
 #include <utility>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"
 #include "dnnl_postops_composer.h"
@@ -45,6 +44,7 @@
 #include "onednn/iml_type_mapper.h"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "post_ops.hpp"
 #include "shape_inference/custom/convolution.hpp"
 #include "thread_pool_imp.hpp"
@@ -528,8 +528,7 @@ static std::vector<DnnlPrimitiveAttrs> createPrimitiveAttrs(const ConvAttrs& att
 
     std::vector<DnnlPrimitiveAttrs> attributeVariants{legacyCompose};
 
-    if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx) &&
-        attrs.inputZeroPointsType == ZeroPointsType::PerTensor) {
+    if (ov::with_cpu_x86_avx512_core_amx() && attrs.inputZeroPointsType == ZeroPointsType::PerTensor) {
         DnnlPostOpsComposer legacyPostOpsOriginalZeroPoints(attrs.postOps,
                                                             context->getEngine(),
                                                             outputDims,
@@ -910,8 +909,8 @@ std::tuple<size_t, size_t, size_t, size_t> DnnlConvolutionPrimitive::getChannelP
 
 bool DnnlConvolutionPrimitive::isJitPlanarAvailable(const ConvConfig& config) {
     // Only apply this heuristic logic on FP32 IR. IC=1, OC=1 would disable brgconv on avx2.
-    const bool isAvx2FP32 = !dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) &&
-                            dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2) && !config.attrs.isGraphQuantized;
+    const bool isAvx2FP32 =
+        !ov::with_cpu_x86_avx512_core() && ov::with_cpu_x86_avx2() && !config.attrs.isGraphQuantized;
 
     const auto [groupNum, groupIC, IC, groupOC] = getChannelParams(config);
 
@@ -920,15 +919,12 @@ bool DnnlConvolutionPrimitive::isJitPlanarAvailable(const ConvConfig& config) {
 
 bool DnnlConvolutionPrimitive::isBrgConvAvailable(const ConvConfig& config) {
     // When avx2 brgconv heuristic case,  disable brgconv to WA the regression.
-    const bool isBrgConvAvailable =
-        dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2) && !isJitPlanarAvailable(config);
+    const bool isBrgConvAvailable = ov::with_cpu_x86_avx2() && !isJitPlanarAvailable(config);
 
     return isBrgConvAvailable;
 }
 
 bool DnnlConvolutionPrimitive::isNspcAvailable(const ConvConfig& config) {
-    using impl::cpu::x64::mayiuse;
-
     // do not use in non-quantized networks until it is enforced externally
     if (!config.attrs.isGraphQuantized) {
         return false;
@@ -981,7 +977,7 @@ bool DnnlConvolutionPrimitive::isNspcAvailable(const ConvConfig& config) {
 
     // if the activation field size is 1x1 the avx512 1x1 nspc convolution pollutes caches so that the layer after
     // the convolution performs slow
-    if (mayiuse(impl::cpu::x64::avx512_core) && is1x1) {
+    if (ov::with_cpu_x86_avx512_core() && is1x1) {
         auto end = inpDims.rbegin();
         std::advance(end, spatialRank);
         if (std::all_of(inpDims.rbegin(), end, [](size_t x) {
@@ -994,7 +990,7 @@ bool DnnlConvolutionPrimitive::isNspcAvailable(const ConvConfig& config) {
     unsigned thresholdNumChannels = 128U;  // for avx and below
     if (is1x1) {
         thresholdNumChannels = 2048U;
-    } else if (mayiuse(impl::cpu::x64::avx512_core)) {
+    } else if (ov::with_cpu_x86_avx512_core()) {
         thresholdNumChannels = 512U;
     }
 
@@ -1003,7 +999,7 @@ bool DnnlConvolutionPrimitive::isNspcAvailable(const ConvConfig& config) {
         return false;
     }
 
-    if (!mayiuse(impl::cpu::x64::avx)) {
+    if (!ov::with_cpu_x86_avx()) {
         // SSE41 nspc convolutions do not support ic and oc tails yet
         // the blocked implementation is faster than gemm
         if ((IC % 8) || (OC % 8)) {

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include "config.h"
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_memory.h"
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"
@@ -37,6 +36,7 @@
 #include "onednn/iml_type_mapper.h"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "thread_pool_imp.hpp"
 #include "utils/cpu_utils.hpp"
 #include "utils/debug_capabilities.h"
@@ -141,7 +141,7 @@ DnnlMemoryDescPtr DnnlFCPrimitive::makeTransposedWeightDescriptor(const DnnlMemo
 bool DnnlFCPrimitive::useWeightsDecompressionImpl(const ov::element::Type inputType,
                                                   const ov::element::Type weightsType,
                                                   const ov::intel_cpu::Config::ModelType modelType) {
-    if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2)) {
+    if (ov::with_cpu_x86_avx2()) {
         if (any_of(inputType, f32, bf16) && any_of(weightsType, u8, i8, nf4, u4, i4, f4e2m1, u2)) {
             return true;
         }
@@ -170,17 +170,16 @@ static bool useDynamicQuantizationImpl(size_t dqGroupSize,
     // AVX512-VNNI impl in oneDNN (only avx512_core_vnni instance is registered for bf16 src).
     const auto srcPrecision = srcDesc->getPrecision();
     if (srcPrecision == ov::element::bf16) {
-        if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16)) {
+        if (!ov::with_cpu_x86_bfloat16()) {
             return false;
         }
         // On AMX-capable HW, AMX BF16 TMUL outperforms VNNI int8 dyn-quant for bf16 src.
         // Disable the bf16 dyn-quant entry here so the AMX BF16 path stays in use.
-        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
+        if (ov::with_cpu_x86_avx512_core_amx()) {
             return false;
         }
     } else if (srcPrecision == ov::element::f32) {
-        if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni) &&
-            !dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_vnni)) {
+        if (!ov::with_cpu_x86_avx2_vnni() && !ov::with_cpu_x86_avx512_core_vnni()) {
             return false;
         }
     } else {

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -6,7 +6,6 @@
 #include <optional>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "debug_messages.hpp"
 #include "implementation_utils.hpp"
 #include "memory_desc/cpu_memory_desc.h"
@@ -29,6 +28,7 @@
 #include "nodes/executors/precision_translation.hpp"
 #include "nodes/executors/type_mask.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "utils/arch_macros.h"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
@@ -63,13 +63,6 @@ using LayoutConfig = std::vector<LayoutType>;
 static const LayoutConfig dnnlFCLayoutConfig{LayoutType::ncsp, LayoutType::ncsp, LayoutType::ncsp, LayoutType::ncsp};
 static const LayoutConfig aclFCLayoutConfig{LayoutType::ncsp, LayoutType::ncsp, LayoutType::ncsp, LayoutType::ncsp};
 
-template <dnnl::impl::cpu::x64::cpu_isa_t ISA>
-struct Require {
-    bool operator()() {
-        return dnnl::impl::cpu::x64::mayiuse(ISA);
-    }
-};
-
 // clang-format off
 static const TypeMapping dnnlFCTypeMapping {
     // {src, wei, bia, dst}                                   pt<src, wei, bias, dst>
@@ -92,7 +85,7 @@ static const TypeMapping dnnlFCTypeMapping {
     {{_u8 | _i8, _i8, _any, _any}, {bypass(), bypass(), just<f32>(), just<f32>()}},
     // compresses int weights (@todo more strict requrements for output precision?)
     {{_bf16, _u8 | _i8 | _nf4 | _u4 | _i4 | _f4e2m1 | _u2, _any, _any},       {bypass(), bypass(), use<0>(), use<0>()},
-     Require<dnnl::impl::cpu::x64::avx512_core_bf16>()}, // Ticket 122347
+     []() { return ov::with_cpu_x86_bfloat16(); }}, // Ticket 122347
     {{_bf16, _u8 | _i8 | _nf4 | _u4 | _i4 | _f4e2m1, _any, _any},       {just<f32>(), bypass(), just<f32>(), just<f32>()}},
     {{_f32,  _u8 | _i8 | _nf4 | _u4 | _i4 | _f4e2m1 | _u2, _any, _any},       {bypass(), bypass(), use<0>(), use<0>()}},
     // @todo should we fallback to FPXX instead of _f32?
@@ -228,7 +221,7 @@ const std::vector<ExecutorImplementation<FCAttrs>>& getImplementations() {
                     return wrapped.offset0();
                 };
 
-                VERIFY(dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core), UNSUPPORTED_ISA);
+                VERIFY(ov::with_cpu_x86_avx512_core(), UNSUPPORTED_ISA);
                 VERIFY(srcType(config) == ov::element::f32, UNSUPPORTED_SRC_PRECISIONS);
                 // disable rank=4:
                 // if layout is nhwc:

--- a/src/plugins/intel_cpu/src/nodes/executors/implementation_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/implementation_utils.hpp
@@ -195,7 +195,7 @@ std::optional<executor::Config<Attrs>> createOptimalConfigCommon(const executor:
                 return true;
             }
 
-            const int i = notation.at(argId);
+            const size_t i = notation.at(argId);
             const auto type = typeConfig.at(argId);
 
             if (desc->empty()) {

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -506,7 +506,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
 // blockND: ncdhw cdhw  dhw   hw   w    1
 // index  : 0      1    2     3    4    5
 inline VectorDims getBlockND(const VectorDims& shape) {
-    int shapeRank = shape.size();
+    int shapeRank = static_cast<int>(shape.size());
     VectorDims blockND(shapeRank + 1, 1);
     for (int i = shapeRank - 1; i >= 0; i--) {
         blockND[i] = shape[i] * blockND[i + 1];

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "cpu_memory.h"
+#include "cpu_types.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "nodes/common/cpu_memcpy.h"
 #include "openvino/core/except.hpp"
@@ -590,7 +591,7 @@ const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vect
                 srcDim5d[2],
                 srcDim5d[3],
                 srcDim5d[4],
-                [&](int n, int cb, int d, int h, int w) {
+                [&](Dim n, Dim cb, Dim d, Dim h, Dim w) {
                     const uint8_t* src = src_data_origin +
                                          (n * CB * srcDim5d[2] * srcDim5d[3] * srcDim5d[4] * blkSize) * srcDataSize +
                                          (cb * srcDim5d[2] * srcDim5d[3] * srcDim5d[4] * blkSize) * srcDataSize +

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -75,16 +75,16 @@ void ov::intel_cpu::InterpolateExecutor::buildTblNN(const VectorDims& srcDimPad5
                                                     const std::vector<float>& dataScales,
                                                     [[maybe_unused]] InterpolateLayoutType layout,
                                                     InterpolateNearestMode nearestMode) {
-    const int dimSize = static_cast<int>(dataRank);
+    const auto dimSize = static_cast<int>(dataRank);
     float fz = (dimSize == 5) ? dataScales[dimSize - 3] : 1.F;
     float fy = dataScales[dimSize - 2];
     float fx = dataScales[dimSize - 1];
-    int ID = static_cast<int>(srcDimPad5d[2]);
-    int IH = static_cast<int>(srcDimPad5d[3]);
-    int IW = static_cast<int>(srcDimPad5d[4]);
-    int OD = static_cast<int>(dstDim5d[2]);
-    int OH = static_cast<int>(dstDim5d[3]);
-    int OW = static_cast<int>(dstDim5d[4]);
+    const auto ID = static_cast<int>(srcDimPad5d[2]);
+    const auto IH = static_cast<int>(srcDimPad5d[3]);
+    const auto IW = static_cast<int>(srcDimPad5d[4]);
+    const auto OD = static_cast<int>(dstDim5d[2]);
+    const auto OH = static_cast<int>(dstDim5d[3]);
+    const auto OW = static_cast<int>(dstDim5d[4]);
 
     indexTable.resize(static_cast<size_t>(OD) + OH + OW);
     bool isDDownsample = fz < 1;
@@ -205,16 +205,16 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinearOnnx(const VectorDims& sr
                                                             const VectorDims& dstDim5d,
                                                             const std::vector<float>& dataScales,
                                                             InterpolateLayoutType layout) {
-    int dimSize = static_cast<int>(dataRank);
+    const auto dimSize = static_cast<int>(dataRank);
     float fz = (spatialDimSize > 2) ? dataScales[dimSize - 3] : 1.F;
     float fy = (spatialDimSize > 1) ? dataScales[dimSize - 2] : 1.F;
     float fx = dataScales[dimSize - 1];
-    int ID = static_cast<int>(srcDimPad5d[2]);
-    int IH = static_cast<int>(srcDimPad5d[3]);
-    int IW = static_cast<int>(srcDimPad5d[4]);
-    int OD = static_cast<int>(dstDim5d[2]);
-    int OH = static_cast<int>(dstDim5d[3]);
-    int OW = static_cast<int>(dstDim5d[4]);
+    const auto ID = static_cast<int>(srcDimPad5d[2]);
+    const auto IH = static_cast<int>(srcDimPad5d[3]);
+    const auto IW = static_cast<int>(srcDimPad5d[4]);
+    const auto OD = static_cast<int>(dstDim5d[2]);
+    const auto OH = static_cast<int>(dstDim5d[3]);
+    const auto OW = static_cast<int>(dstDim5d[4]);
 
     std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, nullptr);
     std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, nullptr);
@@ -339,25 +339,25 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
                                                         const std::vector<float>& dataScales,
                                                         int kernel_width,
                                                         bool antialias) {
-    int dimSize = static_cast<int>(dataRank);
+    const auto dimSize = static_cast<int>(dataRank);
     float fz = (dimSize == 5) ? dataScales[dimSize - 3] : 1.F;
     float fy = dataScales[dimSize - 2];
     float fx = dataScales[dimSize - 1];
-    int ID = static_cast<int>(srcDimPad5d[2]);
-    int IH = static_cast<int>(srcDimPad5d[3]);
-    int IW = static_cast<int>(srcDimPad5d[4]);
-    int OD = static_cast<int>(dstDim5d[2]);
-    int OH = static_cast<int>(dstDim5d[3]);
-    int OW = static_cast<int>(dstDim5d[4]);
+    const auto ID = static_cast<int>(srcDimPad5d[2]);
+    const auto IH = static_cast<int>(srcDimPad5d[3]);
+    const auto IW = static_cast<int>(srcDimPad5d[4]);
+    const auto OD = static_cast<int>(dstDim5d[2]);
+    const auto OH = static_cast<int>(dstDim5d[3]);
+    const auto OW = static_cast<int>(dstDim5d[4]);
 
     if (IW != OW || IH != OH || ID != OD) {
         float ax = antialias ? fx : 1.0F;
         float ay = antialias ? fy : 1.0F;
         float az = antialias ? fz : 1.0F;
 
-        int rx = (fx > 1.0F) ? 2 : static_cast<int>(ceil(static_cast<float>(kernel_width) / ax));
-        int ry = (fy > 1.0F) ? 2 : static_cast<int>(ceil(static_cast<float>(kernel_width) / ay));
-        int rz = (fz > 1.0F) ? 2 : static_cast<int>(ceil(static_cast<float>(kernel_width) / az));
+        const auto rx = (fx > 1.0F) ? 2 : static_cast<int>(std::ceil(static_cast<float>(kernel_width) / ax));
+        const auto ry = (fy > 1.0F) ? 2 : static_cast<int>(std::ceil(static_cast<float>(kernel_width) / ay));
+        const auto rz = (fz > 1.0F) ? 2 : static_cast<int>(std::ceil(static_cast<float>(kernel_width) / az));
 
         int diaOD = 2 * rz + 1;
         int diaOH = 2 * ry + 1;
@@ -376,12 +376,12 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
         auto* idxOH = (&idxTable[sizeOD]);
         auto* idxOW = (&idxTable[sizeOD + sizeOH]);
 
-        for (int oz = 0; oz < static_cast<int>(OD); oz++) {
+        for (int oz = 0; oz < OD; oz++) {
             float iz = coordTransToInput(oz, fz, ID, OD);
             auto iz_r = static_cast<int>(std::round(iz));
             for (int r = iz_r - rz, i = 0; r <= iz_r + rz; r++, i++) {
                 idxOD[oz * diaOD + i] = r;
-                if (r < 0 || r >= static_cast<int>(ID)) {
+                if (r < 0 || r >= ID) {
                     weightOD[oz * diaOD + i] = 0.F;
                 } else {
                     float dz = iz - static_cast<float>(r);
@@ -389,12 +389,12 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
                 }
             }
         }
-        for (int oy = 0; oy < static_cast<int>(OH); oy++) {
+        for (int oy = 0; oy < OH; oy++) {
             float iy = coordTransToInput(oy, fy, IH, OH);
             auto iy_r = static_cast<int>(std::round(iy));
             for (int r = iy_r - ry, i = 0; r <= iy_r + ry; r++, i++) {
                 idxOH[oy * diaOH + i] = r;
-                if (r < 0 || r >= static_cast<int>(IH)) {
+                if (r < 0 || r >= IH) {
                     weightOH[oy * diaOH + i] = 0.F;
                 } else {
                     float dy = iy - static_cast<float>(r);
@@ -402,12 +402,12 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
                 }
             }
         }
-        for (int ox = 0; ox < static_cast<int>(OW); ox++) {
+        for (int ox = 0; ox < OW; ox++) {
             float ix = coordTransToInput(ox, fx, IW, OW);
             auto ix_r = static_cast<int>(std::round(ix));
             for (int r = ix_r - rx, i = 0; r <= ix_r + rx; r++, i++) {
                 idxOW[ox * diaOW + i] = r;
-                if (r < 0 || r >= static_cast<int>(IW)) {
+                if (r < 0 || r >= IW) {
                     weightOW[ox * diaOW + i] = 0.F;
                 } else {
                     float dx = ix - static_cast<float>(r);
@@ -437,13 +437,13 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
                                                        const std::vector<float>& dataScales,
                                                        float cubicCoeff,
                                                        InterpolateLayoutType layout) {
-    int dimSize = static_cast<int>(dataRank);
+    const auto dimSize = static_cast<int>(dataRank);
     float fy = dataScales[dimSize - 2];
     float fx = dataScales[dimSize - 1];
-    int IH = static_cast<int>(srcDimPad5d[3]);
-    int IW = static_cast<int>(srcDimPad5d[4]);
-    int OH = static_cast<int>(dstDim5d[3]);
-    int OW = static_cast<int>(dstDim5d[4]);
+    const auto IH = static_cast<int>(srcDimPad5d[3]);
+    const auto IW = static_cast<int>(srcDimPad5d[4]);
+    const auto OH = static_cast<int>(dstDim5d[3]);
+    const auto OW = static_cast<int>(dstDim5d[4]);
 
     // idxNum for index, CUBIC_GRID_LEN for weight
     const int idxNum = 1;
@@ -506,7 +506,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
 // blockND: ncdhw cdhw  dhw   hw   w    1
 // index  : 0      1    2     3    4    5
 inline VectorDims getBlockND(const VectorDims& shape) {
-    int shapeRank = static_cast<int>(shape.size());
+    const auto shapeRank = static_cast<int>(shape.size());
     VectorDims blockND(shapeRank + 1, 1);
     for (int i = shapeRank - 1; i >= 0; i--) {
         blockND[i] = shape[i] * blockND[i + 1];

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -545,7 +545,7 @@ const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vect
             srcPadded.resize(inShapePadBlock[0] * srcDataSize, 0);
             auto* src_data_pad = static_cast<uint8_t*>(srcPadded.data());
             cpuParallel
-                ->parallel_for4d(srcDim5d[0], srcDim5d[1], srcDim5d[2], srcDim5d[3], [&](int n, int c, int d, int h) {
+                ->parallel_for4d(srcDim5d[0], srcDim5d[1], srcDim5d[2], srcDim5d[3], [&](Dim n, Dim c, Dim d, Dim h) {
                     const uint8_t* src = src_data_origin + (inShapeBlock[1] * n + inShapeBlock[2] * c +
                                                             inShapeBlock[3] * d + inShapeBlock[4] * h) *
                                                                srcDataSize;
@@ -560,7 +560,7 @@ const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vect
             srcPadded.resize(inShapePadBlock[0] * srcDataSize, 0);
             auto* src_data_pad = static_cast<uint8_t*>(srcPadded.data());
             cpuParallel
-                ->parallel_for4d(srcDim5d[0], srcDim5d[2], srcDim5d[3], srcDim5d[4], [&](int n, int d, int h, int w) {
+                ->parallel_for4d(srcDim5d[0], srcDim5d[2], srcDim5d[3], srcDim5d[4], [&](Dim n, Dim d, Dim h, Dim w) {
                     const uint8_t* src =
                         src_data_origin +
                         (inShapeBlock[1] * n +

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -32,7 +32,7 @@ bool ov::intel_cpu::InterpolateExecutor::init(const InterpolateAttrs& interpolat
     srcDataSize = interpolateAttrs.inPrc.size();
     dstDataSize = interpolateAttrs.outPrc.size();
     dataRank = srcDims.size();
-    spatialDimSize = getSpatialDimsNum(dataRank);
+    spatialDimSize = static_cast<int>(getSpatialDimsNum(dataRank));
 
     switch (interpAttrs.mode) {
     case InterpolateMode::nearest: {
@@ -75,32 +75,32 @@ void ov::intel_cpu::InterpolateExecutor::buildTblNN(const VectorDims& srcDimPad5
                                                     const std::vector<float>& dataScales,
                                                     [[maybe_unused]] InterpolateLayoutType layout,
                                                     InterpolateNearestMode nearestMode) {
-    const int dimSize = dataRank;
+    const int dimSize = static_cast<int>(dataRank);
     float fz = (dimSize == 5) ? dataScales[dimSize - 3] : 1.F;
     float fy = dataScales[dimSize - 2];
     float fx = dataScales[dimSize - 1];
-    size_t ID = srcDimPad5d[2];
-    size_t IH = srcDimPad5d[3];
-    size_t IW = srcDimPad5d[4];
-    size_t OD = dstDim5d[2];
-    size_t OH = dstDim5d[3];
-    size_t OW = dstDim5d[4];
+    int ID = static_cast<int>(srcDimPad5d[2]);
+    int IH = static_cast<int>(srcDimPad5d[3]);
+    int IW = static_cast<int>(srcDimPad5d[4]);
+    int OD = static_cast<int>(dstDim5d[2]);
+    int OH = static_cast<int>(dstDim5d[3]);
+    int OW = static_cast<int>(dstDim5d[4]);
 
-    indexTable.resize(OD + OH + OW);
+    indexTable.resize(static_cast<size_t>(OD) + OH + OW);
     bool isDDownsample = fz < 1;
     bool isHDownsample = fy < 1;
     bool isWDownsample = fx < 1;
-    for (int oz = 0; oz < static_cast<int>(OD); oz++) {
+    for (int oz = 0; oz < OD; oz++) {
         float iz = coordTransToInput(oz, fz, ID, OD);
         indexTable[oz] = nearestRound(iz, isDDownsample, nearestMode);
         indexTable[oz] = clipCoord(indexTable[oz], ID);
     }
-    for (int oy = 0; oy < static_cast<int>(OH); oy++) {
+    for (int oy = 0; oy < OH; oy++) {
         float iy = coordTransToInput(oy, fy, IH, OH);
         indexTable[OD + oy] = nearestRound(iy, isHDownsample, nearestMode);
         indexTable[OD + oy] = clipCoord(indexTable[OD + oy], IH);
     }
-    for (int ox = 0; ox < static_cast<int>(OW); ox++) {
+    for (int ox = 0; ox < OW; ox++) {
         float ix = coordTransToInput(ox, fx, IW, OW);
         indexTable[OD + OH + ox] = nearestRound(ix, isWDownsample, nearestMode);
         indexTable[OD + OH + ox] = clipCoord(indexTable[OD + OH + ox], IW);
@@ -205,16 +205,16 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinearOnnx(const VectorDims& sr
                                                             const VectorDims& dstDim5d,
                                                             const std::vector<float>& dataScales,
                                                             InterpolateLayoutType layout) {
-    int dimSize = dataRank;
+    int dimSize = static_cast<int>(dataRank);
     float fz = (spatialDimSize > 2) ? dataScales[dimSize - 3] : 1.F;
     float fy = (spatialDimSize > 1) ? dataScales[dimSize - 2] : 1.F;
     float fx = dataScales[dimSize - 1];
-    int ID = srcDimPad5d[2];
-    int IH = srcDimPad5d[3];
-    int IW = srcDimPad5d[4];
-    int OD = dstDim5d[2];
-    int OH = dstDim5d[3];
-    int OW = dstDim5d[4];
+    int ID = static_cast<int>(srcDimPad5d[2]);
+    int IH = static_cast<int>(srcDimPad5d[3]);
+    int IW = static_cast<int>(srcDimPad5d[4]);
+    int OD = static_cast<int>(dstDim5d[2]);
+    int OH = static_cast<int>(dstDim5d[3]);
+    int OW = static_cast<int>(dstDim5d[4]);
 
     std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, nullptr);
     std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, nullptr);
@@ -253,7 +253,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinearOnnx(const VectorDims& sr
             weightPtr[4] = reinterpret_cast<float*>(&indexTable[scratchLen + 4 * OW * OH * OD]);
             weightPtr[5] = reinterpret_cast<float*>(&indexTable[scratchLen + 5 * OW * OH * OD]);
         }
-        int scale = ov::with_cpu_x86_sse42() ? srcDataSize : 1;
+        int scale = ov::with_cpu_x86_sse42() ? static_cast<int>(srcDataSize) : 1;
 
         for (int oz = 0; oz < OD; oz++) {
             int izF = 0;
@@ -339,16 +339,16 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
                                                         const std::vector<float>& dataScales,
                                                         int kernel_width,
                                                         bool antialias) {
-    int dimSize = dataRank;
+    int dimSize = static_cast<int>(dataRank);
     float fz = (dimSize == 5) ? dataScales[dimSize - 3] : 1.F;
     float fy = dataScales[dimSize - 2];
     float fx = dataScales[dimSize - 1];
-    size_t ID = srcDimPad5d[2];
-    size_t IH = srcDimPad5d[3];
-    size_t IW = srcDimPad5d[4];
-    size_t OD = dstDim5d[2];
-    size_t OH = dstDim5d[3];
-    size_t OW = dstDim5d[4];
+    int ID = static_cast<int>(srcDimPad5d[2]);
+    int IH = static_cast<int>(srcDimPad5d[3]);
+    int IW = static_cast<int>(srcDimPad5d[4]);
+    int OD = static_cast<int>(dstDim5d[2]);
+    int OH = static_cast<int>(dstDim5d[3]);
+    int OW = static_cast<int>(dstDim5d[4]);
 
     if (IW != OW || IH != OH || ID != OD) {
         float ax = antialias ? fx : 1.0F;
@@ -437,13 +437,13 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
                                                        const std::vector<float>& dataScales,
                                                        float cubicCoeff,
                                                        InterpolateLayoutType layout) {
-    int dimSize = dataRank;
+    int dimSize = static_cast<int>(dataRank);
     float fy = dataScales[dimSize - 2];
     float fx = dataScales[dimSize - 1];
-    int IH = srcDimPad5d[3];
-    int IW = srcDimPad5d[4];
-    int OH = dstDim5d[3];
-    int OW = dstDim5d[4];
+    int IH = static_cast<int>(srcDimPad5d[3]);
+    int IW = static_cast<int>(srcDimPad5d[4]);
+    int OH = static_cast<int>(dstDim5d[3]);
+    int OW = static_cast<int>(dstDim5d[4]);
 
     // idxNum for index, CUBIC_GRID_LEN for weight
     const int idxNum = 1;

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <oneapi/dnnl/dnnl.hpp>
@@ -16,6 +15,7 @@
 #include "memory_desc/cpu_memory_desc.h"
 #include "nodes/common/cpu_memcpy.h"
 #include "openvino/core/except.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "utils/general_utils.h"
 
 using namespace ov::intel_cpu;
@@ -253,7 +253,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinearOnnx(const VectorDims& sr
             weightPtr[4] = reinterpret_cast<float*>(&indexTable[scratchLen + 4 * OW * OH * OD]);
             weightPtr[5] = reinterpret_cast<float*>(&indexTable[scratchLen + 5 * OW * OH * OD]);
         }
-        int scale = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::sse41) ? srcDataSize : 1;
+        int scale = ov::with_cpu_x86_sse42() ? srcDataSize : 1;
 
         for (int oz = 0; oz < OD; oz++) {
             int izF = 0;
@@ -577,7 +577,7 @@ const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vect
                 });
             src_data = src_data_pad;
         } else if (interpAttrs.layout == InterpolateLayoutType::block) {
-            size_t blkSize = dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) ? 16 : 8;
+            size_t blkSize = ov::with_cpu_x86_avx512_core() ? 16 : 8;
             size_t CB = div_up(srcDimPad5d[1], blkSize);
             size_t eltsTotal = srcDimPad5d[0] * CB * srcDimPad5d[2] * srcDimPad5d[3] * srcDimPad5d[4] * blkSize;
             srcPadded.resize(eltsTotal * srcDataSize, 0x0);

--- a/src/plugins/intel_cpu/src/nodes/executors/matmul_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/matmul_implementations.cpp
@@ -5,7 +5,6 @@
 #include <optional>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "memory_desc/cpu_memory_desc.h"
 #include "nodes/executors/dnnl/dnnl_matmul_primitive.hpp"
 #include "nodes/executors/executor.hpp"
@@ -38,13 +37,6 @@ static const LayoutConfig dnnlMatMulLayoutConfig{LayoutType::ncsp,
                                                  LayoutType::ncsp,
                                                  LayoutType::ncsp,
                                                  LayoutType::ncsp};
-
-template <dnnl::impl::cpu::x64::cpu_isa_t ISA>
-struct Require {
-    bool operator()() {
-        return dnnl::impl::cpu::x64::mayiuse(ISA);
-    }
-};
 
 // clang-format off
 static const TypeMapping dnnlMatMulTypeMapping {

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cmath>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -31,6 +30,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/op/extractimagepatches.hpp"
 #include "openvino/op/util/attr_types.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
 
@@ -39,12 +39,12 @@
 
 #    include "cpu/x64/jit_generator.hpp"
 #    include "utils/cpu_utils.hpp"
-#endif
 
 using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::cpu;
 using namespace dnnl::impl::utils;
 using namespace Xbyak;
+#endif
 
 namespace ov::intel_cpu::node {
 #if defined(OPENVINO_ARCH_X86_64)
@@ -452,7 +452,7 @@ void ExtractImagePatches::prepareParams() {
     const auto& out_dims = getChildEdgeAt(0)->getMemory().getStaticDims();
     const auto prcSize = getOriginalInputPrecisionAtPort(0).size();
     ExtractImagePatchesKey key = {in_dims, out_dims, _ksizes, _strides, _rates, _auto_pad, prcSize};
-    const auto isJit = mayiuse(x64::sse41);
+    const auto isJit = ov::with_cpu_x86_sse42();
     auto buildExecutor = [&isJit](const ExtractImagePatchesKey& key) -> executorPtr {
         if (isJit) {
             return std::make_shared<ExtractImagePatchesJitExecutor>(key.inDims,
@@ -701,12 +701,12 @@ jit_extract_image_patches_params ExtractImagePatches::ExtractImagePatchesExecuto
     }
 
     jpp.dtype_size = prcSize;
-    if (mayiuse(x64::avx512_core)) {
-        jpp.block_size = dnnl::impl::cpu::x64::cpu_isa_traits_t<x64::avx512_core>::vlen / prcSize;
-    } else if (mayiuse(x64::avx2)) {
-        jpp.block_size = dnnl::impl::cpu::x64::cpu_isa_traits_t<x64::avx2>::vlen / prcSize;
-    } else if (mayiuse(x64::sse41)) {
-        jpp.block_size = dnnl::impl::cpu::x64::cpu_isa_traits_t<x64::sse41>::vlen / prcSize;
+    if (ov::with_cpu_x86_avx512_core()) {
+        jpp.block_size = 64 / prcSize;
+    } else if (ov::with_cpu_x86_avx2()) {
+        jpp.block_size = 32 / prcSize;
+    } else if (ov::with_cpu_x86_sse42()) {
+        jpp.block_size = 16 / prcSize;
     } else {
         jpp.block_size = 1;
     }

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
@@ -37,6 +37,7 @@
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 #    include <xbyak/xbyak.h>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #    include "utils/cpu_utils.hpp"
 

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1421,7 +1421,7 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ov::Node>& op, const GraphConte
 
                 isFakeQuantization = isFakeQuantization && il == ol && ih == oh;
                 isFakeQuantizationWithScale = isFakeQuantizationWithScale && il != ih && ol != oh &&
-                                              (abs(ol / (oh - ol) - il / (ih - il)) < 0.001F);
+                                              (std::abs(ol / (oh - ol) - il / (ih - il)) < 0.001F);
             }
 
             if (isFakeQuantizationWithScale) {
@@ -2243,7 +2243,7 @@ void FakeQuantize::updateOptimizedFormula(bool do_rounding) {
     auto isPerTensor =
         [](const std::vector<float>& v, float ref, const float zero_thr = std::numeric_limits<float>::min()) {
             return std::all_of(v.cbegin(), v.cend(), [&](float val) {
-                return abs(val - ref) < zero_thr;
+                return std::abs(val - ref) < zero_thr;
             });
         };
     size_t OC = std::max({inputScale.size(),
@@ -2352,7 +2352,7 @@ void FakeQuantize::updateOptimizedFormula(bool do_rounding) {
     // we can save an additional eltwise linear for negligible shift
     if (all_of(1U, f.ish.size(), f.clo.size(), f.chi.size())) {
         auto range = (f.chi[0] - f.clo[0]);
-        if (abs(f.ish[0]) < range * 0.00001F) {
+        if (std::abs(f.ish[0]) < range * 0.00001F) {
             f.ish[0] = 0.0F;
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -14,7 +14,6 @@
 #include <common/c_types_map.hpp>
 #include <common/nstl.hpp>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -47,6 +46,7 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/util/attr_types.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "utils/cpu_utils.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
@@ -66,9 +66,11 @@
 using namespace dnnl;
 using namespace ov;
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 namespace ov::intel_cpu::node {
 #if defined(OPENVINO_ARCH_X86_64)
@@ -1454,7 +1456,7 @@ std::vector<LayoutType> FakeQuantize::getDataFormats() const {
     }
     if (any_of(dims.size(), 4U, 5U)) {
         if (getAxis() == 1) {
-            auto blkFormat = mayiuse(cpu::x64::avx512_core) ? LayoutType::nCsp16c : LayoutType::nCsp8c;
+            auto blkFormat = ov::with_cpu_x86_avx512_core() ? LayoutType::nCsp16c : LayoutType::nCsp8c;
             return {blkFormat, LayoutType::nspc, LayoutType::ncsp};
         }
         return {LayoutType::ncsp};
@@ -1503,18 +1505,18 @@ void FakeQuantize::initSupportedPrimitiveDescriptors() {
     }
 
     impl_desc_type impl_type = []() {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             return impl_desc_type::jit_sse42;
         }
         return impl_desc_type::ref;
     }();
-    if (!mayiuse(cpu::x64::sse41) || getAxis() != 1) {
+    if (!ov::with_cpu_x86_sse42() || getAxis() != 1) {
         impl_type = impl_desc_type::ref;
 
         if (!isBinarization()) {

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -54,6 +54,7 @@
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 #    include <xbyak/xbyak.h>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #endif
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -5,7 +5,6 @@
 #include "fullyconnected.h"
 
 #include <algorithm>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -41,6 +40,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "openvino/runtime/threading/cpu_message.hpp"
 #include "ov_ops/fully_connected.hpp"
 #include "ov_ops/fully_connected_compressed.hpp"
@@ -98,7 +98,7 @@ ov::element::TypeVector FullyConnected::getSupportedCompressedActivationsTypes()
     // dynamic-quant kernels. On AMX-capable HW, AMX BF16 TMUL outperforms
     // VNNI int8 on prefill, so keep f32 here and let the existing AMX BF16
     // path handle bf16 inference precision.
-    if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
+    if (ov::with_cpu_x86_avx512_core_amx()) {
         return {Type_t::f32};
     }
     return {Type_t::f32, Type_t::bf16};
@@ -152,12 +152,11 @@ bool FullyConnected::isSupportedCompressedOperation([[maybe_unused]] const std::
             return false;
         }
 
-        if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2)) {
+        if (!ov::with_cpu_x86_avx2()) {
             return false;
         }
 
-        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx) &&
-            config.inferencePrecision == ov::element::bf16) {
+        if (ov::with_cpu_x86_avx512_core_amx() && config.inferencePrecision == ov::element::bf16) {
             // OneDNN AMX IP implementation has limited shapes support due to performance considerations. As a
             // current solution conditions below are copied from OneDNN to make sure correct IP impl will be
             // used since fallback one doesn't support weights decompression feature.
@@ -520,7 +519,7 @@ static bool useSparseWeightsDecompression(const NodePtr& weightsInput,
         return false;
     }
 
-    if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
+    if (!ov::with_cpu_x86_avx512_core_amx()) {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -354,7 +354,7 @@ void FullyConnected::execTensorParallelSync() {
             return parts;
         };
 
-        const int dim = static_cast<int>(dims.size() - 1);
+        const auto dim = static_cast<int>(dims.size() - 1);
         // selected dim bytes
         auto channel_size = dims[dim] * prec.size();
         // total bytes

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -287,12 +287,12 @@ void FullyConnected::needPrepareParamsForTensorParallel() {
         auto dst_desc = dstMemoryBuffer->getDescPtr();
         auto dims = dst_shape.getDims();
         if (dim < 0) {
-            dim += dims.size();
+            dim += static_cast<int>(dims.size());
         }
         CPU_NODE_ASSERT(static_cast<int>(dims[dim]) >= tp_cfg.w_size,
                         getName() + " dim[" + std::to_string(dim) + "] is " + std::to_string(dims[dim]) +
                             ", which is larger than w_size " + std::to_string(tp_cfg.w_size));
-        auto splited_dim_vec = split_parts(dims[dim], tp_cfg.w_size);
+        auto splited_dim_vec = split_parts(static_cast<int>(dims[dim]), tp_cfg.w_size);
 
         VectorDims new_dims = std::move(dims);
         new_dims[dim] = splited_dim_vec[tp_cfg.w_rank];
@@ -354,7 +354,7 @@ void FullyConnected::execTensorParallelSync() {
             return parts;
         };
 
-        const int dim = dims.size() - 1;
+        const int dim = static_cast<int>(dims.size() - 1);
         // selected dim bytes
         auto channel_size = dims[dim] * prec.size();
         // total bytes
@@ -362,7 +362,7 @@ void FullyConnected::execTensorParallelSync() {
         // the steps need to copy.
         const size_t count = (mem_size / channel_size);
 
-        auto splited_dim_vec = split_parts(dims[dim], tp_cfg.w_size);
+        auto splited_dim_vec = split_parts(static_cast<int>(dims[dim]), tp_cfg.w_size);
         const auto strideSize = splited_dim_vec[0] * prec.size();
 
         tp_cfg.sub_memory->_memorys_table[tp_cfg.id][tp_cfg.w_rank].send_buf = cur_dst->getData();
@@ -722,7 +722,7 @@ void FullyConnected::createPrimitive() {
     for (const auto& entry : m_atoi) {
         const auto argumentId = entry.first;
         const auto inputId = entry.second;
-        memory[argumentId] = getSrcMemoryAtPort(inputId);
+        memory[static_cast<int>(argumentId)] = getSrcMemoryAtPort(inputId);
     }
 
     memory[ARG_DST] = getDstMemoryAtPort(0);

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -39,6 +39,7 @@
 
 #    include <common/utils.hpp>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #    include "emitters/plugin/x64/jit_load_store_emitters.hpp"
 #    include "openvino/core/type.hpp"

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "common/cpu_memcpy.h"
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_memory.h"
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"
@@ -29,6 +28,7 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #ifdef CPU_DEBUG_CAPS
 #    include "utils/debug_capabilities.h"
@@ -46,8 +46,10 @@
 #    include "utils/cpu_utils.hpp"
 #endif
 
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 namespace ov::intel_cpu::node {
 
@@ -227,7 +229,7 @@ void Interaction::initSupportedPrimitiveDescriptors() {
         return;
     }
     dataPrecision = getOriginalInputPrecisionAtPort(0);
-    if (dataPrecision != ov::element::f32 && dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16)) {
+    if (dataPrecision != ov::element::f32 && ov::with_cpu_x86_bfloat16()) {
         dataPrecision = ov::element::bf16;
     } else {
         dataPrecision = ov::element::f32;

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -10,7 +10,6 @@
 #include <common/primitive_attr.hpp>
 #include <common/primitive_hashing_utils.hpp>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -45,6 +44,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/interpolate.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/bfloat16.hpp"
@@ -71,9 +71,11 @@ using namespace dnnl;
 
 using namespace dnnl::impl;
 using namespace dnnl::impl::cpu;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 #define GET_OFF(field) offsetof(jit_interpolate_call_args, field)
 
@@ -2174,7 +2176,7 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
     }
 
 #if !defined(OV_CPU_WITH_ACL)
-    if (!mayiuse(cpu::x64::sse41)) {
+    if (!ov::with_cpu_x86_sse42()) {
         inputPrecision = outputPrecision = ov::element::f32;
     }
 #endif
@@ -2274,19 +2276,19 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
 #endif
 
         if (dataRank == 4) {
-            if (mayiuse(cpu::x64::avx512_core)) {
+            if (ov::with_cpu_x86_avx512_core()) {
                 if (interpAttrs.NCHWAsNHWC) {
                     pushDesc(LayoutType::ncsp, jit_avx512, true);
                 } else {
                     pushDesc(LayoutType::nspc, jit_avx512, true);
                 }
-            } else if (mayiuse(cpu::x64::avx2)) {
+            } else if (ov::with_cpu_x86_avx2()) {
                 if (interpAttrs.NCHWAsNHWC) {
                     pushDesc(LayoutType::ncsp, jit_avx2, true);
                 } else {
                     pushDesc(LayoutType::nspc, jit_avx2, true);
                 }
-            } else if (mayiuse(cpu::x64::sse41)) {
+            } else if (ov::with_cpu_x86_sse42()) {
                 if (interpAttrs.NCHWAsNHWC) {
                     pushDesc(LayoutType::ncsp, jit_sse42, true);
                 } else {
@@ -2311,12 +2313,12 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
         inputPrecision = outputPrecision = ov::element::f32;
 #endif
 
-        if (!mayiuse(cpu::x64::sse41) || interpAttrs.mode == InterpolateMode::linear) {
+        if (!ov::with_cpu_x86_sse42() || interpAttrs.mode == InterpolateMode::linear) {
             pushDesc(LayoutType::ncsp, ref, false);
         } else {
             // blk and by_channel JIT kernel on sse41 or above machine
             if (dataRank == 4 || (dataRank == 5 && interpAttrs.mode != InterpolateMode::cubic)) {
-                if (mayiuse(cpu::x64::avx512_core)) {
+                if (ov::with_cpu_x86_avx512_core()) {
                     if (interpAttrs.NCHWAsNHWC) {
                         pushDesc(LayoutType::ncsp, jit_avx512, false);
                     } else {
@@ -2325,7 +2327,7 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
                     if (isBlkApplied) {
                         pushDesc(LayoutType::nCsp16c, jit_avx512, false);
                     }
-                } else if (mayiuse(cpu::x64::avx2)) {
+                } else if (ov::with_cpu_x86_avx2()) {
                     if (interpAttrs.NCHWAsNHWC) {
                         pushDesc(LayoutType::ncsp, jit_avx2, false);
                     } else {
@@ -2350,7 +2352,7 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
             // 1.ref on machine w/o avx2(no fuse)
             // 2.JIT kernel for avx2(gatherps is available).(with fuse)
             if (inputPrecision == ov::element::f32) {
-                if (mayiuse(cpu::x64::avx2)) {
+                if (ov::with_cpu_x86_avx2()) {
                     pushDesc(LayoutType::ncsp, jit_avx2, false);
                 } else {
                     pushDesc(LayoutType::ncsp, ref, false);
@@ -2537,15 +2539,15 @@ void Interpolate::prepareParams() {
         bool isNearestLinearOrCubic = key.nodeAttrs.mode == InterpolateMode::nearest ||
                                       key.nodeAttrs.mode == InterpolateMode::linear_onnx ||
                                       key.nodeAttrs.mode == InterpolateMode::cubic;
-        bool isPlanarLayourAndSse41 = key.nodeAttrs.layout != InterpolateLayoutType::planar && mayiuse(cpu::x64::sse41);
-        bool isAvx2AndF32 = mayiuse(cpu::x64::avx2) && key.nodeAttrs.inPrc == ov::element::f32;
+        bool isPlanarLayourAndSse41 = key.nodeAttrs.layout != InterpolateLayoutType::planar && ov::with_cpu_x86_sse42();
+        bool isAvx2AndF32 = ov::with_cpu_x86_avx2() && key.nodeAttrs.inPrc == ov::element::f32;
         bool isPillowMode = key.nodeAttrs.mode == InterpolateMode::bilinear_pillow ||
                             key.nodeAttrs.mode == InterpolateMode::bicubic_pillow;
         bool isByChannelLayout = key.nodeAttrs.layout == InterpolateLayoutType::by_channel;
         bool isNearestLinearOrCubicSupported = isNearestLinearOrCubic && (isPlanarLayourAndSse41 || isAvx2AndF32);
         bool isPillowModeSupported = isPillowMode && isByChannelLayout;
 
-        if ((isNearestLinearOrCubicSupported || isPillowModeSupported) && mayiuse(cpu::x64::sse41)) {
+        if ((isNearestLinearOrCubicSupported || isPillowModeSupported) && ov::with_cpu_x86_sse42()) {
             executor = std::make_shared<InterpolateJitExecutor>(key.nodeAttrs,
                                                                 key.srcDims,
                                                                 key.dstDims,
@@ -2734,7 +2736,7 @@ void Interpolate::execute([[maybe_unused]] const dnnl::stream& strm) {
                     });
                 src_data = src_data_pad;
             } else if (interpAttrs.layout == InterpolateLayoutType::block) {
-                size_t blkSize = mayiuse(cpu::x64::avx512_core) ? 16 : 8;
+                size_t blkSize = ov::with_cpu_x86_avx512_core() ? 16 : 8;
                 size_t CB = div_up(srcDimPad5d[1], blkSize);
                 size_t eltsTotal = srcDimPad5d[0] * CB * srcDimPad5d[2] * srcDimPad5d[3] * srcDimPad5d[4] * blkSize;
                 srcPadded.resize(eltsTotal * srcDataSize, 0x0);
@@ -2819,7 +2821,7 @@ void Interpolate::InterpolateJitExecutor::NNCGathered(const uint8_t* in_ptr_,
                 (*interpolateKernel)(&arg);
             });
         } else {  // for blk
-            int blk_size = mayiuse(cpu::x64::avx512_core) ? 16 : 8;
+            int blk_size = ov::with_cpu_x86_avx512_core() ? 16 : 8;
             int CB = div_up(C, blk_size);
             const uint8_t* in_ptr = in_ptr_ + (IW * IH * ID * CB * blk_size * b) * srcDataSize;
             uint8_t* out_ptr = out_ptr_ + (OW * OH * OD * CB * blk_size * b) * dstDataSize;
@@ -2963,7 +2965,7 @@ void Interpolate::InterpolateJitExecutor::linearOnnxCGathered(const uint8_t* in_
 
     bool isByChannel = configured_for_layout == by_channel;
 
-    int blkSize = mayiuse(cpu::x64::avx512_core) ? 16 : 8;
+    int blkSize = ov::with_cpu_x86_avx512_core() ? 16 : 8;
     int CB = isByChannel ? 1 : div_up(C, blkSize);
     int CGatherLen = isByChannel ? C : blkSize;
     int workAmount = isByChannel ? C : CB;
@@ -3029,7 +3031,7 @@ void Interpolate::InterpolateJitExecutor::cubicCGathered(const uint8_t* in_ptr_,
     auto* yOrigin = static_cast<int*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW]);
     auto* yFactor = reinterpret_cast<float*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW + OH]);
 
-    int blkSize = mayiuse(cpu::x64::avx512_core) ? 16 : 8;
+    int blkSize = ov::with_cpu_x86_avx512_core() ? 16 : 8;
     int CB = div_up(C, blkSize);
     int CSize = configured_for_layout == InterpolateLayoutType::by_channel ? C : blkSize * CB;
     int CGatherLen = configured_for_layout == InterpolateLayoutType::by_channel ? C : blkSize;
@@ -3333,7 +3335,7 @@ void Interpolate::InterpolateExecutorBase::buildTblLinearOnnx(const VectorDims& 
             weightPtr[4] = reinterpret_cast<float*>(&auxTable[scratchLen + 4 * OW * OH * OD]);
             weightPtr[5] = reinterpret_cast<float*>(&auxTable[scratchLen + 5 * OW * OH * OD]);
         }
-        int scale = mayiuse(cpu::x64::sse41) ? srcDataSize : 1;
+        int scale = ov::with_cpu_x86_sse42() ? srcDataSize : 1;
 
         for (int oz = 0; oz < OD; oz++) {
             int izF = 0;
@@ -4552,9 +4554,9 @@ size_t Interpolate::getSpatialDimsNum(const std::vector<float>& scales) {
 }
 
 bool Interpolate::canFuse(const NodePtr& node) const {
-    if (!mayiuse(cpu::x64::sse41) || interpAttrs.mode == InterpolateMode::linear ||
+    if (!ov::with_cpu_x86_sse42() || interpAttrs.mode == InterpolateMode::linear ||
         interpAttrs.mode == InterpolateMode::bilinear_pillow || interpAttrs.mode == InterpolateMode::bicubic_pillow ||
-        (none_of(dataRank, 4U, 5U) && !mayiuse(cpu::x64::avx2))) {
+        (none_of(dataRank, 4U, 5U) && !ov::with_cpu_x86_avx2())) {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -58,6 +58,7 @@
 #    include <common/c_types_map.hpp>
 #    include <unordered_map>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/injectors/jit_uni_depthwise_injector.hpp"
 #    include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #    include "cpu/x64/injectors/jit_uni_quantization_injector.hpp"

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -5,7 +5,6 @@
 #include <cfloat>
 #include <cmath>
 #include <cpu/platform.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -42,6 +41,8 @@
 #include "utils/plain_tensor.hpp"
 #include "xattention.hpp"
 #if defined(OPENVINO_ARCH_X86_64)
+#    include <cpu/x64/cpu_isa_traits.hpp>
+
 #    include "nodes/kernels/x64/brgemm_kernel.hpp"
 #elif defined(OPENVINO_ARCH_ARM64) && defined(HAVE_SVE)
 #    include "arm_sve.h"
@@ -2803,8 +2804,7 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
                                                          const CpuParallelPtr& cpu_parallel) {
     std::shared_ptr<PagedAttentionExecutor> executor;
     if (params.is_sage_attn) {
-        bool s8s8_available = (ov::with_cpu_x86_avx512_core_amx_int8() ||
-                               dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::cpu_isa_t::avx2_vnni_2));
+        bool s8s8_available = (ov::with_cpu_x86_avx512_core_amx_int8() || ov::with_cpu_x86_avx2_vnni_2());
         OPENVINO_ASSERT(s8s8_available, "make_pa_executor: sage_attn needs amx_int8/vnni2 to support");
     }
 #if defined(OPENVINO_ARCH_X86_64)

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa_common.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa_common.hpp
@@ -3,17 +3,21 @@
 //
 #pragma once
 
-#include <xbyak/xbyak.h>
-
 #include <cstddef>
 #include <cstdint>
 #include <openvino/core/type/element_type.hpp>
 #include <utility>
 #include <vector>
 
-#include "cpu/x64/jit_generator.hpp"
 #include "cpu_memory.h"
+#include "openvino/core/visibility.hpp"
 #include "utils/plain_tensor.hpp"
+
+#if defined(OPENVINO_ARCH_X86_64)
+#    include <xbyak/xbyak.h>
+
+#    include "cpu/x64/jit_generator.hpp"
+#endif  // OPENVINO_ARCH_X86_64
 
 namespace ov::Extensions::Cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.hpp
@@ -4,14 +4,19 @@
 
 #pragma once
 
-#include <xbyak/xbyak.h>
-
 #include <cassert>
-#include <common/utils.hpp>
 #include <cstddef>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
-#include "cpu/x64/jit_generator.hpp"
+#include "openvino/core/visibility.hpp"
+
+#if defined(OPENVINO_ARCH_X86_64)
+#    include <xbyak/xbyak.h>
+
+#    include <common/utils.hpp>
+
+#    include "cpu/x64/cpu_isa_traits.hpp"
+#    include "cpu/x64/jit_generator.hpp"
+#endif
 
 namespace ov::intel_cpu {
 
@@ -61,6 +66,8 @@ struct jit_uni_fft_kernel {
 
     virtual void create_ker() = 0;
 };
+
+#if defined(OPENVINO_ARCH_X86_64)
 
 template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 struct jit_uni_dft_kernel_f32 : public jit_uni_dft_kernel, public dnnl::impl::cpu::x64::jit_generator_t {
@@ -141,5 +148,7 @@ private:
     void move_data(const Xbyak::Address& addr, const Xbyak::Xmm& x, int count);
     void move_data(const Xbyak::Xmm& x, const Xbyak::Address& addr, int count);
 };
+
+#endif  // OPENVINO_ARCH_X86_64
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
@@ -21,18 +21,23 @@
 
 #pragma once
 
-#include <xbyak/xbyak.h>
-
 #include <cassert>
-#include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 
-#include "cpu/x64/jit_generator.hpp"
-#include "emitters/plugin/x64/jit_conversion_emitters.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/visibility.hpp"
+
+#if defined(OPENVINO_ARCH_X86_64)
+#    include <xbyak/xbyak.h>
+
+#    include <common/utils.hpp>
+#    include <cpu/x64/cpu_isa_traits.hpp>
+
+#    include "cpu/x64/jit_generator.hpp"
+#    include "emitters/plugin/x64/jit_conversion_emitters.hpp"
+#endif
 
 namespace ov::intel_cpu {
 
@@ -125,6 +130,8 @@ protected:
     const bool is_real16_to_f32 = false;
     const bool is_f32_to_bf16 = false;
 };
+
+#if defined(OPENVINO_ARCH_X86_64)
 
 template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 struct jitUniGatherKernel : public jitGatherKernelBase, public dnnl::impl::cpu::x64::jit_generator_t {
@@ -235,5 +242,7 @@ protected:
     size_t dstStep = 0;
     std::unique_ptr<jit_convert_saturation_emitter> convert_emitter = nullptr;
 };
+
+#endif  // OPENVINO_ARCH_X86_64
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/grid_sample.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/grid_sample.hpp
@@ -4,17 +4,22 @@
 
 #pragma once
 
-#include <xbyak/xbyak.h>
-
 #include <cassert>
-#include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
-#include <cpu/x64/jit_generator.hpp>
 #include <cstdint>
 
 #include "jit_kernel_base.hpp"
-#include "nodes/kernels/x64/registers_pool.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/visibility.hpp"
+
+#if defined(OPENVINO_ARCH_X86_64)
+#    include <xbyak/xbyak.h>
+
+#    include <common/utils.hpp>
+#    include <cpu/x64/cpu_isa_traits.hpp>
+#    include <cpu/x64/jit_generator.hpp>
+
+#    include "nodes/kernels/x64/registers_pool.hpp"
+#endif  // OPENVINO_ARCH_X86_64
 
 namespace ov::intel_cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel_base.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel_base.hpp
@@ -4,11 +4,7 @@
 
 #pragma once
 
-#include <xbyak/xbyak.h>
-
 #include <cassert>
-#include <common/c_types_map.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -19,6 +15,11 @@
 #include "utils/cpu_utils.hpp"
 
 #if defined(OPENVINO_ARCH_X86_64)
+#    include <xbyak/xbyak.h>
+
+#    include <common/c_types_map.hpp>
+#    include <cpu/x64/cpu_isa_traits.hpp>
+
 #    include "cpu/x64/jit_generator.hpp"
 #    include "registers_pool.hpp"
 #endif  // OPENVINO_ARCH_X86_64

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/non_max_suppression.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/non_max_suppression.hpp
@@ -4,19 +4,21 @@
 
 #pragma once
 
-#include <xbyak/xbyak.h>
-
-#include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
-#include <cpu/x64/jit_generator.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>
 
 #include "jit_kernel_base.hpp"
+#include "openvino/core/visibility.hpp"
 
 #if defined(OPENVINO_ARCH_X86_64)
+#    include <xbyak/xbyak.h>
+
+#    include <common/utils.hpp>
+#    include <cpu/x64/cpu_isa_traits.hpp>
+#    include <cpu/x64/jit_generator.hpp>
+
 #    include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #    include "emitters/plugin/x64/jit_load_store_emitters.hpp"
 #endif  // OPENVINO_ARCH_X86_64

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/random_uniform.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/random_uniform.hpp
@@ -4,19 +4,21 @@
 
 #pragma once
 
-#include <xbyak/xbyak.h>
-
-#include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
-#include <cpu/x64/jit_generator.hpp>
 #include <cstdint>
 #include <vector>
 
 #include "jit_kernel_base.hpp"
-#include "nodes/kernels/x64/registers_pool.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/visibility.hpp"
 
 #if defined(OPENVINO_ARCH_X86_64)
+#    include <xbyak/xbyak.h>
+
+#    include <common/utils.hpp>
+#    include <cpu/x64/cpu_isa_traits.hpp>
+#    include <cpu/x64/jit_generator.hpp>
+
+#    include "nodes/kernels/x64/registers_pool.hpp"
 
 namespace ov::intel_cpu::kernel::random_uniform {
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.hpp
@@ -4,17 +4,20 @@
 
 #pragma once
 
-#include <xbyak/xbyak.h>
-
 #include <cassert>
-#include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <vector>
+
+#include "openvino/core/visibility.hpp"
+#include "utils/cpu_utils.hpp"
 #ifndef OPENVINO_ARCH_ARM64
+#    include <xbyak/xbyak.h>
+
+#    include <common/utils.hpp>
+#    include <cpu/x64/cpu_isa_traits.hpp>
+
 #    include "cpu/x64/jit_generator.hpp"
 #endif
-#include "utils/cpu_utils.hpp"
 
 namespace ov::intel_cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.hpp
@@ -10,7 +10,7 @@
 
 #include "openvino/core/visibility.hpp"
 #include "utils/cpu_utils.hpp"
-#ifndef OPENVINO_ARCH_ARM64
+#if defined(OPENVINO_ARCH_X86_64)
 #    include <xbyak/xbyak.h>
 
 #    include <common/utils.hpp>
@@ -42,7 +42,7 @@ struct jit_dft_args {
     size_t output_end;
 };
 
-#ifndef OPENVINO_ARCH_ARM64
+#if defined(OPENVINO_ARCH_X86_64)
 struct jit_dft_kernel {
     jit_dft_kernel(bool is_inverse, enum dft_type type) : is_inverse_(is_inverse), kernel_type_(type) {}
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.hpp
@@ -4,22 +4,24 @@
 
 #pragma once
 
-#include <xbyak/xbyak.h>
-
-#include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
-#include <cpu/x64/jit_generator.hpp>
 #include <cstddef>
 #include <memory>
 #include <unordered_map>
 #include <vector>
 
-#include "emitters/plugin/x64/jit_emitter.hpp"
 #include "jit_kernel_base.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/visibility.hpp"
 
 #if defined(OPENVINO_ARCH_X86_64)
-#endif
+#    include <xbyak/xbyak.h>
+
+#    include <common/utils.hpp>
+#    include <cpu/x64/cpu_isa_traits.hpp>
+#    include <cpu/x64/jit_generator.hpp>
+
+#    include "emitters/plugin/x64/jit_emitter.hpp"
+#endif  // OPENVINO_ARCH_X86_64
 
 namespace ov::intel_cpu::kernel {
 

--- a/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
+++ b/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "dnnl_scratch_pad.h"
 #include "graph_context.h"
 #include "memory_desc/cpu_memory_desc.h"
@@ -21,6 +20,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "transformations/cpu_opset/x64/op/llm_mlp.hpp"
 #include "utils/debug_capabilities.h"
@@ -568,9 +568,9 @@ void LLMMLP::initSupportedPrimitiveDescriptors() {
 
     if (rtPrecision == ov::element::f32) {
         // fallback to supported precision if possible
-        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx_fp16)) {
+        if (ov::with_cpu_x86_avx512_core_amx_fp16()) {
             rtPrecision = ov::element::f16;
-        } else if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
+        } else if (ov::with_cpu_x86_avx512_core_amx()) {
             rtPrecision = ov::element::bf16;
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
@@ -35,6 +34,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "post_ops.hpp"
 #include "shape_inference/custom/matmul.hpp"
 #include "utils/debug_capabilities.h"
@@ -104,7 +104,7 @@ MatMul::MatMul(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
 
 bool MatMul::canFuse(const NodePtr& node) const {
     // WA for CVS-84056: oneDNN brgemm impl has problem with per-OC binary-postOps for MatMul with 6D inputs
-    if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         if (auto* eltwiseNode = dynamic_cast<Eltwise*>(node.get())) {
             if (eltwiseNode->getBroadcastingPolicy() == EltwiseBroadcastingPolicy::PerChannel) {
                 auto rank = getInputShapeAtPort(0).getRank();

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -51,6 +51,7 @@
 #    include <common/c_types_map.hpp>
 #    include <functional>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/injectors/jit_uni_depthwise_injector.hpp"
 #    include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #    include "cpu/x64/injectors/jit_uni_quantization_injector.hpp"

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -9,7 +9,6 @@
 #include <cmath>
 #include <common/primitive_hashing_utils.hpp>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -41,6 +40,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/mvn.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
 #include "utils/precision_support.h"
@@ -62,9 +62,11 @@
 using namespace dnnl;
 
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 #define GET_OFF(field) offsetof(jit_mvn_call_args, field)
 
@@ -2098,19 +2100,19 @@ void MVN::initSupportedPrimitiveDescriptors() {
 #endif  // OV_CPU_WITH_ACL
 
     impl_desc_type impl_type = [&]() {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             return impl_desc_type::jit_sse42;
         }
         return impl_desc_type::ref;
     }();
 
-    if (mayiuse(cpu::x64::sse41)) {
+    if (ov::with_cpu_x86_sse42()) {
         // nspc
         if (getInputShapeAtPort(0).getRank() == 4 || getInputShapeAtPort(0).getRank() == 5) {
             pushDesc(LayoutType::nspc, impl_type);
@@ -2277,7 +2279,7 @@ void MVN::prepareParams() {
 
     auto builder = [&](const MVNKey& key) -> std::shared_ptr<MVNExecutorBase> {
         std::shared_ptr<MVNExecutorBase> executor;
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             executor = std::make_shared<MVNJitExecutor>(key.mvnAttrs, key.attr);
         } else {
             executor = std::make_shared<MVNRefExecutor>(key.mvnAttrs);
@@ -2386,11 +2388,11 @@ void MVN::MVNJitExecutor::mvn_pln(const uint8_t* src_data,
                                   const VectorDims& shape5d,
                                   const CpuParallelPtr& cpu_parallel) {
     size_t blk_size = 1;  // blk size in vmm
-    if (mayiuse(cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         blk_size = 16;
-    } else if (mayiuse(cpu::x64::avx2)) {
+    } else if (ov::with_cpu_x86_avx2()) {
         blk_size = 8;
-    } else if (mayiuse(cpu::x64::sse41)) {
+    } else if (ov::with_cpu_x86_sse42()) {
         blk_size = 4;
     }
 
@@ -2637,9 +2639,9 @@ void MVN::MVNJitExecutor::mvn_nspc(const uint8_t* src_data,
                                    const void* post_ops_data_,
                                    const VectorDims& shape5d) {
     size_t blk_size = 1;  // channel blk for memory layout
-    if (mayiuse(cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         blk_size = 16;
-    } else if (mayiuse(cpu::x64::avx2)) {
+    } else if (ov::with_cpu_x86_avx2()) {
         blk_size = 8;
     } else {
         blk_size = 4;
@@ -2772,7 +2774,7 @@ void MVN::MVNJitExecutor::mvn_blk(const uint8_t* src_data,
                                   const VectorDims& shape5d,
                                   const CpuParallelPtr& cpu_parallel) {
     size_t blk_size = 1;  // channel blk for memory layout
-    if (mayiuse(cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         blk_size = 16;
     } else {
         blk_size = 8;
@@ -3050,7 +3052,7 @@ void MVN::MVNJitExecutor::mvn_blk(const uint8_t* src_data,
 }
 
 bool MVN::canFuse(const NodePtr& node) const {
-    if (!mayiuse(cpu::x64::sse41)) {
+    if (!ov::with_cpu_x86_sse42()) {
         return false;
     }
     // limit post ops to unary when shape transformed on channel

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -56,6 +56,7 @@
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 #    include <xbyak/xbyak.h>
 
+#    include <cpu/x64/cpu_isa_traits.hpp>
 #    include <cpu/x64/jit_generator.hpp>
 
 #    include "cpu/x64/injectors/jit_uni_depthwise_injector.hpp"

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -13,7 +13,6 @@
 #include <common/utils.hpp>
 #include <cpu/primitive_attr_postops.hpp>
 #include <cpu/ref_depthwise_injector.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -49,6 +48,7 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/normalize_l2.hpp"
 #include "openvino/op/util/attr_types.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "selective_build.h"
 #include "utils/bfloat16.hpp"
 #include "utils/general_utils.h"
@@ -68,9 +68,11 @@
 using namespace dnnl;
 
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 #if defined(OPENVINO_ARCH_X86_64)
 #    define GET_OFF(field) offsetof(jit_normalize_call_args, field)
@@ -859,14 +861,14 @@ void NormalizeL2::initSupportedPrimitiveDescriptors() {
     }
 
     if (inputPrecision == ov::element::bf16 || outputPrecision == ov::element::bf16) {
-        if (!mayiuse(avx512_core)) {
+        if (!ov::with_cpu_x86_avx512_core()) {
             inputPrecision = outputPrecision = ov::element::f32;
         } else {
             inputPrecision = outputPrecision = ov::element::bf16;
         }
     }
 
-    if (any_of(ov::element::f16, inputPrecision, outputPrecision) && mayiuse(cpu::x64::sse41)) {
+    if (any_of(ov::element::f16, inputPrecision, outputPrecision) && ov::with_cpu_x86_sse42()) {
         inputPrecision = outputPrecision = ov::element::f32;
     }
 
@@ -913,9 +915,9 @@ void NormalizeL2::initSupportedPrimitiveDescriptors() {
 
     // only plain layout support when w/o sse42
     if (getInputShapeAtPort(DATA).getRank() == 4 && !attrs.cornerCase) {
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             pushDesc(LayoutType::nspc, impl_type);
-            if (mayiuse(cpu::x64::avx512_core)) {
+            if (ov::with_cpu_x86_avx512_core()) {
                 pushDesc(LayoutType::nCsp16c, impl_type);
             } else {
                 pushDesc(LayoutType::nCsp8c, impl_type);

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -46,9 +46,6 @@ using namespace ov::Extensions::Cpu::XARCH;
 
 using namespace ov::Extensions::Cpu;
 using namespace dnnl::impl;
-#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
-using namespace dnnl::impl::cpu::x64;
-#endif
 
 namespace ov::intel_cpu::node {
 

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -46,7 +46,9 @@ using namespace ov::Extensions::Cpu::XARCH;
 
 using namespace ov::Extensions::Cpu;
 using namespace dnnl::impl;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 using namespace dnnl::impl::cpu::x64;
+#endif
 
 namespace ov::intel_cpu::node {
 

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -123,7 +123,7 @@ PSROIPooling::PSROIPooling(const std::shared_ptr<ov::Node>& op, const GraphConte
         spatialBinsX = static_cast<size_t>(defPsroi->get_spatial_bins_x());
         spatialBinsY = static_cast<size_t>(defPsroi->get_spatial_bins_y());
         transStd = defPsroi->get_trans_std();
-        partSize = static_cast<size_t>(defPsroi->get_part_size());
+        partSize = static_cast<int>(defPsroi->get_part_size());
         // temporary workaround due to incorrect usage of group_size in the nGraph operation for the
         // DeformablePSROIPooling
         pooledHeight = groupSize;
@@ -612,7 +612,7 @@ void PSROIPooling::executeSpecified() {
     //  for Deformable PSROIPooling
     const float* bottomTrans = nullptr;
     int numClasses = 1;
-    int channelsEachClass = outputDim;
+    auto channelsEachClass = static_cast<int>(outputDim);
     if (!noTrans) {
         const auto mem = getSrcMemoryAtPort(2);
         bottomTrans = mem->getDataAs<const float>();

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -306,38 +306,37 @@ void PSROIPooling::executeAverage(const inputType* srcData,
     const float roiHeight = std::max<float>(roiEndH - roiStartH, 0.1F);
 
     auto avgPsroi = [&](int h, int w, size_t binOffIn, size_t binOffOut, size_t inBlkRes, size_t outBlkRes) {
-            float binSizeH = roiHeight / static_cast<float>(pooledHeight);
-            float binSizeW = roiWidth / static_cast<float>(pooledWidth);
+        float binSizeH = roiHeight / static_cast<float>(pooledHeight);
+        float binSizeW = roiWidth / static_cast<float>(pooledWidth);
 
-            auto hStart = static_cast<int>(std::floor(static_cast<float>(h) * binSizeH + roiStartH));
-            auto hEnd = static_cast<int>(std::ceil(static_cast<float>(h + 1) * binSizeH + roiStartH));
+        auto hStart = static_cast<int>(std::floor(static_cast<float>(h) * binSizeH + roiStartH));
+        auto hEnd = static_cast<int>(std::ceil(static_cast<float>(h + 1) * binSizeH + roiStartH));
 
-            hStart = std::min<int>(std::max<int>(hStart, 0), height);
-            hEnd = std::min<int>(std::max<int>(hEnd, 0), height);
-            auto wStart = static_cast<int>(std::floor(static_cast<float>(w) * binSizeW + roiStartW));
-            auto wEnd = static_cast<int>(std::ceil(static_cast<float>(w + 1) * binSizeW + roiStartW));
+        hStart = std::min<int>(std::max<int>(hStart, 0), height);
+        hEnd = std::min<int>(std::max<int>(hEnd, 0), height);
+        auto wStart = static_cast<int>(std::floor(static_cast<float>(w) * binSizeW + roiStartW));
+        auto wEnd = static_cast<int>(std::ceil(static_cast<float>(w + 1) * binSizeW + roiStartW));
 
-            wStart = std::min<int>(std::max<int>(wStart, 0), width);
-            wEnd = std::min<int>(std::max<int>(wEnd, 0), width);
+        wStart = std::min<int>(std::max<int>(wStart, 0), width);
+        wEnd = std::min<int>(std::max<int>(wEnd, 0), width);
 
-            const auto binArea = static_cast<float>((hEnd - hStart) * (wEnd - wStart));
+        const auto binArea = static_cast<float>((hEnd - hStart) * (wEnd - wStart));
 
-            size_t dstIndex = binOffOut + static_cast<size_t>(h) * hOutputStride + static_cast<size_t>(w) * wOutputStride +
-                              outBlkRes;
-            dstData[dstIndex] = 0;
-            if (static_cast<bool>(binArea)) {
-                float outSum = 0.0F;
-                const size_t heightIndexBound = static_cast<size_t>(hEnd) * hInputStride;
-                const size_t widthIndexBound = static_cast<size_t>(wEnd) * wInputStride;
-                for (size_t hh = static_cast<size_t>(hStart) * hInputStride; hh < heightIndexBound; hh += hInputStride) {
-                    for (size_t ww = static_cast<size_t>(wStart) * wInputStride; ww < widthIndexBound;
-                         ww += wInputStride) {
-                        outSum += srcData[binOffIn + hh + ww + inBlkRes];
-                    }
+        size_t dstIndex =
+            binOffOut + static_cast<size_t>(h) * hOutputStride + static_cast<size_t>(w) * wOutputStride + outBlkRes;
+        dstData[dstIndex] = 0;
+        if (static_cast<bool>(binArea)) {
+            float outSum = 0.0F;
+            const size_t heightIndexBound = static_cast<size_t>(hEnd) * hInputStride;
+            const size_t widthIndexBound = static_cast<size_t>(wEnd) * wInputStride;
+            for (size_t hh = static_cast<size_t>(hStart) * hInputStride; hh < heightIndexBound; hh += hInputStride) {
+                for (size_t ww = static_cast<size_t>(wStart) * wInputStride; ww < widthIndexBound; ww += wInputStride) {
+                    outSum += srcData[binOffIn + hh + ww + inBlkRes];
                 }
-                dstData[dstIndex] = outSum / binArea;
             }
-        };
+            dstData[dstIndex] = outSum / binArea;
+        }
+    };
     if (srcDesc.hasLayoutType(LayoutType::nspc)) {
         cpu_parallel->parallel_for2d(nh, nw, [&](int h, int w) {
             const size_t binOffsetOutput = static_cast<size_t>(n) * nc * nh * nw;
@@ -350,9 +349,11 @@ void PSROIPooling::executeAverage(const inputType* srcData,
     } else if (srcDesc.hasLayoutType(LayoutType::ncsp)) {
         cpu_parallel->parallel_for3d(nc, nh, nw, [&](int c, int h, int w) {
             const size_t gc = (static_cast<size_t>(c) * groupSize + h) * groupSize + w;
-            const size_t outputBlockResidual = dstDesc.hasLayoutType(LayoutType::ncsp) ? 0 : static_cast<size_t>(c) % inBlockSize;
+            const size_t outputBlockResidual =
+                dstDesc.hasLayoutType(LayoutType::ncsp) ? 0 : static_cast<size_t>(c) % inBlockSize;
             const size_t outputBlockIdx = (static_cast<size_t>(c) / outBlockSize) * outBlockSize;
-            const size_t binOffsetInput = (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + gc) * height * width;
+            const size_t binOffsetInput =
+                (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + gc) * height * width;
             const size_t binOffsetOutput = (static_cast<size_t>(n) * outputChannelsPadding + outputBlockIdx) * nh * nw;
             avgPsroi(h, w, binOffsetInput, binOffsetOutput, 0, outputBlockResidual);
         });
@@ -366,9 +367,10 @@ void PSROIPooling::executeAverage(const inputType* srcData,
                 const size_t outputBlockResidual = dstDesc.hasLayoutType(LayoutType::ncsp) ? 0 : c % inBlockSize;
                 const size_t inputBlockIdx = (gc / inBlockSize) * inBlockSize;
                 const size_t outputBlockIdx = (c / outBlockSize) * outBlockSize;
-                const size_t binOffsetInput = (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + inputBlockIdx) *
-                                              height * width;
-                const size_t binOffsetOutput = (static_cast<size_t>(n) * outputChannelsPadding + outputBlockIdx) * nh * nw;
+                const size_t binOffsetInput =
+                    (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + inputBlockIdx) * height * width;
+                const size_t binOffsetOutput =
+                    (static_cast<size_t>(n) * outputChannelsPadding + outputBlockIdx) * nh * nw;
                 avgPsroi(h, w, binOffsetInput, binOffsetOutput, inputBlockResidual, outputBlockResidual);
             }
         });
@@ -417,8 +419,8 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
         float accum = 0.0F;
         size_t binOffIn = 0;
         size_t inBlkRes = 0;
-        size_t dstIndex = binOffOut + static_cast<size_t>(h) * hOutputStride + static_cast<size_t>(w) * wOutputStride +
-                          outBlkRes;
+        size_t dstIndex =
+            binOffOut + static_cast<size_t>(h) * hOutputStride + static_cast<size_t>(w) * wOutputStride + outBlkRes;
         dstData[dstIndex] = 0;
 
         for (size_t binY = 0; binY < spatialBinsY; binY++) {
@@ -436,7 +438,8 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
                     inBlkRes = 0;
                 } else {  // nchw, nChw16c, nChw8c
                     const size_t inputBlockIdx = (gc / inBlockSize) * inBlockSize;
-                    binOffIn = (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + inputBlockIdx) * height * width;
+                    binOffIn =
+                        (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + inputBlockIdx) * height * width;
                     inBlkRes =
                         ((srcDesc.hasLayoutType(LayoutType::nCsp16c) || srcDesc.hasLayoutType(LayoutType::nCsp8c))
                              ? gc % inBlockSize
@@ -499,11 +502,12 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
         });
     } else if (srcDesc.hasLayoutType(LayoutType::ncsp)) {
         cpu_parallel->parallel_for3d(nc, nh, nw, [&](int c, int h, int w) {
-            bilinearPsroi(c,
-                          h,
-                          w,
-                          0,
-                          (static_cast<size_t>(currentRoi) * outputChannelsPadding + c) * static_cast<size_t>(binCount));
+            bilinearPsroi(
+                c,
+                h,
+                w,
+                0,
+                (static_cast<size_t>(currentRoi) * outputChannelsPadding + c) * static_cast<size_t>(binCount));
         });
     } else {  // nChw16c, nChw8c
         cpu_parallel->parallel_for3d(outBlockCount, nh, nw, [&](size_t blkIdx, int h, int w) {
@@ -512,7 +516,8 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
             for (size_t c = cStart; c < cEnd; c++) {
                 const size_t outputBlockIdx = (c / inBlockSize) * inBlockSize;
                 const size_t binOffsetOutput =
-                    (static_cast<size_t>(currentRoi) * outputChannelsPadding + outputBlockIdx) * static_cast<size_t>(binCount);
+                    (static_cast<size_t>(currentRoi) * outputChannelsPadding + outputBlockIdx) *
+                    static_cast<size_t>(binCount);
                 const size_t outputBlockResidual =
                     ((srcDesc.hasLayoutType(LayoutType::nCsp16c) || srcDesc.hasLayoutType(LayoutType::nCsp8c))
                          ? c % inBlockSize

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -297,40 +297,41 @@ void PSROIPooling::executeAverage(const inputType* srcData,
                  outBlockCount,
                  inputChannelsPadding,
                  outputChannelsPadding);
-    const float roiStartW = round(bottomRois[1]) * spatialScale;
-    const float roiStartH = round(bottomRois[2]) * spatialScale;
-    const float roiEndW = round(bottomRois[3] + 1.0F) * spatialScale;
-    const float roiEndH = round(bottomRois[4] + 1.0F) * spatialScale;
+    const float roiStartW = std::round(bottomRois[1]) * spatialScale;
+    const float roiStartH = std::round(bottomRois[2]) * spatialScale;
+    const float roiEndW = std::round(bottomRois[3] + 1.0F) * spatialScale;
+    const float roiEndH = std::round(bottomRois[4] + 1.0F) * spatialScale;
     // Force too small ROIs to be 1x1
     const float roiWidth = std::max<float>(roiEndW - roiStartW, 0.1F);  // avoid 0
     const float roiHeight = std::max<float>(roiEndH - roiStartH, 0.1F);
 
-    auto avgPsroi =
-        [&]([[maybe_unused]] int c, int h, int w, int binOffIn, int binOffOut, int inBlkRes, int outBlkRes) {
+    auto avgPsroi = [&](int h, int w, size_t binOffIn, size_t binOffOut, size_t inBlkRes, size_t outBlkRes) {
             float binSizeH = roiHeight / static_cast<float>(pooledHeight);
             float binSizeW = roiWidth / static_cast<float>(pooledWidth);
 
-            auto hStart = static_cast<int>(floor(static_cast<float>(h + 0) * binSizeH + roiStartH));
-            auto hEnd = static_cast<int>(ceil(static_cast<float>(h + 1) * binSizeH + roiStartH));
+            auto hStart = static_cast<int>(std::floor(static_cast<float>(h) * binSizeH + roiStartH));
+            auto hEnd = static_cast<int>(std::ceil(static_cast<float>(h + 1) * binSizeH + roiStartH));
 
             hStart = std::min<int>(std::max<int>(hStart, 0), height);
             hEnd = std::min<int>(std::max<int>(hEnd, 0), height);
-            auto wStart = static_cast<int>(floor(static_cast<float>(w + 0) * binSizeW + roiStartW));
-            auto wEnd = static_cast<int>(ceil(static_cast<float>(w + 1) * binSizeW + roiStartW));
+            auto wStart = static_cast<int>(std::floor(static_cast<float>(w) * binSizeW + roiStartW));
+            auto wEnd = static_cast<int>(std::ceil(static_cast<float>(w + 1) * binSizeW + roiStartW));
 
             wStart = std::min<int>(std::max<int>(wStart, 0), width);
             wEnd = std::min<int>(std::max<int>(wEnd, 0), width);
 
             const auto binArea = static_cast<float>((hEnd - hStart) * (wEnd - wStart));
 
-            size_t dstIndex = binOffOut + h * hOutputStride + w * wOutputStride + outBlkRes;
+            size_t dstIndex = binOffOut + static_cast<size_t>(h) * hOutputStride + static_cast<size_t>(w) * wOutputStride +
+                              outBlkRes;
             dstData[dstIndex] = 0;
             if (static_cast<bool>(binArea)) {
                 float outSum = 0.0F;
-                const int heightIndexBound = hEnd * hInputStride;
-                const int widthIndexBound = wEnd * wInputStride;
-                for (int hh = hStart * hInputStride; hh < heightIndexBound; hh += hInputStride) {
-                    for (int ww = wStart * wInputStride; ww < widthIndexBound; ww += wInputStride) {
+                const size_t heightIndexBound = static_cast<size_t>(hEnd) * hInputStride;
+                const size_t widthIndexBound = static_cast<size_t>(wEnd) * wInputStride;
+                for (size_t hh = static_cast<size_t>(hStart) * hInputStride; hh < heightIndexBound; hh += hInputStride) {
+                    for (size_t ww = static_cast<size_t>(wStart) * wInputStride; ww < widthIndexBound;
+                         ww += wInputStride) {
                         outSum += srcData[binOffIn + hh + ww + inBlkRes];
                     }
                 }
@@ -339,37 +340,36 @@ void PSROIPooling::executeAverage(const inputType* srcData,
         };
     if (srcDesc.hasLayoutType(LayoutType::nspc)) {
         cpu_parallel->parallel_for2d(nh, nw, [&](int h, int w) {
-            const int binOffsetOutput = n * nc * nh * nw;
-            const int binOffsetInput = roiBatchInd * channels * height * width;
+            const size_t binOffsetOutput = static_cast<size_t>(n) * nc * nh * nw;
+            const size_t binOffsetInput = static_cast<size_t>(roiBatchInd) * channels * height * width;
             for (int c = 0; c < nc; c++) {
-                const int gc = (c * groupSize + h) * groupSize + w;
-                avgPsroi(c, h, w, 0, 0, binOffsetInput + gc, binOffsetOutput + c);
+                const size_t gc = (static_cast<size_t>(c) * groupSize + h) * groupSize + w;
+                avgPsroi(h, w, binOffsetInput + gc, binOffsetOutput + c, 0, 0);
             }
         });
     } else if (srcDesc.hasLayoutType(LayoutType::ncsp)) {
         cpu_parallel->parallel_for3d(nc, nh, nw, [&](int c, int h, int w) {
-            const int gc = (c * groupSize + h) * groupSize + w;
-            const int outputBlockResidual = (dstDesc.hasLayoutType(LayoutType::ncsp) ? 0 : c % inBlockSize);
-            const int outputBlockIdx = (c / outBlockSize) * outBlockSize;
-            const int binOffsetInput = (roiBatchInd * static_cast<int>(inputChannelsPadding) + gc) * height * width;
-            const int binOffsetOutput = (n * static_cast<int>(outputChannelsPadding) + outputBlockIdx) * nh * nw;
-            avgPsroi(c, h, w, 0, outputBlockResidual, binOffsetInput, binOffsetOutput);
+            const size_t gc = (static_cast<size_t>(c) * groupSize + h) * groupSize + w;
+            const size_t outputBlockResidual = dstDesc.hasLayoutType(LayoutType::ncsp) ? 0 : static_cast<size_t>(c) % inBlockSize;
+            const size_t outputBlockIdx = (static_cast<size_t>(c) / outBlockSize) * outBlockSize;
+            const size_t binOffsetInput = (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + gc) * height * width;
+            const size_t binOffsetOutput = (static_cast<size_t>(n) * outputChannelsPadding + outputBlockIdx) * nh * nw;
+            avgPsroi(h, w, binOffsetInput, binOffsetOutput, 0, outputBlockResidual);
         });
     } else {  // nChw16c, nChw8c
-        cpu_parallel->parallel_for3d(outBlockCount, nh, nw, [&](int blkIdx, int h, int w) {
-            int cStart = blkIdx * outBlockSize;
-            int cEnd =
-                static_cast<size_t>(blkIdx) == (outBlockCount - 1LU) ? nc : cStart + static_cast<int>(outBlockSize);
-            for (int c = cStart; c < cEnd; c++) {
-                const int gc = (c * groupSize + h) * groupSize + w;
-                const int inputBlockResidual = (srcDesc.hasLayoutType(LayoutType::ncsp) ? 0 : gc % inBlockSize);
-                const int outputBlockResidual = (dstDesc.hasLayoutType(LayoutType::ncsp) ? 0 : c % inBlockSize);
-                const int inputBlockIdx = (gc / inBlockSize) * inBlockSize;
-                const int outputBlockIdx = (c / outBlockSize) * outBlockSize;
-                const int binOffsetInput =
-                    (roiBatchInd * static_cast<int>(inputChannelsPadding) + inputBlockIdx) * height * width;
-                const int binOffsetOutput = (n * static_cast<int>(outputChannelsPadding) + outputBlockIdx) * nh * nw;
-                avgPsroi(c, h, w, inputBlockResidual, outputBlockResidual, binOffsetInput, binOffsetOutput);
+        cpu_parallel->parallel_for3d(outBlockCount, nh, nw, [&](size_t blkIdx, int h, int w) {
+            const size_t cStart = blkIdx * outBlockSize;
+            const size_t cEnd = blkIdx == (outBlockCount - 1LU) ? static_cast<size_t>(nc) : cStart + outBlockSize;
+            for (size_t c = cStart; c < cEnd; c++) {
+                const size_t gc = (c * groupSize + h) * groupSize + w;
+                const size_t inputBlockResidual = srcDesc.hasLayoutType(LayoutType::ncsp) ? 0 : gc % inBlockSize;
+                const size_t outputBlockResidual = dstDesc.hasLayoutType(LayoutType::ncsp) ? 0 : c % inBlockSize;
+                const size_t inputBlockIdx = (gc / inBlockSize) * inBlockSize;
+                const size_t outputBlockIdx = (c / outBlockSize) * outBlockSize;
+                const size_t binOffsetInput = (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + inputBlockIdx) *
+                                              height * width;
+                const size_t binOffsetOutput = (static_cast<size_t>(n) * outputChannelsPadding + outputBlockIdx) * nh * nw;
+                avgPsroi(h, w, binOffsetInput, binOffsetOutput, inputBlockResidual, outputBlockResidual);
             }
         });
     }
@@ -413,11 +413,12 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
     size_t numBins = spatialBinsX * spatialBinsY;
     const int binCount = nh * nw;
 
-    auto bilinearPsroi = [&](int c, int h, int w, int binOffOut, int outBlkRes) {
+    auto bilinearPsroi = [&](size_t c, int h, int w, size_t binOffOut, size_t outBlkRes) {
         float accum = 0.0F;
-        int binOffIn = 0;
-        int inBlkRes = 0;
-        size_t dstIndex = binOffOut + h * hOutputStride + w * wOutputStride + outBlkRes;
+        size_t binOffIn = 0;
+        size_t inBlkRes = 0;
+        size_t dstIndex = binOffOut + static_cast<size_t>(h) * hOutputStride + static_cast<size_t>(w) * wOutputStride +
+                          outBlkRes;
         dstData[dstIndex] = 0;
 
         for (size_t binY = 0; binY < spatialBinsY; binY++) {
@@ -431,11 +432,11 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
             for (size_t binX = 0; binX < spatialBinsX; binX++) {
                 size_t gc = c + (binY * spatialBinsX + binX) * nc;
                 if (srcDesc.hasLayoutType(LayoutType::nspc)) {
-                    binOffIn = roiBatchInd * channels * height * width + gc;
+                    binOffIn = static_cast<size_t>(roiBatchInd) * channels * height * width + gc;
                     inBlkRes = 0;
                 } else {  // nchw, nChw16c, nChw8c
-                    const int inputBlockIdx = (gc / inBlockSize) * inBlockSize;
-                    binOffIn = (roiBatchInd * static_cast<int>(inputChannelsPadding) + inputBlockIdx) * height * width;
+                    const size_t inputBlockIdx = (gc / inBlockSize) * inBlockSize;
+                    binOffIn = (static_cast<size_t>(roiBatchInd) * inputChannelsPadding + inputBlockIdx) * height * width;
                     inBlkRes =
                         ((srcDesc.hasLayoutType(LayoutType::nCsp16c) || srcDesc.hasLayoutType(LayoutType::nCsp8c))
                              ? gc % inBlockSize
@@ -490,7 +491,7 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
     };
 
     if (srcDesc.hasLayoutType(LayoutType::nspc)) {
-        const int binOffsetOutput = currentRoi * nc * nh * nw;
+        const size_t binOffsetOutput = static_cast<size_t>(currentRoi) * nc * nh * nw;
         cpu_parallel->parallel_for2d(nh, nw, [&](int h, int w) {
             for (int c = 0; c < nc; c++) {
                 bilinearPsroi(c, h, w, 0, binOffsetOutput + c);
@@ -498,18 +499,21 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
         });
     } else if (srcDesc.hasLayoutType(LayoutType::ncsp)) {
         cpu_parallel->parallel_for3d(nc, nh, nw, [&](int c, int h, int w) {
-            bilinearPsroi(c, h, w, 0, (currentRoi * static_cast<int>(outputChannelsPadding) + c) * binCount);
+            bilinearPsroi(c,
+                          h,
+                          w,
+                          0,
+                          (static_cast<size_t>(currentRoi) * outputChannelsPadding + c) * static_cast<size_t>(binCount));
         });
     } else {  // nChw16c, nChw8c
-        cpu_parallel->parallel_for3d(outBlockCount, nh, nw, [&](int blkIdx, int h, int w) {
-            int cStart = blkIdx * outBlockSize;
-            int cEnd =
-                static_cast<size_t>(blkIdx) == (outBlockCount - 1LU) ? nc : cStart + static_cast<int>(outBlockSize);
-            for (int c = cStart; c < cEnd; c++) {
-                const int outputBlockIdx = (c / inBlockSize) * inBlockSize;
-                const int binOffsetOutput =
-                    (currentRoi * static_cast<int>(outputChannelsPadding) + outputBlockIdx) * binCount;
-                const int outputBlockResidual =
+        cpu_parallel->parallel_for3d(outBlockCount, nh, nw, [&](size_t blkIdx, int h, int w) {
+            const size_t cStart = blkIdx * outBlockSize;
+            const size_t cEnd = blkIdx == (outBlockCount - 1LU) ? static_cast<size_t>(nc) : cStart + outBlockSize;
+            for (size_t c = cStart; c < cEnd; c++) {
+                const size_t outputBlockIdx = (c / inBlockSize) * inBlockSize;
+                const size_t binOffsetOutput =
+                    (static_cast<size_t>(currentRoi) * outputChannelsPadding + outputBlockIdx) * static_cast<size_t>(binCount);
+                const size_t outputBlockResidual =
                     ((srcDesc.hasLayoutType(LayoutType::nCsp16c) || srcDesc.hasLayoutType(LayoutType::nCsp8c))
                          ? c % inBlockSize
                          : 0);
@@ -529,10 +533,10 @@ void PSROIPooling::executeBilinearDeformable(const inputType* srcData,
                                              const int currentRoi,
                                              const int roiBatchInd) {
     const auto& cpu_parallel = context->getCpuParallel();
-    const float roiStartW = round(bottomRois[1]) * spatialScale - 0.5F;
-    const float roiStartH = round(bottomRois[2]) * spatialScale - 0.5F;
-    const float roiEndW = (round(bottomRois[3]) + 1.0F) * spatialScale - 0.5F;
-    const float roiEndH = (round(bottomRois[4]) + 1.0F) * spatialScale - 0.5F;
+    const float roiStartW = std::round(bottomRois[1]) * spatialScale - 0.5F;
+    const float roiStartH = std::round(bottomRois[2]) * spatialScale - 0.5F;
+    const float roiEndW = (std::round(bottomRois[3]) + 1.0F) * spatialScale - 0.5F;
+    const float roiEndH = (std::round(bottomRois[4]) + 1.0F) * spatialScale - 0.5F;
     // Force too small ROIs to be 1x1
     const float roiWidth = std::max<float>(roiEndW - roiStartW, 0.1F);  // avoid 0
     const float roiHeight = std::max<float>(roiEndH - roiStartH, 0.1F);
@@ -546,8 +550,8 @@ void PSROIPooling::executeBilinearDeformable(const inputType* srcData,
         float subBinSizeH = binSizeH / static_cast<float>(spatialBinsY);
         float subBinSizeW = binSizeW / static_cast<float>(spatialBinsX);
 
-        int partH = h * partSize / pooledHeight;
-        int partW = w * partSize / pooledWidth;
+        int partH = h * partSize / static_cast<int>(pooledHeight);
+        int partW = w * partSize / static_cast<int>(pooledWidth);
         int classId = c / channelsEachClass;
         float transX =
             noTrans ? 0
@@ -564,10 +568,10 @@ void PSROIPooling::executeBilinearDeformable(const inputType* srcData,
 
         float sum = 0;
         int count = 0;
-        int gw = w * groupSize / pooledWidth;
-        int gh = h * groupSize / pooledHeight;
-        gw = (std::min)((std::max)(gw, 0), static_cast<int>(groupSize - 1));
-        gh = (std::min)((std::max)(gh, 0), static_cast<int>(groupSize - 1));
+        int gw = w * static_cast<int>(groupSize) / static_cast<int>(pooledWidth);
+        int gh = h * static_cast<int>(groupSize) / static_cast<int>(pooledHeight);
+        gw = (std::min)((std::max)(gw, 0), static_cast<int>(groupSize) - 1);
+        gh = (std::min)((std::max)(gh, 0), static_cast<int>(groupSize) - 1);
 
         const inputType* offsetBottomData = srcData + (roiBatchInd * channels) * height * width;
         for (size_t ih = 0; ih < spatialBinsY; ih++) {

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -28,6 +27,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/deformable_psroi_pooling.hpp"
 #include "openvino/op/psroi_pooling.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "selective_build.h"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/bfloat16.hpp"
@@ -36,7 +36,6 @@
 
 using namespace dnnl;
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
 
 namespace ov::intel_cpu::node {
@@ -149,13 +148,13 @@ void PSROIPooling::initSupportedPrimitiveDescriptors() {
     }
 
     impl_desc_type impl_type = [&]() {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             return impl_desc_type::jit_sse42;
         }
         return impl_desc_type::ref;

--- a/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
+++ b/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "graph_context.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "node.h"
@@ -20,6 +19,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "transformations/cpu_opset/x64/op/qkv_proj.hpp"
 #include "utils/debug_capabilities.h"
@@ -383,9 +383,9 @@ void QKVProjection::initSupportedPrimitiveDescriptors() {
 
     if (rtPrecision == ov::element::f32) {
         // fallback to supported precision if possible
-        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx_fp16)) {
+        if (ov::with_cpu_x86_avx512_core_amx_fp16()) {
             rtPrecision = ov::element::f16;
-        } else if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
+        } else if (ov::with_cpu_x86_avx512_core_amx()) {
             rtPrecision = ov::element::bf16;
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/rdft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rdft.cpp
@@ -38,10 +38,10 @@
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "openvino/core/parallel.hpp"
-#endif
 
 using namespace dnnl::impl;
 using namespace dnnl::impl::cpu::x64;
+#endif
 
 namespace ov::intel_cpu::node {
 

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -10,7 +10,6 @@
 #include <common/c_types_map.hpp>
 #include <common/primitive_attr.hpp>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -56,6 +55,7 @@
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/util/arithmetic_reductions_keep_dims.hpp"
 #include "openvino/op/util/logical_reduction_keep_dims.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/bfloat16.hpp"
 #include "utils/general_utils.h"
@@ -80,9 +80,11 @@
 using namespace dnnl;
 
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 #define SET_SRC_DIM_VALUE(batch, channel, depth, height, width) \
     IB = batch;                                                 \
@@ -2139,11 +2141,11 @@ void Reduce::initSupportedPrimitiveDescriptors() {
         // use BF16/FP16 output precision due to the possible accuracy loss. Therefore, for such mods, we will change
         // the output precision to FP32.
         if (ov::element::bf16 == output_prec) {
-            if (!mayiuse(avx512_core) || is_precision_sensitive_reduce(algorithm)) {
+            if (!ov::with_cpu_x86_avx512_core() || is_precision_sensitive_reduce(algorithm)) {
                 output_prec = ov::element::f32;
             }
         } else if (ov::element::f16 == output_prec) {
-            if (!mayiuse(cpu::x64::avx2) || is_precision_sensitive_reduce(algorithm)) {
+            if (!ov::with_cpu_x86_avx2() || is_precision_sensitive_reduce(algorithm)) {
                 output_prec = ov::element::f32;
             }
         }
@@ -2249,9 +2251,9 @@ void Reduce::initSupportedPrimitiveDescriptors() {
 
     if (jit_mode) {
         impl_desc_type impl_type = impl_desc_type::jit_sse42;
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             impl_type = impl_desc_type::jit_avx512;
-        } else if (mayiuse(cpu::x64::avx2)) {
+        } else if (ov::with_cpu_x86_avx2()) {
             impl_type = impl_desc_type::jit_avx2;
         }
 
@@ -2259,18 +2261,18 @@ void Reduce::initSupportedPrimitiveDescriptors() {
         if ((getInputShapeAtPort(REDUCE_DATA).getRank() == 4 || getInputShapeAtPort(REDUCE_DATA).getRank() == 5) &&
             getInputShapeAtPort(REDUCE_DATA).getMinDims()[1] > 1) {
             if (keep_dims) {
-                if (mayiuse(cpu::x64::avx512_core)) {
+                if (ov::with_cpu_x86_avx512_core()) {
                     pushDesc(LayoutType::nspc, LayoutType::nspc, input_prec, output_prec, impl_type);
                     pushDesc(LayoutType::nCsp16c, LayoutType::nCsp16c, input_prec, output_prec, impl_type);
-                } else if (mayiuse(cpu::x64::avx2) || mayiuse(cpu::x64::sse41)) {
+                } else if (ov::with_cpu_x86_avx2() || ov::with_cpu_x86_sse42()) {
                     pushDesc(LayoutType::nspc, LayoutType::nspc, input_prec, output_prec, impl_type);
                     pushDesc(LayoutType::nCsp8c, LayoutType::nCsp8c, input_prec, output_prec, impl_type);
                 }
             } else {
-                if (mayiuse(cpu::x64::avx512_core)) {
+                if (ov::with_cpu_x86_avx512_core()) {
                     pushDesc(LayoutType::nspc, LayoutType::ncsp, input_prec, output_prec, impl_type);
                     pushDesc(LayoutType::nCsp16c, LayoutType::ncsp, input_prec, output_prec, impl_type);
-                } else if (mayiuse(cpu::x64::avx2) || mayiuse(cpu::x64::sse41)) {
+                } else if (ov::with_cpu_x86_avx2() || ov::with_cpu_x86_sse42()) {
                     pushDesc(LayoutType::nspc, LayoutType::ncsp, input_prec, output_prec, impl_type);
                     pushDesc(LayoutType::nCsp8c, LayoutType::ncsp, input_prec, output_prec, impl_type);
                 }
@@ -2417,7 +2419,7 @@ void Reduce::createPrimitive() {
     compile_post_kernel = false;
 #endif  // OPENVINO_ARCH_X86_64
 
-    if (mayiuse(cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         blk_size = 16;
     } else {
         blk_size = 8;
@@ -2579,7 +2581,7 @@ void Reduce::reduce_PLN(const uint8_t* in_ptr, uint8_t* out_ptr) {
             GET_PTR_N_PLN;
             if (!ReduceC && !ReduceD && ReduceW) {
                 size_t work_amount = ReduceH ? IH * IW : IW;
-                if (work_amount < blk_size && mayiuse(cpu::x64::avx2)) {
+                if (work_amount < blk_size && ov::with_cpu_x86_avx2()) {
                     size_t outer_size = ReduceH ? IC * ID : IC * ID * IH;
                     size_t inner_size = ReduceH ? IH * IW : IW;
                     size_t output_inner_size = ReduceH ? OH * OW : OW;
@@ -3418,9 +3420,9 @@ inline void Reduce::create_hybrid_working_memory() {
             return (rank == 4) ? memory::format_tag::nhwc : memory::format_tag::ndhwc;
         }
         if (rank == 4) {
-            return mayiuse(cpu::x64::avx512_core) ? memory::format_tag::nChw16c : memory::format_tag::nChw8c;
+            return ov::with_cpu_x86_avx512_core() ? memory::format_tag::nChw16c : memory::format_tag::nChw8c;
         }
-        return mayiuse(cpu::x64::avx512_core) ? memory::format_tag::nCdhw16c : memory::format_tag::nCdhw8c;
+        return ov::with_cpu_x86_avx512_core() ? memory::format_tag::nCdhw16c : memory::format_tag::nCdhw8c;
     }();
     auto prc_dims = rank == 4 ? std::vector<size_t>{OB, OC, OH, OW} : std::vector<size_t>{OB, OC, OD, OH, OW};
     auto desc = dnnl::memory::desc(DnnlExtensionUtils::convertToDnnlDims(prc_dims),
@@ -3836,7 +3838,7 @@ bool Reduce::canApplyJIT(const ov::element::Type& input_prec, const ov::element:
     static const ov::element::Type supportedPrecisions[] =
         {ov::element::f32, ov::element::f16, ov::element::bf16, ov::element::i32, ov::element::i8, ov::element::u8};
 
-    return (mayiuse(cpu::x64::sse41)) && (getInputShapeAtPort(REDUCE_DATA).getRank() <= 5 || jit_beyond_5D) &&
+    return (ov::with_cpu_x86_sse42()) && (getInputShapeAtPort(REDUCE_DATA).getRank() <= 5 || jit_beyond_5D) &&
            std::find(std::begin(supportedPrecisions), std::end(supportedPrecisions), input_prec) !=
                std::end(supportedPrecisions) &&
            std::find(std::begin(supportedPrecisions), std::end(supportedPrecisions), output_prec) !=

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -63,6 +63,7 @@
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 #    include <xbyak/xbyak.h>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/injectors/jit_uni_depthwise_injector.hpp"
 #    include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #    include "cpu/x64/injectors/jit_uni_quantization_injector.hpp"

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
 

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -9,10 +9,8 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "common/cpu_convert.h"
 #include "cpu_types.h"
@@ -38,6 +36,7 @@
 #    include <common/c_types_map.hpp>
 #    include <common/utils.hpp>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #    include "emitters/plugin/x64/jit_bf16_emitters.hpp"

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -27,6 +26,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/region_yolo.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/bfloat16.hpp"
 #include "utils/cpp/bit_cast.hpp"
@@ -46,7 +46,9 @@
 
 using namespace dnnl::impl;
 using namespace dnnl::impl::cpu;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 using namespace dnnl::impl::cpu::x64;
+#endif
 using namespace dnnl::impl::utils;
 
 #if defined(OPENVINO_ARCH_X86_64)
@@ -324,19 +326,19 @@ void RegionYolo::initSupportedPrimitiveDescriptors() {
     }
 
     if (ov::element::bf16 == output_prec) {
-        if (!mayiuse(avx512_core)) {
+        if (!ov::with_cpu_x86_avx512_core()) {
             output_prec = ov::element::f32;
         }
     }
 
     impl_desc_type impl_type = [&] {
-        if (mayiuse(x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
-        if (mayiuse(x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             return impl_desc_type::jit_sse42;
         }
         return impl_desc_type::ref;

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -312,7 +312,7 @@ void Reorder::prepareParams() {
             if (dstStrides.back() != 1) {
                 return false;
             }
-            for (int i = inDims.size() - 1; i > 0; i--) {
+            for (int i = static_cast<int>(inDims.size()) - 1; i > 0; i--) {
                 if (dstStrides[i - 1] != dstStrides[i] * inDims[dstOrder[i]] && dstOrder[i] != channelDim) {
                     return false;
                 }

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -8,7 +8,6 @@
 #include <oneapi/dnnl/dnnl_types.h>
 
 #include <algorithm>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -53,6 +52,7 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "thread_pool_imp.hpp"
 #include "utils/debug_capabilities.h"
 #include "utils/general_utils.h"
@@ -145,7 +145,7 @@ void Reorder::initSupportedPrimitiveDescriptors() {
             // oneDNN JIT reorder shows bad perf for nspc to ncsp reorder case so we fallback on simple c++
             // implementation
             isNspc2NcspCase = true;
-        } else if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2) && any_of(inShape.getRank(), 4U, 5U) &&
+        } else if (!ov::with_cpu_x86_avx2() && any_of(inShape.getRank(), 4U, 5U) &&
                    config.inConfs[0].getMemDesc()->hasLayoutType(LayoutType::ncsp) &&
                    config.outConfs[0].getMemDesc()->hasLayoutType(LayoutType::nspc) &&
                    config.inConfs[0].getMemDesc()->getPrecision() == config.outConfs[0].getMemDesc()->getPrecision() &&

--- a/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_memory.h"
 #include "graph_context.h"
 #include "memory_desc/cpu_memory_desc.h"
@@ -22,6 +21,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "ov_ops/rms.hpp"
 #include "shape_inference/custom/rms_norm.hpp"
 #include "utils/general_utils.h"
@@ -35,7 +35,6 @@
 #include <vector>
 
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 
 namespace ov::intel_cpu::node {
 
@@ -69,9 +68,9 @@ bool RMSNormKey::operator==(const RMSNormKey& rhs) const {
 static std::shared_ptr<kernel::JitKernelBase> createJitKernel(const kernel::jit_rms_compile_params& param) {
     std::shared_ptr<kernel::JitKernelBase> res;
 
-    if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         res = std::make_shared<kernel::jit_rms_kernel<dnnl::impl::cpu::x64::avx512_core>>(param);
-    } else if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2)) {
+    } else if (ov::with_cpu_x86_avx2()) {
         res = std::make_shared<kernel::jit_rms_kernel<dnnl::impl::cpu::x64::avx2>>(param);
     }
 
@@ -145,10 +144,10 @@ void RMSNorm::initSupportedPrimitiveDescriptors() {
     }
 
     auto impl_type = [&]() {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
         return impl_desc_type::ref;
@@ -196,7 +195,7 @@ bool RMSNorm::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, st
     try {
         const auto rms = ov::as_type_ptr<const ov::op::internal::RMS>(op);
         if (rms) {
-            if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2)) {
+            if (!ov::with_cpu_x86_avx2()) {
                 errorMessage = "RMSNorm needs avx2+.";
                 return false;
             }

--- a/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
@@ -26,6 +26,7 @@
 #include "shape_inference/custom/rms_norm.hpp"
 #include "utils/general_utils.h"
 #ifdef OPENVINO_ARCH_X86_64
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu_parallel.hpp"
 #    include "kernels/x64/rms_kernel.hpp"
 #    include "nodes/kernels/x64/jit_kernel_base.hpp"

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -47,6 +47,7 @@
 #    include <type_traits>
 #    include <unordered_map>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #    include "emitters/plugin/x64/jit_emitter.hpp"
 #    include "emitters/plugin/x64/jit_load_store_emitters.hpp"

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -20,7 +20,6 @@
 #include <utils/bfloat16.hpp>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_types.h"
 #include "dnnl_extension_utils.h"
 #include "graph_context.h"
@@ -36,6 +35,7 @@
 #include "openvino/core/parallel.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "selective_build.h"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
@@ -56,9 +56,11 @@
 using namespace dnnl;
 using namespace dnnl::impl;
 using namespace dnnl::impl::cpu;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 namespace ov::intel_cpu::node {
 
@@ -826,7 +828,7 @@ void ROIAlign::initSupportedPrimitiveDescriptors() {
     ov::element::Type outputPrec = getOriginalOutputPrecisionAtPort(0);
 
     if (inputPrec0 != ov::element::f32 || outputPrec != ov::element::f32) {
-        if ((outputPrec == ov::element::bf16 || inputPrec0 == ov::element::bf16) && mayiuse(avx512_core)) {
+        if ((outputPrec == ov::element::bf16 || inputPrec0 == ov::element::bf16) && ov::with_cpu_x86_avx512_core()) {
             outputPrec = inputPrec0 = ov::element::bf16;
         } else {
             outputPrec = inputPrec0 = ov::element::f32;
@@ -838,13 +840,13 @@ void ROIAlign::initSupportedPrimitiveDescriptors() {
     config.outConfs.resize(1);
 
     impl_desc_type impl_type = [&]() {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             return impl_desc_type::jit_sse42;
         }
         return impl_desc_type::ref;
@@ -852,7 +854,7 @@ void ROIAlign::initSupportedPrimitiveDescriptors() {
 
     std::vector<std::pair<LayoutType, LayoutType>> supportedFormats{{LayoutType::ncsp, LayoutType::ncsp}};
 
-    if (mayiuse(cpu::x64::sse41)) {
+    if (ov::with_cpu_x86_sse42()) {
         supportedFormats.emplace_back(LayoutType::nspc, LayoutType::nspc);
         if (impl_desc_type::jit_avx512 == impl_type) {
             supportedFormats.emplace_back(LayoutType::nCsp16c, LayoutType::nCsp16c);

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -1020,8 +1020,8 @@ void ROIAlign::executeSpecified() {
         float binHeight = roiHeight / static_cast<float>(pooledH);
         float binWidth = roiWidth / static_cast<float>(pooledW);
 
-        auto samplingRatioX = samplingRatio == 0 ? static_cast<int>(ceil(binWidth)) : samplingRatio;
-        auto samplingRatioY = samplingRatio == 0 ? static_cast<int>(ceil(binHeight)) : samplingRatio;
+        auto samplingRatioX = samplingRatio == 0 ? static_cast<int>(std::ceil(binWidth)) : samplingRatio;
+        auto samplingRatioY = samplingRatio == 0 ? static_cast<int>(std::ceil(binHeight)) : samplingRatio;
 
         uint64_t numSamplesInBin = static_cast<uint64_t>(samplingRatioX) * samplingRatioY;
         numSamples[n] = numSamplesInBin;

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -38,6 +38,7 @@
 #if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
 #    include <xbyak/xbyak.h>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #    include "emitters/plugin/x64/jit_load_store_emitters.hpp"
 #    include "utils/cpu_utils.hpp"

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -8,7 +8,6 @@
 #include <cmath>
 #include <common/float16.hpp>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
@@ -30,6 +29,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/roi_pooling.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "selective_build.h"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/bfloat16.hpp"
@@ -45,9 +45,11 @@
 
 using namespace dnnl;
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 #define GET_OFF(field) offsetof(jit_roi_pooling_call_args, field)
 
@@ -468,15 +470,15 @@ void ROIPooling::initSupportedPrimitiveDescriptors() {
         return;
     }
 
-    auto format = mayiuse(avx512_core) ? LayoutType::nCsp16c : LayoutType::nCsp8c;
+    auto format = ov::with_cpu_x86_avx512_core() ? LayoutType::nCsp16c : LayoutType::nCsp8c;
     impl_desc_type impl_type = [&]() {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             return impl_desc_type::jit_sse42;
         }
         return impl_desc_type::ref;
@@ -484,7 +486,7 @@ void ROIPooling::initSupportedPrimitiveDescriptors() {
 
     refParams.src_prc = getOriginalInputPrecisionAtPort(0);
 
-    if (!mayiuse(avx512_core)) {
+    if (!ov::with_cpu_x86_avx512_core()) {
         if (refParams.src_prc == ov::element::bf16) {
             refParams.src_prc = ov::element::f32;
         }
@@ -503,9 +505,9 @@ void ROIPooling::createPrimitive() {
     auto* selectedPD = getSelectedPrimitiveDescriptor();
     CPU_NODE_ASSERT(selectedPD, "doesn't have primitive descriptors.");
 
-    refParams.c_block = mayiuse(cpu::x64::avx512_core) ? 16 : 8;
+    refParams.c_block = ov::with_cpu_x86_avx512_core() ? 16 : 8;
     ;
-    refParams.nb_c_blocking = mayiuse(cpu::x64::avx512_core) ? 15 : 7;
+    refParams.nb_c_blocking = ov::with_cpu_x86_avx512_core() ? 15 : 7;
     refParams.alg = getAlgorithm();
 
     const auto& config = selectedPD->getConfig();

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -16,7 +16,6 @@
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_memory.h"
 #include "cpu_parallel.hpp"
 #include "dnnl_extension_utils.h"
@@ -75,15 +74,16 @@
 #include "kernels/scaled_attn/mha_kv_cache_codec.hpp"
 #include "kernels/scaled_attn/mha_single_token.hpp"
 #include "kernels/scaled_attn/softmax.hpp"
-#include "kernels/x64/brgemm_kernel.hpp"
 #include "utils/precision_support.h"
+#if defined(OPENVINO_ARCH_X86_64)
+#    include "kernels/x64/brgemm_kernel.hpp"
+#endif
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
 #    include "nodes/common/cpu_convert.h"
 #endif
 
 using namespace ov::Extensions::Cpu::XARCH;
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 
 namespace ov::intel_cpu::node {
 
@@ -316,6 +316,7 @@ struct MHAKernel {
     }
 };
 
+#if defined(OPENVINO_ARCH_X86_64)
 template <typename T>
 struct MHAKernel<ScaledDotProductAttention::KT_ONEDNN, T> {
     // q: [B, H, q_len, S]
@@ -655,6 +656,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_ONEDNN, T> {
                        d_scale);
     }
 };
+#endif  // OPENVINO_ARCH_X86_64
 
 #ifdef OV_CPU_WITH_ACL
 template <typename T>
@@ -2996,7 +2998,7 @@ ov::element::Type ScaledDotProductAttention::getKeyCachePrecision() {
     const auto rtPrecision = getRuntimePrecision();
     const auto keyHint = context->getConfig().keyCachePrecision;
     const auto valueHint = context->getConfig().valueCachePrecision;
-    const bool enableKVCacheFP16 = m_config.config.fuse_concat && mayiuse(cpu_isa_t::avx2) &&
+    const bool enableKVCacheFP16 = m_config.config.fuse_concat && ov::with_cpu_x86_avx2() &&
                                    rtPrecision != ov::element::bf16 && all_of(ov::element::f16, keyHint, valueHint);
     return side_cache_precision(m_key_spec.alg == ov::internal::CacheQuantAlgorithm::TURBO,
                                 keyHint,
@@ -3008,7 +3010,7 @@ ov::element::Type ScaledDotProductAttention::getValueCachePrecision() {
     const auto rtPrecision = getRuntimePrecision();
     const auto keyHint = context->getConfig().keyCachePrecision;
     const auto valueHint = context->getConfig().valueCachePrecision;
-    const bool enableKVCacheFP16 = m_config.config.fuse_concat && mayiuse(cpu_isa_t::avx2) &&
+    const bool enableKVCacheFP16 = m_config.config.fuse_concat && ov::with_cpu_x86_avx2() &&
                                    rtPrecision != ov::element::bf16 && all_of(ov::element::f16, keyHint, valueHint);
     return side_cache_precision(m_value_spec.alg == ov::internal::CacheQuantAlgorithm::TURBO,
                                 valueHint,
@@ -3019,7 +3021,7 @@ ov::element::Type ScaledDotProductAttention::getValueCachePrecision() {
 ov::element::Type ScaledDotProductAttention::getRuntimePrecision() const {
     auto rtPrecision = getOriginalInputPrecisionAtPort(0);
     // bf16 should be enabled only when platform supports
-    if (rtPrecision == ov::element::bf16 && (ov::with_cpu_x86_bfloat16() || mayiuse(cpu_isa_t::avx2_vnni_2))) {
+    if (rtPrecision == ov::element::bf16 && (ov::with_cpu_x86_bfloat16() || ov::with_cpu_x86_avx2_vnni_2())) {
         rtPrecision = ov::element::bf16;
     } else if (rtPrecision == ov::element::f16 && ov::intel_cpu::hasHardwareSupport(ov::element::f16)) {
         rtPrecision = ov::element::f16;

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -30,7 +30,6 @@
 #include "onednn/iml_type_mapper.h"
 #include "openvino/core/except.hpp"
 #include "openvino/core/node.hpp"
-#include "openvino/core/parallel.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
@@ -42,9 +41,13 @@
 #include "utils/plain_tensor.hpp"
 
 #if defined(OPENVINO_ARCH_X86_64) || defined(OPENVINO_ARCH_X86)
+#    include "kernels/scaled_attn/softmax.hpp"
+#    include "openvino/core/parallel.hpp"
 #    include "openvino/core/type/bfloat16.hpp"
 #    include "openvino/core/type/float16.hpp"
 #elif defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
+#    include "kernels/scaled_attn/softmax.hpp"
+#    include "openvino/core/parallel.hpp"
 #    include "openvino/core/type/float16.hpp"
 #endif
 
@@ -73,7 +76,6 @@
 #include "kernels/scaled_attn/codecs/turboq_rotation.hpp"
 #include "kernels/scaled_attn/mha_kv_cache_codec.hpp"
 #include "kernels/scaled_attn/mha_single_token.hpp"
-#include "kernels/scaled_attn/softmax.hpp"
 #include "utils/precision_support.h"
 #if defined(OPENVINO_ARCH_X86_64)
 #    include "kernels/x64/brgemm_kernel.hpp"

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -193,11 +193,11 @@ struct MHAKernel {
 #endif
         float sum = 0.0F;
         for (int i = 0; i < len; i++) {
-            a[i] = exp(a[i] - max);
+            a[i] = std::exp(a[i] - max);
             sum += a[i];
         }
         if (sink != nullptr) {
-            sum += exp((*sink) - max);
+            sum += std::exp((*sink) - max);
         }
         float scale = 1.0F / sum;
         for (int i = 0; i < len; i++) {

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -91,7 +91,7 @@ ShuffleChannels::ShuffleChannels(const std::shared_ptr<ov::Node>& op, const Grap
     auto shuffleChannels = ov::as_type_ptr<const ov::op::v0::ShuffleChannels>(op);
     attrs.group = shuffleChannels->get_group();
     attrs.axis = static_cast<int>(shuffleChannels->get_axis());
-    attrs.dataRank = getInputShapeAtPort(0).getRank();
+    attrs.dataRank = static_cast<int>(getInputShapeAtPort(0).getRank());
     if (attrs.axis < 0) {
         attrs.axis += attrs.dataRank;
     }

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -6,7 +6,6 @@
 
 #include <cmath>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -30,13 +29,13 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
 
 using namespace dnnl;
 
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 
 namespace ov::intel_cpu::node {
 
@@ -110,13 +109,13 @@ void ShuffleChannels::initSupportedPrimitiveDescriptors() {
     }
 
     auto impl_type = []() {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             return impl_desc_type::jit_sse42;
         }
         return impl_desc_type::ref;

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -6,7 +6,6 @@
 
 #include <cmath>
 #include <common/utils.hpp>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -33,6 +32,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/space_to_depth.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "openvino/util/pp.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
@@ -129,11 +129,11 @@ void SpaceToDepth::initSupportedPrimitiveDescriptors() {
     ov::element::Type precision = getOriginalInputPrecisionAtPort(0);
 
     impl_desc_type impl_type = impl_desc_type::ref;
-    if (cpu::x64::mayiuse(impl::cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         impl_type = impl_desc_type::jit_avx512;
-    } else if (cpu::x64::mayiuse(cpu::x64::avx2)) {
+    } else if (ov::with_cpu_x86_avx2()) {
         impl_type = impl_desc_type::jit_avx2;
-    } else if (cpu::x64::mayiuse(cpu::x64::sse41)) {
+    } else if (ov::with_cpu_x86_sse42()) {
         impl_type = impl_desc_type::jit_sse42;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -166,7 +166,8 @@ void SpaceToDepth::initSupportedPrimitiveDescriptors() {
     }
     supportedTypes.push_back(LayoutType::ncsp);
     auto creators = BlockedDescCreator::getCommonCreators();
-    auto range = BlockedDescCreator::makeFilteredRange(creators, inputDataShape.getRank(), supportedTypes);
+    auto range =
+        BlockedDescCreator::makeFilteredRange(creators, static_cast<unsigned>(inputDataShape.getRank()), supportedTypes);
 
     for (auto itr = range.first; itr != range.second; ++itr) {
         config.inConfs[0].setMemDesc(itr->second->createSharedDesc(precision, inputDataShape));

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -166,8 +166,9 @@ void SpaceToDepth::initSupportedPrimitiveDescriptors() {
     }
     supportedTypes.push_back(LayoutType::ncsp);
     auto creators = BlockedDescCreator::getCommonCreators();
-    auto range =
-        BlockedDescCreator::makeFilteredRange(creators, static_cast<unsigned>(inputDataShape.getRank()), supportedTypes);
+    auto range = BlockedDescCreator::makeFilteredRange(creators,
+                                                       static_cast<unsigned>(inputDataShape.getRank()),
+                                                       supportedTypes);
 
     for (auto itr = range.first; itr != range.second; ++itr) {
         config.inConfs[0].setMemDesc(itr->second->createSharedDesc(precision, inputDataShape));

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -36,6 +35,7 @@
 #include "openvino/op/topk.hpp"
 #include "openvino/op/util/attr_types.hpp"
 #include "openvino/op/util/topk_base.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "utils/general_utils.h"
 #include "utils/ngraph_utils.hpp"
@@ -53,9 +53,11 @@
 
 using namespace dnnl;
 using namespace dnnl::impl;
-using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::utils;
+#if defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64)
+using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
+#endif
 
 namespace ov::intel_cpu::node {
 
@@ -1972,13 +1974,13 @@ void TopK::initSupportedPrimitiveDescriptors() {
     }
 
     impl_desc_type impl_type = [&]() {
-        if (mayiuse(cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             return impl_desc_type::jit_avx512;
         }
-        if (mayiuse(cpu::x64::avx2)) {
+        if (ov::with_cpu_x86_avx2()) {
             return impl_desc_type::jit_avx2;
         }
-        if (mayiuse(cpu::x64::sse41)) {
+        if (ov::with_cpu_x86_sse42()) {
             return impl_desc_type::jit_sse42;
         }
         return impl_desc_type::ref;
@@ -1999,7 +2001,8 @@ void TopK::initSupportedPrimitiveDescriptors() {
     ov::element::Type dataPrecision = getOriginalOutputPrecisionAtPort(TOPK_DATA);
     bool precisionSupported = std::find(std::begin(supportedPrecision), std::end(supportedPrecision), dataPrecision) !=
                               std::end(supportedPrecision);
-    precisionSupported = (dataPrecision == ov::element::bf16 && !mayiuse(avx512_core)) ? false : precisionSupported;
+    precisionSupported =
+        (dataPrecision == ov::element::bf16 && !ov::with_cpu_x86_avx512_core()) ? false : precisionSupported;
     if (!precisionSupported) {
         if (dataPrecision.is_real()) {
             dataPrecision = ov::element::f32;
@@ -2043,9 +2046,9 @@ void TopK::preset_params() {
         ((layout == TopKLayoutType::topk_ncsp && axis == (getOutputShapeAtPort(TOPK_DATA).getRank() - 1LU)) ||
          ((layout == TopKLayoutType::topk_nspc || layout == TopKLayoutType::topk_blocked) && axis == 1LU));
 
-    if (mayiuse(cpu::x64::avx512_core)) {
+    if (ov::with_cpu_x86_avx512_core()) {
         blk_size = 16;
-    } else if (mayiuse(cpu::x64::sse41)) {
+    } else if (ov::with_cpu_x86_sse42()) {
         blk_size = 8;
     }
 
@@ -2346,7 +2349,7 @@ inline void TopK::prepare_original_idx() {
                 }
             }
         } else {
-            size_t blk_len = mayiuse(cpu::x64::avx2) ? blk_size : 4;
+            size_t blk_len = ov::with_cpu_x86_avx2() ? blk_size : 4;
             if (vec_idx_block.empty()) {
                 vec_idx_block.resize(axis_dim * blk_len);
                 for (size_t i = 0; i < axis_dim; i++) {

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -45,6 +45,7 @@
 
 #    include <common/utils.hpp>
 
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "cpu/x64/jit_generator.hpp"
 #    include "emitters/plugin/x64/jit_emitter.hpp"
 #    include "emitters/plugin/x64/jit_load_store_emitters.hpp"

--- a/src/plugins/intel_cpu/src/onednn/dnnl.cpp
+++ b/src/plugins/intel_cpu/src/onednn/dnnl.cpp
@@ -12,7 +12,9 @@
 #include <cstring>
 #include <oneapi/dnnl/dnnl.hpp>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
+#if defined(OPENVINO_ARCH_X86_64)
+#    include "cpu/x64/cpu_isa_traits.hpp"
+#endif
 
 namespace dnnl::utils {
 
@@ -133,6 +135,7 @@ unsigned get_cache_size(int level, bool per_core) {
     if (per_core) {
         return dnnl::impl::cpu::platform::get_per_core_cache_size(level);
     }
+#if defined(OPENVINO_ARCH_X86_64)
     using namespace dnnl::impl::cpu::x64;
     if (cpu().getDataCacheLevels() == 0) {
         // this function can return stub values in case of unknown CPU type
@@ -144,6 +147,9 @@ unsigned get_cache_size(int level, bool per_core) {
         return cpu().getDataCacheSize(l);
     }
     return 0U;
+#else
+    return dnnl::impl::cpu::platform::get_per_core_cache_size(level);
+#endif
 }
 
 }  // namespace dnnl::utils

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -28,7 +28,6 @@
 
 #include "compiled_model.h"
 #include "config.h"
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "cpu_streams_calculation.hpp"
 #include "graph_context.h"
 #include "internal_properties.hpp"
@@ -52,6 +51,7 @@
 #include "openvino/runtime/iplugin.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
+#include "openvino/runtime/system_conf.hpp"
 #include "openvino/runtime/threading/cpu_message.hpp"
 #include "openvino/runtime/threading/executor_manager.hpp"
 #include "openvino/runtime/threading/istreams_executor.hpp"
@@ -67,7 +67,10 @@
 #include "utils/graph_serializer/serializer.hpp"
 #include "utils/precision_support.h"
 #include "weights_cache.hpp"
-#include "xbyak/xbyak_util.h"
+
+#if defined(OPENVINO_ARCH_X86_64)
+#    include "xbyak/xbyak_util.h"
+#endif
 
 #ifdef _MSC_VER
 #    pragma warning(pop)
@@ -242,10 +245,12 @@ static std::string getDeviceFullName() {
 
 Plugin::Plugin() : deviceFullName(getDeviceFullName()), specialSetup(new CPUSpecialSetup) {
     set_device_name("CPU");
+#if defined(OPENVINO_ARCH_X86_64)
     // Initialize Xbyak::util::Cpu object on Pcore for hybrid cores machine
     get_executor_manager()->execute_task_by_streams_executor(ov::hint::SchedulingCoreType::PCORE_ONLY, [] {
         dnnl::impl::cpu::x64::cpu();
     });
+#endif
     const auto& ov_version = ov::get_openvino_version();
     m_compiled_model_runtime_properties["OV_VERSION"] = std::string(ov_version.buildNumber);
     m_msg_manager = ov::threading::message_manager();
@@ -410,6 +415,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
         new_result.get_tensor().set_names(orig_result.get_tensor().get_names());
     }
 
+#if defined(OPENVINO_ARCH_X86_64)
     // SSE runtime check is needed for some ATOM machine, which is x86-64 but w/o SSE
     static Xbyak::util::Cpu cpu;
     if (cpu.has(Xbyak::util::Cpu::tSSE)) {
@@ -421,6 +427,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
             denormals_as_zero(false);
         }
     }
+#endif
     return std::make_shared<CompiledModel>(cloned_model, shared_from_this(), conf, false);
 }
 
@@ -633,11 +640,10 @@ ov::Any Plugin::get_ro_property(const std::string& name, [[maybe_unused]] const 
     }
     if (name == ov::device::capabilities) {
         std::vector<std::string> capabilities;
-        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16) ||
-            dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni_2)) {
+        if (ov::with_cpu_x86_bfloat16() || ov::with_cpu_x86_avx2_vnni_2()) {
             capabilities.emplace_back(ov::device::capability::BF16);
         }
-        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+        if (ov::with_cpu_x86_avx512_core()) {
             capabilities.emplace_back(ov::device::capability::WINOGRAD);
         }
         capabilities.emplace_back(ov::device::capability::FP32);

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -69,6 +69,7 @@
 #include "weights_cache.hpp"
 
 #if defined(OPENVINO_ARCH_X86_64)
+#    include "cpu/x64/cpu_isa_traits.hpp"
 #    include "xbyak/xbyak_util.h"
 #endif
 


### PR DESCRIPTION
### Details:
 - The plugin included `cpu/x64/cpu_isa_traits.hpp` (which transitively pulls `xbyak/xbyak.h`) unconditionally in many architecture-common source files, including on `AArch64`/`RISC-V` builds, where those symbols don't apply.
 - This forced the build to expose the x86 xbyak include directory on non-x86 targets.
 - This PR removes that dependency from all architecture-common files, so the x64 header is pulled only where x86-specific JIT kernels are actually compiled.
 - `static_cast` and other type related fixes are not the goal of this PR, but they are forced by `clang-tidy`

### `mayiuse` to `with_cpu_x86_*` mapping

```
  ┌───────────────────────────_──────────────────────────────────────────_───────────────────────────────────────────────────────┐
  │    oneDNN mayiuse(...)    │               replacement                │                         note                          │
  ├───────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ sse41                     │ ov::with_cpu_x86_sse42()                 │ see SSE section below                                 │
  ├───────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ avx / avx2 / avx2_vnni    │ with_cpu_x86_avx() / _avx2() /           │ identical predicate                                   │
  │                           │ _avx2_vnni()                             │                                                       │
  ├───────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ avx2_vnni_2               │ with_cpu_x86_avx2_vnni_2()               │ identical (avx2 && AVX_VNNI && AVX_VNNI_INT8 &&       │
  │                           │                                          │ AVX_NE_CONVERT)                                       │
  ├───────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ avx512_core / _vnni /     │ matching with_cpu_x86_*                  │ identical                                             │
  │ _fp16                     │                                          │                                                       │
  ├───────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ avx512_core_bf16          │ with_cpu_x86_bfloat16()                  │ checks AVX512_BF16 bit; equivalent on all shipping    │
  │                           │                                          │ BF16 AVX-512 CPUs                                     │
  ├───────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ avx512_core_amx           │ with_cpu_x86_avx512_core_amx()           │ broader predicate - see note                          │
  ├───────────────────────────┼──────────────────────────────────────────┼───────────────────────────────────────────────────────┤
  │ avx512_core_amx_fp16      │ with_cpu_x86_avx512_core_amx_fp16()      │ broader; only gates format lists / behind strict      │
  │                           │                                          │ upstream gate                                         │
  └───────────────────────────┴──────────────────────────────────────────┴───────────────────────────────────────────────────────┘
```

#### Mapping notes
 - SSE4.1 to SSE4.2 transition: There is no `ov::with_cpu_x86_sse41()` in the OpenVINO API, and this PR intentionally does not add one: the plugin's lowest SSE JIT tier is already named `impl_desc_type::jit_sse42`, and the test infrastructure already treats `ov::with_cpu_x86_sse42()` as the "JIT kernel available" floor: https://github.com/openvinotoolkit/openvino/blob/c9da68121640267f5eb0c5bc7880b7befb50865b/src/plugins/intel_cpu/tests/functional/utils/x64/filter_cpu_info.cpp#L67
- `avx512_core_amx` predicate is broader than oneDNN's. `with_cpu_x86_avx512_core_amx()` = `AMX_INT8 || AMX_BF16` (CPUID only); oneDNN's `mayiuse(avx512_core_amx)` = `amx_int8 && amx_bf16 && avx512_core_fp16`, and additionally performs the Linux AMX tile-permission request (`arch_prctl`). At the converted sites this is a safe superset. The custom AMX microkernels in `llm_mlp/qkv_proj` remain protected by the unchanged strict `mayiuse(avx512_core_amx)` gate in `transformation_pipeline.cpp`.

### Tickets:
 - *ticket-id*