### PR TITLE
[ONNX FE] Add FLOAT4E2M1 and FLOAT8E8M0 type support

### DIFF
--- a/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
@@ -60,10 +60,14 @@ const ov::element::Type& get_ov_element_type(int64_t onnx_type) {
         return ov::element::dynamic;
     case TensorProto_DataType::TensorProto_DataType_BFLOAT16:
         return ov::element::bf16;
+    case TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1:
+        return ov::element::f4e2m1;
     case TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN:
         return ov::element::f8e4m3;
     case TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2:
         return ov::element::f8e5m2;
+    case TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0:
+        return ov::element::f8e8m0;
     case TensorProto_DataType::TensorProto_DataType_STRING:
         return ov::element::string;
     }
@@ -467,8 +471,10 @@ ov::frontend::onnx::TensorMetaInfo extract_tensor_meta_info(const TensorProto* t
             case TensorProto_DataType::TensorProto_DataType_BOOL:
             case TensorProto_DataType::TensorProto_DataType_BFLOAT16:
             case TensorProto_DataType::TensorProto_DataType_FLOAT16:
+            case TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1:
             case TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN:
             case TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2:
+            case TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0:
                 assign_numeric_data(tensor_info->int32_data());
                 break;
             case TensorProto_DataType::TensorProto_DataType_INT64:

--- a/src/frontends/onnx/frontend/src/core/tensor.cpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.cpp
@@ -251,10 +251,11 @@ std::vector<uint8_t> Tensor::get_data() const {
         return detail::__get_raw_data<uint8_t>(m_tensor_proto->raw_data(), m_tensor_proto->data_type());
     }
     if (m_tensor_proto->data_type() == TensorProto_DataType::TensorProto_DataType_UINT8 ||
-        m_tensor_proto->data_type() == TensorProto_DataType::TensorProto_DataType_UINT4) {
+        m_tensor_proto->data_type() == TensorProto_DataType::TensorProto_DataType_UINT4 ||
+        m_tensor_proto->data_type() == TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1) {
         return detail::__get_data<uint8_t>(m_tensor_proto->int32_data());
     }
-    ONNX_INVALID_DATA_TYPE(m_tensor_proto->data_type(), "UINT4, UINT8, raw data");
+    ONNX_INVALID_DATA_TYPE(m_tensor_proto->data_type(), "UINT4, UINT8, FLOAT4E2M1, raw data");
 }
 
 template <>
@@ -384,6 +385,38 @@ std::vector<ov::float8_e5m2> Tensor::get_data() const {
         return detail::__get_data<ov::float8_e5m2>(float8_data);
     }
     ONNX_INVALID_DATA_TYPE(m_tensor_proto->data_type(), "FLOAT8E5M2, raw data");
+}
+
+template <>
+std::vector<ov::float8_e8m0> Tensor::get_data() const {
+    const auto bits_to_float8_e8m0 = [](const auto& int32_data) {
+        std::vector<ov::float8_e8m0> float8_data;
+        float8_data.reserve(int32_data.size());
+        std::transform(std::begin(int32_data), std::end(int32_data), std::back_inserter(float8_data), [](int32_t elem) {
+            return ov::float8_e8m0::from_bits(static_cast<uint8_t>(elem));
+        });
+        return float8_data;
+    };
+
+    if (has_external_data()) {
+        return get_external_data<ov::float8_e8m0>();
+    }
+    if (m_tensor_place != nullptr) {
+        if (m_tensor_place->is_raw()) {
+            return detail::__get_data<ov::float8_e8m0, ov::float8_e8m0>(
+                m_tensor_place->get_data(),
+                raw_value_count<ov::float8_e8m0>(m_tensor_place));
+        }
+        const auto* const int32_data = static_cast<const int32_t*>(m_tensor_place->get_data());
+        return bits_to_float8_e8m0(std::vector<int32_t>(int32_data, int32_data + m_tensor_place->get_data_size()));
+    }
+    if (m_tensor_proto->has_raw_data()) {
+        return detail::__get_raw_data<ov::float8_e8m0>(m_tensor_proto->raw_data(), m_tensor_proto->data_type());
+    }
+    if (m_tensor_proto->data_type() == TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0) {
+        return bits_to_float8_e8m0(m_tensor_proto->int32_data());
+    }
+    ONNX_INVALID_DATA_TYPE(m_tensor_proto->data_type(), "FLOAT8E8M0, raw data");
 }
 
 template <>
@@ -520,18 +553,26 @@ std::shared_ptr<ov::op::v0::Constant> Tensor::get_ov_constant() const {
         case TensorProto_DataType::TensorProto_DataType_FLOAT16:
             constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<ov::float16>().data());
             break;
+        case TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1:
+            // f4e2m1 is a nibble type - two values are packed into a single byte, same as in ONNX
+            constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<uint8_t>().data());
+            break;
         case TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN:
             constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<ov::float8_e4m3>().data());
             break;
         case TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2:
             constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<ov::float8_e5m2>().data());
             break;
+        case TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0:
+            constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<ov::float8_e8m0>().data());
+            break;
         case TensorProto_DataType::TensorProto_DataType_STRING:
             constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<std::string>().data());
             break;
         default:
             ONNX_UNSUPPORTED_DATA_TYPE(m_tensor_proto->data_type(),
-                                       "BOOL, BFLOAT16, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT, FLOAT16, DOUBLE, INT4, "
+                                       "BOOL, BFLOAT16, FLOAT4E2M1, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT8E8M0, FLOAT, "
+                                       "FLOAT16, DOUBLE, INT4, "
                                        "INT8, INT16, INT32, INT64, "
                                        "UINT4, UINT8, UINT16, UINT32, UINT64, STRING");
         }
@@ -575,18 +616,26 @@ std::shared_ptr<ov::op::v0::Constant> Tensor::get_ov_constant() const {
             case ov::element::f16:
                 constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<ov::float16>().data());
                 break;
+            case ov::element::f4e2m1:
+                // f4e2m1 is a nibble type - two values are packed into a single byte, same as in ONNX
+                constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<uint8_t>().data());
+                break;
             case ov::element::f8e4m3:
                 constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<ov::float8_e4m3>().data());
                 break;
             case ov::element::f8e5m2:
                 constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<ov::float8_e5m2>().data());
                 break;
+            case ov::element::f8e8m0:
+                constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<ov::float8_e8m0>().data());
+                break;
             case ov::element::string:
                 constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, get_data<std::string>().data());
                 break;
             default:
                 ONNX_UNSUPPORTED_DATA_TYPE(m_tensor_proto->data_type(),
-                                           "BOOL, BFLOAT16, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT, FLOAT16, DOUBLE, INT4, "
+                                           "BOOL, BFLOAT16, FLOAT4E2M1, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT8E8M0, FLOAT, "
+                                           "FLOAT16, DOUBLE, INT4, "
                                            "INT8, INT16, INT32, INT64, "
                                            "UINT4, UINT8, UINT16, UINT32, UINT64, STRING");
             }

--- a/src/frontends/onnx/frontend/src/core/tensor.hpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.hpp
@@ -183,8 +183,10 @@ public:
         bfloat16 = TensorProto_DataType::TensorProto_DataType_BFLOAT16,
         complex64 = TensorProto_DataType::TensorProto_DataType_COMPLEX64,
         complex128 = TensorProto_DataType::TensorProto_DataType_COMPLEX128,
+        float4e2m1 = TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1,
         float8e4m3fn = TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN,
         float8e5m2 = TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2,
+        float8e8m0 = TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0,
     };
 
     Tensor() = delete;
@@ -282,10 +284,14 @@ public:
             return ov::element::u64;
         case TensorProto_DataType::TensorProto_DataType_BFLOAT16:
             return ov::element::bf16;
+        case TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1:
+            return ov::element::f4e2m1;
         case TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN:
             return ov::element::f8e4m3;
         case TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2:
             return ov::element::f8e5m2;
+        case TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0:
+            return ov::element::f8e8m0;
         case TensorProto_DataType::TensorProto_DataType_STRING:
             return ov::element::string;
         case TensorProto_DataType::TensorProto_DataType_UNDEFINED:
@@ -293,8 +299,8 @@ public:
         default:
             ONNX_UNSUPPORTED_DATA_TYPE(
                 m_tensor_proto->data_type(),
-                "BOOL, BFLOAT16, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT, FLOAT16, DOUBLE, INT4, INT8, INT16, INT32, INT64, "
-                "UINT4, UINT8, UINT16, UINT32, UINT64, STRING");
+                "BOOL, BFLOAT16, FLOAT4E2M1, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT8E8M0, FLOAT, FLOAT16, DOUBLE, INT4, INT8, "
+                "INT16, INT32, INT64, UINT4, UINT8, UINT16, UINT32, UINT64, STRING");
         }
     }
 
@@ -408,15 +414,19 @@ private:
             [[fallthrough]];
         case TensorProto_DataType::TensorProto_DataType_FLOAT16:
             [[fallthrough]];
+        case TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1:
+            [[fallthrough]];
         case TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN:
             [[fallthrough]];
         case TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2:
+            [[fallthrough]];
+        case TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0:
             return m_tensor_proto->int32_data_size();
         default: {
             ONNX_INVALID_DATA_TYPE(
                 m_tensor_proto->data_type(),
-                "BOOL, BFLOAT16, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT, FLOAT16, DOUBLE, INT4, INT8, INT16, INT32, INT64, "
-                "UINT4, UINT8, UINT16, UINT32, UINT64, STRING");
+                "BOOL, BFLOAT16, FLOAT4E2M1, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT8E8M0, FLOAT, FLOAT16, DOUBLE, INT4, INT8, "
+                "INT16, INT32, INT64, UINT4, UINT8, UINT16, UINT32, UINT64, STRING");
         }
         }
     }

--- a/src/frontends/onnx/frontend/src/editor.cpp
+++ b/src/frontends/onnx/frontend/src/editor.cpp
@@ -157,8 +157,9 @@ void modify_initializer(TensorProto& initializer,
         initializer.add_dims(dim);
     }
 
-    const auto data_size_in_bytes = shape_size(values->get_shape()) * get_onnx_data_size(initializer.data_type());
-    initializer.set_raw_data(values->get_data_ptr(), data_size_in_bytes);
+    // Constant::get_byte_size() accounts for sub-byte (nibble) types, which are stored packed,
+    // unlike shape_size() * get_onnx_data_size(), which would over-read the constant buffer.
+    initializer.set_raw_data(values->get_data_ptr(), values->get_byte_size());
 
     // update input with type and shape of initializer
     if (input) {

--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -78,7 +78,9 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node, int64_t
     if (opset >= 13) {
         valid_types.emplace(ov::element::f16);
         valid_types.emplace(ov::element::bf16);
-        // MX block scales, added to DequantizeLinear in opset 24
+        // MX block scales (formally added to DequantizeLinear in opset 24) are grouped here
+        // with f16/bf16 rather than gated behind opset >= 24, consistent with bf16 above
+        // (only valid as a scale type since opset 19) already being accepted under opset >= 13.
         valid_types.emplace(ov::element::f8e8m0);
     }
 
@@ -211,22 +213,25 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
                             inputs.size());
     const auto& x = inputs[0];
     const auto& scale = inputs[1];
-    const auto precision = ai_onnx::opset_1::detail::get_dequantization_precision(node, scale);
-    const auto zero_point = ai_onnx::opset_1::detail::get_zero_point(inputs, precision);
 
     const auto& scale_shape = scale.get_partial_shape();
-    // per-tensor quantization, axis attribute ignored
-    if ((scale_shape.rank().is_static() && scale_shape.size() == 0) ||
-        (scale_shape.is_static() && shape_size(scale_shape.get_shape()) == 1)) {
-        if (!zero_point) {
-            return ai_onnx::opset_1::detail::dequantize_linear(node, 13);
-        }
-        const auto& zero_point_shape = zero_point->get_output_partial_shape(0);
-        if ((zero_point_shape.rank().is_static() && zero_point_shape.size() == 0) ||
-            (zero_point_shape.is_static() && shape_size(zero_point_shape.get_shape()) == 1)) {
-            return ai_onnx::opset_1::detail::dequantize_linear(node, 13);
-        }
+    // per-tensor quantization, axis attribute ignored. The zero point's shape (if present) is
+    // checked directly on the raw input so that get_dequantization_precision()/get_zero_point()
+    // (which perform output_dtype validation and may build a Convert node) run only once, on
+    // whichever path below actually needs their result.
+    bool is_per_tensor = (scale_shape.rank().is_static() && scale_shape.size() == 0) ||
+                         (scale_shape.is_static() && shape_size(scale_shape.get_shape()) == 1);
+    if (is_per_tensor && inputs.size() == 3 && !ov::op::util::is_null(inputs[2])) {
+        const auto& zero_point_shape = inputs[2].get_partial_shape();
+        is_per_tensor = (zero_point_shape.rank().is_static() && zero_point_shape.size() == 0) ||
+                        (zero_point_shape.is_static() && shape_size(zero_point_shape.get_shape()) == 1);
     }
+    if (is_per_tensor) {
+        return ai_onnx::opset_1::detail::dequantize_linear(node, 13);
+    }
+
+    const auto precision = ai_onnx::opset_1::detail::get_dequantization_precision(node, scale);
+    const auto zero_point = ai_onnx::opset_1::detail::get_zero_point(inputs, precision);
     // these reshapes make sure that dequantization happens over the specified axis
     return detail::dequantize_linear(x,
                                      scale,

--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -7,6 +7,7 @@
 
 #include "core/null_node.hpp"
 #include "core/operator_set.hpp"
+#include "exceptions.hpp"
 #include "openvino/core/validation_util.hpp"
 #include "openvino/decompositions/low_precision_dequantize.hpp"
 #include "openvino/frontend/exception.hpp"
@@ -37,7 +38,16 @@ ov::element::Type get_dequantization_precision(const ov::frontend::onnx::Node& n
                                                const ov::Output<ov::Node>& scale) {
     const auto output_dtype = node.get_attribute_value<int64_t>("output_dtype", 0);
     if (output_dtype != 0) {
-        return common::get_ov_element_type(output_dtype);
+        const auto& precision = common::get_ov_element_type(output_dtype);
+        // T3 of the ONNX spec. An unsupported type here wouldn't fail later - it would silently
+        // produce a graph doing the dequantization arithmetic in a wrong precision.
+        CHECK_VALID_NODE(
+            node,
+            precision == ov::element::f32 || precision == ov::element::f16 || precision == ov::element::bf16,
+            "The \"output_dtype\" attribute of DequantizeLinear must be one of the supported types: "
+            "f32, f16 or bf16. Got: ",
+            precision);
+        return precision;
     }
     const auto& scale_et = scale.get_element_type();
     return scale_et == ov::element::f8e8m0 ? ov::element::f32 : scale_et;

--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -29,13 +29,26 @@ namespace onnx {
 namespace ai_onnx {
 namespace opset_1 {
 namespace detail {
-std::shared_ptr<ov::Node> get_zero_point(const ov::OutputVector& inputs) {
+// Returns the element type in which the dequantization arithmetic is performed and which
+// is produced by the operator. It is defined by the "output_dtype" attribute (since opset 21)
+// and, in its absence, by the scale element type. FLOAT8E8M0 scales (used by MX formats since
+// opset 24) can't be an output type, so f32 is used in that case.
+ov::element::Type get_dequantization_precision(const ov::frontend::onnx::Node& node,
+                                               const ov::Output<ov::Node>& scale) {
+    const auto output_dtype = node.get_attribute_value<int64_t>("output_dtype", 0);
+    if (output_dtype != 0) {
+        return common::get_ov_element_type(output_dtype);
+    }
+    const auto& scale_et = scale.get_element_type();
+    return scale_et == ov::element::f8e8m0 ? ov::element::f32 : scale_et;
+}
+
+std::shared_ptr<ov::Node> get_zero_point(const ov::OutputVector& inputs, const ov::element::Type& precision) {
     if (inputs.size() == 3 && !ov::op::util::is_null(inputs[2])) {
-        const auto& scale = inputs[1];
         const auto& zero_point = inputs[2];
 
-        if (zero_point.get_element_type() != scale.get_element_type()) {
-            return std::make_shared<v0::Convert>(zero_point, scale.get_element_type());
+        if (zero_point.get_element_type() != precision) {
+            return std::make_shared<v0::Convert>(zero_point, precision);
         }
 
         return zero_point.get_node_shared_ptr();
@@ -48,12 +61,15 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node, int64_t
 
     const auto& x = inputs[0];
     const auto& scale = inputs[1];
-    const auto zero_point = detail::get_zero_point(inputs);
+    const auto precision = get_dequantization_precision(node, scale);
+    const auto zero_point = detail::get_zero_point(inputs, precision);
 
     std::set<ov::element::Type> valid_types = {ov::element::f32};
     if (opset >= 13) {
         valid_types.emplace(ov::element::f16);
         valid_types.emplace(ov::element::bf16);
+        // MX block scales, added to DequantizeLinear in opset 24
+        valid_types.emplace(ov::element::f8e8m0);
     }
 
     common::validate_scalar_input("Dequantization scale", scale.get_node_shared_ptr(), valid_types);
@@ -62,7 +78,7 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node, int64_t
         common::validate_scalar_input("Zero point", zero_point);
     }
 
-    auto result = ov::decomposition::low_precision_dequantize(x, scale, zero_point);
+    auto result = ov::decomposition::low_precision_dequantize(x, scale, zero_point, {}, precision);
     return {result};
 }
 }  // namespace detail
@@ -154,7 +170,8 @@ ov::OutputVector dequantize_linear(const ov::Output<ov::Node>& x,
                                    const ov::Output<ov::Node>& scale,
                                    const std::shared_ptr<ov::Node>& zero_point,
                                    int64_t axis,
-                                   const Node& node) {
+                                   const Node& node,
+                                   const ov::element::Type& precision) {
     const auto& x_shape = x.get_partial_shape();
 
     FRONT_END_GENERAL_CHECK(x_shape.rank().is_static(), "Rank of the input data tensor has to be known (static).");
@@ -170,7 +187,7 @@ ov::OutputVector dequantize_linear(const ov::Output<ov::Node>& x,
         zp = reshape_input(zero_point, axis, x_shape);
     }
 
-    auto result = ov::decomposition::low_precision_dequantize(x, scale_reshaped, zp);
+    auto result = ov::decomposition::low_precision_dequantize(x, scale_reshaped, zp, {}, precision);
     return {result};
 }
 }  // namespace detail
@@ -184,7 +201,8 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
                             inputs.size());
     const auto& x = inputs[0];
     const auto& scale = inputs[1];
-    const auto zero_point = ai_onnx::opset_1::detail::get_zero_point(inputs);
+    const auto precision = ai_onnx::opset_1::detail::get_dequantization_precision(node, scale);
+    const auto zero_point = ai_onnx::opset_1::detail::get_zero_point(inputs, precision);
 
     const auto& scale_shape = scale.get_partial_shape();
     // per-tensor quantization, axis attribute ignored
@@ -200,7 +218,12 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
         }
     }
     // these reshapes make sure that dequantization happens over the specified axis
-    return detail::dequantize_linear(x, scale, zero_point, node.get_attribute_value<int64_t>("axis", 1), node);
+    return detail::dequantize_linear(x,
+                                     scale,
+                                     zero_point,
+                                     node.get_attribute_value<int64_t>("axis", 1),
+                                     node,
+                                     precision);
 }
 ONNX_OP("DequantizeLinear", {13, 18}, ai_onnx::opset_13::dequantize_linear);
 }  // namespace opset_13
@@ -223,6 +246,8 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
     if (scale_shape.rank().is_static() && scale_shape.rank().get_length() <= 1) {
         return ai_onnx::opset_13::dequantize_linear(node);
     }
+
+    const auto precision = ai_onnx::opset_1::detail::get_dequantization_precision(node, scale);
 
     FRONT_END_GENERAL_CHECK(scale_shape.rank().is_static(), "Rank of the input data tensor has to be known (static).");
     FRONT_END_GENERAL_CHECK(src_x.get_partial_shape().is_static(),
@@ -252,7 +277,7 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
         if (inputs.size() > 2) {
             zp = inputs[2];
         }
-        auto scaled_x = ov::decomposition::low_precision_dequantize(src_x, scale, zp);
+        auto scaled_x = ov::decomposition::low_precision_dequantize(src_x, scale, zp, {}, precision);
         return {scaled_x};
     }
 
@@ -289,7 +314,8 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
 
     auto out_shape = std::make_shared<v0::ShapeOf>(src_x);
 
-    auto reshaped_scaled_x = ov::decomposition::low_precision_dequantize(broadcastable_x, scale, zp, out_shape);
+    auto reshaped_scaled_x =
+        ov::decomposition::low_precision_dequantize(broadcastable_x, scale, zp, out_shape, precision);
 
     reshaped_scaled_x.get_node_shared_ptr()->set_friendly_name(node.get_name());
 

--- a/src/frontends/onnx/frontend/src/op/qlinear_conv.cpp
+++ b/src/frontends/onnx/frontend/src/op/qlinear_conv.cpp
@@ -24,7 +24,8 @@ extern ov::OutputVector dequantize_linear(const ov::Output<ov::Node>& x,
                                           const ov::Output<ov::Node>& scale,
                                           const std::shared_ptr<ov::Node>& zero_point,
                                           int64_t axis,
-                                          const Node& node);
+                                          const Node& node,
+                                          const ov::element::Type& precision = ov::element::dynamic);
 }  // namespace detail
 }  // namespace opset_13
 namespace opset_1 {

--- a/src/frontends/onnx/frontend/src/op/qlinear_matmul.cpp
+++ b/src/frontends/onnx/frontend/src/op/qlinear_matmul.cpp
@@ -18,7 +18,8 @@ extern ov::OutputVector dequantize_linear(const ov::Output<ov::Node>& x,
                                           const ov::Output<ov::Node>& scale,
                                           const std::shared_ptr<ov::Node>& zero_point,
                                           int64_t axis,
-                                          const Node& node);
+                                          const Node& node,
+                                          const ov::element::Type& precision = ov::element::dynamic);
 }  // namespace detail
 }  // namespace opset_13
 namespace detail {

--- a/src/frontends/onnx/frontend/src/op/quantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/quantize_linear.cpp
@@ -52,17 +52,16 @@ void validate_zero_point_type(const Node& onnx_node, const ov::Output<ov::Node>&
         "\"y_zero_point\" input data for QuantizeLinear operator must be one of the supported types: u4, i4, u8, i8, "
         "u16, i16, f8e4m3, f8e5m2 or f4e2m1.");
 
-    // The ONNX spec requires the zero point to be 0 for low precision floating point types.
-    // f8e4m3, f8e5m2 and f4e2m1 all encode 0.0 as the all-zero bit pattern,
-    // so checking that every raw byte is zero is sufficient.
+    // The ONNX spec requires the zero point to be 0 for low precision floating point types,
+    // so when it is a constant, decode it and check that every element is equal to 0.0.
     if (y_zero_point_et == ov::element::f8e4m3 || y_zero_point_et == ov::element::f8e5m2 ||
         y_zero_point_et == ov::element::f4e2m1) {
         const auto zp_const = ov::util::get_constant_from_source(y_zero_point);
         if (zp_const) {
-            const auto raw = zp_const->cast_vector<float>();
+            const auto values = zp_const->cast_vector<float>();
             CHECK_VALID_NODE(onnx_node,
-                             std::all_of(raw.begin(),
-                                         raw.end(),
+                             std::all_of(values.begin(),
+                                         values.end(),
                                          [](const float value) {
                                              return value == 0.0f;
                                          }),

--- a/src/frontends/onnx/frontend/src/op/quantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/quantize_linear.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 
+#include "core/null_node.hpp"
 #include "core/operator_set.hpp"
 #include "exceptions.hpp"
 #include "openvino/core/validation_util.hpp"
@@ -26,12 +27,16 @@ namespace onnx {
 namespace ai_onnx {
 namespace detail {
 namespace {
-ov::Output<ov::Node> get_zero_point(const ov::OutputVector& inputs) {
-    if (inputs.size() > 2) {
+ov::Output<ov::Node> get_zero_point(const Node& onnx_node, const ov::OutputVector& inputs) {
+    if (inputs.size() > 2 && !ov::op::util::is_null(inputs.at(2))) {
         return inputs.at(2);
-    } else {
-        return std::make_shared<v0::Constant>(ov::element::u8, ov::Shape{}, std::uint8_t(0));
     }
+    // Since opset 21 the destination type may be defined by the "output_dtype" attribute
+    // instead of the "y_zero_point" input. u8 is the default, as defined by the ONNX spec.
+    const auto output_dtype = onnx_node.get_attribute_value<int64_t>("output_dtype", 0);
+    const auto destination_type =
+        output_dtype != 0 ? common::get_ov_element_type(output_dtype) : ov::element::Type(ov::element::u8);
+    return std::make_shared<v0::Constant>(destination_type, ov::Shape{}, 0);
 }
 
 void validate_zero_point_type(const Node& onnx_node, const ov::Output<ov::Node>& y_zero_point) {
@@ -42,14 +47,16 @@ void validate_zero_point_type(const Node& onnx_node, const ov::Output<ov::Node>&
             (y_zero_point_et == ov::element::u4 || y_zero_point_et == ov::element::i4 ||
              y_zero_point_et == ov::element::u8 || y_zero_point_et == ov::element::i8 ||
              y_zero_point_et == ov::element::u16 || y_zero_point_et == ov::element::i16 ||
-             y_zero_point_et == ov::element::f8e4m3 || y_zero_point_et == ov::element::f8e5m2),
+             y_zero_point_et == ov::element::f8e4m3 || y_zero_point_et == ov::element::f8e5m2 ||
+             y_zero_point_et == ov::element::f4e2m1),
         "\"y_zero_point\" input data for QuantizeLinear operator must be one of the supported types: u4, i4, u8, i8, "
-        "u16, i16, f8e4m3 or f8e5m2.");
+        "u16, i16, f8e4m3, f8e5m2 or f4e2m1.");
 
-    // The ONNX spec requires the zero point to be 0 for fp8 types.
-    // Both f8e4m3 and f8e5m2 encode 0.0 as the all-zero bit pattern (0x00),
+    // The ONNX spec requires the zero point to be 0 for low precision floating point types.
+    // f8e4m3, f8e5m2 and f4e2m1 all encode 0.0 as the all-zero bit pattern,
     // so checking that every raw byte is zero is sufficient.
-    if (y_zero_point_et == ov::element::f8e4m3 || y_zero_point_et == ov::element::f8e5m2) {
+    if (y_zero_point_et == ov::element::f8e4m3 || y_zero_point_et == ov::element::f8e5m2 ||
+        y_zero_point_et == ov::element::f4e2m1) {
         const auto zp_const = ov::util::get_constant_from_source(y_zero_point);
         if (zp_const) {
             const auto raw = zp_const->cast_vector<float>();
@@ -59,9 +66,20 @@ void validate_zero_point_type(const Node& onnx_node, const ov::Output<ov::Node>&
                                          [](const float value) {
                                              return value == 0.0f;
                                          }),
-                             "Expecting \"y_zero_point\" in QuantizeLinear equal zero for 8-bit floating point types.");
+                             "Expecting \"y_zero_point\" in QuantizeLinear equal zero for low precision floating "
+                             "point types.");
         }
     }
+}
+
+void validate_output_dtype(const Node& onnx_node, const ov::Output<ov::Node>& y_zero_point) {
+    const auto output_dtype = onnx_node.get_attribute_value<int64_t>("output_dtype", 0);
+    if (output_dtype == 0) {
+        return;
+    }
+    CHECK_VALID_NODE(onnx_node,
+                     common::get_ov_element_type(output_dtype) == y_zero_point.get_element_type(),
+                     "The \"output_dtype\" attribute of QuantizeLinear must match the \"y_zero_point\" element type.");
 }
 
 ov::Output<ov::Node> validate_scale(const Node& onnx_node, const ov::Output<ov::Node>& y_scale) {
@@ -174,8 +192,9 @@ std::shared_ptr<ov::Node> make_fake_quantize(const ov::Output<ov::Node>& y_scale
     const ov::element::Type& destination_type = y_zero_point.get_element_type();
     const ov::element::Type& data_type = data.get_element_type();
 
-    // For 8-bit floating point output types, use FakeConvert instead of FakeQuantize
-    if (destination_type == ov::element::f8e4m3 || destination_type == ov::element::f8e5m2) {
+    // For low precision floating point output types, use FakeConvert instead of FakeQuantize
+    if (destination_type == ov::element::f8e4m3 || destination_type == ov::element::f8e5m2 ||
+        destination_type == ov::element::f4e2m1) {
         return make_fake_convert(y_scale, y_zero_point, data);
     }
 
@@ -209,10 +228,11 @@ ov::OutputVector quantize_linear(const ov::frontend::onnx::Node& node) {
     ov::OutputVector inputs{node.get_ov_inputs()};
     auto x = inputs.at(0);
     auto y_scale = inputs.at(1);
-    auto y_zero_point = detail::get_zero_point(inputs);
+    auto y_zero_point = detail::get_zero_point(node, inputs);
 
     x = detail::validate_data(node, x);
     detail::validate_zero_point_type(node, y_zero_point);
+    detail::validate_output_dtype(node, y_zero_point);
     y_scale = detail::validate_scale(node, y_scale);
 
     return {detail::make_fake_quantize(y_scale, y_zero_point, x)};
@@ -233,6 +253,7 @@ ov::OutputVector quantize_linear(ov::Output<ov::Node> x,
 
     x = detail::validate_data(node, x);
     detail::validate_zero_point_type(node, y_zero_point);
+    detail::validate_output_dtype(node, y_zero_point);
     y_scale = detail::validate_scale(node, y_scale);
 
     const auto& x_shape = x.get_partial_shape();
@@ -314,7 +335,7 @@ ov::OutputVector quantize_linear(const ov::frontend::onnx::Node& node) {
 
     const auto& x = inputs[0];
     const auto& scale = inputs[1];
-    const auto zero_point = ai_onnx::detail::get_zero_point(inputs);
+    const auto zero_point = ai_onnx::detail::get_zero_point(node, inputs);
 
     // per-tensor quantization, axis attribute ignored
     if (ai_onnx::detail::is_per_tensor_quantization(scale, zero_point)) {
@@ -337,7 +358,7 @@ ov::OutputVector quantize_linear(const ov::frontend::onnx::Node& node) {
 
     const auto& x = inputs[0];
     const auto& scale = inputs[1];
-    const auto zero_point = ai_onnx::detail::get_zero_point(inputs);
+    const auto zero_point = ai_onnx::detail::get_zero_point(node, inputs);
 
     if (ai_onnx::detail::is_per_tensor_quantization(scale, zero_point)) {
         return ai_onnx::opset_1::quantize_linear(node);

--- a/src/frontends/onnx/frontend/src/utils/common.cpp
+++ b/src/frontends/onnx/frontend/src/utils/common.cpp
@@ -67,15 +67,20 @@ const ov::element::Type& get_ov_element_type(int64_t onnx_type) {
         return ov::element::dynamic;
     case TensorProto_DataType::TensorProto_DataType_BFLOAT16:
         return ov::element::bf16;
+    case TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1:
+        return ov::element::f4e2m1;
     case TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN:
         return ov::element::f8e4m3;
     case TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2:
         return ov::element::f8e5m2;
+    case TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0:
+        return ov::element::f8e8m0;
     case TensorProto_DataType::TensorProto_DataType_STRING:
         return ov::element::string;
     }
     ONNX_UNSUPPORTED_DATA_TYPE(onnx_type,
-                               "BOOL, BFLOAT16, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT, FLOAT16, DOUBLE, INT4, INT8, INT16, "
+                               "BOOL, BFLOAT16, FLOAT4E2M1, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT8E8M0, FLOAT, FLOAT16, "
+                               "DOUBLE, INT4, INT8, INT16, "
                                "INT32, INT64, UINT4, UINT8, UINT16, UINT32, UINT64, STRING, UNDEFINED");
 }
 

--- a/src/frontends/onnx/onnx_common/src/utils.cpp
+++ b/src/frontends/onnx/onnx_common/src/utils.cpp
@@ -26,10 +26,14 @@ size_t get_onnx_data_size(int32_t onnx_type) {
         return 2;
     case TensorProto_DataType_FLOAT:
         return sizeof(float);
+    case TensorProto_DataType_FLOAT4E2M1:
+        return sizeof(uint8_t);
     case TensorProto_DataType_FLOAT8E4M3FN:
         return sizeof(ov::float8_e4m3);
     case TensorProto_DataType_FLOAT8E5M2:
         return sizeof(ov::float8_e5m2);
+    case TensorProto_DataType_FLOAT8E8M0:
+        return sizeof(ov::float8_e8m0);
     case TensorProto_DataType_INT4:
         return sizeof(int8_t);
     case TensorProto_DataType_INT8:
@@ -57,8 +61,10 @@ size_t get_onnx_data_size(int32_t onnx_type) {
 }
 const std::map<ov::element::Type_t, TensorProto_DataType> OV_2_ONNX_TYPES = {
     {ov::element::Type_t::bf16, TensorProto_DataType::TensorProto_DataType_BFLOAT16},
+    {ov::element::Type_t::f4e2m1, TensorProto_DataType::TensorProto_DataType_FLOAT4E2M1},
     {ov::element::Type_t::f8e4m3, TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN},
     {ov::element::Type_t::f8e5m2, TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2},
+    {ov::element::Type_t::f8e8m0, TensorProto_DataType::TensorProto_DataType_FLOAT8E8M0},
     {ov::element::Type_t::f16, TensorProto_DataType::TensorProto_DataType_FLOAT16},
     {ov::element::Type_t::f32, TensorProto_DataType::TensorProto_DataType_FLOAT},
     {ov::element::Type_t::f64, TensorProto_DataType::TensorProto_DataType_DOUBLE},

--- a/src/frontends/onnx/tests/CMakeLists.txt
+++ b/src/frontends/onnx/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SRC
     conversion.cpp
     convert_tests.cpp
     convert_partially_tests.cpp
+    float_types_tests.cpp
     gather_block_quantized_tests.cpp
     graph_iterator.cpp
     library_extension.cpp

--- a/src/frontends/onnx/tests/float_types_tests.cpp
+++ b/src/frontends/onnx/tests/float_types_tests.cpp
@@ -150,3 +150,17 @@ TEST(ONNXFeFloatTypes, quantize_linear_float4e2m1_zero_point) {
     ASSERT_EQ(model->get_results().size(), 1);
     EXPECT_EQ(model->get_results()[0]->get_element_type(), ov::element::f4e2m1);
 }
+
+TEST(ONNXFeFloatTypes, dequantize_linear_invalid_output_dtype) {
+    // "output_dtype" set to INT32, which is not a valid output type of DequantizeLinear.
+    // Without validation this would silently produce a graph doing the dequantization in i32.
+    try {
+        convert_model("dequantize_linear_invalid_output_dtype.onnx");
+        FAIL() << "Expected an exception for an unsupported \"output_dtype\" attribute";
+    } catch (const std::exception& e) {
+        EXPECT_NE(std::string{e.what()}.find(
+                      "The \"output_dtype\" attribute of DequantizeLinear must be one of the supported types"),
+                  std::string::npos)
+            << e.what();
+    }
+}

--- a/src/frontends/onnx/tests/float_types_tests.cpp
+++ b/src/frontends/onnx/tests/float_types_tests.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <vector>
 
+#include "common_test_utils/test_case.hpp"
 #include "onnx_utils.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
@@ -117,4 +118,35 @@ TEST(ONNXFeFloatTypes, cast_float32_to_float8e8m0) {
 
     ASSERT_EQ(model->get_results().size(), 1);
     EXPECT_EQ(model->get_results()[0]->get_element_type(), ov::element::f8e8m0);
+}
+
+TEST(ONNXFeFloatTypes, dequantize_linear_float8e8m0_scale) {
+    const auto model = convert_model("dequantize_linear_f8e8m0_scale.onnx");
+
+    ASSERT_EQ(model->get_results().size(), 1);
+    EXPECT_EQ(model->get_results()[0]->get_element_type(), ov::element::f32);
+
+    ov::test::TestCase test_case(model);
+    test_case.add_expected_output<float>(ov::Shape{6}, {0.0f, 1.0f, 2.0f, -2.0f, 12.0f, -12.0f});
+    test_case.run();
+}
+
+TEST(ONNXFeFloatTypes, quantize_dequantize_linear_float4e2m1) {
+    const auto model = convert_model("quant_dequant_f4e2m1.onnx");
+
+    ASSERT_EQ(model->get_results().size(), 1);
+    EXPECT_EQ(model->get_results()[0]->get_element_type(), ov::element::f32);
+
+    ov::test::TestCase test_case(model);
+    test_case.add_input<float>(ov::Shape{6}, {0.0f, 1.0f, 2.0f, -2.0f, 12.0f, 20.0f});
+    // 20.0 / 2.0 = 10.0 saturates to the maximal f4e2m1 value (6.0)
+    test_case.add_expected_output<float>(ov::Shape{6}, {0.0f, 1.0f, 2.0f, -2.0f, 12.0f, 12.0f});
+    test_case.run();
+}
+
+TEST(ONNXFeFloatTypes, quantize_linear_float4e2m1_zero_point) {
+    const auto model = convert_model("quantize_linear_f4e2m1_zero_point.onnx");
+
+    ASSERT_EQ(model->get_results().size(), 1);
+    EXPECT_EQ(model->get_results()[0]->get_element_type(), ov::element::f4e2m1);
 }

--- a/src/frontends/onnx/tests/float_types_tests.cpp
+++ b/src/frontends/onnx/tests/float_types_tests.cpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "onnx_utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+
+using namespace ov;
+using namespace ov::frontend::onnx::tests;
+
+namespace {
+std::shared_ptr<ov::op::v0::Constant> get_single_constant(const std::shared_ptr<ov::Model>& model) {
+    std::shared_ptr<ov::op::v0::Constant> found{nullptr};
+    for (const auto& op : model->get_ordered_ops()) {
+        if (const auto constant = ov::as_type_ptr<ov::op::v0::Constant>(op)) {
+            EXPECT_EQ(found, nullptr) << "More than one Constant found in the model";
+            found = constant;
+        }
+    }
+    EXPECT_NE(found, nullptr) << "No Constant found in the model";
+    return found;
+}
+}  // namespace
+
+TEST(ONNXFeFloatTypes, float4e2m1_input) {
+    const auto model = convert_model("float4e2m1_input.onnx");
+
+    ASSERT_EQ(model->get_parameters().size(), 1);
+    EXPECT_EQ(model->get_parameters()[0]->get_element_type(), ov::element::f4e2m1);
+    EXPECT_EQ(model->get_parameters()[0]->get_partial_shape(), ov::PartialShape({6}));
+    ASSERT_EQ(model->get_results().size(), 2);
+    EXPECT_EQ(model->get_results()[1]->get_element_type(), ov::element::f4e2m1);
+}
+
+TEST(ONNXFeFloatTypes, float4e2m1_constant) {
+    const auto model = convert_model("float4e2m1_constant.onnx");
+
+    const auto constant = get_single_constant(model);
+    ASSERT_NE(constant, nullptr);
+    EXPECT_EQ(constant->get_element_type(), ov::element::f4e2m1);
+    EXPECT_EQ(constant->get_shape(), ov::Shape({6}));
+    EXPECT_EQ(constant->cast_vector<float>(), std::vector<float>({0.0f, 0.5f, 1.0f, -1.0f, 6.0f, -6.0f}));
+}
+
+TEST(ONNXFeFloatTypes, float4e2m1_initializer) {
+    const auto model = convert_model("float4e2m1_initializer.onnx");
+
+    const auto constant = get_single_constant(model);
+    ASSERT_NE(constant, nullptr);
+    EXPECT_EQ(constant->get_element_type(), ov::element::f4e2m1);
+    EXPECT_EQ(constant->get_shape(), ov::Shape({6}));
+    EXPECT_EQ(constant->cast_vector<float>(), std::vector<float>({0.0f, 0.5f, 1.0f, -1.0f, 6.0f, -6.0f}));
+}
+
+TEST(ONNXFeFloatTypes, cast_float32_to_float4e2m1) {
+    const auto model = convert_model("cast_float32_to_float4e2m1.onnx");
+
+    ASSERT_EQ(model->get_results().size(), 1);
+    EXPECT_EQ(model->get_results()[0]->get_element_type(), ov::element::f4e2m1);
+}
+
+TEST(ONNXFeFloatTypes, float8e8m0_input) {
+    const auto model = convert_model("float8e8m0_input.onnx");
+
+    ASSERT_EQ(model->get_parameters().size(), 1);
+    EXPECT_EQ(model->get_parameters()[0]->get_element_type(), ov::element::f8e8m0);
+    EXPECT_EQ(model->get_parameters()[0]->get_partial_shape(), ov::PartialShape({6}));
+    ASSERT_EQ(model->get_results().size(), 2);
+    EXPECT_EQ(model->get_results()[1]->get_element_type(), ov::element::f8e8m0);
+}
+
+TEST(ONNXFeFloatTypes, float8e8m0_constant) {
+    const auto model = convert_model("float8e8m0_constant.onnx");
+
+    const auto constant = get_single_constant(model);
+    ASSERT_NE(constant, nullptr);
+    EXPECT_EQ(constant->get_element_type(), ov::element::f8e8m0);
+    EXPECT_EQ(constant->get_shape(), ov::Shape({6}));
+
+    // f8e8m0 stores an exponent only: value = 2^(bits - 127), 0xFF encodes NaN
+    const auto values = constant->cast_vector<float>();
+    ASSERT_EQ(values.size(), 6);
+    EXPECT_EQ(values[0], 1.0f);
+    EXPECT_EQ(values[1], 2.0f);
+    EXPECT_EQ(values[2], 0.5f);
+    EXPECT_EQ(values[3], 4.0f);
+    EXPECT_EQ(values[4], 0.25f);
+    EXPECT_TRUE(std::isnan(values[5]));
+}
+
+TEST(ONNXFeFloatTypes, float8e8m0_initializer) {
+    const auto model = convert_model("float8e8m0_initializer.onnx");
+
+    const auto constant = get_single_constant(model);
+    ASSERT_NE(constant, nullptr);
+    EXPECT_EQ(constant->get_element_type(), ov::element::f8e8m0);
+    EXPECT_EQ(constant->get_shape(), ov::Shape({6}));
+
+    const auto values = constant->cast_vector<float>();
+    ASSERT_EQ(values.size(), 6);
+    EXPECT_EQ(values[0], 1.0f);
+    EXPECT_EQ(values[1], 2.0f);
+    EXPECT_EQ(values[2], 0.5f);
+    EXPECT_EQ(values[3], 4.0f);
+    EXPECT_EQ(values[4], 0.25f);
+    EXPECT_TRUE(std::isnan(values[5]));
+}
+
+TEST(ONNXFeFloatTypes, cast_float32_to_float8e8m0) {
+    const auto model = convert_model("cast_float32_to_float8e8m0.onnx");
+
+    ASSERT_EQ(model->get_results().size(), 1);
+    EXPECT_EQ(model->get_results()[0]->get_element_type(), ov::element::f8e8m0);
+}

--- a/src/frontends/onnx/tests/models/cast_float32_to_float4e2m1.prototxt
+++ b/src/frontends/onnx/tests/models/cast_float32_to_float4e2m1.prototxt
@@ -1,0 +1,45 @@
+ir_version: 11
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "input"
+    output: "output"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 23
+      type: INT
+    }
+  }
+  name: "test-model-cast"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 23
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 23
+}

--- a/src/frontends/onnx/tests/models/cast_float32_to_float8e8m0.prototxt
+++ b/src/frontends/onnx/tests/models/cast_float32_to_float8e8m0.prototxt
@@ -1,0 +1,45 @@
+ir_version: 12
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "input"
+    output: "output"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 24
+      type: INT
+    }
+  }
+  name: "test-model-cast"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 24
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 24
+}

--- a/src/frontends/onnx/tests/models/dequantize_linear_f8e8m0_scale.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_f8e8m0_scale.prototxt
@@ -1,0 +1,37 @@
+ir_version: 12
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "scale"
+    output: "y"
+    name: "DequantizeLinear"
+    op_type: "DequantizeLinear"
+  }
+  name: "test_graph"
+  initializer {
+    dims: 6
+    data_type: 23
+    name: "x"
+    raw_data: "\020\242\367"
+  }
+  initializer {
+    data_type: 24
+    name: "scale"
+    raw_data: "\200"
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 6 }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 24
+}

--- a/src/frontends/onnx/tests/models/dequantize_linear_invalid_output_dtype.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_invalid_output_dtype.prototxt
@@ -1,0 +1,42 @@
+ir_version: 12
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "scale"
+    output: "y"
+    name: "DequantizeLinear"
+    op_type: "DequantizeLinear"
+    attribute {
+      name: "output_dtype"
+      i: 6
+      type: INT
+    }
+  }
+  name: "test_graph"
+  initializer {
+    dims: 6
+    data_type: 3
+    name: "x"
+    raw_data: "\000\001\002\003\004\005"
+  }
+  initializer {
+    data_type: 1
+    name: "scale"
+    raw_data: "\000\000\000\100"
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim { dim_value: 6 }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 24
+}

--- a/src/frontends/onnx/tests/models/float4e2m1_constant.prototxt
+++ b/src/frontends/onnx/tests/models/float4e2m1_constant.prototxt
@@ -1,0 +1,58 @@
+ir_version: 11
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test"
+  node {
+    output: "Y"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 6
+        data_type: 23
+        raw_data: "\x10\xA2\xF7"
+        name: "float4e2m1_const"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "Y"
+    output: "O"
+    op_type: "Shape"
+  }
+  node {
+    input: "Y"
+    output: "V"
+    op_type: "Identity"
+  }
+  output {
+    name: "O"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "V"
+    type {
+      tensor_type {
+        elem_type: 23
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 23
+}

--- a/src/frontends/onnx/tests/models/float4e2m1_initializer.prototxt
+++ b/src/frontends/onnx/tests/models/float4e2m1_initializer.prototxt
@@ -1,0 +1,34 @@
+ir_version: 11
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test"
+  initializer {
+    dims: 6
+    data_type: 23
+    int32_data: 16
+    int32_data: 162
+    int32_data: 247
+    name: "W"
+  }
+  node {
+    input: "W"
+    output: "V"
+    op_type: "Identity"
+  }
+  output {
+    name: "V"
+    type {
+      tensor_type {
+        elem_type: 23
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 23
+}

--- a/src/frontends/onnx/tests/models/float4e2m1_input.prototxt
+++ b/src/frontends/onnx/tests/models/float4e2m1_input.prototxt
@@ -1,0 +1,57 @@
+ir_version: 11
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test"
+  node {
+    input: "I"
+    output: "O"
+    op_type: "Shape"
+  }
+  node {
+    input: "I"
+    output: "V"
+    op_type: "Identity"
+  }
+  input {
+    name: "I"
+    type {
+      tensor_type {
+        elem_type: 23
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "O"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "V"
+    type {
+      tensor_type {
+        elem_type: 23
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 23
+}

--- a/src/frontends/onnx/tests/models/float8e8m0_constant.prototxt
+++ b/src/frontends/onnx/tests/models/float8e8m0_constant.prototxt
@@ -1,0 +1,58 @@
+ir_version: 12
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test"
+  node {
+    output: "Y"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 6
+        data_type: 24
+        raw_data: "\x7F\x80\x7E\x81\x7D\xFF"
+        name: "float8e8m0_const"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "Y"
+    output: "O"
+    op_type: "Shape"
+  }
+  node {
+    input: "Y"
+    output: "V"
+    op_type: "Identity"
+  }
+  output {
+    name: "O"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "V"
+    type {
+      tensor_type {
+        elem_type: 24
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 24
+}

--- a/src/frontends/onnx/tests/models/float8e8m0_initializer.prototxt
+++ b/src/frontends/onnx/tests/models/float8e8m0_initializer.prototxt
@@ -1,0 +1,37 @@
+ir_version: 12
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test"
+  initializer {
+    dims: 6
+    data_type: 24
+    int32_data: 127
+    int32_data: 128
+    int32_data: 126
+    int32_data: 129
+    int32_data: 125
+    int32_data: 255
+    name: "W"
+  }
+  node {
+    input: "W"
+    output: "V"
+    op_type: "Identity"
+  }
+  output {
+    name: "V"
+    type {
+      tensor_type {
+        elem_type: 24
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 24
+}

--- a/src/frontends/onnx/tests/models/float8e8m0_input.prototxt
+++ b/src/frontends/onnx/tests/models/float8e8m0_input.prototxt
@@ -1,0 +1,57 @@
+ir_version: 12
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test"
+  node {
+    input: "I"
+    output: "O"
+    op_type: "Shape"
+  }
+  node {
+    input: "I"
+    output: "V"
+    op_type: "Identity"
+  }
+  input {
+    name: "I"
+    type {
+      tensor_type {
+        elem_type: 24
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "O"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "V"
+    type {
+      tensor_type {
+        elem_type: 24
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 24
+}

--- a/src/frontends/onnx/tests/models/model_editor/cast_1D_f4e2m1.prototxt
+++ b/src/frontends/onnx/tests/models/model_editor/cast_1D_f4e2m1.prototxt
@@ -1,0 +1,45 @@
+ir_version: 11
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "A"
+    output: "X"
+    name: "cast_node"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test_graph"
+  input {
+    name: "A"
+    type {
+      tensor_type {
+        elem_type: 23
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 23
+}

--- a/src/frontends/onnx/tests/models/quant_dequant_f4e2m1.prototxt
+++ b/src/frontends/onnx/tests/models/quant_dequant_f4e2m1.prototxt
@@ -1,0 +1,54 @@
+ir_version: 11
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "scale"
+    output: "y_q"
+    name: "QuantizeLinear"
+    op_type: "QuantizeLinear"
+    attribute {
+      name: "output_dtype"
+      i: 23
+      type: INT
+    }
+  }
+  node {
+    input: "y_q"
+    input: "scale"
+    output: "y"
+    name: "DequantizeLinear"
+    op_type: "DequantizeLinear"
+  }
+  name: "test_graph"
+  initializer {
+    data_type: 1
+    name: "scale"
+    raw_data: "\000\000\000\100"
+  }
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 6 }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 6 }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 23
+}

--- a/src/frontends/onnx/tests/models/quantize_linear_f4e2m1_zero_point.prototxt
+++ b/src/frontends/onnx/tests/models/quantize_linear_f4e2m1_zero_point.prototxt
@@ -1,0 +1,49 @@
+ir_version: 11
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "scale"
+    input: "zero_point"
+    output: "y_q"
+    name: "QuantizeLinear"
+    op_type: "QuantizeLinear"
+  }
+  name: "test_graph"
+  initializer {
+    data_type: 1
+    name: "scale"
+    raw_data: "\000\000\000\100"
+  }
+  initializer {
+    dims: 1
+    data_type: 23
+    name: "zero_point"
+    raw_data: "\000"
+  }
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 6 }
+        }
+      }
+    }
+  }
+  output {
+    name: "y_q"
+    type {
+      tensor_type {
+        elem_type: 23
+        shape {
+          dim { dim_value: 6 }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 23
+}

--- a/src/frontends/onnx/tests/onnx_editor.cpp
+++ b/src/frontends/onnx/tests/onnx_editor.cpp
@@ -772,6 +772,22 @@ OPENVINO_TEST(onnx_editor, subgraph__custom_input_name_already_exist) {
     }
 }
 
+OPENVINO_TEST(onnx_editor, values__append_one_nibble_initializer) {
+    SKIP_ONNX_EDITOR_IF_GRAPH_ITERATOR_ENABLED();
+    FrontEnd::Ptr front_end;
+    auto input_model = load_model("model_editor/cast_1D_f4e2m1.onnx", &front_end);
+
+    // 6 f4e2m1 values packed two per byte (LSB first): 0.0, 0.5, 1.0, -1.0, 6.0, -6.0
+    const std::vector<uint8_t> packed{0x10, 0xa2, 0xf7};
+    auto place = input_model->get_place_by_tensor_name("A");
+    input_model->set_tensor_value(place, packed.data());
+
+    const auto model = front_end->convert(input_model);
+    auto test_case = ov::test::TestCase(model);
+    test_case.add_expected_output<float>(Shape{6}, {0.0f, 0.5f, 1.0f, -1.0f, 6.0f, -6.0f});
+    test_case.run();
+}
+
 OPENVINO_TEST(onnx_editor, values__append_one_initializer) {
     SKIP_ONNX_EDITOR_IF_GRAPH_ITERATOR_ENABLED();
     FrontEnd::Ptr front_end;

--- a/src/frontends/onnx/tests/unit_test.manifest
+++ b/src/frontends/onnx/tests/unit_test.manifest
@@ -2,3 +2,7 @@
 ONNXLoadTest/FrontEndLoadFromTest.testLoadFromTwoFiles/onnx
 ONNXLoadTest/FrontEndLoadFromTest.testLoadFromTwoStreams/onnx
 
+# QuantizeLinear with the f4e2m1 destination type (ONNX opset 23) fails in
+# ov::op::v13::FakeConvert, which supports f8e4m3 and f8e5m2 only
+ONNXFeFloatTypes.quantize_dequantize_linear_float4e2m1
+ONNXFeFloatTypes.quantize_linear_float4e2m1_zero_point


### PR DESCRIPTION
### Details:
 - Mapped ONNX `FLOAT4E2M1` (23) and `FLOAT8E8M0` (24) to `ov::element::f4e2m1` / `f8e8m0` in the type maps and in both `get_ov_element_type()` implementations, which also enables `Cast`/`CastLike`.
 - Enabled reading tensors of these types from `raw_data`, `int32_data` and external data, covering graph inputs/outputs, `value_info`, initializers and `Constant`s, in both the graph-iterator and the legacy `TensorProto` conversion paths.
 - `DequantizeLinear`: accepts `f4e2m1` data (`T1`) and `f8e8m0` MX block scales (`T2`) on all opset paths. Since `f8e8m0` can't be an output type, the dequantization precision is now derived explicitly and falls back to `f32` for such scales.
 - `QuantizeLinear`: accepts `f4e2m1` as a destination type (`T3`), with the zero-point-must-be-zero rule required by the spec.
 - Both operators now honor the `output_dtype` attribute (opset 21+), so the output type can be selected without a zero point. For `DequantizeLinear` it is validated against `T3` (`f32`/`f16`/`bf16`), since an unsupported value there would silently dequantize in the wrong precision rather than fail.
 - Fixed `raw_data` sizing for sub-byte types in the ONNX Editor: `modify_initializer()` over-read the `Constant` buffer for nibble types and now uses `Constant::get_byte_size()`. Pre-existing (`u4`/`i4` were already affected), fixed here since `f4e2m1` widens the exposure.
 - Added tests and models for all of the above.

Known limitation: `QuantizeLinear` to `f4e2m1` is accepted by the frontend but fails in `ov::op::v13::FakeConvert`, which supports `f8e4m3`/`f8e5m2` only. The frontend intentionally doesn't reject it, so it will work once `FakeConvert` supports the type; the two tests are listed in `unit_test.manifest` until then.

### Tickets:
 - CVS-190802

### AI Assistance:
 - AI assistance used: yes
 - Implementation and tests were drafted with AI assistance. Human validation: local build and `ov_onnx_frontend_tests` full suite (2033 passed), plus a run with `ONNX_ITERATOR=0` covering the legacy path and the ONNX Editor tests (2077 passed). The editor regression test was confirmed to fail without the fix.
