### PR TITLE
[GHA] Remove old version of NodeJS warnings from `cache` action

### DIFF
--- a/.github/actions/cache/package-lock.json
+++ b/.github/actions/cache/package-lock.json
@@ -27,7 +27,7 @@
         "prettier": "^3.8.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {

--- a/.github/actions/cache/package.json
+++ b/.github/actions/cache/package.json
@@ -10,7 +10,7 @@
     "JavaScript"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "type": "module",
   "main": "dist/restore/index.js",


### PR DESCRIPTION
### Details:
GitHub still complaints about old unsafe NodeJS version, despite it works with NodeJS 24. Let's try to remove the warning
