### PR TITLE
[GPU] Support b_fs_yx_fsv16 in the optimized GridSample bilinear/zeros kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
@@ -28,6 +28,33 @@ inline const bool FUNC(is_between)(int val, int min, int max) {
 }
 #define is_between FUNC_CALL(is_between)
 
+// Same "always load, mask afterward" trick as the original kernel (see the
+// comment on LOAD_INPUT below for why): substitute a safe in-bounds fallback
+// position (0,0) when the true position would be out-of-bounds, and zero the
+// contribution out in INTERPOLATE below instead of branching around the load.
+#define PRE_CALC_VALID_OFFSETS_FOR_INPUT_LOAD(x_n, y_n)                \
+    const grid_et y_d = denormalize(y_n, INPUT0_SIZE_Y);               \
+    const grid_et x_d = denormalize(x_n, INPUT0_SIZE_X);               \
+    const int y_topleft = (int)floor(y_d);                             \
+    const int x_topleft = (int)floor(x_d);                             \
+    const grid_et dy = y_d - y_topleft;                                \
+    const grid_et dx = x_d - x_topleft;                                \
+                                                                        \
+    const bool y0_valid = is_between(y_topleft, 0, INPUT0_SIZE_Y);     \
+    const bool y1_valid = is_between(y_topleft + 1, 0, INPUT0_SIZE_Y); \
+    const bool x0_valid = is_between(x_topleft, 0, INPUT0_SIZE_X);     \
+    const bool x1_valid = is_between(x_topleft + 1, 0, INPUT0_SIZE_X); \
+                                                                        \
+    const bool v00_valid = y0_valid && x0_valid;                       \
+    const bool v01_valid = y0_valid && x1_valid;                       \
+    const bool v10_valid = y1_valid && x0_valid;                       \
+    const bool v11_valid = y1_valid && x1_valid;                       \
+                                                                        \
+    const int y0c = y0_valid ? y_topleft : 0;                          \
+    const int y1c = y1_valid ? (y_topleft + 1) : 0;                    \
+    const int x0c = x0_valid ? x_topleft : 0;                          \
+    const int x1c = x1_valid ? (x_topleft + 1) : 0;
+
 // WARNING: This loads may read from 'wrong' location
 // (in sense that is has nothing to do with
 // sampling point being calculated) - this is done
@@ -116,32 +143,7 @@ KERNEL(grid_sample_opt_bilinear_zeros)(const __global data_t* restrict data,
         const grid_et x_n = grid[INPUT1_GET_INDEX(n, h, w, 0)];
         const grid_et y_n = grid[INPUT1_GET_INDEX(n, h, w, 1)];
 
-        const grid_et y_d = denormalize(y_n, INPUT0_SIZE_Y);
-        const grid_et x_d = denormalize(x_n, INPUT0_SIZE_X);
-        const int y_topleft = (int)floor(y_d);
-        const int x_topleft = (int)floor(x_d);
-        const grid_et dy = y_d - y_topleft;
-        const grid_et dx = x_d - x_topleft;
-
-        const bool y0_valid = is_between(y_topleft, 0, INPUT0_SIZE_Y);
-        const bool y1_valid = is_between(y_topleft + 1, 0, INPUT0_SIZE_Y);
-        const bool x0_valid = is_between(x_topleft, 0, INPUT0_SIZE_X);
-        const bool x1_valid = is_between(x_topleft + 1, 0, INPUT0_SIZE_X);
-
-        const bool v00_valid = y0_valid && x0_valid;
-        const bool v01_valid = y0_valid && x1_valid;
-        const bool v10_valid = y1_valid && x0_valid;
-        const bool v11_valid = y1_valid && x1_valid;
-
-        // Same "always load, mask afterward" trick as the original kernel (see its
-        // comment on avoiding warp-divergence from conditional loads): substitute a
-        // safe in-bounds fallback position (0,0) when the true position would be
-        // out-of-bounds, and zero the contribution out in the blend below instead of
-        // branching around the load itself.
-        const int y0c = y0_valid ? y_topleft : 0;
-        const int y1c = y1_valid ? (y_topleft + 1) : 0;
-        const int x0c = x0_valid ? x_topleft : 0;
-        const int x1c = x1_valid ? (x_topleft + 1) : 0;
+        PRE_CALC_VALID_OFFSETS_FOR_INPUT_LOAD(x_n, y_n);
 
 #pragma unroll
         for (int c = 0; c < OUTPUT_FEATURE_NUM; ++c) {
@@ -157,3 +159,4 @@ KERNEL(grid_sample_opt_bilinear_zeros)(const __global data_t* restrict data,
 #undef STORE
 #undef INTERPOLATE
 #undef LOAD_INPUT
+#undef PRE_CALC_VALID_OFFSETS_FOR_INPUT_LOAD

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
@@ -64,14 +64,14 @@ KERNEL(grid_sample_opt_bilinear_zeros)(const __global data_t* restrict data,
     const int n = get_global_id(0);
 
     const int OUTPUT_C_STRIDE = OUTPUT_SIZE_Y * OUTPUT_SIZE_X;
-    const int LOCAL_GRID_OFFSET_FOR_THI_BLOCK = GRID_ITEMS_PER_BLOCK * 2 * get_group_id(1);
+    const int LOCAL_GRID_OFFSET_FOR_THIS_BLOCK = GRID_ITEMS_PER_BLOCK * 2 * get_group_id(1);
     const int BLOCK_SIZE = get_local_size(1);
     const int GRID_ITEMS_FOR_THIS_BLOCK =
-        min(OUTPUT_C_STRIDE * 2 - LOCAL_GRID_OFFSET_FOR_THI_BLOCK, GRID_ITEMS_PER_BLOCK * 2);
+        min(OUTPUT_C_STRIDE * 2 - LOCAL_GRID_OFFSET_FOR_THIS_BLOCK, GRID_ITEMS_PER_BLOCK * 2);
 
     for (int thisThreadHW = get_local_linear_id() * 2; thisThreadHW < GRID_ITEMS_FOR_THIS_BLOCK;
          thisThreadHW += 2 * BLOCK_SIZE) {
-        const int globalThisThreadHW = (thisThreadHW + LOCAL_GRID_OFFSET_FOR_THI_BLOCK) / 2;
+        const int globalThisThreadHW = (thisThreadHW + LOCAL_GRID_OFFSET_FOR_THIS_BLOCK) / 2;
         const int h = globalThisThreadHW / OUTPUT_SIZE_X;
         const int w = globalThisThreadHW % OUTPUT_SIZE_X;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
@@ -28,6 +28,33 @@ inline const bool FUNC(is_between)(int val, int min, int max) {
 }
 #define is_between FUNC_CALL(is_between)
 
+// WARNING: This loads may read from 'wrong' location
+// (in sense that is has nothing to do with
+// sampling point being calculated) - this is done
+// intentianally to keep warp without need to sync
+// and allows for having multiple such loads on the fly - if
+// compiler is smart enough.
+// Otherwise, if load is done conditionally, software pipelinging
+// is hindered by having warp sync due to warp divergence.
+// Tested on a770 GPU with ocl 3.0
+#define LOAD_INPUT(c)                                             \
+    const data_et v00_d = data[INPUT0_GET_INDEX(n, c, y0c, x0c)]; \
+    const data_et v01_d = data[INPUT0_GET_INDEX(n, c, y0c, x1c)]; \
+    const data_et v10_d = data[INPUT0_GET_INDEX(n, c, y1c, x0c)]; \
+    const data_et v11_d = data[INPUT0_GET_INDEX(n, c, y1c, x1c)];
+
+#define INTERPOLATE()                                      \
+    const data_et v00 = v00_valid ? v00_d * (1 - dx) : 0;  \
+    const data_et v01 = v01_valid ? v01_d * dx : 0;        \
+    const data_et v10 = v10_valid ? v10_d * (1 - dx) : 0;  \
+    const data_et v11 = v11_valid ? v11_d * dx : 0;        \
+                                                           \
+    const data_et q0 = v00 + v01;                          \
+    const data_et q1 = v10 + v11;                          \
+    const data_et out = dy * q1 + (1 - dy) * q0;
+
+#define STORE(c) output[OUTPUT_GET_INDEX(n, c, h, w)] = out;
+
 // ====================================================================
 //
 // GRID SAMPLE KERNEL (layout-agnostic data/output addressing)
@@ -118,24 +145,15 @@ KERNEL(grid_sample_opt_bilinear_zeros)(const __global data_t* restrict data,
 
 #pragma unroll
         for (int c = 0; c < OUTPUT_FEATURE_NUM; ++c) {
-            const data_et v00_d = data[INPUT0_GET_INDEX(n, c, y0c, x0c)];
-            const data_et v01_d = data[INPUT0_GET_INDEX(n, c, y0c, x1c)];
-            const data_et v10_d = data[INPUT0_GET_INDEX(n, c, y1c, x0c)];
-            const data_et v11_d = data[INPUT0_GET_INDEX(n, c, y1c, x1c)];
-
-            const data_et v00 = v00_valid ? v00_d * (1 - dx) : 0;
-            const data_et v01 = v01_valid ? v01_d * dx : 0;
-            const data_et v10 = v10_valid ? v10_d * (1 - dx) : 0;
-            const data_et v11 = v11_valid ? v11_d * dx : 0;
-
-            const data_et q0 = v00 + v01;
-            const data_et q1 = v10 + v11;
-            const data_et out = dy * q1 + (1 - dy) * q0;
-
-            output[OUTPUT_GET_INDEX(n, c, h, w)] = out;
+            LOAD_INPUT(c);
+            INTERPOLATE();
+            STORE(c);
         }
     }
 }
 
 #undef denormalize
 #undef is_between
+#undef STORE
+#undef INTERPOLATE
+#undef LOAD_INPUT

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
@@ -84,23 +84,7 @@ inline const bool FUNC(is_between)(int val, int min, int max) {
 
 // ====================================================================
 //
-// GRID SAMPLE KERNEL (layout-agnostic data/output addressing)
-//
-// Same batched grid-coordinate-caching strategy as the original bfyx-only
-// kernel (decode each spatial location's sampling coordinates once, reuse
-// across all channels -- this is the actual performance win over the
-// reference kernel, which redoes this math redundantly per (n,c,h,w)
-// thread). The only change is that `data`/`output` element addresses now go
-// through INPUT0_GET_INDEX/OUTPUT_GET_INDEX -- the kernel_selector's
-// standard layout-aware indexing macros (same ones grid_sample_ref.cl uses)
-// -- instead of the previous hand-rolled `base + c * H * W` planar-only
-// arithmetic, so this kernel works correctly for any layout the tensor
-// actually has (bfyx, b_fs_yx_fsv16, ...), not just bfyx. `grid` (input1)
-// keeps the original flat block-cached access pattern unchanged: it's a
-// [N,H,W,2] auxiliary tensor, not a feature-map subject to the same
-// blocked-layout optimization decisions as `data`, so this loop's core
-// optimization (reading a whole block of grid values as one contiguous
-// stream) is unaffected either way.
+// GRID SAMPLE KERNEL
 //
 // ====================================================================
 
@@ -129,17 +113,6 @@ KERNEL(grid_sample_opt_bilinear_zeros)(const __global data_t* restrict data,
         const int h = globalThisThreadHW / OUTPUT_SIZE_X;
         const int w = globalThisThreadHW % OUTPUT_SIZE_X;
 
-        // Layout-aware grid read (was: raw contiguous-block pointer arithmetic, which assumed
-        // `grid` is always a simple planar [N,H,W,2] buffer). That assumption broke once `data`
-        // (and therefore, coupled through the layout optimizer, `grid`) could be laid out in a
-        // blocked format like b_fs_yx_fsv16 -- silently corrupting these reads. INPUT1_GET_INDEX
-        // is layout-aware regardless of what `grid`'s actual runtime layout is. Axis mapping
-        // (n, h, w, c) -- not (n, c, h, w) -- matches grid_sample_ref.cl's own established
-        // convention for this tensor's real [N,H,W,2] shape (OpenVINO's generic 4D tensor
-        // descriptor maps dims positionally to batch/feature/y/x regardless of what they
-        // semantically represent, so dim1=H is "feature", dim2=W is "y", dim3=2 is "x" here).
-        // This does trade away the batched block-cached grid read for a per-thread lookup, but
-        // only for these 2 reads -- the channel loop below (the actual hot path) is unaffected.
         const grid_et x_n = grid[INPUT1_GET_INDEX(n, h, w, 0)];
         const grid_et y_n = grid[INPUT1_GET_INDEX(n, h, w, 1)];
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
@@ -1,5 +1,5 @@
 // Copyright (C) 2018-2026 Intel Corporation
-// SPdx_1-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 //
 
 typedef INPUT0_TYPE data_t;
@@ -28,59 +28,25 @@ inline const bool FUNC(is_between)(int val, int min, int max) {
 }
 #define is_between FUNC_CALL(is_between)
 
-#define PRE_CALC_VALID_OFFSETS_FOR_INPUT_LOAD(x_n, x_y, GLOBAL_OFFSET)                                    \
-    const grid_et y_d = denormalize(y_n, INPUT0_SIZE_Y);                                                  \
-    const grid_et x_d = denormalize(x_n, INPUT0_SIZE_X);                                                  \
-    const int y_topleft = (int)floor(y_d);                                                                \
-    const int x_topleft = (int)floor(x_d);                                                                \
-    const grid_et dy = y_d - y_topleft;                                                                   \
-    const grid_et dx = x_d - x_topleft;                                                                   \
-                                                                                                          \
-    const bool y_topleft_valid = is_between(y_topleft, 0, INPUT0_SIZE_Y);                                 \
-    const bool y_topleft_plus_valid = is_between(y_topleft + 1, 0, INPUT0_SIZE_Y);                        \
-    const bool x_topleft_valid = is_between(x_topleft, 0, INPUT0_SIZE_X);                                 \
-    const bool x_topleft_plus_valid = is_between(x_topleft + 1, 0, INPUT0_SIZE_X);                        \
-                                                                                                          \
-    const bool v00_valid = y_topleft_valid && x_topleft_valid;                                            \
-    const bool v01_valid = y_topleft_valid && x_topleft_plus_valid;                                       \
-    const bool v10_valid = y_topleft_plus_valid && x_topleft_valid;                                       \
-    const bool v11_valid = y_topleft_plus_valid && x_topleft_plus_valid;                                  \
-                                                                                                          \
-    const int v00_OFFSET = v00_valid ? (GLOBAL_OFFSET + y_topleft * INPUT0_SIZE_X + x_topleft) : 0;       \
-    const int v01_OFFSET = v01_valid ? (GLOBAL_OFFSET + y_topleft * INPUT0_SIZE_X + x_topleft + 1) : 0;   \
-    const int v10_OFFSET = v10_valid ? (GLOBAL_OFFSET + (y_topleft + 1) * INPUT0_SIZE_X + x_topleft) : 0; \
-    const int v11_OFFSET = v11_valid ? (GLOBAL_OFFSET + (y_topleft + 1) * INPUT0_SIZE_X + x_topleft + 1) : 0;
-
-// WARNING: This loads may read from 'wrong' location
-// (in sense that is has nothing to do with 
-// sampling point being calculated) - this is done
-// intentianally to keep warp without need to sync
-// and allows for having multiple such loads on the fly - if
-// compiler is smart enough.
-// Otherwise, if load is done conditionally, software pipelinging
-// is hindered by having warp sync due to warp divergence.
-// Tested on a770 GPU with ocl 3.0
-#define LOAD_INPUT(c, C_STRIDE)                            \
-    const data_et v00_d = data[v00_OFFSET + c * C_STRIDE]; \
-    const data_et v01_d = data[v01_OFFSET + c * C_STRIDE]; \
-    const data_et v10_d = data[v10_OFFSET + c * C_STRIDE]; \
-    const data_et v11_d = data[v11_OFFSET + c * C_STRIDE];
-
-#define INTERPOLATE()                                     \
-    const data_et v00 = v00_valid ? v00_d * (1 - dx) : 0; \
-    const data_et v01 = v01_valid ? v01_d * dx : 0;       \
-    const data_et v10 = v10_valid ? v10_d * (1 - dx) : 0; \
-    const data_et v11 = v11_valid ? v11_d * dx : 0;       \
-                                                          \
-    const data_et q0 = v00 + v01;                         \
-    const data_et q1 = v10 + v11;                         \
-    const data_et out = dy * q1 + (1 - dy) * q0;
-
-#define STORE(c, GLOBAL_OFFSET, C_STRIDE) output[GLOBAL_OFFSET + c * C_STRIDE] = out;
-
 // ====================================================================
 //
-// GRID SAMPLE KERNEL
+// GRID SAMPLE KERNEL (layout-agnostic data/output addressing)
+//
+// Same batched grid-coordinate-caching strategy as the original bfyx-only
+// kernel (decode each spatial location's sampling coordinates once, reuse
+// across all channels -- this is the actual performance win over the
+// reference kernel, which redoes this math redundantly per (n,c,h,w)
+// thread). The only change is that `data`/`output` element addresses now go
+// through INPUT0_GET_INDEX/OUTPUT_GET_INDEX -- the kernel_selector's
+// standard layout-aware indexing macros (same ones grid_sample_ref.cl uses)
+// -- instead of the previous hand-rolled `base + c * H * W` planar-only
+// arithmetic, so this kernel works correctly for any layout the tensor
+// actually has (bfyx, b_fs_yx_fsv16, ...), not just bfyx. `grid` (input1)
+// keeps the original flat block-cached access pattern unchanged: it's a
+// [N,H,W,2] auxiliary tensor, not a feature-map subject to the same
+// blocked-layout optimization decisions as `data`, so this loop's core
+// optimization (reading a whole block of grid values as one contiguous
+// stream) is unaffected either way.
 //
 // ====================================================================
 
@@ -97,43 +63,79 @@ KERNEL(grid_sample_opt_bilinear_zeros)(const __global data_t* restrict data,
 
     const int n = get_global_id(0);
 
-    const int LOCAL_GRID_OFFSET_FOR_THI_BLOCK = GRID_ITEMS_PER_BLOCK * 2 * get_group_id(1);
     const int OUTPUT_C_STRIDE = OUTPUT_SIZE_Y * OUTPUT_SIZE_X;
-    const int GLOBAL_GRID_OFFSET_FOR_THIS_BLOCK = n * OUTPUT_C_STRIDE * 2 + LOCAL_GRID_OFFSET_FOR_THI_BLOCK;
+    const int LOCAL_GRID_OFFSET_FOR_THI_BLOCK = GRID_ITEMS_PER_BLOCK * 2 * get_group_id(1);
     const int BLOCK_SIZE = get_local_size(1);
-    const grid_t* restrict grid_for_this_block = grid + GLOBAL_GRID_OFFSET_FOR_THIS_BLOCK;
     const int GRID_ITEMS_FOR_THIS_BLOCK =
         min(OUTPUT_C_STRIDE * 2 - LOCAL_GRID_OFFSET_FOR_THI_BLOCK, GRID_ITEMS_PER_BLOCK * 2);
 
-    const int INPUT_C_STRIDE = INPUT0_SIZE_Y * INPUT0_SIZE_X;
-    const int GLOBAL_INPUT_OFFSET_THIS_THREAD = n * INPUT0_FEATURE_NUM * INPUT_C_STRIDE;
-
-    // The basic idea is to cache and reuse grid vals for getting close to
-    // optimal numer of loads(and stores).
     for (int thisThreadHW = get_local_linear_id() * 2; thisThreadHW < GRID_ITEMS_FOR_THIS_BLOCK;
          thisThreadHW += 2 * BLOCK_SIZE) {
         const int globalThisThreadHW = (thisThreadHW + LOCAL_GRID_OFFSET_FOR_THI_BLOCK) / 2;
         const int h = globalThisThreadHW / OUTPUT_SIZE_X;
         const int w = globalThisThreadHW % OUTPUT_SIZE_X;
-        const int GLOBAL_OUTPUT_OFFSET_THIS_THREAD =
-            n * OUTPUT_FEATURE_NUM * OUTPUT_SIZE_Y * OUTPUT_SIZE_X + h * OUTPUT_SIZE_X + w;
 
-        const grid_et x_n = grid_for_this_block[thisThreadHW];
-        const grid_et y_n = grid_for_this_block[thisThreadHW + 1];
+        // Layout-aware grid read (was: raw contiguous-block pointer arithmetic, which assumed
+        // `grid` is always a simple planar [N,H,W,2] buffer). That assumption broke once `data`
+        // (and therefore, coupled through the layout optimizer, `grid`) could be laid out in a
+        // blocked format like b_fs_yx_fsv16 -- silently corrupting these reads. INPUT1_GET_INDEX
+        // is layout-aware regardless of what `grid`'s actual runtime layout is. Axis mapping
+        // (n, h, w, c) -- not (n, c, h, w) -- matches grid_sample_ref.cl's own established
+        // convention for this tensor's real [N,H,W,2] shape (OpenVINO's generic 4D tensor
+        // descriptor maps dims positionally to batch/feature/y/x regardless of what they
+        // semantically represent, so dim1=H is "feature", dim2=W is "y", dim3=2 is "x" here).
+        // This does trade away the batched block-cached grid read for a per-thread lookup, but
+        // only for these 2 reads -- the channel loop below (the actual hot path) is unaffected.
+        const grid_et x_n = grid[INPUT1_GET_INDEX(n, h, w, 0)];
+        const grid_et y_n = grid[INPUT1_GET_INDEX(n, h, w, 1)];
 
-        PRE_CALC_VALID_OFFSETS_FOR_INPUT_LOAD(x_n, y_n, GLOBAL_INPUT_OFFSET_THIS_THREAD);
+        const grid_et y_d = denormalize(y_n, INPUT0_SIZE_Y);
+        const grid_et x_d = denormalize(x_n, INPUT0_SIZE_X);
+        const int y_topleft = (int)floor(y_d);
+        const int x_topleft = (int)floor(x_d);
+        const grid_et dy = y_d - y_topleft;
+        const grid_et dx = x_d - x_topleft;
+
+        const bool y0_valid = is_between(y_topleft, 0, INPUT0_SIZE_Y);
+        const bool y1_valid = is_between(y_topleft + 1, 0, INPUT0_SIZE_Y);
+        const bool x0_valid = is_between(x_topleft, 0, INPUT0_SIZE_X);
+        const bool x1_valid = is_between(x_topleft + 1, 0, INPUT0_SIZE_X);
+
+        const bool v00_valid = y0_valid && x0_valid;
+        const bool v01_valid = y0_valid && x1_valid;
+        const bool v10_valid = y1_valid && x0_valid;
+        const bool v11_valid = y1_valid && x1_valid;
+
+        // Same "always load, mask afterward" trick as the original kernel (see its
+        // comment on avoiding warp-divergence from conditional loads): substitute a
+        // safe in-bounds fallback position (0,0) when the true position would be
+        // out-of-bounds, and zero the contribution out in the blend below instead of
+        // branching around the load itself.
+        const int y0c = y0_valid ? y_topleft : 0;
+        const int y1c = y1_valid ? (y_topleft + 1) : 0;
+        const int x0c = x0_valid ? x_topleft : 0;
+        const int x1c = x1_valid ? (x_topleft + 1) : 0;
 
 #pragma unroll
         for (int c = 0; c < OUTPUT_FEATURE_NUM; ++c) {
-            LOAD_INPUT(c, INPUT_C_STRIDE);
-            INTERPOLATE();
-            STORE(c, GLOBAL_OUTPUT_OFFSET_THIS_THREAD, OUTPUT_C_STRIDE);
+            const data_et v00_d = data[INPUT0_GET_INDEX(n, c, y0c, x0c)];
+            const data_et v01_d = data[INPUT0_GET_INDEX(n, c, y0c, x1c)];
+            const data_et v10_d = data[INPUT0_GET_INDEX(n, c, y1c, x0c)];
+            const data_et v11_d = data[INPUT0_GET_INDEX(n, c, y1c, x1c)];
+
+            const data_et v00 = v00_valid ? v00_d * (1 - dx) : 0;
+            const data_et v01 = v01_valid ? v01_d * dx : 0;
+            const data_et v10 = v10_valid ? v10_d * (1 - dx) : 0;
+            const data_et v11 = v11_valid ? v11_d * dx : 0;
+
+            const data_et q0 = v00 + v01;
+            const data_et q1 = v10 + v11;
+            const data_et out = dy * q1 + (1 - dy) * q0;
+
+            output[OUTPUT_GET_INDEX(n, c, h, w)] = out;
         }
     }
 }
 
 #undef denormalize
-#undef STORE
-#undef INTERPOLATE
-#undef PRE_CALC_VALID_OFFSETS_FOR_INPUT_LOAD
-#undef LOAD_INPUT
+#undef is_between

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/grid_sample_opt_bilinear_zeros.cl
@@ -28,10 +28,6 @@ inline const bool FUNC(is_between)(int val, int min, int max) {
 }
 #define is_between FUNC_CALL(is_between)
 
-// Same "always load, mask afterward" trick as the original kernel (see the
-// comment on LOAD_INPUT below for why): substitute a safe in-bounds fallback
-// position (0,0) when the true position would be out-of-bounds, and zero the
-// contribution out in INTERPOLATE below instead of branching around the load.
 #define PRE_CALC_VALID_OFFSETS_FOR_INPUT_LOAD(x_n, y_n)                \
     const grid_et y_d = denormalize(y_n, INPUT0_SIZE_Y);               \
     const grid_et x_d = denormalize(x_n, INPUT0_SIZE_X);               \

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_opt_bilinear_zeros.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_opt_bilinear_zeros.cpp
@@ -57,7 +57,9 @@ bool GridSampleKernelOpt_BilinearZeros::Validate(const Params& params) const {
 JitConstants GridSampleKernelOpt_BilinearZeros::GetJitConstants(const grid_sample_params& kernel_params) const {
     auto jit_constants = TBase::GetJitConstants(kernel_params);
 
-    jit_constants.AddConstants({MakeJitConstant("GRID_ITEMS_PER_BLOCK", GRID_ITEMS_PER_BLOCK)});
+    jit_constants.AddConstants({
+        MakeJitConstant("GRID_ITEMS_PER_BLOCK", GRID_ITEMS_PER_BLOCK)
+    });
 
     return jit_constants;
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_opt_bilinear_zeros.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_opt_bilinear_zeros.cpp
@@ -47,8 +47,8 @@ bool GridSampleKernelOpt_BilinearZeros::Validate(const Params& params) const {
     if (kernel_params.padding_mode != grid_sample_params::PaddingMode::ZEROS)
         DO_NOT_USE_THIS_KERNEL(params.layerID);
 
-    if (kernel_params.inputs[0].GetDims().size() != 4 || kernel_params.outputs[0].GetDims().size() != 4 ||
-        PaddedSpatial(kernel_params.inputs) || PaddedSpatial(kernel_params.outputs))
+    if (kernel_params.inputs[0].GetDims().size() != 4 || kernel_params.outputs[0].GetDims().size() != 4 || PaddedSpatial(kernel_params.inputs) ||
+        PaddedSpatial(kernel_params.outputs))
         DO_NOT_USE_THIS_KERNEL(params.layerID);
 
     return true;
@@ -57,9 +57,7 @@ bool GridSampleKernelOpt_BilinearZeros::Validate(const Params& params) const {
 JitConstants GridSampleKernelOpt_BilinearZeros::GetJitConstants(const grid_sample_params& kernel_params) const {
     auto jit_constants = TBase::GetJitConstants(kernel_params);
 
-    jit_constants.AddConstants({
-        MakeJitConstant("GRID_ITEMS_PER_BLOCK", GRID_ITEMS_PER_BLOCK)
-    });
+    jit_constants.AddConstants({MakeJitConstant("GRID_ITEMS_PER_BLOCK", GRID_ITEMS_PER_BLOCK)});
 
     return jit_constants;
 }
@@ -71,6 +69,16 @@ ParamsKey GridSampleKernelOpt_BilinearZeros::GetSupportedKey() const {
     key.EnableDifferentTypes();
     key.EnableInputLayout(DataLayout::bfyx);
     key.EnableOutputLayout(DataLayout::bfyx);
+    // b_fs_yx_fsv16: the data/output addressing below now goes through the
+    // kernel_selector's standard INPUT0_GET_INDEX/OUTPUT_GET_INDEX macros (see the
+    // .cl kernel), which are layout-aware, so this kernel is no longer restricted to
+    // planar bfyx. Added specifically because the GPU plugin's layout optimizer
+    // prefers b_fs_yx_fsv16 for channel counts that block evenly into 16 (a decision
+    // made for the benefit of neighboring convolutions, independent of GridSample) --
+    // without this, every such tensor silently fell back to the much slower
+    // reference kernel even though bilinear+zeros+4D+unpadded otherwise qualified.
+    key.EnableInputLayout(DataLayout::b_fs_yx_fsv16);
+    key.EnableOutputLayout(DataLayout::b_fs_yx_fsv16);
     key.EnableTensorOffset();
     key.EnableTensorPitches();
     key.EnableBatching();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_opt_bilinear_zeros.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grid_sample/grid_sample_kernel_opt_bilinear_zeros.cpp
@@ -47,8 +47,8 @@ bool GridSampleKernelOpt_BilinearZeros::Validate(const Params& params) const {
     if (kernel_params.padding_mode != grid_sample_params::PaddingMode::ZEROS)
         DO_NOT_USE_THIS_KERNEL(params.layerID);
 
-    if (kernel_params.inputs[0].GetDims().size() != 4 || kernel_params.outputs[0].GetDims().size() != 4 || PaddedSpatial(kernel_params.inputs) ||
-        PaddedSpatial(kernel_params.outputs))
+    if (kernel_params.inputs[0].GetDims().size() != 4 || kernel_params.outputs[0].GetDims().size() != 4 ||
+        PaddedSpatial(kernel_params.inputs) || PaddedSpatial(kernel_params.outputs))
         DO_NOT_USE_THIS_KERNEL(params.layerID);
 
     return true;
@@ -69,14 +69,6 @@ ParamsKey GridSampleKernelOpt_BilinearZeros::GetSupportedKey() const {
     key.EnableDifferentTypes();
     key.EnableInputLayout(DataLayout::bfyx);
     key.EnableOutputLayout(DataLayout::bfyx);
-    // b_fs_yx_fsv16: the data/output addressing below now goes through the
-    // kernel_selector's standard INPUT0_GET_INDEX/OUTPUT_GET_INDEX macros (see the
-    // .cl kernel), which are layout-aware, so this kernel is no longer restricted to
-    // planar bfyx. Added specifically because the GPU plugin's layout optimizer
-    // prefers b_fs_yx_fsv16 for channel counts that block evenly into 16 (a decision
-    // made for the benefit of neighboring convolutions, independent of GridSample) --
-    // without this, every such tensor silently fell back to the much slower
-    // reference kernel even though bilinear+zeros+4D+unpadded otherwise qualified.
     key.EnableInputLayout(DataLayout::b_fs_yx_fsv16);
     key.EnableOutputLayout(DataLayout::b_fs_yx_fsv16);
     key.EnableTensorOffset();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/grid_sample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/grid_sample_gpu_test.cpp
@@ -687,6 +687,16 @@ INSTANTIATE_TEST_SUITE_P(smoke_grid_sample_gpu_test_FLOAT16_FLOAT16,
                                           testing::Values(RUN_CACHING_TEST)),
                          grid_sample_gpu_test_FLOAT16_FLOAT16::PrintToStringParamName);
 
+// Layout coverage for fp16, mirroring smoke_grid_sample_gpu_test_float_float above -- previously
+// only float/float exercised non-bfyx layouts (including b_fs_yx_fsv16) here, leaving fp16 (the
+// precision GPU-plugin inference actually runs by default) with no blocked-layout coverage at all.
+INSTANTIATE_TEST_SUITE_P(smoke_grid_sample_gpu_test_FLOAT16_FLOAT16_layouts,
+                         grid_sample_gpu_test_FLOAT16_FLOAT16,
+                         testing::Combine(testing::ValuesIn(getParamsToCheckLayouts<ov::float16, ov::float16>()),
+                                          testing::ValuesIn(layout_formats),
+                                          testing::Values(RUN_CACHING_TEST)),
+                         grid_sample_gpu_test_FLOAT16_FLOAT16::PrintToStringParamName);
+
 #ifndef RUN_ALL_MODEL_CACHING_TESTS
 INSTANTIATE_TEST_SUITE_P(smoke_grid_sample_gpu_test_FLOAT16_FLOAT16_cached,
                          grid_sample_gpu_test_FLOAT16_FLOAT16,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/grid_sample_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/grid_sample_gpu_test.cpp
@@ -687,9 +687,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_grid_sample_gpu_test_FLOAT16_FLOAT16,
                                           testing::Values(RUN_CACHING_TEST)),
                          grid_sample_gpu_test_FLOAT16_FLOAT16::PrintToStringParamName);
 
-// Layout coverage for fp16, mirroring smoke_grid_sample_gpu_test_float_float above -- previously
-// only float/float exercised non-bfyx layouts (including b_fs_yx_fsv16) here, leaving fp16 (the
-// precision GPU-plugin inference actually runs by default) with no blocked-layout coverage at all.
 INSTANTIATE_TEST_SUITE_P(smoke_grid_sample_gpu_test_FLOAT16_FLOAT16_layouts,
                          grid_sample_gpu_test_FLOAT16_FLOAT16,
                          testing::Combine(testing::ValuesIn(getParamsToCheckLayouts<ov::float16, ov::float16>()),


### PR DESCRIPTION
## Issue

`GridSampleOpt_BilinearZeros` (the fast bilinear+zeros-padding GPU kernel, ~2-4x faster than the reference implementation in practice on this workload) only declares support for planar `bfyx` layout. Any GridSample whose data/output tensor gets laid out as `b_fs_yx_fsv16` by the layout optimizer -- which happens whenever neighboring convolutions prefer a blocked format, independent of GridSample itself, e.g. for channel counts that divide evenly into 16 -- silently falls back to the much slower reference kernel (`grid_sample_ref`) with no warning.

Observed on a real video-interpolation workload (RIFE-style optical-flow warping) on an Arc B70: 8 of 18 GridSample calls per frame were exactly this shape and stuck on the reference kernel, costing ~0.85-0.91ms each vs. ~0.08ms for the (already `bfyx`, already fast) calls of a different channel count.

## Root cause / fix

`GridSampleKernelOpt_BilinearZeros`'s `.cl` kernel computes data/output element addresses via hand-rolled planar pointer arithmetic (`base + c * H * W`), which is only correct for `bfyx`. The reference kernel instead uses the kernel_selector's generic `INPUT0_GET_INDEX`/`OUTPUT_GET_INDEX` macros, which resolve correctly for any declared layout -- this is why `grid_sample_ref` already handled `b_fs_yx_fsv16` correctly, just slowly.

This change:
- Rewrites the `.cl` kernel's data/output addressing to use `INPUT0_GET_INDEX`/`OUTPUT_GET_INDEX` instead of the planar-only formula, preserving the kernel's actual performance advantage over the reference implementation (decoding each spatial location's sampling coordinates once and reusing them across the whole channel loop, rather than redoing that work per-channel).
- Extends `GetSupportedKey()` to declare `b_fs_yx_fsv16` support alongside `bfyx`.
- Also rewrites the `grid` input's read path to go through `INPUT1_GET_INDEX` (previously raw contiguous-block pointer arithmetic, reading a whole cached block of coordinates at once). This is necessary, not optional: `ParamsKey::EnableInputLayout()` applies to all kernel inputs collectively, not per-input-index, so once `data` became eligible for `b_fs_yx_fsv16` the layout optimizer was free to lay `grid` out the same way too (to avoid a Reorder against its own upstream producer) -- and the old raw-pointer grid read silently assumed planar layout, corrupting every sampled coordinate once `grid` actually became blocked-format. This was caught during development via a real accuracy regression (PSNR ~36dB vs. the correct ~52dB on real content), root-caused by comparing kernel selection against tensor layouts directly rather than assumed. The grid read is now correct for any layout at the cost of losing the batched block-cache read pattern for those 2 reads per thread; the actual hot path (the per-channel interpolation loop) is unaffected.

## Testing

- Added `smoke_grid_sample_gpu_test_FLOAT16_FLOAT16_layouts`, mirroring the existing `smoke_grid_sample_gpu_test_float_float` layout-coverage suite (`getParamsToCheckLayouts` x `layout_formats`) but for fp16 -- the precision this bug actually manifested at. Previously `FLOAT16_FLOAT16` only ran against `bfyx`, so no existing test covered fp16 + blocked layouts at all.
- All 499 existing + new GridSample unit tests pass (`ov_gpu_unit_tests --gtest_filter="*grid_sample*:*GridSample*"`) on Arc B70 (Battlemage), including the full existing float32 layout matrix (216 tests, nearest/bilinear/bicubic x zeros/border/reflection x 6 layout formats) and the new fp16 layout matrix (216 tests, same coverage).
- Validated against a real 1080p RIFE-style optical-flow network on Arc B70: correctness unchanged (PSNR ~51.7-56.1dB across several real anime frame pairs, matching pre-patch numbers exactly -- this is a speed fix, not a precision change), all 18 real GridSample calls per frame now select the optimized kernel (confirmed via runtime `primitiveType` introspection), GridSample cost per frame dropped from ~7.9ms to ~4.2ms.

## AI assistance disclosure

AI assistance used: yes
If yes: Claude (Anthropic) was used throughout root-causing the performance gap (via source review of `kernel_selector/jitter.cpp` and the GPU plugin's GridSample kernel sources) and iterating on the fix, including diagnosing and fixing a real correctness regression found during development (the grid-layout coupling issue described above) via direct comparison against a known-correct baseline build and runtime layout introspection, not by inspection alone.
Human validation performed: build verified locally (scoped GPU+CPU plugin + Python wheel build from a clean master checkout); full existing + new GridSample GPU unit test suite run and passed on real Arc B70 hardware; correctness and performance independently validated against a real downstream video-interpolation workload across multiple real content frame pairs, not synthetic data alone.

---

Opened as a draft while I finish reviewing -- not yet requesting review.
