### PR TITLE
[GPU] Fix compiled model cache serialization for Qwen3.5-4B

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gated_delta_net_ref.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/gated_delta_net_ref.cpp
@@ -161,4 +161,5 @@ std::unique_ptr<primitive_impl> GatedDeltaNetRef::create_impl(const program_node
 
 }  // namespace ov::intel_gpu::ocl
 
+BIND_BINARY_BUFFER_WITH_TYPE(cldnn::gated_delta_net)
 BIND_BINARY_BUFFER_WITH_TYPE(ov::intel_gpu::ocl::GatedDeltaNetRefImpl)

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_router_fused_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_router_fused_opt.cpp
@@ -151,3 +151,6 @@ std::unique_ptr<primitive_impl> MoeRouterFusedOpt::create_impl(const program_nod
 }
 
 }  // namespace ov::intel_gpu::ocl
+
+BIND_BINARY_BUFFER_WITH_TYPE(cldnn::moe_router_fused)
+BIND_BINARY_BUFFER_WITH_TYPE(ov::intel_gpu::ocl::MoeRouterFusedImpl)

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_causal_conv1d_ref.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_causal_conv1d_ref.cpp
@@ -147,4 +147,5 @@ std::unique_ptr<primitive_impl> PagedCausalConv1DRef::create_impl(const program_
 
 }  // namespace ov::intel_gpu::ocl
 
+BIND_BINARY_BUFFER_WITH_TYPE(cldnn::paged_causal_conv1d)
 BIND_BINARY_BUFFER_WITH_TYPE(ov::intel_gpu::ocl::PagedCausalConv1DRefImpl)

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_gated_delta_net.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_gated_delta_net.cpp
@@ -240,5 +240,6 @@ std::unique_ptr<primitive_impl> PagedGatedDeltaNetOpt::create_impl(const program
 
 }  // namespace ov::intel_gpu::ocl
 
+BIND_BINARY_BUFFER_WITH_TYPE(cldnn::paged_gated_delta_net)
 BIND_BINARY_BUFFER_WITH_TYPE(ov::intel_gpu::ocl::PagedGatedDeltaNetRefImpl)
 BIND_BINARY_BUFFER_WITH_TYPE(ov::intel_gpu::ocl::PagedGatedDeltaNetOptImpl)

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gated_delta_net.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gated_delta_net.cpp
@@ -25,14 +25,16 @@ struct gated_delta_net_test_params {
     int32_t value_num_heads;
     int32_t head_size;
     ov::element::Type precision;
+    bool is_caching_test;
 
-    gated_delta_net_test_params(int batch, int t, int num_heads, int value_num_heads, int head_size, ov::element::Type precision)
+    gated_delta_net_test_params(int batch, int t, int num_heads, int value_num_heads, int head_size, ov::element::Type precision, bool is_caching_test = false)
         : batch(batch),
           t(t),
           num_heads(num_heads),
           value_num_heads(value_num_heads),
           head_size(head_size),
-          precision(precision) {}
+          precision(precision),
+          is_caching_test(is_caching_test) {}
 };
 
 struct gated_delta_net_gpu_test : public ::testing::TestWithParam<gated_delta_net_test_params> {
@@ -302,6 +304,9 @@ struct gated_delta_net_gpu_test : public ::testing::TestWithParam<gated_delta_ne
                              std::to_string(info.param.t) + "_" + std::to_string(info.param.num_heads) + "_" + std::to_string(info.param.value_num_heads) +
                              "_" + std::to_string(info.param.head_size);
 
+        if (info.param.is_caching_test)
+            result += "_cached";
+
         return result;
     }
 
@@ -318,7 +323,7 @@ struct gated_delta_net_gpu_test : public ::testing::TestWithParam<gated_delta_ne
 
 TEST_P(gated_delta_net_gpu_test, basic) {
     auto p = GetParam();
-    execute(p);
+    execute(p, p.is_caching_test);
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke_gated_delta_net_gpu_test,
@@ -336,7 +341,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_gated_delta_net_gpu_test,
                              gated_delta_net_test_params{2, 8, 2, 2, 16, ov::element::f32},
                              gated_delta_net_test_params{1, 8, 2, 2, 128, ov::element::f32},
                              gated_delta_net_test_params{2, 8, 2, 2, 128, ov::element::f32},
-                             gated_delta_net_test_params{1, 8, 4, 4, 128, ov::element::f32}),
+                             gated_delta_net_test_params{1, 8, 4, 4, 128, ov::element::f32},
+                             gated_delta_net_test_params{1, 1, 2, 2, 16, ov::element::f16, true}),
                          gated_delta_net_gpu_test::PrintToStringParamName);
 
 }  // namespace

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_causal_conv1d.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_causal_conv1d.cpp
@@ -25,6 +25,7 @@ struct paged_causal_conv1d_test_params {
     int32_t kernel_size;
     ov::element::Type precision;
     bool with_bias;
+    bool is_caching_test = false;
 };
 
 struct paged_causal_conv1d_gpu_test : public ::testing::TestWithParam<paged_causal_conv1d_test_params> {
@@ -222,13 +223,14 @@ struct paged_causal_conv1d_gpu_test : public ::testing::TestWithParam<paged_caus
                                                                     cldnn::memory::ptr block_idx_mem,
                                                                     cldnn::memory::ptr block_idx_begins_mem,
                                                                     cldnn::memory::ptr past_lens_mem,
-                                                                    cldnn::memory::ptr cache_interval_mem) {
+                                                                    cldnn::memory::ptr cache_interval_mem,
+                                                                    bool is_caching_test) {
         auto& engine = get_test_engine();
 
         ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
-        cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), false);
+        cldnn::network::ptr net = get_network(engine, topo, config, get_test_stream_ptr(), is_caching_test);
 
         net->set_input_data("input_embeds", input_mem);
         net->set_input_data("conv_state_table", state_mem);
@@ -320,7 +322,17 @@ struct paged_causal_conv1d_gpu_test : public ::testing::TestWithParam<paged_caus
                                     data_type);
 
         auto [out_mem, net] =
-            run_network(topo, input_mem, state_mem, weight_mem, bias_mem, subseq_mem, block_idx_mem, block_idx_begins_mem, past_lens_mem, cache_interval_mem);
+            run_network(topo,
+                        input_mem,
+                        state_mem,
+                        weight_mem,
+                        bias_mem,
+                        subseq_mem,
+                        block_idx_mem,
+                        block_idx_begins_mem,
+                        past_lens_mem,
+                        cache_interval_mem,
+                        p.is_caching_test);
 
         ASSERT_TRUE(out_mem != nullptr);
         ASSERT_EQ(out_mem->count(), ref_output.size());
@@ -360,7 +372,8 @@ struct paged_causal_conv1d_gpu_test : public ::testing::TestWithParam<paged_caus
     static std::string PrintToStringParamName(const testing::TestParamInfo<paged_causal_conv1d_test_params>& info) {
         const auto& p = info.param;
         return "paged_causal_conv1d_gpu_test_" + p.precision.to_string() + "_tokens_" + std::to_string(p.tokens) + "_seq_" + std::to_string(p.num_sequences) +
-               "_hidden_" + std::to_string(p.hidden_size) + "_kernel_" + std::to_string(p.kernel_size) + (p.with_bias ? "_bias" : "_no_bias");
+               "_hidden_" + std::to_string(p.hidden_size) + "_kernel_" + std::to_string(p.kernel_size) + (p.with_bias ? "_bias" : "_no_bias") +
+               (p.is_caching_test ? "_cached" : "");
     }
 };
 
@@ -376,7 +389,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_paged_causal_conv1d_gpu_test,
                                            paged_causal_conv1d_test_params{8, 2, 16, 4, ov::element::f32, true},
                                            paged_causal_conv1d_test_params{12, 3, 32, 5, ov::element::f32, true},
                                            paged_causal_conv1d_test_params{8, 2, 16, 4, ov::element::f16, false},
-                                           paged_causal_conv1d_test_params{8, 2, 16, 4, ov::element::f32, false}),
+                                           paged_causal_conv1d_test_params{8, 2, 16, 4, ov::element::f32, false},
+                                           paged_causal_conv1d_test_params{8, 2, 16, 4, ov::element::f16, true, true}),
                          paged_causal_conv1d_gpu_test::PrintToStringParamName);
 
 }  // namespace

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_gated_delta_net.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_gated_delta_net.cpp
@@ -27,6 +27,7 @@ struct paged_gated_delta_net_test_params {
     int32_t v_heads;                          // Number of value heads
     int32_t head_size;                        // Per-head hidden size (K and V dims in this test)
     ov::element::Type precision;              // Data precision for query/key/value/state tensors
+    bool is_caching_test = false;
 };
 
 struct paged_gated_delta_net_gpu_test : public ::testing::TestWithParam<paged_gated_delta_net_test_params> {
@@ -295,7 +296,7 @@ struct paged_gated_delta_net_gpu_test : public ::testing::TestWithParam<paged_ga
 
         ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
-        auto network = get_network(engine, topo, config, get_test_stream_ptr(), false);
+        auto network = get_network(engine, topo, config, get_test_stream_ptr(), p.is_caching_test);
 
         network->set_input_data("q", q_mem);
         network->set_input_data("k", k_mem);
@@ -396,6 +397,8 @@ struct paged_gated_delta_net_gpu_test : public ::testing::TestWithParam<paged_ga
         std::string result = "paged_gated_delta_net_gpu_test_" + info.param.precision.to_string() + "_" + subseq_tokens_str + "_" + past_lens_str + "_" +
                              cache_intervals_str + "_" + std::to_string(info.param.qk_heads) + "_" + std::to_string(info.param.v_heads) + "_" +
                              std::to_string(info.param.head_size);
+        if (info.param.is_caching_test)
+            result += "_cached";
         return result;
     }
 };
@@ -443,7 +446,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_paged_gated_delta_net_gpu_test,
                              // fully occupied past blocks
                              paged_gated_delta_net_test_params{{16, 32, 48, 64}, {16, 32, 48, 64}, {16, 16, 16, 16}, 2, 2, 64, ov::element::f32},
                              // partially occupied past blocks
-                             paged_gated_delta_net_test_params{{16, 32, 48, 64}, {1, 17, 33, 49}, {16, 16, 16, 16}, 2, 2, 64, ov::element::f32}),
+                             paged_gated_delta_net_test_params{{16, 32, 48, 64}, {1, 17, 33, 49}, {16, 16, 16, 16}, 2, 2, 64, ov::element::f32},
+                             paged_gated_delta_net_test_params{{3, 3}, {2, 3}, {2, 3}, 2, 2, 16, ov::element::f16, true}),
                          paged_gated_delta_net_gpu_test::PrintToStringParamName);
 
 }  // namespace


### PR DESCRIPTION
### Details:
 - Register binary serialization for `gated_delta_net`, `paged_causal_conv1d`, `paged_gated_delta_net`, and `moe_router_fused` GPU primitives and implementations.
 - Enable Qwen3.5-4B with Paged Attention to load the language model from the compiled-model cache.
 - Reduce warm pipeline initialization time while preserving generated output.

### Tickets:
 - [CVS-192028](https://jira.devtools.intel.com/browse/CVS-192028)

### AI Assistance:
 - *AI assistance used: no*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
