### PR TITLE
[GPU][CLANG-TIDY] Enable modernize-use-equals-default and modernize-use-equals-delete

### DIFF
--- a/src/plugins/intel_gpu/.clang-tidy
+++ b/src/plugins/intel_gpu/.clang-tidy
@@ -19,6 +19,8 @@ Checks: >
   modernize-redundant-void-arg,
   readability-container-size-empty,
   readability-redundant-string-cstr,
+  modernize-use-equals-default,
+  modernize-use-equals-delete,
 # Treat every enabled check as an error so they are enforced during the build.
 # Scope is controlled via 'Checks' above; matches the CPU plugin configuration.
 WarningsAsErrors: '*'

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/bind.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/bind.hpp
@@ -51,10 +51,11 @@ struct saver_storage {
         map.insert(pair);
     }
 
-private:
-    saver_storage() = default;
     saver_storage(const saver_storage&) = delete;
     void operator=(const saver_storage&) = delete;
+
+private:
+    saver_storage() = default;
 
     std::unordered_map<std::string, save_function> map;
 };
@@ -85,10 +86,11 @@ struct loader_storage {
         map.insert(pair);
     }
 
-private:
-    loader_storage() = default;
     loader_storage(const loader_storage&) = delete;
     void operator=(const loader_storage&) = delete;
+
+private:
+    loader_storage() = default;
 
     std::unordered_map<std::string, FuncT> map;
 };
@@ -110,13 +112,13 @@ public:
         return instance;
     }
 
+    buffer_binder(const buffer_binder&) = delete;
+    void operator=(const buffer_binder&) = delete;
+
 private:
     buffer_binder() {
         saver_storage<BufferType>::instance().set_save_function({T::get_type_info_s(), save});
     }
-
-    buffer_binder(const buffer_binder&) = delete;
-    void operator=(const buffer_binder&) = delete;
 
     template <typename Derived>
     static const Derived* downcast(const void* base_ptr) {
@@ -138,6 +140,9 @@ public:
         return instance;
     }
 
+    buffer_binder(const buffer_binder&) = delete;
+    void operator=(const buffer_binder&) = delete;
+
 private:
     buffer_binder() {
         def<BufferType>::instance().set_load_function(
@@ -147,9 +152,6 @@ private:
             result_ptr.reset(derived_ptr.release());
         }});
     }
-
-    buffer_binder(const buffer_binder&) = delete;
-    void operator=(const buffer_binder&) = delete;
 };
 
 template <typename BufferType, typename T>
@@ -161,6 +163,9 @@ public:
         return instance;
     }
 
+    buffer_binder(const buffer_binder&) = delete;
+    void operator=(const buffer_binder&) = delete;
+
 private:
     buffer_binder() {
         dif<BufferType>::instance().set_load_function(
@@ -170,9 +175,6 @@ private:
             result_ptr.reset(derived_ptr.release());
         }});
     }
-
-    buffer_binder(const buffer_binder&) = delete;
-    void operator=(const buffer_binder&) = delete;
 };
 
 template <typename BufferType, typename T>

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/weights_reorder_params.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/serialization/weights_reorder_params.hpp
@@ -9,7 +9,7 @@
 
 namespace cldnn {
     struct WeightsReorderParams {
-        WeightsReorderParams() {}
+        WeightsReorderParams() = default;
 
         WeightsReorderParams(const layout& in_layout, const layout& out_layout, bool transposed = false, bool grouped = false)
             : _in_layout(in_layout),
@@ -66,7 +66,7 @@ namespace cldnn {
 #ifdef ENABLE_ONEDNN_FOR_GPU
     namespace onednn {
         struct WeightsReorderParamsOneDNN : public cldnn::WeightsReorderParams {
-            WeightsReorderParamsOneDNN() {}
+            WeightsReorderParamsOneDNN() = default;
             WeightsReorderParamsOneDNN(const layout& in_layout,
                                        const layout& out_layout,
                                        const dnnl::memory::desc& in_desc,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
@@ -146,7 +146,7 @@ struct loop : public primitive_base<loop> {
         /// @param to Input data primitive id of body topology
         backedge_mapping(primitive_id from, primitive_id to)
             : from(from), to(to) {}
-        backedge_mapping() {}
+        backedge_mapping() = default;
         primitive_id from;
         primitive_id to;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_cell.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/lstm_cell.hpp
@@ -19,6 +19,6 @@ struct lstm_cell : public RNNParams<lstm_cell> {
     using vec_activation_param = std::vector<activation_additional_params>;
     using RNNParams::RNNParams;
     lstm_cell(const lstm_cell&) = default;
-    lstm_cell() {}
+    lstm_cell() = default;
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
@@ -98,8 +98,7 @@ struct loop_impl : typed_primitive_impl<loop> {
 
     loop_impl() : parent() {}
 
-    loop_impl(const loop_impl& other) : typed_primitive_impl<loop>(other),
-        _back_edges(other._back_edges) {}
+    loop_impl(const loop_impl& other) = default;
 
     explicit loop_impl(const loop_node& node) {
         set_node_params(node);

--- a/src/plugins/intel_gpu/src/graph/impls/common/wait_for_events.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/wait_for_events.cpp
@@ -21,7 +21,7 @@ public:
     explicit wait_for_events_impl(const program_node& /*node*/)
         : primitive_impl("wait_for_events") { }
 
-    wait_for_events_impl() {}
+    wait_for_events_impl() = default;
 
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::common::wait_for_events_impl)
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -80,7 +80,7 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
     }
 
     custom_gpu_primitive_impl()
- {}
+ = default;
 
     custom_gpu_primitive_impl(const custom_gpu_primitive_impl& other)
     : parent(other.get_kernel_name())

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -117,7 +117,7 @@ struct kv_cache_impl : multi_stage_primitive<kv_cache> {
 
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::kv_cache_impl)
 
-    kv_cache_impl() {}
+    kv_cache_impl() = default;
 
     kv_cache_impl(const kv_cache_impl& other)
         : parent(other)

--- a/src/plugins/intel_gpu/src/graph/include/loop_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/loop_inst.h
@@ -152,14 +152,7 @@ public:
             sliced_data_prim(std::move(sliced_data_prim)),
             io_prim_map(io_prim_map) {}
 
-        concatenated_memory_mapping(const concatenated_memory_mapping& o) :
-            concatenated_mem(o.concatenated_mem),
-            sliced_mems(o.sliced_mems),
-            stream(o.stream),
-            engine(o.engine),
-            concat_data_prim(o.concat_data_prim),
-            sliced_data_prim(o.sliced_data_prim),
-            io_prim_map(o.io_prim_map) {}
+        concatenated_memory_mapping(const concatenated_memory_mapping& o) = default;
 
         void update_concatenated_mem(memory::ptr mem) {
             concatenated_mem = mem;

--- a/src/plugins/intel_gpu/src/graph/include/pass_manager.h
+++ b/src/plugins/intel_gpu/src/graph/include/pass_manager.h
@@ -41,7 +41,7 @@ public:
     void run(program& p, base_pass& pass);
     uint32_t get_pass_count() { return pass_count; }
     uint32_t inc_pass_count() { return ++pass_count; }
-    ~pass_manager() {}
+    ~pass_manager() = default;
 
 private:
     uint32_t pass_count;

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -230,8 +230,7 @@ program::program(engine& engine, const ExecutionConfig& config)
     _layout_optimizer = std::make_unique<layout_optimizer>();
 }
 
-program::~program() {
-}
+program::~program() = default;
 
 void program::init_program() {
     set_options();

--- a/src/plugins/intel_gpu/src/graph/registry/implementation_map.hpp
+++ b/src/plugins/intel_gpu/src/graph/registry/implementation_map.hpp
@@ -18,10 +18,11 @@ namespace cldnn {
 template <typename T, typename primitive_type>
 class singleton_list : public std::vector<T> {
     singleton_list() : std::vector<T>() {}
+
+public:
     singleton_list(singleton_list const&) = delete;
     void operator=(singleton_list const&) = delete;
 
-public:
     using type = primitive_type;
     static singleton_list& instance() {
         static singleton_list instance_;

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.h
@@ -151,7 +151,7 @@ protected:
 public:
     std::string GetJitName() { return _name; }
     virtual JitDefinitions GetDefinitions() const = 0;
-    virtual ~JitConstant() {}
+    virtual ~JitConstant() = default;
 };
 
 class simple_jit_constant : public JitConstant {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base.h
@@ -36,7 +36,7 @@ public:
     using IndexType = FusedOpsConfiguration::IndexType;
 
     explicit KernelBase(const std::string name) : kernelName(name) {}
-    virtual ~KernelBase() {}
+    virtual ~KernelBase() = default;
 
     virtual KernelsData GetKernelsData(const Params& params) const = 0;
     virtual KernelsData GetKernelsDataForAutoTune(const Params& params) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.h
@@ -15,7 +15,7 @@ namespace kernel_selector {
 class KernelBaseOpenCL : public KernelBase {
 public:
     using KernelBase::KernelBase;
-    ~KernelBaseOpenCL() override {}
+    ~KernelBaseOpenCL() override = default;
 
 protected:
     virtual bool Validate(const Params&) const { return true; }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector.h
@@ -20,7 +20,7 @@ using ForceList = std::map<std::string, bool>;
 class kernel_selector_base {
 public:
     kernel_selector_base();
-    virtual ~kernel_selector_base() {}
+    virtual ~kernel_selector_base() = default;
 
     KernelData get_best_kernel(const Params& params) const;
     std::shared_ptr<KernelBase> GetImplementation(std::string& kernel_name) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -30,7 +30,7 @@ class JitConstants;
 // fuse_params
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct fuse_params {
-    virtual ~fuse_params() {}
+    virtual ~fuse_params() = default;
 
     KernelType GetType() const { return kType; }
 protected:
@@ -420,7 +420,7 @@ struct EngineInfo {
 // Params
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct Params {
-    virtual ~Params() {}
+    virtual ~Params() = default;
 
     KernelType GetType() const { return kType; }
     virtual ParamsKey GetParamsKey() const;
@@ -655,7 +655,7 @@ struct fused_operation_desc {
 // base_params
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct base_params : public Params {
-    ~base_params() override {}
+    ~base_params() override = default;
 
     enum class ArgType {
         Input,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_base.h
@@ -43,7 +43,7 @@ public:
     using DispatchData = CommonDispatchData;
     using KernelBaseOpenCL::KernelBaseOpenCL;
 
-    ~ActivationKernelBase() override {}
+    ~ActivationKernelBase() override = default;
 
 protected:
     bool Validate(const Params& p) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_opt.h
@@ -13,7 +13,7 @@ class ActivationKernelOpt : public ActivationKernelBase {
 public:
     using Parent = ActivationKernelBase;
     ActivationKernelOpt() : Parent("activation_opt") {}
-    ~ActivationKernelOpt() override {}
+    ~ActivationKernelOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_ref.h
@@ -15,7 +15,7 @@ public:
     using Parent::Parent;
 
     ActivationKernelRef() : ActivationKernelBase("activation_ref") {}
-    ~ActivationKernelRef() override {}
+    ~ActivationKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     activation_kernel_selector();
 
-    ~activation_kernel_selector() override {}
+    ~activation_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class ArgMaxMinKernelAxis : public ArgMaxMinKernelBase {
 public:
     ArgMaxMinKernelAxis() : ArgMaxMinKernelBase("arg_max_min_axis") {}
-    ~ArgMaxMinKernelAxis() override {}
+    ~ArgMaxMinKernelAxis() override = default;
 
     JitConstants GetJitConstants(const arg_max_min_params& params) const override;
     DispatchData SetDefault(const arg_max_min_params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_base.h
@@ -36,7 +36,7 @@ struct arg_max_min_params : public base_params {
 class ArgMaxMinKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~ArgMaxMinKernelBase() override {}
+    ~ArgMaxMinKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {
     };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_gpu_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_gpu_ref.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class ArgMaxMinKernelGPURef : public ArgMaxMinKernelBase {
 public:
     ArgMaxMinKernelGPURef() : ArgMaxMinKernelBase("arg_max_min_gpu_ref") {}
-    ~ArgMaxMinKernelGPURef() override {}
+    ~ArgMaxMinKernelGPURef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_opt.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class ArgMaxMinKernelOpt : public ArgMaxMinKernelBase {
 public:
     ArgMaxMinKernelOpt() : ArgMaxMinKernelBase("arg_max_min_opt") {}
-    ~ArgMaxMinKernelOpt() override {}
+    ~ArgMaxMinKernelOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     arg_max_min_kernel_selector();
 
-    ~arg_max_min_kernel_selector() override {}
+    ~arg_max_min_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_topk_radix.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_topk_radix.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ArgMaxMinKernelTopKRadix : public ArgMaxMinKernelBase {
 public:
     ArgMaxMinKernelTopKRadix() : ArgMaxMinKernelBase("arg_max_min_topk_radix") {}
-    ~ArgMaxMinKernelTopKRadix() override {}
+    ~ArgMaxMinKernelTopKRadix() override = default;
 
     JitConstants GetJitConstants(const arg_max_min_params& params) const override;
     DispatchData SetDefault(const arg_max_min_params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_base.h
@@ -41,7 +41,7 @@ struct batch_to_space_fuse_params : fuse_params {
 class BatchToSpaceKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~BatchToSpaceKernelBase() override {}
+    ~BatchToSpaceKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {};
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_ref.h
@@ -11,7 +11,7 @@ class BatchToSpaceKernelRef : public BatchToSpaceKernelBase {
 public:
     using Parent = BatchToSpaceKernelBase;
     BatchToSpaceKernelRef() : BatchToSpaceKernelBase("batch_to_space_ref") {}
-    ~BatchToSpaceKernelRef() override {}
+    ~BatchToSpaceKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/batch_to_space/batch_to_space_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     batch_to_space_kernel_selector();
 
-    ~batch_to_space_kernel_selector() override {}
+    ~batch_to_space_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv16.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ConcatenationKernel_b_fs_yx_fsv16 : public ConcatenationKernelBase {
 public:
     ConcatenationKernel_b_fs_yx_fsv16() : ConcatenationKernelBase("concatenation_gpu_blocked") {}
-    ~ConcatenationKernel_b_fs_yx_fsv16() override {}
+    ~ConcatenationKernel_b_fs_yx_fsv16() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv32.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ConcatenationKernel_b_fs_yx_fsv32 : public ConcatenationKernelBase {
 public:
     ConcatenationKernel_b_fs_yx_fsv32() : ConcatenationKernelBase("concatenation_gpu_b_fs_yx_fsv32") {}
-    ~ConcatenationKernel_b_fs_yx_fsv32() override {}
+    ~ConcatenationKernel_b_fs_yx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_base.h
@@ -40,7 +40,7 @@ struct concatenation_params : public base_params {
 class ConcatenationKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~ConcatenationKernelBase() override {}
+    ~ConcatenationKernelBase() override = default;
 
     using DispatchData = CommonDispatchData;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_depth_bfyx_no_pitch.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_depth_bfyx_no_pitch.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ConcatenationKernel_depth_bfyx_no_pitch : public ConcatenationKernelBase {
 public:
     ConcatenationKernel_depth_bfyx_no_pitch() : ConcatenationKernelBase("concatenation_gpu_depth_bfyx_no_pitch") {}
-    ~ConcatenationKernel_depth_bfyx_no_pitch() override {}
+    ~ConcatenationKernel_depth_bfyx_no_pitch() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_fs_b_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_fs_b_yx_fsv32.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ConcatenationKernel_fs_b_yx_fsv32 : public ConcatenationKernelBase {
 public:
     ConcatenationKernel_fs_b_yx_fsv32() : ConcatenationKernelBase("concatenation_gpu_fs_b_yx_fsv32") {}
-    ~ConcatenationKernel_fs_b_yx_fsv32() override {}
+    ~ConcatenationKernel_fs_b_yx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     DeviceFeaturesKey get_required_device_features_key(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ConcatenationKernelRef : public ConcatenationKernelBase {
 public:
     ConcatenationKernelRef() : ConcatenationKernelBase("concatenation_gpu_ref") {}
-    ~ConcatenationKernelRef() override {}
+    ~ConcatenationKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     concatenation_kernel_selector();
 
-    ~concatenation_kernel_selector() override {}
+    ~concatenation_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_simple_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_simple_ref.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ConcatenationKernel_simple_Ref : public ConcatenationKernelBase {
 public:
     ConcatenationKernel_simple_Ref() : ConcatenationKernelBase("concatenation_gpu_simple_ref") {}
-    ~ConcatenationKernel_simple_Ref() override {}
+    ~ConcatenationKernel_simple_Ref() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convert_color/convert_color_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convert_color/convert_color_kernel_base.h
@@ -29,7 +29,7 @@ struct convert_color_fuse_params : fuse_params {
 class ConvertColorKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~ConvertColorKernelBase() override {}
+    ~ConvertColorKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {};
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convert_color/convert_color_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convert_color/convert_color_kernel_ref.h
@@ -11,7 +11,7 @@ class ConvertColorKernelRef : public ConvertColorKernelBase {
 public:
     using Parent = ConvertColorKernelBase;
     ConvertColorKernelRef() : ConvertColorKernelBase("convert_color_ref") {}
-    ~ConvertColorKernelRef() override {}
+    ~ConvertColorKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convert_color/convert_color_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convert_color/convert_color_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     convert_color_kernel_selector();
 
-    ~convert_color_kernel_selector() override {}
+    ~convert_color_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16.h
@@ -15,7 +15,7 @@ public:
     using Parent = ConvolutionKernelBase;
 
     ConvolutionKernel_b_fs_yx_fsv16();
-    ~ConvolutionKernel_b_fs_yx_fsv16() override {}
+    ~ConvolutionKernel_b_fs_yx_fsv16() override = default;
 
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_1x1.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_1x1.h
@@ -15,7 +15,7 @@ public:
     using Parent = ConvolutionKernelBase;
 
     ConvolutionKernel_b_fs_yx_fsv16_1x1();
-    ~ConvolutionKernel_b_fs_yx_fsv16_1x1() override {}
+    ~ConvolutionKernel_b_fs_yx_fsv16_1x1() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_depthwise.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_depthwise.h
@@ -12,7 +12,7 @@ class ConvolutionKernel_b_fs_yx_fsv16_depthwise : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_b_fs_yx_fsv16_depthwise() : ConvolutionKernelBase("convolution_gpu_bfyx_f16_depthwise") {}
-    ~ConvolutionKernel_b_fs_yx_fsv16_depthwise() override {}
+    ~ConvolutionKernel_b_fs_yx_fsv16_depthwise() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_imad_1x1.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv16_imad_1x1.h
@@ -14,7 +14,7 @@ class Convolution_kernel_b_fs_yx_fsv16_imad_1x1 : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     Convolution_kernel_b_fs_yx_fsv16_imad_1x1();
-    ~Convolution_kernel_b_fs_yx_fsv16_imad_1x1() override {}
+    ~Convolution_kernel_b_fs_yx_fsv16_imad_1x1() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params & params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv4_int8.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv4_int8.h
@@ -13,7 +13,7 @@ class ConvolutionKernel_b_fs_yx_fsv4_int8 : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_b_fs_yx_fsv4_int8() : Parent("convolution_gpu_b_fs_yx_fsv4_int8") {}
-    ~ConvolutionKernel_b_fs_yx_fsv4_int8() override {}
+    ~ConvolutionKernel_b_fs_yx_fsv4_int8() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.hpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_yx_fsv_16_32_imad_dw.hpp
@@ -13,7 +13,7 @@ class ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw : public ConvolutionKernelBase
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw();
-    ~ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw() override {}
+    ~ConvolutionKernel_b_fs_yx_fsv_16_32_imad_dw() override = default;
 
     ParamsKey GetSupportedKey() const override;
     DeviceFeaturesKey get_required_device_features_key(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16.h
@@ -17,7 +17,7 @@ public:
         ConvolutionKernelBase(use_data_type == Datatype::F32 ? "gen9_common_conv_fwd_data_f32" : "gen9_common_conv_fwd_data_f16"),
         use_data_type(use_data_type) {}
 
-    ~ConvolutionKernel_b_fs_zyx_fsv16() override {}
+    ~ConvolutionKernel_b_fs_zyx_fsv16() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_fp16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_fp16.h
@@ -14,6 +14,6 @@ public:
 
     ConvolutionKernel_b_fs_zyx_fsv16_fp16() : ConvolutionKernel_b_fs_zyx_fsv16(Datatype::F16) {}
 
-    ~ConvolutionKernel_b_fs_zyx_fsv16_fp16() override {}
+    ~ConvolutionKernel_b_fs_zyx_fsv16_fp16() override = default;
 };
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_fp32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_fp32.h
@@ -14,6 +14,6 @@ public:
 
     ConvolutionKernel_b_fs_zyx_fsv16_fp32() : ConvolutionKernel_b_fs_zyx_fsv16(Datatype::F32) {}
 
-    ~ConvolutionKernel_b_fs_zyx_fsv16_fp32() override {}
+    ~ConvolutionKernel_b_fs_zyx_fsv16_fp32() override = default;
 };
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_imad.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_imad.h
@@ -14,7 +14,7 @@ public:
     using Parent = ConvolutionKernelBase;
     using BlockParams = DispatchData::BlockParams;
     Convolution_kernel_b_fs_zyx_fsv16_imad() : ConvolutionKernelBase("convolution_gpu_b_fs_zyx_fsv16_imad") {}
-    ~Convolution_kernel_b_fs_zyx_fsv16_imad() override {}
+    ~Convolution_kernel_b_fs_zyx_fsv16_imad() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_base.h
@@ -16,7 +16,7 @@ namespace kernel_selector {
 class ConvolutionKernelBase : public WeightBiasKernelBase {
 public:
     using WeightBiasKernelBase::WeightBiasKernelBase;
-    ~ConvolutionKernelBase() override {}
+    ~ConvolutionKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {
         struct CLDNNStyle {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1.h
@@ -14,7 +14,7 @@ public:
     using Parent = ConvolutionKernelBase;
 
     ConvolutionKernel_bfyx_1x1() : ConvolutionKernelBase("convolution_gpu_bfyx_1x1") {}
-    ~ConvolutionKernel_bfyx_1x1() override {}
+    ~ConvolutionKernel_bfyx_1x1() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1_gemm_buf.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1_gemm_buf.h
@@ -14,7 +14,7 @@ public:
     using Parent = ConvolutionKernelBase;
 
     ConvolutionKernel_bfyx_1x1_gemm_buf() : ConvolutionKernelBase("convolution_gpu_bfyx_1x1_hgemm_buf_16x1") {}
-    ~ConvolutionKernel_bfyx_1x1_gemm_buf() override {}
+    ~ConvolutionKernel_bfyx_1x1_gemm_buf() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_1x1_opt.h
@@ -13,7 +13,7 @@ class convolution_kernel_bfyx_1x1_opt : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     convolution_kernel_bfyx_1x1_opt();
-    ~convolution_kernel_bfyx_1x1_opt() override {}
+    ~convolution_kernel_bfyx_1x1_opt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_depthwise_weights_lwg.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_depthwise_weights_lwg.h
@@ -13,7 +13,7 @@ public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_bfyx_depthwise_weights_lwg()
         : ConvolutionKernelBase("convolution_gpu_bfyx_depthwise_weights_lwg") {}
-    ~ConvolutionKernel_bfyx_depthwise_weights_lwg() override {}
+    ~ConvolutionKernel_bfyx_depthwise_weights_lwg() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_direct_10_12_16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_direct_10_12_16.h
@@ -13,7 +13,7 @@ class ConvolutionKernel_bfyx_Direct_10_10_12 : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_bfyx_Direct_10_10_12() : ConvolutionKernelBase("convolution_gpu_bfyx_direct_10_12_16") {}
-    ~ConvolutionKernel_bfyx_Direct_10_10_12() override {}
+    ~ConvolutionKernel_bfyx_Direct_10_10_12() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_gemm_like.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_gemm_like.h
@@ -14,7 +14,7 @@ class ConvolutionKernel_bfyx_GEMMLike : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_bfyx_GEMMLike() : Parent("convolution_gpu_bfyx_gemm_like") {}
-    ~ConvolutionKernel_bfyx_GEMMLike() override {}
+    ~ConvolutionKernel_bfyx_GEMMLike() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_iyxo.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_iyxo.h
@@ -13,7 +13,7 @@ class ConvolutionKernel_bfyx_iyxo : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_bfyx_iyxo() : Parent("convolution_gpu_bfyx_iyxo") {}
-    ~ConvolutionKernel_bfyx_iyxo() override {}
+    ~ConvolutionKernel_bfyx_iyxo() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.h
@@ -15,7 +15,7 @@ class ConvolutionKernel_bfyx_os_iyx_osv16 : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_bfyx_os_iyx_osv16();
-    ~ConvolutionKernel_bfyx_os_iyx_osv16() override {}
+    ~ConvolutionKernel_bfyx_os_iyx_osv16() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv32.h
@@ -15,7 +15,7 @@ class ConvolutionKernel_bfyx_os_iyx_osv32 : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_bfyx_os_iyx_osv32();
-    ~ConvolutionKernel_bfyx_os_iyx_osv32() override {}
+    ~ConvolutionKernel_bfyx_os_iyx_osv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_b_fs_yx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_b_fs_yx_fsv16.h
@@ -15,7 +15,7 @@ public:
     using Parent = ConvolutionKernelBase;
 
     explicit ConvolutionKernel_bfyx_to_bfyx_f16(std::string kernel_name = "convolution_gpu_bfyx_to_bfyx_f16");
-    ~ConvolutionKernel_bfyx_to_bfyx_f16() override {}
+    ~ConvolutionKernel_bfyx_to_bfyx_f16() override = default;
 
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_bs_fs_yx_bsv16_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_bs_fs_yx_bsv16_fsv16.h
@@ -14,7 +14,7 @@ namespace kernel_selector {
 class ConvolutionKernel_bfyx_to_bfyx_bsv16_fsv16 : public ConvolutionKernel_bfyx_to_bfyx_f16 {
 public:
     ConvolutionKernel_bfyx_to_bfyx_bsv16_fsv16();
-    ~ConvolutionKernel_bfyx_to_bfyx_bsv16_fsv16() override {}
+    ~ConvolutionKernel_bfyx_to_bfyx_bsv16_fsv16() override = default;
 
     ParamsKey GetSupportedKey() const override;
     DeviceFeaturesKey get_required_device_features_key(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_fs_byx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_to_fs_byx_fsv32.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class ConvolutionKernel_bfyx_to_fs_byx_fsv32 : public ConvolutionKernelBase {
 public:
     ConvolutionKernel_bfyx_to_fs_byx_fsv32();
-    ~ConvolutionKernel_bfyx_to_fs_byx_fsv32() override {}
+    ~ConvolutionKernel_bfyx_to_fs_byx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_fs_byx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_fs_byx_fsv32.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class ConvolutionKernel_fs_byx_fsv32 : public ConvolutionKernelBase {
 public:
     ConvolutionKernel_fs_byx_fsv32();
-    ~ConvolutionKernel_fs_byx_fsv32() override {}
+    ~ConvolutionKernel_fs_byx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_fs_byx_fsv32_1x1.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_fs_byx_fsv32_1x1.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class ConvolutionKernel_fs_byx_fsv32_1x1 : public ConvolutionKernelBase {
 public:
     ConvolutionKernel_fs_byx_fsv32_1x1();
-    ~ConvolutionKernel_fs_byx_fsv32_1x1() override {}
+    ~ConvolutionKernel_fs_byx_fsv32_1x1() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_fs_byx_fsv32_depthwise.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_fs_byx_fsv32_depthwise.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class ConvolutionKernel_fs_byx_fsv32_depthwise : public ConvolutionKernelBase {
 public:
     ConvolutionKernel_fs_byx_fsv32_depthwise();
-    ~ConvolutionKernel_fs_byx_fsv32_depthwise() override {}
+    ~ConvolutionKernel_fs_byx_fsv32_depthwise() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad.h
@@ -13,7 +13,7 @@ class ConvolutionKernel_imad : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_imad() : ConvolutionKernelBase("convolution_gpu_imad") {}
-    ~ConvolutionKernel_imad() override {}
+    ~ConvolutionKernel_imad() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_1x1.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_1x1.h
@@ -13,7 +13,7 @@ class Convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_1x1 : public ConvolutionKerne
 public:
     using Parent = ConvolutionKernelBase;
     Convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_1x1() : ConvolutionKernelBase("convolution_gpu_imad_bs_fs_yx_bsv16_fsv16_1x1") {}
-    ~Convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_1x1() override {}
+    ~Convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_1x1() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_3x3.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_3x3.h
@@ -13,7 +13,7 @@ class Convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_3x3 : public ConvolutionKerne
 public:
     using Parent = ConvolutionKernelBase;
     Convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_3x3() : ConvolutionKernelBase("convolution_gpu_imad_bs_fs_yx_bsv16_fsv16_3x3") {}
-    ~Convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_3x3() override {}
+    ~Convolution_kernel_imad_bs_fs_yx_bsv16_fsv16_3x3() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_b_fs_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_b_fs_yx_fsv32.h
@@ -14,7 +14,7 @@ class ConvolutionKernel_mmad_b_fs_yx_fsv32 : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_mmad_b_fs_yx_fsv32() : ConvolutionKernelBase("convolution_gpu_mmad_b_fs_yx_fsv32") {}
-    ~ConvolutionKernel_mmad_b_fs_yx_fsv32() override {}
+    ~ConvolutionKernel_mmad_b_fs_yx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_b_fs_yx_fsv32_dw.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_b_fs_yx_fsv32_dw.h
@@ -14,7 +14,7 @@ class ConvolutionKernel_mmad_b_fs_yx_fsv32_dw : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_mmad_b_fs_yx_fsv32_dw() : ConvolutionKernelBase("convolution_gpu_mmad_b_fs_yx_fsv32_dw") {}
-    ~ConvolutionKernel_mmad_b_fs_yx_fsv32_dw() override {}
+    ~ConvolutionKernel_mmad_b_fs_yx_fsv32_dw() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv32.h
@@ -14,7 +14,7 @@ class ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv32 : public ConvolutionKernelBas
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv32() : ConvolutionKernelBase("convolution_gpu_mmad_bfyx_to_b_fs_yx_fsv32") {}
-    ~ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv32() override {}
+    ~ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv4.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_mmad_bfyx_to_b_fs_yx_fsv4.h
@@ -14,7 +14,7 @@ class ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv4 : public ConvolutionKernelBase
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv4() : ConvolutionKernelBase("convolution_gpu_mmad_bfyx_to_b_fs_yx_fsv4") {}
-    ~ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv4() override {}
+    ~ConvolutionKernel_mmad_bfyx_to_b_fs_yx_fsv4() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsData GetKernelsDataForAutoTune(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class ConvolutionKernel_Ref : public ConvolutionKernelBase {
 public:
     ConvolutionKernel_Ref() : ConvolutionKernelBase("convolution_gpu_ref") {}
-    ~ConvolutionKernel_Ref() override {}
+    ~ConvolutionKernel_Ref() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     convolution_kernel_selector();
 
-    ~convolution_kernel_selector() override {}
+    ~convolution_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_2x3_s1.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_2x3_s1.h
@@ -13,7 +13,7 @@ class ConvolutionKernel_Winograd_2x3_s1 : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_Winograd_2x3_s1() : ConvolutionKernelBase("convolution_gpu_winograd_2x3_s1") {}
-    ~ConvolutionKernel_Winograd_2x3_s1() override {}
+    ~ConvolutionKernel_Winograd_2x3_s1() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_2x3_s1_fused.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_2x3_s1_fused.h
@@ -13,7 +13,7 @@ class ConvolutionKernel_Winograd_2x3_s1_fused : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_Winograd_2x3_s1_fused() : ConvolutionKernelBase("convolution_gpu_winograd_2x3_s1_fused") {}
-    ~ConvolutionKernel_Winograd_2x3_s1_fused() override {}
+    ~ConvolutionKernel_Winograd_2x3_s1_fused() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_6x3_s1_fused.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_winograd_6x3_s1_fused.h
@@ -13,7 +13,7 @@ class ConvolutionKernel_Winograd_6x3_s1_fused : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_Winograd_6x3_s1_fused() : ConvolutionKernelBase("convolution_gpu_winograd_6x3_s1_fused") {}
-    ~ConvolutionKernel_Winograd_6x3_s1_fused() override {}
+    ~ConvolutionKernel_Winograd_6x3_s1_fused() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_ref.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class ConvolutionKernel_yxfb_Ref : public ConvolutionKernelBase {
 public:
     ConvolutionKernel_yxfb_Ref() : ConvolutionKernelBase("convolution_gpu_yxfb_ref") {}
-    ~ConvolutionKernel_yxfb_Ref() override {}
+    ~ConvolutionKernel_yxfb_Ref() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b16.h
@@ -14,7 +14,7 @@ class ConvolutionKernel_yxfb_yxio_b16 : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
     ConvolutionKernel_yxfb_yxio_b16() : ConvolutionKernelBase("convolution_gpu_yxfb_yxio_b16") {}
-    ~ConvolutionKernel_yxfb_yxio_b16() override {}
+    ~ConvolutionKernel_yxfb_yxio_b16() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b1_block_multiple_x.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b1_block_multiple_x.h
@@ -13,7 +13,7 @@ class ConvolutionKernel_yxfb_yxio_b1_block_multiple_x : public ConvolutionKernel
 public:
     ConvolutionKernel_yxfb_yxio_b1_block_multiple_x()
         : ConvolutionKernelBase("convolution_gpu_yxfb_yxio_b1_block_multiple_x_fp32") {}
-    ~ConvolutionKernel_yxfb_yxio_b1_block_multiple_x() override {}
+    ~ConvolutionKernel_yxfb_yxio_b1_block_multiple_x() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b8.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_yxfb_yxio_b8.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class ConvolutionKernel_yxfb_yxio_b8 : public ConvolutionKernelBase {
 public:
     ConvolutionKernel_yxfb_yxio_b8() : ConvolutionKernelBase("convolution_gpu_yxfb_yxio_b8_fp32") {}
-    ~ConvolutionKernel_yxfb_yxio_b8() override {}
+    ~ConvolutionKernel_yxfb_yxio_b8() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/deformable_convolution_kernel_bfyx_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/deformable_convolution_kernel_bfyx_opt.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class DeformableConvolutionKernel_bfyx_opt : public ConvolutionKernelBase {
 public:
     DeformableConvolutionKernel_bfyx_opt() : ConvolutionKernelBase("deformable_convolution_gpu_bfyx_opt") {}
-    ~DeformableConvolutionKernel_bfyx_opt() override {}
+    ~DeformableConvolutionKernel_bfyx_opt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/deformable_convolution_kernel_bfyx_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/deformable_convolution_kernel_bfyx_ref.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class DeformableConvolutionKernel_bfyx_Ref : public ConvolutionKernelBase {
 public:
     DeformableConvolutionKernel_bfyx_Ref() : ConvolutionKernelBase("deformable_convolution_gpu_bfyx_ref") {}
-    ~DeformableConvolutionKernel_bfyx_Ref() override {}
+    ~DeformableConvolutionKernel_bfyx_Ref() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/ctc_greedy_decoder/ctc_greedy_decoder_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/ctc_greedy_decoder/ctc_greedy_decoder_kernel_base.h
@@ -26,7 +26,7 @@ struct ctc_greedy_decoder_params : public base_params {
 class CTCGreedyDecoderKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~CTCGreedyDecoderKernelBase() override {}
+    ~CTCGreedyDecoderKernelBase() override = default;
     using DispatchData = CommonDispatchData;
 
 protected:

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/ctc_greedy_decoder/ctc_greedy_decoder_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/ctc_greedy_decoder/ctc_greedy_decoder_kernel_ref.h
@@ -13,7 +13,7 @@ class CTCGreedyDecoderKernelRef : public CTCGreedyDecoderKernelBase {
 public:
     using Parent = CTCGreedyDecoderKernelBase;
     CTCGreedyDecoderKernelRef() : CTCGreedyDecoderKernelBase("ctc_greedy_decoder_ref") {}
-    ~CTCGreedyDecoderKernelRef() override {}
+    ~CTCGreedyDecoderKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/ctc_greedy_decoder/ctc_greedy_decoder_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/ctc_greedy_decoder/ctc_greedy_decoder_kernel_selector.h
@@ -15,7 +15,7 @@ public:
     }
 
     ctc_greedy_decoder_kernel_selector();
-    ~ctc_greedy_decoder_kernel_selector() override {}
+    ~ctc_greedy_decoder_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16.h
@@ -14,7 +14,7 @@ public:
     using Parent = DeconvolutionKernelBase;
 
     DeconvolutionKernel_b_fs_zyx_fsv16() : DeconvolutionKernelBase("gen9_common_conv_bwd_data") {}
-    ~DeconvolutionKernel_b_fs_zyx_fsv16() override {}
+    ~DeconvolutionKernel_b_fs_zyx_fsv16() override = default;
     ParamsKey GetSupportedKey() const override;
     DeviceFeaturesKey get_required_device_features_key(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16_dw.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_b_fs_zyx_fsv16_dw.h
@@ -14,7 +14,7 @@ public:
     using Parent = DeconvolutionKernelBase;
 
     DeconvolutionKernel_b_fs_zyx_fsv16_dw() : DeconvolutionKernelBase("deconvolution_gpu_b_fs_zyx_fsv16_dw") {}
-    ~DeconvolutionKernel_b_fs_zyx_fsv16_dw() override {}
+    ~DeconvolutionKernel_b_fs_zyx_fsv16_dw() override = default;
     ParamsKey GetSupportedKey() const override;
     DeviceFeaturesKey get_required_device_features_key(const Params& params) const override;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_base.h
@@ -45,7 +45,7 @@ struct deconvolution_params : public weight_bias_params {
 class DeconvolutionKernelBase : public WeightBiasKernelBase {
 public:
     using WeightBiasKernelBase::WeightBiasKernelBase;
-    ~DeconvolutionKernelBase() override {}
+    ~DeconvolutionKernelBase() override = default;
 
     using DispatchData = CommonDispatchData;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_bfyx_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_bfyx_opt.h
@@ -12,7 +12,7 @@ class DeconvolutionKernel_bfyx_opt : public DeconvolutionKernelBase {
 public:
     using Parent = DeconvolutionKernelBase;
     DeconvolutionKernel_bfyx_opt() : DeconvolutionKernelBase("deconvolution_gpu_bfyx_opt") {}
-    ~DeconvolutionKernel_bfyx_opt() override {}
+    ~DeconvolutionKernel_bfyx_opt() override = default;
 
     ParamsKey GetSupportedKey() const override;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_ref.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class DeconvolutionKernelRef : public DeconvolutionKernelBase {
 public:
     DeconvolutionKernelRef() : DeconvolutionKernelBase("deconvolution_gpu_ref") {}
-    ~DeconvolutionKernelRef() override {}
+    ~DeconvolutionKernelRef() override = default;
 
     ParamsKey GetSupportedKey() const override;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/deconvolution/deconvolution_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     deconvolution_kernel_selector();
 
-    ~deconvolution_kernel_selector() override {}
+    ~deconvolution_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_base.h
@@ -30,7 +30,7 @@ struct depth_to_space_fuse_params : fuse_params {
 class DepthToSpaceKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~DepthToSpaceKernelBase() override {}
+    ~DepthToSpaceKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {
     };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_block2_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_block2_opt.h
@@ -12,7 +12,7 @@ public:
     using Parent = DepthToSpaceKernelBase;
 
     DepthToSpaceKernelBlock2Opt() : DepthToSpaceKernelBase("depth_to_space_block2_opt") {}
-    ~DepthToSpaceKernelBlock2Opt() override {}
+    ~DepthToSpaceKernelBlock2Opt() override = default;
 
     bool Validate(const Params&) const override;
     JitConstants GetJitConstants(const depth_to_space_params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_ref.h
@@ -12,7 +12,7 @@ public:
     using Parent = DepthToSpaceKernelBase;
 
     DepthToSpaceKernelRef() : DepthToSpaceKernelBase("depth_to_space_ref") {}
-    ~DepthToSpaceKernelRef() override {}
+    ~DepthToSpaceKernelRef() override = default;
 
     CommonDispatchData SetDefault(const depth_to_space_params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/depth_to_space/depth_to_space_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     depth_to_space_kernel_selector();
 
-    ~depth_to_space_kernel_selector() override {}
+    ~depth_to_space_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_kv_cache.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_kv_cache.h
@@ -14,7 +14,7 @@ namespace kernel_selector {
 class DynamicQuantizeKernelKVCache : public KernelBaseOpenCL {
 public:
     DynamicQuantizeKernelKVCache() : KernelBaseOpenCL("dynamic_quantize_gpu_kv_cache") {}
-    ~DynamicQuantizeKernelKVCache() override {}
+    ~DynamicQuantizeKernelKVCache() override = default;
 
     virtual JitConstants GetJitConstants(const dynamic_quantize_params& params) const;
     virtual CommonDispatchData SetDefault(const dynamic_quantize_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.h
@@ -14,7 +14,7 @@ namespace kernel_selector {
 class DynamicQuantizeKernelOpt : public KernelBaseOpenCL {
 public:
     DynamicQuantizeKernelOpt() : KernelBaseOpenCL("dynamic_quantize_gpu_opt") {}
-    ~DynamicQuantizeKernelOpt() override {}
+    ~DynamicQuantizeKernelOpt() override = default;
 
     virtual JitConstants GetJitConstants(const dynamic_quantize_params& params) const;
     virtual CommonDispatchData SetDefault(const dynamic_quantize_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_ref.h
@@ -27,7 +27,7 @@ struct dynamic_quantize_params : public base_params {
 class DynamicQuantizeKernelRef : public KernelBaseOpenCL {
 public:
     DynamicQuantizeKernelRef() : KernelBaseOpenCL("dynamic_quantize_gpu_ref") {}
-    ~DynamicQuantizeKernelRef() override {}
+    ~DynamicQuantizeKernelRef() override = default;
 
     virtual JitConstants GetJitConstants(const dynamic_quantize_params& params) const;
     virtual CommonDispatchData SetDefault(const dynamic_quantize_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     dynamic_quantize_kernel_selector();
 
-    ~dynamic_quantize_kernel_selector() override {}
+    ~dynamic_quantize_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/ed_pgg/prior_grid_generator_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/ed_pgg/prior_grid_generator_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     experimental_detectron_prior_grid_generator_kernel_selector();
 
-    ~experimental_detectron_prior_grid_generator_kernel_selector() override {}
+    ~experimental_detectron_prior_grid_generator_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_base.h
@@ -96,7 +96,7 @@ struct eltwise_fuse_params : fuse_params {
 class EltwiseKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~EltwiseKernelBase() override {}
+    ~EltwiseKernelBase() override = default;
 
     using DispatchData = CommonDispatchData;
     JitConstants GetJitConstantsCommon(const eltwise_params& params, bool useVload8) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_blocked_opt.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class EltwiseKernel_blocked_opt : public EltwiseKernelBase {
 public:
     EltwiseKernel_blocked_opt() : EltwiseKernelBase("eltwise_blocked_opt") {}
-    ~EltwiseKernel_blocked_opt() override {}
+    ~EltwiseKernel_blocked_opt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_fs_b_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_fs_b_yx_fsv32.h
@@ -15,7 +15,7 @@ namespace kernel_selector {
 class EltwiseKernel_fs_b_yx_fsv32 : public EltwiseKernelBase {
 public:
     EltwiseKernel_fs_b_yx_fsv32() : EltwiseKernelBase("eltwise_fs_b_yx_fsv32") {}
-    ~EltwiseKernel_fs_b_yx_fsv32() override {}
+    ~EltwiseKernel_fs_b_yx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_mixed_byxf_and_fs_b_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_mixed_byxf_and_fs_b_yx_fsv32.h
@@ -15,7 +15,7 @@ namespace kernel_selector {
 class EltwiseKernel_mixed_byxf_and_fs_b_yx_fsv32 : public EltwiseKernelBase {
 public:
     EltwiseKernel_mixed_byxf_and_fs_b_yx_fsv32() : EltwiseKernelBase("eltwise_mixed_byxf_and_fs_b_yx_fsv32") {}
-    ~EltwiseKernel_mixed_byxf_and_fs_b_yx_fsv32() override {}
+    ~EltwiseKernel_mixed_byxf_and_fs_b_yx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_ref.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class EltwiseKernelRef : public EltwiseKernelBase {
 public:
     EltwiseKernelRef() : EltwiseKernelBase("generic_eltwise_ref") {}
-    ~EltwiseKernelRef() override {}
+    ~EltwiseKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     eltwise_kernel_selector();
 
-    ~eltwise_kernel_selector() override {}
+    ~eltwise_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_vload8.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_vload8.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class EltwiseKernel_vload8 : public EltwiseKernelBase {
 public:
     EltwiseKernel_vload8() : EltwiseKernelBase("eltwise_simple_vload8") {}
-    ~EltwiseKernel_vload8() override {}
+    ~EltwiseKernel_vload8() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/embedding_bag/embedding_bag_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/embedding_bag/embedding_bag_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     embedding_bag_kernel_selector();
 
-    ~embedding_bag_kernel_selector() override {}
+    ~embedding_bag_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/extract_image_patches/extract_image_patches_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/extract_image_patches/extract_image_patches_kernel_base.h
@@ -26,7 +26,7 @@ class ExtractImagePatchesKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
     using DispatchData = CommonDispatchData;
-    ~ExtractImagePatchesKernelBase() override {}
+    ~ExtractImagePatchesKernelBase() override = default;
 
 protected:
     virtual JitConstants GetJitConstants(const extract_image_patches_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_block_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_block_kernel_base.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class FullyConnectedBlockKernelBase : public FullyConnectedKernelBase {
 public:
     using FullyConnectedKernelBase::FullyConnectedKernelBase;
-    ~FullyConnectedBlockKernelBase() override {}
+    ~FullyConnectedBlockKernelBase() override = default;
 
 protected:
     JitConstants GetJitConstants(const fully_connected_params& params, const DispatchData& dispatchData) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.h
@@ -17,7 +17,7 @@ class FullyConnectedKernelBase : public WeightBiasKernelBase {
 public:
     using WeightBiasKernelBase::WeightBiasKernelBase;
     using FusedOpDesc = fused_operation_desc;
-    ~FullyConnectedKernelBase() override {}
+    ~FullyConnectedKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {
         uint32_t unit_byte_size = 0;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     fully_connected_kernel_selector();
 
-    ~fully_connected_kernel_selector() override {}
+    ~fully_connected_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_ref.h
@@ -19,7 +19,7 @@ struct gather_elements_params : public base_params {
 class GatherElementsKernelRef : public KernelBaseOpenCL {
 public:
     GatherElementsKernelRef() : KernelBaseOpenCL("gather_elements_ref") {}
-    ~GatherElementsKernelRef() override {}
+    ~GatherElementsKernelRef() override = default;
     virtual JitConstants GetJitConstants(const gather_elements_params& params) const;
     virtual CommonDispatchData SetDefault(const gather_elements_params& params) const;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     gather_elements_kernel_selector();
 
-    ~gather_elements_kernel_selector() override {}
+    ~gather_elements_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.h
@@ -28,7 +28,7 @@ struct gather_params : public base_params {
 class GatherKernelRef : public KernelBaseOpenCL {
 public:
     GatherKernelRef() : KernelBaseOpenCL("gather_ref") {}
-    ~GatherKernelRef() override {}
+    ~GatherKernelRef() override = default;
     virtual JitConstants GetJitConstants(const gather_params& params) const;
     virtual CommonDispatchData SetDefault(const gather_params& params) const;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     gather_kernel_selector();
 
-    ~gather_kernel_selector() override {}
+    ~gather_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_ref.h
@@ -23,7 +23,7 @@ struct gather_nd_params : public base_params {
 class GatherNDKernelRef : public KernelBaseOpenCL {
 public:
     GatherNDKernelRef() : KernelBaseOpenCL("gather_nd_ref") {}
-    ~GatherNDKernelRef() override {}
+    ~GatherNDKernelRef() override = default;
     virtual JitConstants GetJitConstants(const gather_nd_params& params) const;
     virtual CommonDispatchData SetDefault(const gather_nd_params& params) const;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_nd_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     gather_nd_kernel_selector();
 
-    ~gather_nd_kernel_selector() override {}
+    ~gather_nd_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_base.h
@@ -50,7 +50,7 @@ public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
     using FusedOpDesc = fused_operation_desc;
     using DispatchData = CommonDispatchData;
-    ~GemmKernelBase() override {}
+    ~GemmKernelBase() override = default;
 
 protected:
     virtual JitConstants GetJitConstants(const gemm_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_selector.h
@@ -15,7 +15,7 @@ public:
     }
 
     gemm_kernel_selector();
-    ~gemm_kernel_selector() override {}
+    ~gemm_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grn/grn_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grn/grn_kernel_base.h
@@ -24,7 +24,7 @@ struct grn_params : public base_params {
 class GRNKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~GRNKernelBase() override {}
+    ~GRNKernelBase() override = default;
     using DispatchData = CommonDispatchData;
 
 protected:

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grn/grn_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grn/grn_kernel_ref.h
@@ -13,7 +13,7 @@ class GRNKernelRef : public GRNKernelBase {
 public:
     using Parent = GRNKernelBase;
     GRNKernelRef() : GRNKernelBase("grn_ref") {}
-    ~GRNKernelRef() override {}
+    ~GRNKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/grn/grn_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/grn/grn_kernel_selector.h
@@ -15,7 +15,7 @@ public:
     }
 
     grn_kernel_selector();
-    ~grn_kernel_selector() override {}
+    ~grn_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_across_channel_opt_b8.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_across_channel_opt_b8.h
@@ -12,7 +12,7 @@ class LRNKernelAcrossChannel_b8 : public LRNKernelBase {
 public:
     using Parent = LRNKernelBase;
     LRNKernelAcrossChannel_b8() : LRNKernelBase("lrn_gpu_across_channel_yxfb_b8_opt") {}
-    ~LRNKernelAcrossChannel_b8() override {}
+    ~LRNKernelAcrossChannel_b8() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_across_channel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_across_channel_ref.h
@@ -12,7 +12,7 @@ public:
     using Parent = LRNKernelBase;
 
     LRNKernelAcrossChannelRef() : Parent("lrn_gpu_across_channel_ref") {}
-    ~LRNKernelAcrossChannelRef() override {}
+    ~LRNKernelAcrossChannelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_base.h
@@ -37,7 +37,7 @@ struct lrn_params : public base_params {
 class LRNKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~LRNKernelBase() override {}
+    ~LRNKernelBase() override = default;
 
     using DispatchData = CommonDispatchData;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_ref.h
@@ -12,7 +12,7 @@ class LRNKernelRef : public LRNKernelBase {
 public:
     using Parent = LRNKernelBase;
     LRNKernelRef() : LRNKernelBase("lrn_ref") {}
-    ~LRNKernelRef() override {}
+    ~LRNKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     lrn_kernel_selector();
 
-    ~lrn_kernel_selector() override {}
+    ~lrn_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_within_channel_byxf_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_within_channel_byxf_opt.h
@@ -12,7 +12,7 @@ class LRNKernelWithinChannelByxfOpt : public LRNKernelBase {
 public:
     using Parent = LRNKernelBase;
     LRNKernelWithinChannelByxfOpt() : LRNKernelBase("lrn_within_channel_byxf_opt") {}
-    ~LRNKernelWithinChannelByxfOpt() override {}
+    ~LRNKernelWithinChannelByxfOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_within_channel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_within_channel_ref.h
@@ -12,7 +12,7 @@ class LRNKernelWithinChannel : public LRNKernelBase {
 public:
     using Parent = LRNKernelBase;
     LRNKernelWithinChannel() : LRNKernelBase("lrn_gpu_within_channel") {}
-    ~LRNKernelWithinChannel() override {}
+    ~LRNKernelWithinChannel() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_within_channel_ref_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lrn/lrn_kernel_within_channel_ref_opt.h
@@ -12,7 +12,7 @@ class LRNKernelWithinChannelOpt : public LRNKernelBase {
 public:
     using Parent = LRNKernelBase;
     LRNKernelWithinChannelOpt() : Parent("lrn_gpu_within_channel_opt") {}
-    ~LRNKernelWithinChannelOpt() override {}
+    ~LRNKernelWithinChannelOpt() override = default;
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;
     ParamsKey GetSupportedKey() const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_cell_and_seq_kernel_bfyx.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_cell_and_seq_kernel_bfyx.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class LSTMCellAndSeqKernel_bfyx : public LSTMKernelBase {
 public:
     LSTMCellAndSeqKernel_bfyx() : LSTMKernelBase("lstm_cell_and_seq_bfyx") {}
-    ~LSTMCellAndSeqKernel_bfyx() override {}
+    ~LSTMCellAndSeqKernel_bfyx() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_cell_and_seq_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_cell_and_seq_kernel_ref.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class LSTMCellAndSeqKernelRef : public LSTMKernelBase {
 public:
     LSTMCellAndSeqKernelRef() : LSTMKernelBase("lstm_cell_and_seq_ref") {}
-    ~LSTMCellAndSeqKernelRef() override {}
+    ~LSTMCellAndSeqKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_cell_and_seq_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_cell_and_seq_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     lstm_cell_and_seq_kernel_selector();
 
-    ~lstm_cell_and_seq_kernel_selector() override {}
+    ~lstm_cell_and_seq_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/lstm/lstm_kernel_base.h
@@ -55,7 +55,7 @@ struct lstm_params : public base_params {
 class LSTMKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~LSTMKernelBase() override {}
+    ~LSTMKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {};
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_b_fs_yx_fsv16.hpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_b_fs_yx_fsv16.hpp
@@ -13,7 +13,7 @@ class MVNKernel_b_fs_yx_fsv16 : public MVNKernelBase {
 public:
     using Parent = MVNKernelBase;
     MVNKernel_b_fs_yx_fsv16() : MVNKernelBase("mvn_gpu_b_fs_yx_fsv16") {}
-    ~MVNKernel_b_fs_yx_fsv16() override {}
+    ~MVNKernel_b_fs_yx_fsv16() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_base.h
@@ -38,7 +38,7 @@ struct mvn_params : public base_params {
 class MVNKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~MVNKernelBase() override {}
+    ~MVNKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {
         size_t itemsNum;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bfyx_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bfyx_opt.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class MVNKernelBfyxOpt : public MVNKernelBase {
 public:
     MVNKernelBfyxOpt() : MVNKernelBase("mvn_gpu_bfyx_opt") {}
-    ~MVNKernelBfyxOpt() override {}
+    ~MVNKernelBfyxOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bs_fs_yx_bsv32.hpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bs_fs_yx_bsv32.hpp
@@ -13,7 +13,7 @@ class MVNKernel_bs_fs_yx_bsv32 : public MVNKernelBase {
 public:
     using Parent = MVNKernelBase;
     MVNKernel_bs_fs_yx_bsv32() : MVNKernelBase("mvn_gpu_b_fs_yx_bsv32") {}
-    ~MVNKernel_bs_fs_yx_bsv32() override {}
+    ~MVNKernel_bs_fs_yx_bsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_ref.h
@@ -13,7 +13,7 @@ class MVNKernelRef : public MVNKernelBase {
 public:
     using Parent = MVNKernelBase;
     MVNKernelRef() : MVNKernelBase("mvn_gpu_ref") {}
-    ~MVNKernelRef() override {}
+    ~MVNKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     mvn_kernel_selector();
 
-    ~mvn_kernel_selector() override {}
+    ~mvn_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/count_nonzero_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/count_nonzero_kernel_ref.h
@@ -18,7 +18,7 @@ struct count_nonzero_params : public base_params {
 class CountNonzeroKernelRef : public KernelBaseOpenCL {
 public:
     CountNonzeroKernelRef() : KernelBaseOpenCL("count_nonzero_ref") {}
-    ~CountNonzeroKernelRef() override {}
+    ~CountNonzeroKernelRef() override = default;
 
     struct DispatchData : public CommonDispatchData {
         size_t dataSize;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/count_nonzero_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/count_nonzero_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     count_nonzero_kernel_selector();
 
-    ~count_nonzero_kernel_selector() override {}
+    ~count_nonzero_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/gather_nonzero_kernel_group.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/gather_nonzero_kernel_group.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class GatherNonzeroKernelGroup : public KernelBaseOpenCL {
 public:
     GatherNonzeroKernelGroup() : KernelBaseOpenCL("gather_nonzero_group") {}
-    ~GatherNonzeroKernelGroup() override {}
+    ~GatherNonzeroKernelGroup() override = default;
 
     virtual JitConstants GetJitConstants(const gather_nonzero_params& params) const;
     virtual CommonDispatchData SetDefault(const gather_nonzero_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/gather_nonzero_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/gather_nonzero_kernel_ref.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class GatherNonzeroKernelRef : public KernelBaseOpenCL {
 public:
     GatherNonzeroKernelRef() : KernelBaseOpenCL("gather_nonzero_ref") {}
-    ~GatherNonzeroKernelRef() override {}
+    ~GatherNonzeroKernelRef() override = default;
 
     virtual JitConstants GetJitConstants(const gather_nonzero_params& params) const;
     virtual CommonDispatchData SetDefault(const gather_nonzero_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/gather_nonzero_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/non_zero/gather_nonzero_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     gather_nonzero_kernel_selector();
 
-    ~gather_nonzero_kernel_selector() override {}
+    ~gather_nonzero_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_across_spatial_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_across_spatial_ref.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class NormalizeKernelAcrossSpatialRef : public NormalizeKernelBase {
 public:
     NormalizeKernelAcrossSpatialRef() : NormalizeKernelBase("normalize_gpu_across_spatial_ref") {}
-    ~NormalizeKernelAcrossSpatialRef() override {}
+    ~NormalizeKernelAcrossSpatialRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_base.h
@@ -33,7 +33,7 @@ struct normalize_params : public base_params {
 class NormalizeKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~NormalizeKernelBase() override {}
+    ~NormalizeKernelBase() override = default;
 
     using DispatchData = CommonDispatchData;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     normalize_kernel_selector();
 
-    ~normalize_kernel_selector() override {}
+    ~normalize_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_within_spatial_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/normalize/normalize_kernel_within_spatial_ref.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class NormalizeKernelWithinSpatialRef : public NormalizeKernelBase {
 public:
     NormalizeKernelWithinSpatialRef() : NormalizeKernelBase("normalize_gpu_within_spatial_ref") {}
-    ~NormalizeKernelWithinSpatialRef() override {}
+    ~NormalizeKernelWithinSpatialRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_base.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class PermuteKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~PermuteKernelBase() override {}
+    ~PermuteKernelBase() override = default;
 
     bool Validate(const Params& p) const override;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_bfzyx_to_bfyxz.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_bfzyx_to_bfyxz.h
@@ -15,7 +15,7 @@ public:
     using Parent = PermuteKernelBase;
     using Parent::Parent;
     PermuteKernel_bfzyx_to_bfyxz() : PermuteKernelBase("permute_bfzyx_to_bfyxz") {}
-    ~PermuteKernel_bfzyx_to_bfyxz() override {}
+    ~PermuteKernel_bfzyx_to_bfyxz() override = default;
 
     bool Validate(const Params& p) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_ref.h
@@ -16,7 +16,7 @@ public:
     using Parent = PermuteKernelBase;
     using Parent::Parent;
     PermuteKernelRef() : PermuteKernelBase("permute_ref") {}
-    ~PermuteKernelRef() override {}
+    ~PermuteKernelRef() override = default;
 
     bool Validate(const Params& p) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     permute_kernel_selector();
 
-    ~permute_kernel_selector() override {}
+    ~permute_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4.h
@@ -15,7 +15,7 @@ public:
     using Parent = PermuteKernelBase;
     using Parent::Parent;
     PermuteKernel_tile_8x8_4x4() : PermuteKernelBase("permute_tile_8x8_4x4") {}
-    ~PermuteKernel_tile_8x8_4x4() override {}
+    ~PermuteKernel_tile_8x8_4x4() override = default;
 
     bool Validate(const Params& p) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4_fsv.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_tile_8x8_4x4_fsv.h
@@ -15,7 +15,7 @@ public:
     using Parent = PermuteKernelBase;
     using Parent::Parent;
     PermuteKernel_tile_8x8_4x4_fsv() : PermuteKernelBase("permute_tile_8x8_4x4_fsv") {}
-    ~PermuteKernel_tile_8x8_4x4_fsv() override {}
+    ~PermuteKernel_tile_8x8_4x4_fsv() override = default;
 
     bool Validate(const Params& p) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_base.h
@@ -49,7 +49,7 @@ struct pooling_params : public base_params {
 class PoolingKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~PoolingKernelBase() override {}
+    ~PoolingKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {
         bool needsBoundary;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv16.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class PoolingKernel_b_fs_yx_fsv16 : public PoolingKernelBase {
 public:
     PoolingKernel_b_fs_yx_fsv16() : PoolingKernelBase("pooling_gpu_blocked") {}
-    ~PoolingKernel_b_fs_yx_fsv16() override {}
+    ~PoolingKernel_b_fs_yx_fsv16() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv4.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_b_fs_yx_fsv4.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class PoolingKerneGPU_b_fs_yx_fsv4 : public PoolingKernelBase {
 public:
     PoolingKerneGPU_b_fs_yx_fsv4() : PoolingKernelBase("pooling_gpu_b_fs_yx_fsv4") {}
-    ~PoolingKerneGPU_b_fs_yx_fsv4() override {}
+    ~PoolingKerneGPU_b_fs_yx_fsv4() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_b_fs_zyx_fsv16_imad.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_b_fs_zyx_fsv16_imad.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class PoolingKernelGPU_b_fs_zyx_fsv16_imad: public PoolingKernelBase{
 public:
     PoolingKernelGPU_b_fs_zyx_fsv16_imad() : PoolingKernelBase("pooling_gpu_b_fs_zyx_fsv16_imad") {}
-    ~PoolingKernelGPU_b_fs_zyx_fsv16_imad() override {}
+    ~PoolingKernelGPU_b_fs_zyx_fsv16_imad() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_bfyx_block_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_bfyx_block_opt.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class PoolingKernelGPUBfyxBlockOpt : public PoolingKernelBase {
 public:
     PoolingKernelGPUBfyxBlockOpt() : PoolingKernelBase("pooling_gpu_bfyx_block_opt") {}
-    ~PoolingKernelGPUBfyxBlockOpt() override {}
+    ~PoolingKernelGPUBfyxBlockOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_bs_fs_yx_bsv16_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_bs_fs_yx_bsv16_fsv16.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class Pooling_kernel_gpu_bs_fs_yx_bsv_16_fsv16 : public PoolingKernelBase {
 public:
     Pooling_kernel_gpu_bs_fs_yx_bsv_16_fsv16() : PoolingKernelBase("pooling_gpu_bs_fs_yx_bsv16_fsv16") {}
-    ~Pooling_kernel_gpu_bs_fs_yx_bsv_16_fsv16() override {}
+    ~Pooling_kernel_gpu_bs_fs_yx_bsv_16_fsv16() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_bsv16_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_bsv16_fsv16.h
@@ -14,7 +14,7 @@ public:
 
     PoolingKernel_bsv16_fsv16() : PoolingKernelBase("pooling_gpu_bsv16_fsv16") {}
 
-    ~PoolingKernel_bsv16_fsv16() override {}
+    ~PoolingKernel_bsv16_fsv16() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_byxf_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_byxf_opt.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class PoolingKernelGPUByxfOpt : public PoolingKernelBase {
 public:
     PoolingKernelGPUByxfOpt() : PoolingKernelBase("pooling_gpu_byxf_opt") {}
-    ~PoolingKernelGPUByxfOpt() override {}
+    ~PoolingKernelGPUByxfOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_byxf_padding_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_byxf_padding_opt.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class PoolingKernelGPUByxfPaddingOpt : public PoolingKernelBase {
 public:
     PoolingKernelGPUByxfPaddingOpt() : PoolingKernelBase("pooling_gpu_byxf_padding_opt") {}
-    ~PoolingKernelGPUByxfPaddingOpt() override {}
+    ~PoolingKernelGPUByxfPaddingOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_fs_b_yx_fsv32.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_fs_b_yx_fsv32.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class PoolingKerneGPU_fs_b_yx_fsv32 : public PoolingKernelBase {
 public:
     PoolingKerneGPU_fs_b_yx_fsv32() : PoolingKernelBase("pooling_gpu_fs_b_yx_fsv32") {}
-    ~PoolingKerneGPU_fs_b_yx_fsv32() override {}
+    ~PoolingKerneGPU_fs_b_yx_fsv32() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_int8_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_int8_ref.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class PoolingKernelGPUInt8Ref : public PoolingKernelBase {
 public:
     PoolingKernelGPUInt8Ref() : PoolingKernelBase("pooling_gpu_int8_ref") {}
-    ~PoolingKernelGPUInt8Ref() override {}
+    ~PoolingKernelGPUInt8Ref() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_gpu_ref.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class PoolingKernelGPURef : public PoolingKernelBase {
 public:
     PoolingKernelGPURef() : PoolingKernelBase("pooling_gpu_ref") {}
-    ~PoolingKernelGPURef() override {}
+    ~PoolingKernelGPURef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/pooling/pooling_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     pooling_kernel_selector();
 
-    ~pooling_kernel_selector() override {}
+    ~pooling_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_base.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 class QuantizeKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~QuantizeKernelBase() override {}
+    ~QuantizeKernelBase() override = default;
 
     bool Validate(const Params& p) const override;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_ref.h
@@ -13,7 +13,7 @@ public:
     using Parent = QuantizeKernelBase;
 
     QuantizeKernelRef() : QuantizeKernelBase("quantize_gpu_ref") {}
-    ~QuantizeKernelRef() override {}
+    ~QuantizeKernelRef() override = default;
 
     JitConstants GetJitConstants(const quantize_params& params, const CommonDispatchData& dispatchData) const override;
     CommonDispatchData SetDefault(const quantize_params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_opt.h
@@ -13,7 +13,7 @@ public:
     using Parent = QuantizeKernelBase;
 
     QuantizeKernelScaleShift() : QuantizeKernelBase("quantize_gpu_scale_shift_opt") {}
-    ~QuantizeKernelScaleShift() override {}
+    ~QuantizeKernelScaleShift() override = default;
 
     JitConstants GetJitConstants(const quantize_params& params, const CommonDispatchData& dispatchData) const override;
     CommonDispatchData SetDefault(const quantize_params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_vload8_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_scale_shift_vload8_opt.h
@@ -13,7 +13,7 @@ public:
     using Parent = QuantizeKernelBase;
 
     QuantizeKernelScaleShift_vload8() : QuantizeKernelBase("quantize_gpu_scale_shift_vload8_opt") {}
-    ~QuantizeKernelScaleShift_vload8() override {}
+    ~QuantizeKernelScaleShift_vload8() override = default;
     CommonDispatchData SetDefault(const quantize_params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;
     ParamsKey GetSupportedKey() const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/quantize/quantize_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     quantize_kernel_selector();
 
-    ~quantize_kernel_selector() override {}
+    ~quantize_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/range/range_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/range/range_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     range_kernel_selector();
 
-    ~range_kernel_selector() override {}
+    ~range_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_b_fs_yx_fsv16.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_b_fs_yx_fsv16.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ReduceKernel_b_fs_yx_fsv16 : public ReduceKernelBase {
 public:
     ReduceKernel_b_fs_yx_fsv16() : ReduceKernelBase("reduce_gpu_b_fs_yx_fsv16") {}
-    ~ReduceKernel_b_fs_yx_fsv16() override {}
+    ~ReduceKernel_b_fs_yx_fsv16() override = default;
     CommonDispatchData SetDefault(const reduce_params& params) const override;
     JitConstants GetJitConstants(const reduce_params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_base.h
@@ -27,7 +27,7 @@ public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
     using DispatchData = CommonDispatchData;
 
-    ~ReduceKernelBase() override {}
+    ~ReduceKernelBase() override = default;
 
 protected:
     bool Validate(const Params&) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_ref.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ReduceKernelRef : public ReduceKernelBase {
 public:
     ReduceKernelRef() : ReduceKernelBase("reduce_ref") {}
-    ~ReduceKernelRef() override {}
+    ~ReduceKernelRef() override = default;
     CommonDispatchData SetDefault(const reduce_params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     reduce_kernel_selector();
 
-    ~reduce_kernel_selector() override {}
+    ~reduce_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_simple_to_scalar.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reduce/reduce_kernel_simple_to_scalar.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class ReduceKernelSimpleToScalar : public ReduceKernelBase {
 public:
     ReduceKernelSimpleToScalar() : ReduceKernelBase("reduce_simple_to_scalar") {}
-    ~ReduceKernelSimpleToScalar() override {}
+    ~ReduceKernelSimpleToScalar() override = default;
     CommonDispatchData SetDefault(const reduce_params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/region_yolo/region_yolo_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/region_yolo/region_yolo_kernel_ref.h
@@ -33,7 +33,7 @@ struct region_yolo_params : public base_params {
 class RegionYoloKernelRef : public KernelBaseOpenCL {
 public:
     RegionYoloKernelRef() : KernelBaseOpenCL("region_yolo_gpu_ref") {}
-    ~RegionYoloKernelRef() override {}
+    ~RegionYoloKernelRef() override = default;
 
     using DispatchData = CommonDispatchData;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/region_yolo/region_yolo_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/region_yolo/region_yolo_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     region_yolo_kernel_selector();
 
-    ~region_yolo_kernel_selector() override {}
+    ~region_yolo_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_biplanar_nv12.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_biplanar_nv12.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class reorder_biplanar_nv12 : public ReorderKernelBase {
 public:
     reorder_biplanar_nv12() : ReorderKernelBase("reorder_biplanar_nv12") {}
-    ~reorder_biplanar_nv12() override {}
+    ~reorder_biplanar_nv12() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class ReorderKernelRef : public ReorderKernelBase {
 public:
     ReorderKernelRef() : ReorderKernelBase("reorder_data") {}
-    ~ReorderKernelRef() override {}
+    ~ReorderKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_base.h
@@ -98,7 +98,7 @@ struct reorder_weights_params : public Params {
 class ReorderKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~ReorderKernelBase() override {}
+    ~ReorderKernelBase() override = default;
 
     using DispatchData = CommonDispatchData;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fs_b_yx_fsv32_to_bfyx.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fs_b_yx_fsv32_to_bfyx.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class ReorderKernel_fs_b_yx_fsv32_to_bfyx : public ReorderKernelBase {
 public:
     ReorderKernel_fs_b_yx_fsv32_to_bfyx() : ReorderKernelBase("reorder_fs_b_yx_fsv32_to_bfyx") {}
-    ~ReorderKernel_fs_b_yx_fsv32_to_bfyx() override {}
+    ~ReorderKernel_fs_b_yx_fsv32_to_bfyx() override = default;
 
     DispatchData SetDefault(const reorder_params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     reorder_kernel_selector();
 
-    ~reorder_kernel_selector() override {}
+    ~reorder_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class ReorderWeightsKernelInt4 : public ReorderKernelBase {
 public:
     ReorderWeightsKernelInt4() : ReorderKernelBase("reorder_weights_int4") {}
-    ~ReorderWeightsKernelInt4() override {}
+    ~ReorderWeightsKernelInt4() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_kernel.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_kernel.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class ReorderWeightsKernel : public ReorderKernelBase {
 public:
     ReorderWeightsKernel() : ReorderKernelBase("reorder_weights") {}
-    ~ReorderWeightsKernel() override {}
+    ~ReorderWeightsKernel() override = default;
     JitConstants GetJitConstants(const reorder_weights_params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     ReorderWeightsKernelSelector();
 
-    ~ReorderWeightsKernelSelector() override {}
+    ~ReorderWeightsKernelSelector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class ReorderWeightsOpt : public ReorderKernelBase {
 public:
     ReorderWeightsOpt() : ReorderKernelBase("reorder_weights_opt") {}
-    ~ReorderWeightsOpt() override {}
+    ~ReorderWeightsOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorg_yolo/reorg_yolo_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorg_yolo/reorg_yolo_kernel_ref.h
@@ -28,7 +28,7 @@ struct reorg_yolo_params : public base_params {
 class ReorgYoloKernelRef : public KernelBaseOpenCL {
 public:
     ReorgYoloKernelRef() : KernelBaseOpenCL("reorg_yolo_gpu_ref") {}
-    ~ReorgYoloKernelRef() override {}
+    ~ReorgYoloKernelRef() override = default;
 
     using DispatchData = CommonDispatchData;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorg_yolo/reorg_yolo_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorg_yolo/reorg_yolo_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     reorg_yolo_kernel_selector();
 
-    ~reorg_yolo_kernel_selector() override {}
+    ~reorg_yolo_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_base.h
@@ -42,7 +42,7 @@ public:
     using DispatchData = CommonDispatchData;
     using KernelBaseOpenCL::KernelBaseOpenCL;
 
-    ~ResampleKernelBase() override {}
+    ~ResampleKernelBase() override = default;
 
 protected:
     bool Validate(const Params& p) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_opt.h
@@ -11,7 +11,7 @@ class ResampleKernelOpt : public ResampleKernelBase {
 public:
     using Parent = ResampleKernelBase;
     ResampleKernelOpt() : ResampleKernelBase("resample_opt") {}
-    ~ResampleKernelOpt() override {}
+    ~ResampleKernelOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_ref.h
@@ -11,7 +11,7 @@ class ResampleKernelRef : public ResampleKernelBase {
 public:
     using Parent = ResampleKernelBase;
     ResampleKernelRef() : ResampleKernelBase("resample_ref") {}
-    ~ResampleKernelRef() override {}
+    ~ResampleKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/resample/resample_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     resample_kernel_selector();
 
-    ~resample_kernel_selector() override {}
+    ~resample_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reshape/reshape_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reshape/reshape_kernel_ref.h
@@ -17,7 +17,7 @@ struct reshape_params : public base_params {
 class ReshapeKernelRef : public KernelBaseOpenCL {
 public:
     ReshapeKernelRef() : KernelBaseOpenCL("reshape_ref") {}
-    ~ReshapeKernelRef() override {}
+    ~ReshapeKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reshape/reshape_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reshape/reshape_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     reshape_kernel_selector();
 
-    ~reshape_kernel_selector() override {}
+    ~reshape_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reverse/reverse_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reverse/reverse_kernel_ref.h
@@ -23,7 +23,7 @@ class ReverseKernelRef : public KernelBaseOpenCL {
 public:
     ReverseKernelRef() : KernelBaseOpenCL("reverse_ref") {}
 
-    ~ReverseKernelRef() override {}
+    ~ReverseKernelRef() override = default;
 
     virtual JitConstants GetJitConstants(const reverse_params& params) const;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reverse/reverse_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reverse/reverse_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     reverse_kernel_selector();
 
-    ~reverse_kernel_selector() override {}
+    ~reverse_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reverse_sequence/reverse_sequence_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reverse_sequence/reverse_sequence_kernel_ref.h
@@ -21,7 +21,7 @@ struct reverse_sequence_params : public base_params {
 class ReverseSequenceKernelRef : public KernelBaseOpenCL {
 public:
     ReverseSequenceKernelRef() : KernelBaseOpenCL("reverse_sequence_ref") {}
-    ~ReverseSequenceKernelRef() override {}
+    ~ReverseSequenceKernelRef() override = default;
     virtual JitConstants GetJitConstants(const reverse_sequence_params& params) const;
     virtual CommonDispatchData SetDefault(const reverse_sequence_params& params) const;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reverse_sequence/reverse_sequence_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reverse_sequence/reverse_sequence_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     reverse_sequence_kernel_selector();
 
-    ~reverse_sequence_kernel_selector() override {}
+    ~reverse_sequence_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.h
@@ -23,7 +23,7 @@ struct rms_params : public base_params {
 class RMSKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~RMSKernelBase() override {}
+    ~RMSKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {
         size_t dataSize;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.h
@@ -11,7 +11,7 @@ class RMSKernelBfyxOpt : public RMSKernelBase {
 public:
     using Parent = RMSKernelBase;
     RMSKernelBfyxOpt() : RMSKernelBase("rms_gpu_bfyx_opt") {}
-    ~RMSKernelBfyxOpt() override {}
+    ~RMSKernelBfyxOpt() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.h
@@ -11,7 +11,7 @@ class RMSKernelRef : public RMSKernelBase {
 public:
     using Parent = RMSKernelBase;
     RMSKernelRef() : RMSKernelBase("rms_gpu_ref") {}
-    ~RMSKernelRef() override {}
+    ~RMSKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     rms_kernel_selector();
 
-    ~rms_kernel_selector() override {}
+    ~rms_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_pooling/roi_pooling_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_pooling/roi_pooling_kernel_base.h
@@ -43,7 +43,7 @@ struct roi_pooling_params : public base_params {
 class ROIPoolingKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~ROIPoolingKernelBase() override {}
+    ~ROIPoolingKernelBase() override = default;
 
     using DispatchData = CommonDispatchData;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_pooling/roi_pooling_kernel_ps_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_pooling/roi_pooling_kernel_ps_ref.h
@@ -14,7 +14,7 @@ namespace kernel_selector {
 class PSROIPoolingKernelRef : public ROIPoolingKernelBase {
 public:
     PSROIPoolingKernelRef() : ROIPoolingKernelBase("roi_pooling_ps_ref") {}
-    ~PSROIPoolingKernelRef() override {}
+    ~PSROIPoolingKernelRef() override = default;
 
     using DispatchData = CommonDispatchData;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_pooling/roi_pooling_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_pooling/roi_pooling_kernel_ref.h
@@ -14,7 +14,7 @@ namespace kernel_selector {
 class ROIPoolingKernelRef : public ROIPoolingKernelBase {
 public:
     ROIPoolingKernelRef() : ROIPoolingKernelBase("roi_pooling_ref") {}
-    ~ROIPoolingKernelRef() override {}
+    ~ROIPoolingKernelRef() override = default;
 
     using DispatchData = CommonDispatchData;
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_pooling/roi_pooling_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/roi_pooling/roi_pooling_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     roi_pooling_kernel_selector();
 
-    ~roi_pooling_kernel_selector() override {}
+    ~roi_pooling_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_ref.h
@@ -21,7 +21,7 @@ struct scatter_elements_update_params : public base_params {
 class ScatterElementsUpdateKernelRef : public KernelBaseOpenCL {
 public:
     ScatterElementsUpdateKernelRef() : KernelBaseOpenCL("scatter_elements_update_ref") {}
-    ~ScatterElementsUpdateKernelRef() override {}
+    ~ScatterElementsUpdateKernelRef() override = default;
     virtual JitConstants GetJitConstants(const scatter_elements_update_params& params) const;
     virtual CommonDispatchData SetDefault(const scatter_elements_update_params& params, bool is_second) const;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     scatter_elements_update_kernel_selector();
 
-    ~scatter_elements_update_kernel_selector() override {}
+    ~scatter_elements_update_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_ref.h
@@ -19,7 +19,7 @@ struct scatter_update_params : public base_params {
 class ScatterUpdateKernelRef : public KernelBaseOpenCL {
 public:
     ScatterUpdateKernelRef() : KernelBaseOpenCL("scatter_update_ref") {}
-    ~ScatterUpdateKernelRef() override {}
+    ~ScatterUpdateKernelRef() override = default;
     virtual JitConstants GetJitConstants(const scatter_update_params& params) const;
     virtual CommonDispatchData SetDefault(const scatter_update_params& params, bool is_second) const;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_update_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     scatter_update_kernel_selector();
 
-    ~scatter_update_kernel_selector() override {}
+    ~scatter_update_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/select/select_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/select/select_kernel_base.h
@@ -20,7 +20,7 @@ struct select_params : public base_params {
 class SelectKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~SelectKernelBase() override {}
+    ~SelectKernelBase() override = default;
 
     using DispatchData = CommonDispatchData;
     JitConstants GetJitConstantsCommon(const select_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/select/select_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/select/select_kernel_ref.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class SelectKernelRef : public SelectKernelBase {
 public:
     SelectKernelRef() : SelectKernelBase("select_gpu_ref") {}
-    ~SelectKernelRef() override {}
+    ~SelectKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/shuffle_channels/shuffle_channels_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/shuffle_channels/shuffle_channels_kernel_ref.h
@@ -20,7 +20,7 @@ struct shuffle_channels_params : public base_params {
 class ShuffleChannelsKernelRef : public KernelBaseOpenCL {
 public:
     ShuffleChannelsKernelRef() : KernelBaseOpenCL("shuffle_channels_ref") {}
-    ~ShuffleChannelsKernelRef() override {}
+    ~ShuffleChannelsKernelRef() override = default;
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;
     ParamsKey GetSupportedKey() const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/shuffle_channels/shuffle_channels_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/shuffle_channels/shuffle_channels_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     shuffle_channels_kernel_selector();
 
-    ~shuffle_channels_kernel_selector() override {}
+    ~shuffle_channels_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_items_class_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_items_class_kernel_base.h
@@ -11,7 +11,7 @@ namespace kernel_selector {
 class SoftmaxItemsClassKernelBase : public SoftmaxKernelBase {
 public:
     using SoftmaxKernelBase::SoftmaxKernelBase;
-    ~SoftmaxItemsClassKernelBase() override {}
+    ~SoftmaxItemsClassKernelBase() override = default;
 
 protected:
     JitConstants GetJitConstants(const softmax_params& params, DispatchData dispatchData) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_base.h
@@ -29,7 +29,7 @@ struct softmax_params : public base_params {
 class SoftmaxKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~SoftmaxKernelBase() override {}
+    ~SoftmaxKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {
         size_t itemsNum;
@@ -58,7 +58,7 @@ class SoftmaxKernelBaseBF : public SoftmaxKernelBase {
 public:
     using Parent = SoftmaxKernelBase;
     using Parent::Parent;
-    ~SoftmaxKernelBaseBF() override {}
+    ~SoftmaxKernelBaseBF() override = default;
 
 protected:
     bool Validate(const Params&) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_bf.h
@@ -11,7 +11,7 @@ class SoftmaxKernel_bf : public SoftmaxKernelBaseBF {
 public:
     using Parent = SoftmaxKernelBaseBF;
     SoftmaxKernel_bf() : Parent("softmax_gpu_bf") {}
-    ~SoftmaxKernel_bf() override {}
+    ~SoftmaxKernel_bf() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_fb.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_fb.h
@@ -11,7 +11,7 @@ class SoftmaxKernel_fb : public SoftmaxKernelBaseBF {
 public:
     using Parent = SoftmaxKernelBaseBF;
     SoftmaxKernel_fb() : SoftmaxKernelBaseBF("softmax_gpu_fb") {}
-    ~SoftmaxKernel_fb() override {}
+    ~SoftmaxKernel_fb() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_items_class_optimized.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_items_class_optimized.h
@@ -11,7 +11,7 @@ class SoftmaxKerneItemsClassOptimized : public SoftmaxItemsClassKernelBase {
 public:
     using Parent = SoftmaxItemsClassKernelBase;
     SoftmaxKerneItemsClassOptimized() : Parent("softmax_gpu_items_class_optimized") {}
-    ~SoftmaxKerneItemsClassOptimized() override {}
+    ~SoftmaxKerneItemsClassOptimized() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_ref.h
@@ -11,7 +11,7 @@ class SoftmaxKernelRef : public SoftmaxItemsClassKernelBase {
 public:
     using Parent = SoftmaxItemsClassKernelBase;
     SoftmaxKernelRef() : Parent("softmax_gpu_ref") {}
-    ~SoftmaxKernelRef() override {}
+    ~SoftmaxKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     softmax_kernel_selector();
 
-    ~softmax_kernel_selector() override {}
+    ~softmax_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_base.h
@@ -41,7 +41,7 @@ struct space_to_batch_fuse_params : fuse_params {
 class SpaceToBatchKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~SpaceToBatchKernelBase() override {}
+    ~SpaceToBatchKernelBase() override = default;
 
     struct DispatchData : public CommonDispatchData {};
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_ref.h
@@ -11,7 +11,7 @@ class SpaceToBatchKernelRef : public SpaceToBatchKernelBase {
 public:
     using Parent = SpaceToBatchKernelBase;
     SpaceToBatchKernelRef() : SpaceToBatchKernelBase("space_to_batch_ref") {}
-    ~SpaceToBatchKernelRef() override {}
+    ~SpaceToBatchKernelRef() override = default;
 
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_batch/space_to_batch_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     space_to_batch_kernel_selector();
 
-    ~space_to_batch_kernel_selector() override {}
+    ~space_to_batch_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_depth/space_to_depth_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/space_to_depth/space_to_depth_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     space_to_depth_kernel_selector();
 
-    ~space_to_depth_kernel_selector() override {}
+    ~space_to_depth_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_ref.h
@@ -50,7 +50,7 @@ struct strided_slice_params : public base_params {
 class StridedSliceKernelRef : public KernelBaseOpenCL {
 public:
     StridedSliceKernelRef() : KernelBaseOpenCL("strided_slice_ref") {}
-    ~StridedSliceKernelRef() override {}
+    ~StridedSliceKernelRef() override = default;
     virtual JitConstants GetJitConstants(const strided_slice_params& params) const;
     virtual CommonDispatchData SetDefault(const strided_slice_params& params) const;
     KernelsData GetKernelsData(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/strided_slice/strided_slice_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     strided_slice_kernel_selector();
 
-    ~strided_slice_kernel_selector() override {}
+    ~strided_slice_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_base.h
@@ -60,7 +60,7 @@ struct swiglu_fuse_params : fuse_params {
 class SwiGLUKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~SwiGLUKernelBase() override {}
+    ~SwiGLUKernelBase() override = default;
 
     virtual JitConstants GetJitConstants(const swiglu_params& params, const CommonDispatchData& dispatchData) const;
     virtual CommonDispatchData SetDefault(const swiglu_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_opt.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class SwiGLUKernelOpt : public SwiGLUKernelBase {
 public:
     SwiGLUKernelOpt() : SwiGLUKernelBase("swiglu_gpu_opt") {}
-    ~SwiGLUKernelOpt() override {}
+    ~SwiGLUKernelOpt() override = default;
 
 protected:
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_ref.h
@@ -10,7 +10,7 @@ namespace kernel_selector {
 class SwiGLUKernelRef : public SwiGLUKernelBase {
 public:
     SwiGLUKernelRef() : SwiGLUKernelBase("swiglu_gpu_ref") {}
-    ~SwiGLUKernelRef() override {}
+    ~SwiGLUKernelRef() override = default;
 
 protected:
     KernelsPriority GetKernelsPriority(const Params& params) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/swiglu/swiglu_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     swiglu_kernel_selector();
 
-    ~swiglu_kernel_selector() override {}
+    ~swiglu_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/tile/tile_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/tile/tile_kernel_ref.h
@@ -17,7 +17,7 @@ struct tile_params : public base_params {
 class TileKernelRef : public KernelBaseOpenCL {
 public:
     TileKernelRef() : KernelBaseOpenCL("tile_ref") {}
-    ~TileKernelRef() override {}
+    ~TileKernelRef() override = default;
 
     virtual JitConstants GetJitConstants(const tile_params& params) const;
     virtual CommonDispatchData SetDefault(const tile_params& params) const;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/tile/tile_kernel_selector.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/tile/tile_kernel_selector.h
@@ -16,7 +16,7 @@ public:
 
     tile_kernel_selector();
 
-    ~tile_kernel_selector() override {}
+    ~tile_kernel_selector() override = default;
 
     KernelsData GetBestKernels(const Params& params) const override;
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/weight_bias_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/weight_bias_kernel_base.h
@@ -14,7 +14,7 @@ namespace kernel_selector {
 class WeightBiasKernelBase : public KernelBaseOpenCL {
 public:
     using KernelBaseOpenCL::KernelBaseOpenCL;
-    ~WeightBiasKernelBase() override {}
+    ~WeightBiasKernelBase() override = default;
 
 protected:
     virtual JitConstants GetJitConstants(const weight_bias_params& params) const;

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -550,7 +550,7 @@ IncreasePositionIdsPrecisionForGemma4::IncreasePositionIdsPrecisionForGemma4() {
     this->register_matcher(m, callback);
 }
 
-IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() {}
+IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() = default;
 
 bool IncreasePositionIdsPrecision::run_on_model(const std::shared_ptr<ov::Model>& model) {
     ov::pass::SymbolicOptimizations symbolic_optimizations(false, get_pass_config());

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_rms_input_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_rms_input_precision.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -26,7 +26,7 @@
 
 namespace ov::intel_gpu {
 
-IncreaseRMSInputPrecision::IncreaseRMSInputPrecision() {}
+IncreaseRMSInputPrecision::IncreaseRMSInputPrecision() = default;
 
 bool IncreaseRMSInputPrecision::run_on_model(const std::shared_ptr<ov::Model>& model) {
     using namespace ov::pass;

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -128,7 +128,7 @@ bool requires_new_shape_infer(const std::shared_ptr<ov::Node>& op) {
 
 } // namespace
 
-ExecutionConfig::ExecutionConfig() { }
+ExecutionConfig::ExecutionConfig() = default;
 
 ExecutionConfig::ExecutionConfig(const ExecutionConfig& other) : ExecutionConfig() {
     m_user_properties = other.m_user_properties;

--- a/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
+++ b/src/plugins/intel_gpu/src/runtime/memory_pool.cpp
@@ -34,7 +34,7 @@ memory::ptr memory_pool::alloc_memory(const layout& layout, allocation_type type
     return _engine->allocate_memory(layout, type, reset);
 }
 
-memory_pool::~memory_pool() {}
+memory_pool::~memory_pool() = default;
 
 bool memory_pool::has_conflict(const memory_set& mem_cand,
                                const memory_restricter<uint32_t>& restrictions) {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
@@ -583,7 +583,7 @@ public:
     }
 
     //! \brief Default constructor - initializes to NULL.
-    ImageVA() { }
+    ImageVA() = default;
 
     /*! \brief Constructor from cl_mem - takes ownership.
     *
@@ -607,16 +607,12 @@ public:
     /*! \brief Copy constructor to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    ImageVA(const ImageVA& img) :
-        Image2D(img) {}
+    ImageVA(const ImageVA& img) = default;
 
     /*! \brief Copy assignment to forward copy to the superclass correctly.
     * Required for MSVC.
     */
-    ImageVA& operator = (const ImageVA &img) {
-        Image2D::operator=(img);
-        return *this;
-    }
+    ImageVA& operator = (const ImageVA &img) = default;
 
     /*! \brief Move constructor to forward move to the superclass correctly.
     * Required for MSVC.
@@ -767,7 +763,7 @@ private:
 class PlatformVA : public Platform {
 public:
     //! \brief Default constructor - initializes to NULL.
-    PlatformVA() { }
+    PlatformVA() = default;
 
     explicit PlatformVA(const cl_platform_id &platform, bool retainObject = false) :
         Platform(platform, retainObject) { }


### PR DESCRIPTION
Enables the `modernize-use-equals-default` and `modernize-use-equals-delete` checks for the Intel GPU plugin and fixes all findings in scope. For `modernize-use-equals-default` the empty-bodied special members are replaced with `= default`, including a few copy constructors whose member-initializer lists just forwarded to the base or copied every member (in `ocl_ext.hpp`, `loop_inst.h` and `loop.cpp`), which were converted by hand so the defaulted form keeps the exact same semantics. For `modernize-use-equals-delete` the deleted copy constructors and copy-assignment operators in `bind.hpp` and `implementation_map.hpp` are moved into a public section, since a deleted function is not callable regardless of access and the check flags deleting them in a private section; the private default constructors of those singletons are left untouched. Next check in the incremental clang-tidy rollout for the plugin.
