### PR TITLE
[CPU] Skip mbind NUMA binding on Android arm64 (fix SIGSYS seccomp crash)

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -556,11 +556,8 @@ void StaticMemory::StaticMemoryBlock::unregisterMemory(Memory* memPtr) {
     // do nothing
 }
 
-// The mbind() syscall is used for NUMA-aware memory binding. It is a Linux-only feature, but on
-// Android arm64 (aarch64) the seccomp filter forbids the mbind syscall (arm64 #237), so calling it
-// aborts the process with SIGSYS during inference. Android devices are single-NUMA-node anyway, so
-// the binding is unnecessary there: exclude Android arm64 and fall back to the no-op mbind_move
-// below. Other __linux__ targets (incl. non-arm64 Android, if ever built) keep the syscall.
+// Android arm64 (aarch64) the seccomp filter forbids the mbind syscall. Android devices
+// are single-NUMA-node anyway, so the binding is unnecessary there.
 #if defined(__linux__) && !(defined(__ANDROID__) && defined(__aarch64__))
 #    define MPOL_DEFAULT   0
 #    define MPOL_BIND      2

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -556,7 +556,12 @@ void StaticMemory::StaticMemoryBlock::unregisterMemory(Memory* memPtr) {
     // do nothing
 }
 
-#if defined(__linux__)
+// The mbind() syscall is used for NUMA-aware memory binding. It is a Linux-only feature, but on
+// Android arm64 (aarch64) the seccomp filter forbids the mbind syscall (arm64 #237), so calling it
+// aborts the process with SIGSYS during inference. Android devices are single-NUMA-node anyway, so
+// the binding is unnecessary there: exclude Android arm64 and fall back to the no-op mbind_move
+// below. Other __linux__ targets (incl. non-arm64 Android, if ever built) keep the syscall.
+#if defined(__linux__) && !(defined(__ANDROID__) && defined(__aarch64__))
 #    define MPOL_DEFAULT   0
 #    define MPOL_BIND      2
 #    define MPOL_MF_STRICT (1 << 0)
@@ -577,7 +582,7 @@ static int64_t mbind(void* start, uint64_t len, int mode, const uint64_t* nmask,
 }
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) && !(defined(__ANDROID__) && defined(__aarch64__))
 bool mbind_move(void* data, size_t size, int targetNode) {
     int realNode = ov::get_org_numa_id(targetNode);
     auto pagesize = getpagesize();


### PR DESCRIPTION
### Details:
 - The Intel CPU plugin binds memory blocks to NUMA nodes via the `mbind()` syscall in `cpu_memory.cpp`, guarded by `#if defined(__linux__)`.
 - Android also defines `__linux__`, but on **arm64** its seccomp filter forbids the `mbind` syscall (arm64 syscall `#237`). The call therefore aborts the process with **`SIGSYS`** during inference (`ov::intel_cpu::mbind` → `DnnlMemoryBlock::resize` → `Memory` construction).
 - Android devices are single-NUMA-node, so the binding is unnecessary. This change restricts the `mbind` code path to exclude Android arm64 - `#if defined(__linux__) && !(defined(__ANDROID__) && defined(__aarch64__))` - so it falls back to the already-present no-op `mbind_move()` (the same behavior as non-Linux builds). Other Linux targets are unaffected.
 - Two `#if` guards updated in `src/plugins/intel_cpu/src/cpu_memory.cpp`; no functional change on any non-Android-arm64 platform.
