### PR TITLE
Fix QDQ stripping for when FQ input is Parameter

### DIFF
--- a/src/common/low_precision_transformations/src/qdq_stripping.cpp
+++ b/src/common/low_precision_transformations/src/qdq_stripping.cpp
@@ -256,7 +256,24 @@ bool FQStrippingTransformation::run_on_model(const std::shared_ptr<ov::Model>& f
             adjuster.adjust();
         }
 
-        OPENVINO_ASSERT(replace_output_update_name(fq->output(0), fq->input_value(0)), "FQ stripping failed");
+        if (!replace_output_update_name(fq->output(0), fq->input_value(0))) {
+            // replace_output_update_name returns false when the FQ has a Result
+            // consumer and its input source is a Parameter — it cannot transfer
+            // the FQ's friendly name onto the Parameter without changing the
+            // model's public input API. Rewire non-Result consumers directly to
+            // the FQ's input source; Result consumers stay attached (the FQ is
+            // identity-like, so values are numerically equivalent).
+            auto src = fq->input_value(0);
+            std::vector<ov::Input<ov::Node>> non_result_consumers;
+            for (auto& consumer_input : fq->output(0).get_target_inputs()) {
+                if (!ov::is_type<ov::op::v0::Result>(consumer_input.get_node())) {
+                    non_result_consumers.push_back(consumer_input);
+                }
+            }
+            for (auto& consumer_input : non_result_consumers) {
+                consumer_input.replace_source_output(src);
+            }
+        }
         model_changed = true;
     }
 


### PR DESCRIPTION
### Details:
- `qdq_stripping` removes identity-like FakeQuantize nodes via `replace_output_update_name`, wrapped in `OPENVINO_ASSERT`.
- `replace_output_update_name` legitimately returns `false` when the FakeQuantize has a Result consumer and its input is a Parameter — it refuses to transfer the FQ's friendly name onto the Parameter since that would change the model's public input API.
- This topology occurs in quantized ONNX models (e.g. 2-bit weight + activation quantized models) where a QuantizeLinear/DequantizeLinear pair is placed directly on a graph input Parameter. After LPT fuses Q+DQ into a FakeQuantize, the assert fires and compilation fails.

Fix - 
Replace the assert with a conditional fallback. If `replace_output_update_name` succeeds, proceed normally. If it fails, manually rewire all non-Result consumers of the FQ to read directly from the FQ's input source (the Parameter). Result consumers stay attached to the FQ, preserving model output semantics. The FQ is no longer on the compute path — since it's identity-like, the bypassed values are numerically equivalent.

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - analysis of ONNX model topology that triggers the issue and validation of the fix approach. Human validation: manual code review, verified the triggering condition with the target ONNX model, confirmed `replace_output_update_name` semantics from OV source.
