### PR TITLE
[NPUW] Fix KV-cache copy for heterogeneous attention models (Gemma4)

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/embedding/embedding_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/embedding/embedding_infer_request.cpp
@@ -153,8 +153,7 @@ void ov::npuw::EmbeddingInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITenso
         update_kvcache_for(m_prefill_request,
                            m_prefill_in_ports,
                            m_prefill_out_ports,
-                           static_cast<uint32_t>(current_prompts_len),
-                           kvcache_desc.v_tensors_transposed_pre);
+                           static_cast<uint32_t>(current_prompts_len));
 
         // Update attention mask for the next iteration
         std::copy_n(m_attn_mask_in_tensor->data<int64_t>() + m_attn_mask_in_tensor->get_size() - current_prompts_len,

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.cpp
@@ -15,9 +15,11 @@ KVCacheBlockManager::KVCacheBlockManager(uint32_t block_size,
                                          const ov::Shape& base_shape,
                                          ov::element::Type elem_type,
                                          const std::string& device,
-                                         const std::shared_ptr<const ov::IPlugin>& plugin)
+                                         const std::shared_ptr<const ov::IPlugin>& plugin,
+                                         uint32_t seq_dim)
     : block_size_(block_size),
       max_blocks_(max_blocks),
+      seq_dim_(seq_dim),
       element_type_(elem_type),
       block_shape_(base_shape),
       device_(device),
@@ -31,14 +33,14 @@ KVCacheBlockManager::KVCacheBlockManager(uint32_t block_size,
                     "KVCacheBlockManager: plugin must be non-null for non-CPU device '",
                     device_,
                     "'");
-    // Check that the sequence dimension (dim 2 for K/non-transposed-V, dim 3 for transposed V)
-    // equals block_size.
-    OPENVINO_ASSERT(base_shape.size() == 4 && (base_shape[2] == block_size || base_shape[3] == block_size),
+    OPENVINO_ASSERT(seq_dim_ == 2u || seq_dim_ == 3u, "KVCacheBlockManager: seq_dim must be 2 or 3, got ", seq_dim_);
+    OPENVINO_ASSERT(base_shape.size() == 4 && base_shape[seq_dim_] == block_size,
                     "KVCacheBlockManager: base_shape ",
                     base_shape,
                     " does not have block_size=",
                     block_size,
-                    " in sequence dimension (expected at dim 2 or 3)");
+                    " at seq_dim=",
+                    seq_dim_);
 
     // Initialize block pool (tensors allocated on-demand, not here)
     blocks_.reserve(max_blocks);

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
@@ -184,7 +184,7 @@ private:
 
     uint32_t block_size_;                  ///< Number of tokens per block
     uint32_t max_blocks_;                  ///< Maximum blocks in pool
-    uint32_t seq_dim_;                     ///< Sequence dimension index (2 or 3)
+    uint32_t seq_dim_;                     ///< Sequence dimension index
     std::vector<Block> blocks_;            ///< All blocks (free + allocated)
     std::stack<uint32_t> free_block_ids_;  ///< Stack of free block IDs (LIFO for better reuse)
 

--- a/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/kv_cache_block_manager.hpp
@@ -47,13 +47,16 @@ public:
      * @param elem_type Element type (e.g., fp16, fp32)
      * @param device Target device for memory allocation ("NPU", "CPU")
      * @param plugin Plugin instance for memory allocation
+     * @param seq_dim Sequence dimension index (2 or 3), as determined by the
+     *                concat axis in SplitKVCacheIntoBlocks.
      */
     KVCacheBlockManager(uint32_t block_size,
                         uint32_t max_blocks,
                         const ov::Shape& base_shape,
                         ov::element::Type elem_type,
                         const std::string& device,
-                        const std::shared_ptr<const ov::IPlugin>& plugin);
+                        const std::shared_ptr<const ov::IPlugin>& plugin,
+                        uint32_t seq_dim);
 
     ~KVCacheBlockManager() = default;
 
@@ -162,6 +165,13 @@ public:
         return static_cast<uint32_t>(free_block_ids_.size());
     }
 
+    /**
+     * @brief Get the sequence dimension index in the block shape
+     */
+    uint32_t get_seq_dim() const {
+        return seq_dim_;
+    }
+
 private:
     /**
      * @brief Represents a single block of KV cache memory
@@ -174,6 +184,7 @@ private:
 
     uint32_t block_size_;                  ///< Number of tokens per block
     uint32_t max_blocks_;                  ///< Maximum blocks in pool
+    uint32_t seq_dim_;                     ///< Sequence dimension index (2 or 3)
     std::vector<Block> blocks_;            ///< All blocks (free + allocated)
     std::stack<uint32_t> free_block_ids_;  ///< Stack of free block IDs (LIFO for better reuse)
 

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.cpp
@@ -390,12 +390,7 @@ void LLMBlockKVCacheStrategy::on_prefill_chunk_done(uint32_t current_prompts_len
         const uint32_t write_start = kvcache_desc.num_stored_tokens - current_prompts_len;
         LOG_DEBUG("Copying prefill outputs to blocks: num_tokens=" << current_prompts_len
                                                                    << " kv_position=" << write_start);
-        const bool v_transposed = kvcache_desc.v_tensors_transposed_pre;
-        copy_outputs_to_blocks(m_req.m_prefill_request,
-                               m_req.m_prefill_out_ports,
-                               current_prompts_len,
-                               v_transposed,
-                               write_start);
+        copy_outputs_to_blocks(m_req.m_prefill_request, m_req.m_prefill_out_ports, current_prompts_len, write_start);
     }
 }
 
@@ -412,7 +407,6 @@ void LLMBlockKVCacheStrategy::on_generate_kv_init() {
     //    write directly into the shared BlockManager buffer — no re-binding needed.
     //  Tail block (block_tail port): copy-based; refreshed by update_generate_bindings() each step.
 
-    auto& kvcache_desc = m_req.m_npuw_llm_compiled_model->m_kvcache_desc;
     const auto& variant_layer_helpers = m_variant_block_binding_helpers.at(m_req.m_kvcache_request);
 
     auto process_blocks = [&](uint32_t layer_idx,
@@ -448,12 +442,15 @@ void LLMBlockKVCacheStrategy::on_generate_kv_init() {
             process_blocks(layer_idx,
                            layer_managers.key_manager.get(),
                            layer_helpers.key_helper,
-                           kvcache_desc.dim,
+                           layer_managers.key_manager->get_seq_dim(),
                            "key");
         }
         if (layer_managers.value_manager) {
-            const uint32_t kv_dim = kvcache_desc.v_tensors_transposed_gen ? 3u : kvcache_desc.dim;
-            process_blocks(layer_idx, layer_managers.value_manager.get(), layer_helpers.value_helper, kv_dim, "value");
+            process_blocks(layer_idx,
+                           layer_managers.value_manager.get(),
+                           layer_helpers.value_helper,
+                           layer_managers.value_manager->get_seq_dim(),
+                           "value");
         }
     }
 
@@ -474,11 +471,7 @@ void LLMBlockKVCacheStrategy::on_generate_step_done(uint32_t input_tokens_len) {
     const auto& kvcache_desc = m_req.m_npuw_llm_compiled_model->m_kvcache_desc;
     const uint32_t tokens_after = kvcache_desc.num_stored_tokens;
     const uint32_t tokens_before = tokens_after - input_tokens_len;
-    copy_outputs_to_blocks(m_req.m_kvcache_request,
-                           m_req.m_kvcache_out_ports,
-                           input_tokens_len,
-                           kvcache_desc.v_tensors_transposed_gen,
-                           tokens_before);
+    copy_outputs_to_blocks(m_req.m_kvcache_request, m_req.m_kvcache_out_ports, input_tokens_len, tokens_before);
     update_generate_bindings(tokens_before, tokens_after, m_req.m_kvcache_request);
 }
 
@@ -670,7 +663,6 @@ void LLMBlockKVCacheStrategy::update_generate_bindings(uint32_t old_num_tokens,
     LOG_DEBUG("=== Update Block Bindings After Generate ===");
     LOG_BLOCK();
 
-    auto& kvcache_desc = m_req.m_npuw_llm_compiled_model->m_kvcache_desc;
     const auto& variant_layer_helpers = m_variant_block_binding_helpers.at(kvcache_request);
 
     auto update_blocks = [&](uint32_t layer_idx,
@@ -739,12 +731,15 @@ void LLMBlockKVCacheStrategy::update_generate_bindings(uint32_t old_num_tokens,
             update_blocks(layer_idx,
                           layer_managers.key_manager.get(),
                           layer_helpers.key_helper,
-                          kvcache_desc.dim,
+                          layer_managers.key_manager->get_seq_dim(),
                           "key");
         }
         if (layer_managers.value_manager) {
-            const uint32_t kv_dim = kvcache_desc.v_tensors_transposed_gen ? 3u : kvcache_desc.dim;
-            update_blocks(layer_idx, layer_managers.value_manager.get(), layer_helpers.value_helper, kv_dim, "value");
+            update_blocks(layer_idx,
+                          layer_managers.value_manager.get(),
+                          layer_helpers.value_helper,
+                          layer_managers.value_manager->get_seq_dim(),
+                          "value");
         }
     }
 }
@@ -756,10 +751,8 @@ void LLMBlockKVCacheStrategy::update_generate_bindings(uint32_t old_num_tokens,
 void LLMBlockKVCacheStrategy::copy_outputs_to_blocks(const std::shared_ptr<ov::IAsyncInferRequest>& request,
                                                      const PortsMap& src_ports,
                                                      uint32_t num_tokens,
-                                                     bool v_transposed,
                                                      uint32_t current_kv_position) {
     namespace uu = ov::npuw::util;
-    auto& kvcache_desc = m_req.m_npuw_llm_compiled_model->m_kvcache_desc;
     auto& compiled = request->get_compiled_model();
 
     for (std::size_t i = LLMInferBaseRequest::layer_ids::kStartOutputKVCacheLayers; i < compiled->outputs().size();
@@ -780,18 +773,28 @@ void LLMBlockKVCacheStrategy::copy_outputs_to_blocks(const std::shared_ptr<ov::I
 
         auto& layer_managers = it->second;
         auto& block_manager = is_key ? layer_managers.key_manager : layer_managers.value_manager;
-        const uint32_t kv_dim = (!is_key && v_transposed) ? 3u : kvcache_desc.dim;
+
+        // Use per-layer seq dim from block manager (handles mixed transposed/non-transposed V).
+        const uint32_t kv_dim = block_manager->get_seq_dim();
 
         auto src_tensor = request->get_tensor(src_ports.at(output_name));
-        uint32_t src_seq_len = static_cast<uint32_t>(src_tensor->get_shape()[kv_dim]);
-        OPENVINO_ASSERT(num_tokens <= src_seq_len, "num_tokens (", num_tokens, ") > src_seq_len (", src_seq_len, ")");
+        const uint32_t src_seq_len = static_cast<uint32_t>(src_tensor->get_shape()[kv_dim]);
 
-        auto src_to_copy = src_tensor;
-        if (src_seq_len > num_tokens) {
-            src_to_copy = uu::make_tensor_slice(src_tensor, kv_dim, src_seq_len - num_tokens, src_seq_len);
+        uint32_t effective_tokens;
+        ov::SoPtr<ov::ITensor> src_to_copy;
+        if (num_tokens <= src_seq_len) {
+            // Normal case: output has enough (or more) tokens — take the tail.
+            effective_tokens = num_tokens;
+            src_to_copy = (src_seq_len > num_tokens)
+                              ? uu::make_tensor_slice(src_tensor, kv_dim, src_seq_len - num_tokens, src_seq_len)
+                              : src_tensor;
+        } else {
+            // SWA case: sliding-window layer produced fewer tokens than requested.
+            effective_tokens = src_seq_len;
+            src_to_copy = src_tensor;
         }
 
-        const uint32_t start_pos = current_kv_position;
+        const uint32_t start_pos = current_kv_position + (num_tokens - effective_tokens);
         const uint32_t end_pos = current_kv_position + num_tokens;
         const uint32_t start_block_idx = start_pos / m_block_size;
         const uint32_t end_block_idx = (end_pos - 1) / m_block_size;
@@ -820,7 +823,11 @@ void LLMBlockKVCacheStrategy::copy_outputs_to_blocks(const std::shared_ptr<ov::I
             tokens_written += count;
             block_manager->update_block_tokens(block_id, write_end);
         }
-        OPENVINO_ASSERT(tokens_written == num_tokens, "Mismatch: wrote ", tokens_written, " but expected ", num_tokens);
+        OPENVINO_ASSERT(tokens_written == effective_tokens,
+                        "Mismatch: wrote ",
+                        tokens_written,
+                        " but expected ",
+                        effective_tokens);
     }
 }
 
@@ -909,12 +916,15 @@ void LLMBlockKVCacheStrategy::create_block_managers_and_helpers() {
                             " has key blocks but no key_block_0. "
                             "SplitKVCacheIntoBlocks transformation may be broken.");
             auto first_key_port = m_prefill_classified_in_ports.at(key_block0_name).port;
+            const std::string orig_key_name = "past_key_values." + layer_idx_str + ".key";
+            const uint32_t key_seq_dim = compiled_model->m_kvcache_desc.kv_seq_dims.at(orig_key_name);
             layer_managers.key_manager = std::make_unique<KVCacheBlockManager>(block_size,
                                                                                max_blocks,
                                                                                first_key_port.get_shape(),
                                                                                first_key_port.get_element_type(),
                                                                                m_req.m_pre_alloc_device,
-                                                                               compiled_model->get_plugin());
+                                                                               compiled_model->get_plugin(),
+                                                                               key_seq_dim);
         }
         if (presence.has_value_numbered_block) {
             const std::string value_block0_name = make_numbered_block_input_name("value", layer_idx_str, 0);
@@ -924,12 +934,15 @@ void LLMBlockKVCacheStrategy::create_block_managers_and_helpers() {
                             " has value blocks but no value_block_0. "
                             "SplitKVCacheIntoBlocks transformation may be broken.");
             auto first_value_port = m_prefill_classified_in_ports.at(value_block0_name).port;
+            const std::string orig_value_name = "past_key_values." + layer_idx_str + ".value";
+            const uint32_t value_seq_dim = compiled_model->m_kvcache_desc.kv_seq_dims.at(orig_value_name);
             layer_managers.value_manager = std::make_unique<KVCacheBlockManager>(block_size,
                                                                                  max_blocks,
                                                                                  first_value_port.get_shape(),
                                                                                  first_value_port.get_element_type(),
                                                                                  m_req.m_pre_alloc_device,
-                                                                                 compiled_model->get_plugin());
+                                                                                 compiled_model->get_plugin(),
+                                                                                 value_seq_dim);
         }
 
         m_kv_cache_block_managers[layer_idx] = std::move(layer_managers);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.hpp
@@ -151,7 +151,6 @@ private:
     void copy_outputs_to_blocks(const std::shared_ptr<ov::IAsyncInferRequest>& request,
                                 const PortsMap& src_ports,
                                 uint32_t num_tokens,
-                                bool v_transposed,
                                 uint32_t current_kv_position);
 
     void update_generate_bindings(uint32_t old_num_tokens,

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1241,6 +1241,26 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
         }
     }
 
+    // Extract per-parameter KV sequence dimensions from Concat axes in the prefill model.
+    // This is done unconditionally (before any block/continuous decision) so that both
+    // paths can look up seq_dim by parameter name without runtime heuristics.
+    for (const auto& param : prefill_model->get_parameters()) {
+        const auto& name = param->get_friendly_name();
+        auto key_layer = ov::npuw::util::isPastKeyValuesKeyContiguous(name);
+        auto value_layer = ov::npuw::util::isPastKeyValuesValueContiguous(name);
+        if (!key_layer && !value_layer) {
+            continue;
+        }
+        auto [concat, _] = ov::npuw::pass::find_concat_for_param(param);
+        if (!concat) {
+            continue;
+        }
+        const int64_t raw_axis = concat->get_axis();
+        const int64_t rank = static_cast<int64_t>(param->get_partial_shape().rank().get_length());
+        const uint32_t axis = static_cast<uint32_t>((raw_axis < 0) ? raw_axis + rank : raw_axis);
+        m_kvcache_desc.kv_seq_dims[name] = axis;
+    }
+
     // Apply block-based KV cache transformation for chunk prefill after ShapeOfParameter
     // This ensures ShapeOf nodes are already regularized before transformation
     if (m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE>()) {
@@ -1255,24 +1275,21 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
             LOG_BLOCK();
 
             bool all_transformed = true;
-            auto apply_block_kv_transform =
-                [&](std::shared_ptr<ov::Model>& model, bool v_transposed, const std::string& tag) {
-                    ov::pass::Manager mgr(tag);
-                    mgr.register_pass<ov::npuw::pass::SplitKVCacheIntoBlocks>(block_size, v_transposed);
-                    if (mgr.run_passes(model)) {
-                        LOG_INFO("SplitKVCacheIntoBlocks applied: " << tag);
-                    } else {
-                        LOG_WARN("SplitKVCacheIntoBlocks had no effect: " << tag);
-                        all_transformed = false;
-                    }
-                };
+            auto apply_block_kv_transform = [&](std::shared_ptr<ov::Model>& model, const std::string& tag) {
+                ov::npuw::pass::SplitKVCacheIntoBlocks pass(block_size);
+                if (pass.run_on_model(model)) {
+                    LOG_INFO("SplitKVCacheIntoBlocks applied: " << tag);
+                } else {
+                    LOG_WARN("SplitKVCacheIntoBlocks had no effect: " << tag);
+                    all_transformed = false;
+                }
+                return pass;
+            };
 
-            apply_block_kv_transform(prefill_model, m_kvcache_desc.v_tensors_transposed_pre, "prefill");
+            auto prefill_pass = apply_block_kv_transform(prefill_model, "prefill");
 
             for (size_t i = 0; i < generate_model_variants.size(); ++i) {
-                apply_block_kv_transform(generate_model_variants[i],
-                                         m_kvcache_desc.v_tensors_transposed_gen,
-                                         "generate_" + std::to_string(i));
+                apply_block_kv_transform(generate_model_variants[i], "generate_" + std::to_string(i));
             }
 
             if (!all_transformed) {

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1051,6 +1051,31 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     } else {
         LOG_DEBUG("Check and apply opt layout --- SKIPPED");
     }
+
+    const auto extract_kv_seq_dims = [](const std::shared_ptr<ov::Model>& model) {
+        std::unordered_map<std::string, uint32_t> kv_seq_dims;
+        for (const auto& param : model->get_parameters()) {
+            const auto& name = param->get_friendly_name();
+            const auto key_layer = ov::npuw::util::isPastKeyValuesKeyContiguous(name);
+            const auto value_layer = ov::npuw::util::isPastKeyValuesValueContiguous(name);
+            if (!key_layer && !value_layer) {
+                continue;
+            }
+            auto [concat, _] = ov::npuw::pass::find_concat_for_param(param);
+            if (!concat) {
+                continue;
+            }
+            const int64_t raw_axis = concat->get_axis();
+            const int64_t rank = static_cast<int64_t>(param->get_partial_shape().rank().get_length());
+            const uint32_t axis = static_cast<uint32_t>((raw_axis < 0) ? raw_axis + rank : raw_axis);
+            kv_seq_dims[name] = axis;
+        }
+        return kv_seq_dims;
+    };
+
+    // Non-chunk prefill removes empty KV parameters below, so preserve their concat axes first.
+    m_kvcache_desc.kv_seq_dims = extract_kv_seq_dims(prefill_model);
+
     if (!m_is_embedding) {
         if (!m_use_chunk_prefill) {
             LOG_DEBUG("Removing EmptyKVInputs");
@@ -1241,24 +1266,20 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
         }
     }
 
-    // Extract per-parameter KV sequence dimensions from Concat axes in the prefill model.
-    // This is done unconditionally (before any block/continuous decision) so that both
-    // paths can look up seq_dim by parameter name without runtime heuristics.
-    for (const auto& param : prefill_model->get_parameters()) {
-        const auto& name = param->get_friendly_name();
-        auto key_layer = ov::npuw::util::isPastKeyValuesKeyContiguous(name);
-        auto value_layer = ov::npuw::util::isPastKeyValuesValueContiguous(name);
-        if (!key_layer && !value_layer) {
-            continue;
+    // Extract per-parameter KV sequence dimensions from the generate model.
+    // This may differ from prefill when V layout differs (e.g. GPU offload attention).
+    if (!generate_model_variants.empty()) {
+        m_kvcache_desc.kv_seq_dims_gen = extract_kv_seq_dims(generate_model_variants.front());
+        for (size_t idx = 1; idx < generate_model_variants.size(); ++idx) {
+            const auto variant_kv_seq_dims = extract_kv_seq_dims(generate_model_variants[idx]);
+            OPENVINO_ASSERT(variant_kv_seq_dims == m_kvcache_desc.kv_seq_dims_gen,
+                            "Generate model variants have inconsistent KV sequence dimensions: variant 0 and variant ",
+                            idx,
+                            " differ.");
         }
-        auto [concat, _] = ov::npuw::pass::find_concat_for_param(param);
-        if (!concat) {
-            continue;
-        }
-        const int64_t raw_axis = concat->get_axis();
-        const int64_t rank = static_cast<int64_t>(param->get_partial_shape().rank().get_length());
-        const uint32_t axis = static_cast<uint32_t>((raw_axis < 0) ? raw_axis + rank : raw_axis);
-        m_kvcache_desc.kv_seq_dims[name] = axis;
+    } else {
+        // No generate model (e.g. encoder-only): mirror prefill dims.
+        m_kvcache_desc.kv_seq_dims_gen = m_kvcache_desc.kv_seq_dims;
     }
 
     // Apply block-based KV cache transformation for chunk prefill after ShapeOfParameter
@@ -1268,7 +1289,9 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
                         "NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE and NPUW_LLM_ENABLE_PREFIX_CACHING "
                         "cannot be enabled simultaneously — this combination is not yet supported. "
                         "Please disable one of the two options.");
-        if (m_use_chunk_prefill && !m_is_embedding && (prefill_attn_hfa || prefill_attn_pyramid)) {
+        const bool block_kv_axes_compatible = m_kvcache_desc.kv_seq_dims == m_kvcache_desc.kv_seq_dims_gen;
+        if (m_use_chunk_prefill && !m_is_embedding && (prefill_attn_hfa || prefill_attn_pyramid) &&
+            block_kv_axes_compatible) {
             const uint32_t block_size = static_cast<uint32_t>(m_prefill_chunk_size);
 
             LOG_DEBUG("Applying SplitKVCacheIntoBlocks (block_size=" << block_size << ")");
@@ -1300,7 +1323,7 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
         } else {
             LOG_WARN("NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE=YES was requested but could not be applied. "
                      "Block-based KV cache requires: chunk prefill enabled, "
-                     "HFA or Pyramid attention, and a non-embedding model. "
+                     "HFA or Pyramid attention, a non-embedding model, and matching prefill/generate KV axes. "
                      "Falling back to monolithic (continuous) KV cache.");
         }
     }
@@ -1439,10 +1462,11 @@ void ov::npuw::LLMCompiledModel::serialize(std::ostream& raw_stream, const ov::n
         // Serialize LLMCompiledModel-specific data
         stream & m_kvcache_desc.max_prompt_size & m_kvcache_desc.total_size & m_kvcache_desc.num_stored_tokens &
             m_kvcache_desc.dim & m_kvcache_desc.max_generation_token_len & m_kvcache_desc.v_tensors_transposed_pre &
-            m_kvcache_desc.v_tensors_transposed_gen & m_prefill_chunk_size & m_use_chunk_prefill & m_max_lora_rank &
-            m_enable_prefix_caching & m_prefix_caching_block_size & m_prefix_caching_max_num_blocks &
-            m_longrope_context_limit & m_is_whisper & m_eos_token_id & m_decomposed_sdpa_size & m_is_eagle &
-            m_is_embedding & m_is_block_kv_cache & m_is_encoder_embedding;
+            m_kvcache_desc.v_tensors_transposed_gen & m_kvcache_desc.kv_seq_dims & m_kvcache_desc.kv_seq_dims_gen &
+            m_prefill_chunk_size & m_use_chunk_prefill & m_max_lora_rank & m_enable_prefix_caching &
+            m_prefix_caching_block_size & m_prefix_caching_max_num_blocks & m_longrope_context_limit & m_is_whisper &
+            m_eos_token_id & m_decomposed_sdpa_size & m_is_eagle & m_is_embedding & m_is_block_kv_cache &
+            m_is_encoder_embedding;
 
         // Write config
         stream & m_cfg;
@@ -1664,12 +1688,12 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
         stream & compiled->m_kvcache_desc.max_prompt_size & compiled->m_kvcache_desc.total_size &
             compiled->m_kvcache_desc.num_stored_tokens & compiled->m_kvcache_desc.dim &
             compiled->m_kvcache_desc.max_generation_token_len & compiled->m_kvcache_desc.v_tensors_transposed_pre &
-            compiled->m_kvcache_desc.v_tensors_transposed_gen & compiled->m_prefill_chunk_size &
-            compiled->m_use_chunk_prefill & compiled->m_max_lora_rank & compiled->m_enable_prefix_caching &
-            compiled->m_prefix_caching_block_size & compiled->m_prefix_caching_max_num_blocks &
-            compiled->m_longrope_context_limit & compiled->m_is_whisper & compiled->m_eos_token_id &
-            compiled->m_decomposed_sdpa_size & compiled->m_is_eagle & compiled->m_is_embedding &
-            compiled->m_is_block_kv_cache & compiled->m_is_encoder_embedding;
+            compiled->m_kvcache_desc.v_tensors_transposed_gen & compiled->m_kvcache_desc.kv_seq_dims &
+            compiled->m_kvcache_desc.kv_seq_dims_gen & compiled->m_prefill_chunk_size & compiled->m_use_chunk_prefill &
+            compiled->m_max_lora_rank & compiled->m_enable_prefix_caching & compiled->m_prefix_caching_block_size &
+            compiled->m_prefix_caching_max_num_blocks & compiled->m_longrope_context_limit & compiled->m_is_whisper &
+            compiled->m_eos_token_id & compiled->m_decomposed_sdpa_size & compiled->m_is_eagle &
+            compiled->m_is_embedding & compiled->m_is_block_kv_cache & compiled->m_is_encoder_embedding;
 
         // Deserialize config
         stream & compiled->m_cfg;

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1283,10 +1283,9 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
                     LOG_WARN("SplitKVCacheIntoBlocks had no effect: " << tag);
                     all_transformed = false;
                 }
-                return pass;
             };
 
-            auto prefill_pass = apply_block_kv_transform(prefill_model, "prefill");
+            apply_block_kv_transform(prefill_model, "prefill");
 
             for (size_t i = 0; i < generate_model_variants.size(); ++i) {
                 apply_block_kv_transform(generate_model_variants[i], "generate_" + std::to_string(i));

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "compiled_model.hpp"
 #include "npuw_transformations/kv_axes_position.hpp"
@@ -47,6 +49,9 @@ public:
         uint32_t max_generation_token_len = 0u;
         bool v_tensors_transposed_pre = false;  // prefill
         bool v_tensors_transposed_gen = false;  // generate
+        // Per-parameter KV cache sequence dimension.
+        // Key: past_key_values parameter name. Value: seq_dim index (from Concat axis).
+        std::unordered_map<std::string, uint32_t> kv_seq_dims;
     };
 
     // Factory type for creating sub-compiled-models (prefill / generate / lm_head).
@@ -120,6 +125,7 @@ private:
     uint64_t m_prefill_chunk_size = 0;
     bool m_use_chunk_prefill = false;
     bool m_is_block_kv_cache = false;
+
     std::shared_ptr<ov::npuw::ICompiledModel_v0> m_kvcache_compiled;
     std::shared_ptr<ov::npuw::ICompiledModel_v0> m_prefill_compiled;
     // This model is optional, so can be null.

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -49,9 +49,12 @@ public:
         uint32_t max_generation_token_len = 0u;
         bool v_tensors_transposed_pre = false;  // prefill
         bool v_tensors_transposed_gen = false;  // generate
-        // Per-parameter KV cache sequence dimension.
+        // Per-parameter KV cache sequence dimension (prefill model).
         // Key: past_key_values parameter name. Value: seq_dim index (from Concat axis).
         std::unordered_map<std::string, uint32_t> kv_seq_dims;
+        // Per-parameter KV cache sequence dimension (generate model).
+        // May differ from kv_seq_dims when prefill and generate use different V layouts
+        std::unordered_map<std::string, uint32_t> kv_seq_dims_gen;
     };
 
     // Factory type for creating sub-compiled-models (prefill / generate / lm_head).

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
@@ -111,14 +111,14 @@ void LLMContinuousKVCacheStrategy::on_generate_variant_switch(const std::shared_
 
     LOG_DEBUG("Migrating " << num_stored << " KV tokens to new generate variant.");
 
-    const auto& kv_seq_dims = kvcache_desc.kv_seq_dims;
+    const auto& kv_seq_dims_gen = kvcache_desc.kv_seq_dims_gen;
     for (const auto& name : m_req.m_kvcache_past_names) {
         auto src = old_req->get_tensor(old_in_ports.at(name));
         auto dst = new_req->get_tensor(new_in_ports.at(name));
 
-        // Look up per-parameter seq dim from compile-time analysis.
-        auto it = kv_seq_dims.find(name);
-        OPENVINO_ASSERT(it != kv_seq_dims.end(), "KV seq dim not found for parameter: ", name);
+        // Look up per-parameter seq dim from compile-time analysis (generate side).
+        auto it = kv_seq_dims_gen.find(name);
+        OPENVINO_ASSERT(it != kv_seq_dims_gen.end(), "KV seq dim (gen) not found for parameter: ", name);
         const uint32_t kv_dim = it->second;
 
         auto src_slice = uu::make_tensor_slice(src, kv_dim, 0u, num_stored);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
@@ -111,19 +111,15 @@ void LLMContinuousKVCacheStrategy::on_generate_variant_switch(const std::shared_
 
     LOG_DEBUG("Migrating " << num_stored << " KV tokens to new generate variant.");
 
+    const auto& kv_seq_dims = kvcache_desc.kv_seq_dims;
     for (const auto& name : m_req.m_kvcache_past_names) {
         auto src = old_req->get_tensor(old_in_ports.at(name));
         auto dst = new_req->get_tensor(new_in_ports.at(name));
 
-        // Use the "present" name to distinguish key vs value — same pattern as
-        // update_kvcache_for. Direct find("value") on the input name is unreliable
-        // because "past_key_values.N.key" contains "value" via "key_values".
-        const auto present_name =
-            std::regex_replace(name, std::regex(ov::npuw::LLMInferRequest::layer_names::past_key_values), "present");
-        const uint32_t kv_dim =
-            (present_name.find("value") != std::string::npos && kvcache_desc.v_tensors_transposed_gen)
-                ? 3u
-                : kvcache_desc.dim;
+        // Look up per-parameter seq dim from compile-time analysis.
+        auto it = kv_seq_dims.find(name);
+        OPENVINO_ASSERT(it != kv_seq_dims.end(), "KV seq dim not found for parameter: ", name);
+        const uint32_t kv_dim = it->second;
 
         auto src_slice = uu::make_tensor_slice(src, kv_dim, 0u, num_stored);
         auto dst_slice = uu::make_tensor_slice(dst, kv_dim, 0u, num_stored);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_continuous_kvcache_strategy.cpp
@@ -82,12 +82,10 @@ void LLMContinuousKVCacheStrategy::on_prefill_chunk_done(uint32_t current_prompt
     if (is_last) {
         return;
     }
-    const bool v_transposed = m_req.m_npuw_llm_compiled_model->m_kvcache_desc.v_tensors_transposed_pre;
     m_req.update_kvcache_for(m_req.m_prefill_request,
                              m_req.m_prefill_in_ports,
                              m_req.m_prefill_out_ports,
-                             current_prompts_len,
-                             v_transposed);
+                             current_prompts_len);
 }
 
 // on_generate_kv_init: copy the full accumulated prefill KV into the generate
@@ -140,12 +138,10 @@ void LLMContinuousKVCacheStrategy::on_generate_variant_switch(const std::shared_
 // on_generate_step_done: persist the new token's KV output into the past KV input buffer
 // so the next generate step sees the updated context.
 void LLMContinuousKVCacheStrategy::on_generate_step_done(uint32_t input_tokens_len) {
-    const bool v_transposed = m_req.m_npuw_llm_compiled_model->m_kvcache_desc.v_tensors_transposed_gen;
     m_req.update_kvcache_for(m_req.m_kvcache_request,
                              m_req.m_kvcache_in_ports,
                              m_req.m_kvcache_out_ports,
-                             input_tokens_len,
-                             v_transposed);
+                             input_tokens_len);
 }
 
 }  // namespace npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_base_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_base_request.cpp
@@ -14,10 +14,10 @@ void ov::npuw::LLMInferBaseRequest::update_kvcache_for(
     std::shared_ptr<ov::IAsyncInferRequest> request,
     const std::unordered_map<std::string, ov::Output<const ov::Node>>& in_ports,
     const std::unordered_map<std::string, ov::Output<const ov::Node>>& out_ports,
-    uint32_t num_tokens,
-    bool v_transposed) {
+    uint32_t num_tokens) {
     namespace uu = ov::npuw::util;
     auto& kvcache_desc = m_npuw_llm_compiled_model->m_kvcache_desc;
+    const auto& kv_seq_dims = kvcache_desc.kv_seq_dims;
     auto& compiled = request->get_compiled_model();
     // FIXME: Find only matching by names outputs and copy them, having previously checked that such inputs exist
     for (std::size_t i = layer_ids::kStartOutputKVCacheLayers; i < compiled->outputs().size(); ++i) {
@@ -29,7 +29,9 @@ void ov::npuw::LLMInferBaseRequest::update_kvcache_for(
             continue;
         }
         auto dst_tensor = request->get_tensor(in_ports.at(input_name));
-        const auto& kv_dim = (output_name.find("value") != std::string::npos && v_transposed) ? 3u : kvcache_desc.dim;
+        auto it = kv_seq_dims.find(input_name);
+        OPENVINO_ASSERT(it != kv_seq_dims.end(), "KV seq dim not found for parameter: ", input_name);
+        const uint32_t kv_dim = it->second;
         auto dst_slice = uu::make_tensor_slice(dst_tensor,
                                                kv_dim,
                                                kvcache_desc.num_stored_tokens - num_tokens,

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_base_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_base_request.hpp
@@ -52,8 +52,7 @@ protected:
     virtual void update_kvcache_for(std::shared_ptr<ov::IAsyncInferRequest> request,
                                     const PortsMap& in_ports,
                                     const PortsMap& out_ports,
-                                    uint32_t num_tokens,
-                                    bool v_transposed);
+                                    uint32_t num_tokens);
     void init_tensor(const ov::Output<const ov::Node>& port);
     void init_ports();
 

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -637,6 +637,30 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
 
         const auto prefill_chunk_size = m_npuw_llm_compiled_model->m_prefill_chunk_size;
         const bool use_chunk_prefill = m_npuw_llm_compiled_model->m_use_chunk_prefill;
+
+        // Detect per-tensor seq axis to handle heterogeneous models whose layers use
+        // different value-tensor layouts (e.g. sliding-window vs full-attention with MHA).
+        // The KV-sequence axis is the only dimension where the prefill output and the
+        // generate KV-cache input shapes differ; fall back to flag-derived dims when ambiguous.
+        const auto& pre_out_shape = prefill_out_tensor->get_shape();
+        const auto& gen_in_shape = kvcache_in_tensor->get_shape();
+        uint32_t seq_dim_pre = pre_kv_dim;
+        uint32_t seq_dim_gen = gen_kv_dim;
+        if (pre_out_shape.size() == gen_in_shape.size()) {
+            uint32_t diff_count = 0;
+            uint32_t diff_dim = 0;
+            for (uint32_t d = 0; d < pre_out_shape.size(); ++d) {
+                if (pre_out_shape[d] != gen_in_shape[d]) {
+                    ++diff_count;
+                    diff_dim = d;
+                }
+            }
+            if (diff_count == 1) {
+                seq_dim_pre = diff_dim;
+                seq_dim_gen = diff_dim;
+            }
+        }
+
         if (use_chunk_prefill) {
             // The chunk prefilled KV results are divided into two parts:
             // Part 1: The KV results from loops 1 to n-1 have been copied into the 'past' KV input tensor
@@ -659,48 +683,46 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
                                                                    m_npuw_llm_compiled_model->get_plugin());
                     prefill_past_kv->copy_to(tmp_dense_kv_tensor._ptr);
                     prefill_past_kv_chunks = make_tensor_slice(tmp_dense_kv_tensor,
-                                                               pre_kv_dim,
+                                                               seq_dim_pre,
                                                                0u,
                                                                static_cast<uint32_t>(tokens_in_past_chunks));
                 } else {
                     prefill_past_kv_chunks = make_tensor_slice(prefill_past_kv,
-                                                               pre_kv_dim,
+                                                               seq_dim_pre,
                                                                0u,
                                                                static_cast<uint32_t>(tokens_in_past_chunks));
                 }
 
                 auto kvcache_past_kv_chunks = uu::make_tensor_slice(kvcache_in_tensor,
-                                                                    gen_kv_dim,
+                                                                    seq_dim_gen,
                                                                     0u,
                                                                     static_cast<uint32_t>(tokens_in_past_chunks));
 
-                uu::copy_tensor_by_dim(prefill_past_kv_chunks, kvcache_past_kv_chunks, pre_kv_dim, gen_kv_dim);
+                uu::copy_tensor_by_dim(prefill_past_kv_chunks, kvcache_past_kv_chunks, seq_dim_pre, seq_dim_gen);
             }
 
             // Copy part 2 KV results
             auto prefill_present_kv_chunk =
                 uu::make_tensor_slice(prefill_out_tensor,
-                                      pre_kv_dim,
+                                      seq_dim_pre,
                                       static_cast<uint32_t>(prefill_chunk_size - m_tokens_in_present_chunk),
                                       static_cast<uint32_t>(prefill_chunk_size));
 
             auto kvcache_last_kv_chunk = uu::make_tensor_slice(kvcache_in_tensor,
-                                                               gen_kv_dim,
+                                                               seq_dim_gen,
                                                                static_cast<uint32_t>(tokens_in_past_chunks),
                                                                kvcache_desc.num_stored_tokens);
 
-            uu::copy_tensor_by_dim(prefill_present_kv_chunk, kvcache_last_kv_chunk, pre_kv_dim, gen_kv_dim);
+            uu::copy_tensor_by_dim(prefill_present_kv_chunk, kvcache_last_kv_chunk, seq_dim_pre, seq_dim_gen);
         } else {
+            const auto pre_seq = static_cast<uint32_t>(pre_out_shape[seq_dim_pre]);
+            const auto copy_len = std::min(kvcache_desc.num_stored_tokens, pre_seq);
             auto prefill_out_slice =
-                uu::make_tensor_slice(prefill_out_tensor,
-                                      pre_kv_dim,
-                                      kvcache_desc.max_prompt_size - kvcache_desc.num_stored_tokens,
-                                      kvcache_desc.max_prompt_size);
+                uu::make_tensor_slice(prefill_out_tensor, seq_dim_pre, pre_seq - copy_len, pre_seq);
 
-            auto kvcache_in_slice =
-                uu::make_tensor_slice(kvcache_in_tensor, gen_kv_dim, 0u, kvcache_desc.num_stored_tokens);
+            auto kvcache_in_slice = uu::make_tensor_slice(kvcache_in_tensor, seq_dim_gen, 0u, copy_len);
 
-            uu::copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, pre_kv_dim, gen_kv_dim);
+            uu::copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, seq_dim_pre, seq_dim_gen);
         }
     });
     LOG_DEBUG("Done.");
@@ -728,12 +750,32 @@ void ov::npuw::LLMInferRequest::update_kvcache_for(
                         " in output ports map, while it is expected!");
 
         auto dst_tensor = request->get_tensor(in_ports.at(input_name));
-        const auto& kv_dim = (output_name.find("value") != std::string::npos && v_transposed) ? 3u : kvcache_desc.dim;
+        auto src_tensor = request->get_tensor(out_ports.at(output_name));
+
+        // Detect per-tensor seq axis: the unique dim where present output and kvcache input
+        // shapes differ.  Fall back to the global transpose flag when ambiguous.
+        uint32_t kv_dim = (output_name.find("value") != std::string::npos && v_transposed) ? 3u : kvcache_desc.dim;
+        {
+            const auto& s = src_tensor->get_shape();
+            const auto& d = dst_tensor->get_shape();
+            if (s.size() == d.size()) {
+                uint32_t cnt = 0, detected = 0;
+                for (uint32_t i = 0; i < s.size(); ++i) {
+                    if (s[i] != d[i]) {
+                        ++cnt;
+                        detected = i;
+                    }
+                }
+                if (cnt == 1) {
+                    kv_dim = detected;
+                }
+            }
+        }
+
         auto dst_slice = uu::make_tensor_slice(dst_tensor,
                                                kv_dim,
                                                kvcache_desc.num_stored_tokens - num_tokens,
                                                kvcache_desc.num_stored_tokens);
-        auto src_tensor = request->get_tensor(out_ports.at(output_name));
 
         // NOTE: Sometimes present kv layer can contain greater seq_len
         //       than was sent to be processed

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -421,9 +421,9 @@ std::string ov::npuw::LLMInferRequest::init_pre_alloc_device() {
 }
 
 void ov::npuw::LLMInferRequest::bind_past_kv() {
-    auto& kvcache_desc = m_npuw_llm_compiled_model->m_kvcache_desc;
-    if (kvcache_desc.v_tensors_transposed_pre != kvcache_desc.v_tensors_transposed_gen) {
-        // FIXME: disable kv cache sharing when one of the models is transposed for now
+    const auto& kvcache_desc = m_npuw_llm_compiled_model->m_kvcache_desc;
+    if (kvcache_desc.kv_seq_dims != kvcache_desc.kv_seq_dims_gen) {
+        // Different layouts require an explicit copy/transpose between prefill and generate.
         return;
     }
 
@@ -632,7 +632,11 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
         auto it = kv_seq_dims.find(input_name);
         OPENVINO_ASSERT(it != kv_seq_dims.end(), "KV seq dim not found for parameter: ", input_name);
         const uint32_t seq_dim_pre = it->second;
-        const uint32_t seq_dim_gen = seq_dim_pre;
+
+        const auto& kv_seq_dims_gen = m_npuw_llm_compiled_model->m_kvcache_desc.kv_seq_dims_gen;
+        auto it_gen = kv_seq_dims_gen.find(input_name);
+        OPENVINO_ASSERT(it_gen != kv_seq_dims_gen.end(), "KV seq dim (gen) not found for parameter: ", input_name);
+        const uint32_t seq_dim_gen = it_gen->second;
 
         const auto prefill_chunk_size = m_npuw_llm_compiled_model->m_prefill_chunk_size;
         const bool use_chunk_prefill = m_npuw_llm_compiled_model->m_use_chunk_prefill;
@@ -699,7 +703,9 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
             auto prefill_out_slice =
                 uu::make_tensor_slice(prefill_out_tensor, seq_dim_pre, pre_seq - copy_len, pre_seq);
 
-            auto kvcache_in_slice = uu::make_tensor_slice(kvcache_in_tensor, seq_dim_gen, 0u, copy_len);
+            const auto dst_begin = kvcache_desc.num_stored_tokens - copy_len;
+            auto kvcache_in_slice =
+                uu::make_tensor_slice(kvcache_in_tensor, seq_dim_gen, dst_begin, kvcache_desc.num_stored_tokens);
 
             uu::copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, seq_dim_pre, seq_dim_gen);
         }
@@ -730,8 +736,10 @@ void ov::npuw::LLMInferRequest::update_kvcache_for(
         auto dst_tensor = request->get_tensor(in_ports.at(input_name));
         auto src_tensor = request->get_tensor(out_ports.at(output_name));
 
-        // Look up per-parameter seq dim from compile-time analysis.
-        const auto& kv_seq_dims = m_npuw_llm_compiled_model->m_kvcache_desc.kv_seq_dims;
+        // Choose the correct seq dim map: prefill or generate side.
+        const bool is_prefill = (request == m_prefill_request);
+        const auto& kv_seq_dims = is_prefill ? m_npuw_llm_compiled_model->m_kvcache_desc.kv_seq_dims
+                                             : m_npuw_llm_compiled_model->m_kvcache_desc.kv_seq_dims_gen;
         auto it = kv_seq_dims.find(input_name);
         OPENVINO_ASSERT(it != kv_seq_dims.end(), "KV seq dim not found for parameter: ", input_name);
         const uint32_t kv_dim = it->second;

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -627,16 +627,16 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
                         " not found in prefill model outputs.");
         auto prefill_out_tensor = m_prefill_request->get_tensor(m_prefill_out_ports.at(output_name));
 
-        const auto is_value_tensor = output_name.find("value") != std::string::npos;
-        const auto kv_dim = [&](bool v_trans) -> uint32_t {
-            return (is_value_tensor && v_trans) ? 3u : kvcache_desc.dim;
-        };
-
-        const auto& pre_kv_dim = kv_dim(kvcache_desc.v_tensors_transposed_pre);
-        const auto& gen_kv_dim = kv_dim(kvcache_desc.v_tensors_transposed_gen);
+        // Look up per-parameter seq dim from compile-time analysis.
+        const auto& kv_seq_dims = m_npuw_llm_compiled_model->m_kvcache_desc.kv_seq_dims;
+        auto it = kv_seq_dims.find(input_name);
+        OPENVINO_ASSERT(it != kv_seq_dims.end(), "KV seq dim not found for parameter: ", input_name);
+        const uint32_t seq_dim_pre = it->second;
+        const uint32_t seq_dim_gen = seq_dim_pre;
 
         const auto prefill_chunk_size = m_npuw_llm_compiled_model->m_prefill_chunk_size;
         const bool use_chunk_prefill = m_npuw_llm_compiled_model->m_use_chunk_prefill;
+
         if (use_chunk_prefill) {
             // The chunk prefilled KV results are divided into two parts:
             // Part 1: The KV results from loops 1 to n-1 have been copied into the 'past' KV input tensor
@@ -659,48 +659,49 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
                                                                    m_npuw_llm_compiled_model->get_plugin());
                     prefill_past_kv->copy_to(tmp_dense_kv_tensor._ptr);
                     prefill_past_kv_chunks = make_tensor_slice(tmp_dense_kv_tensor,
-                                                               pre_kv_dim,
+                                                               seq_dim_pre,
                                                                0u,
                                                                static_cast<uint32_t>(tokens_in_past_chunks));
                 } else {
                     prefill_past_kv_chunks = make_tensor_slice(prefill_past_kv,
-                                                               pre_kv_dim,
+                                                               seq_dim_pre,
                                                                0u,
                                                                static_cast<uint32_t>(tokens_in_past_chunks));
                 }
 
                 auto kvcache_past_kv_chunks = uu::make_tensor_slice(kvcache_in_tensor,
-                                                                    gen_kv_dim,
+                                                                    seq_dim_gen,
                                                                     0u,
                                                                     static_cast<uint32_t>(tokens_in_past_chunks));
 
-                uu::copy_tensor_by_dim(prefill_past_kv_chunks, kvcache_past_kv_chunks, pre_kv_dim, gen_kv_dim);
+                uu::copy_tensor_by_dim(prefill_past_kv_chunks, kvcache_past_kv_chunks, seq_dim_pre, seq_dim_gen);
             }
 
             // Copy part 2 KV results
             auto prefill_present_kv_chunk =
                 uu::make_tensor_slice(prefill_out_tensor,
-                                      pre_kv_dim,
+                                      seq_dim_pre,
                                       static_cast<uint32_t>(prefill_chunk_size - m_tokens_in_present_chunk),
                                       static_cast<uint32_t>(prefill_chunk_size));
 
             auto kvcache_last_kv_chunk = uu::make_tensor_slice(kvcache_in_tensor,
-                                                               gen_kv_dim,
+                                                               seq_dim_gen,
                                                                static_cast<uint32_t>(tokens_in_past_chunks),
                                                                kvcache_desc.num_stored_tokens);
 
-            uu::copy_tensor_by_dim(prefill_present_kv_chunk, kvcache_last_kv_chunk, pre_kv_dim, gen_kv_dim);
+            uu::copy_tensor_by_dim(prefill_present_kv_chunk, kvcache_last_kv_chunk, seq_dim_pre, seq_dim_gen);
         } else {
+            // For SWA (sliding-window attention) layers, prefill output seq_len may be shorter
+            // than num_stored_tokens because only the last window_size tokens are retained.
+            // Use min(num_stored_tokens, pre_seq) to copy only what was actually produced.
+            const auto pre_seq = static_cast<uint32_t>(prefill_out_tensor->get_shape()[seq_dim_pre]);
+            const auto copy_len = std::min(kvcache_desc.num_stored_tokens, pre_seq);
             auto prefill_out_slice =
-                uu::make_tensor_slice(prefill_out_tensor,
-                                      pre_kv_dim,
-                                      kvcache_desc.max_prompt_size - kvcache_desc.num_stored_tokens,
-                                      kvcache_desc.max_prompt_size);
+                uu::make_tensor_slice(prefill_out_tensor, seq_dim_pre, pre_seq - copy_len, pre_seq);
 
-            auto kvcache_in_slice =
-                uu::make_tensor_slice(kvcache_in_tensor, gen_kv_dim, 0u, kvcache_desc.num_stored_tokens);
+            auto kvcache_in_slice = uu::make_tensor_slice(kvcache_in_tensor, seq_dim_gen, 0u, copy_len);
 
-            uu::copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, pre_kv_dim, gen_kv_dim);
+            uu::copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, seq_dim_pre, seq_dim_gen);
         }
     });
     LOG_DEBUG("Done.");
@@ -710,8 +711,7 @@ void ov::npuw::LLMInferRequest::update_kvcache_for(
     std::shared_ptr<ov::IAsyncInferRequest> request,
     const std::unordered_map<std::string, ov::Output<const ov::Node>>& in_ports,
     const std::unordered_map<std::string, ov::Output<const ov::Node>>& out_ports,
-    uint32_t num_tokens,
-    bool v_transposed) {
+    uint32_t num_tokens) {
     namespace uu = ov::npuw::util;
     auto& kvcache_desc = m_npuw_llm_compiled_model->m_kvcache_desc;
 
@@ -728,12 +728,18 @@ void ov::npuw::LLMInferRequest::update_kvcache_for(
                         " in output ports map, while it is expected!");
 
         auto dst_tensor = request->get_tensor(in_ports.at(input_name));
-        const auto& kv_dim = (output_name.find("value") != std::string::npos && v_transposed) ? 3u : kvcache_desc.dim;
+        auto src_tensor = request->get_tensor(out_ports.at(output_name));
+
+        // Look up per-parameter seq dim from compile-time analysis.
+        const auto& kv_seq_dims = m_npuw_llm_compiled_model->m_kvcache_desc.kv_seq_dims;
+        auto it = kv_seq_dims.find(input_name);
+        OPENVINO_ASSERT(it != kv_seq_dims.end(), "KV seq dim not found for parameter: ", input_name);
+        const uint32_t kv_dim = it->second;
+
         auto dst_slice = uu::make_tensor_slice(dst_tensor,
                                                kv_dim,
                                                kvcache_desc.num_stored_tokens - num_tokens,
                                                kvcache_desc.num_stored_tokens);
-        auto src_tensor = request->get_tensor(out_ports.at(output_name));
 
         // NOTE: Sometimes present kv layer can contain greater seq_len
         //       than was sent to be processed

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.hpp
@@ -47,8 +47,7 @@ protected:
     void update_kvcache_for(std::shared_ptr<ov::IAsyncInferRequest> request,
                             const PortsMap& in_ports,
                             const PortsMap& out_ports,
-                            uint32_t num_tokens,
-                            bool v_transposed) override;
+                            uint32_t num_tokens) override;
     void copy_lincache(std::shared_ptr<ov::IAsyncInferRequest> from_request,
                        std::shared_ptr<ov::IAsyncInferRequest> to_request,
                        const std::unordered_map<std::string, ov::Output<const ov::Node>>& from_ports,

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/split_kvcache_into_blocks.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/split_kvcache_into_blocks.cpp
@@ -10,7 +10,6 @@
 #include "../util.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/node.hpp"
-#include "openvino/core/rt_info.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/parameter.hpp"
@@ -19,22 +18,6 @@ namespace ov {
 namespace npuw {
 namespace pass {
 
-namespace {
-
-// Information collected in the scan phase; all fields are pre-computed so the
-// transform phase never needs to re-query the parameter name.
-struct KVCacheTransformInfo {
-    std::shared_ptr<ov::op::v0::Parameter> param;
-    std::shared_ptr<ov::op::v0::Concat> concat;
-    ov::Output<ov::Node> present_kv_input;
-    std::shared_ptr<ov::Node> convert_node;  // nullptr when Parameter→Concat directly
-    bool is_key;                             // true = K tensor
-    bool is_value;                           // true = V tensor
-    int64_t concat_axis;                     // sequence dimension index in the concat
-};
-
-// Walk a parameter's consumers to find the Concat it feeds (directly or via Convert).
-// Returns {concat, convert_node}; concat is nullptr if the pattern is not found.
 std::pair<std::shared_ptr<ov::op::v0::Concat>, std::shared_ptr<ov::Node>> find_concat_for_param(
     const std::shared_ptr<ov::op::v0::Parameter>& param) {
     for (const auto& output : param->outputs()) {
@@ -58,6 +41,19 @@ std::pair<std::shared_ptr<ov::op::v0::Concat>, std::shared_ptr<ov::Node>> find_c
     return {nullptr, nullptr};
 }
 
+namespace {
+
+// Information collected in the scan phase, all fields are pre-computed
+struct KVCacheTransformInfo {
+    std::shared_ptr<ov::op::v0::Parameter> param;
+    std::shared_ptr<ov::op::v0::Concat> concat;
+    ov::Output<ov::Node> present_kv_input;
+    std::shared_ptr<ov::Node> convert_node;  // nullptr when Parameter→Concat directly
+    bool is_key;                             // true = K tensor
+    bool is_value;                           // true = V tensor
+    int64_t concat_axis;                     // sequence dimension index in the concat
+};
+
 // Build a 4D block shape.  seq_dim is the axis holding the sequence (2 or 3);
 // all other dims are copied from orig_shape.
 ov::Shape make_block_shape(const ov::PartialShape& orig_shape, int64_t seq_dim, size_t seq_size) {
@@ -70,9 +66,7 @@ ov::Shape make_block_shape(const ov::PartialShape& orig_shape, int64_t seq_dim, 
 
 }  // namespace
 
-SplitKVCacheIntoBlocks::SplitKVCacheIntoBlocks(uint32_t block_size, bool v_transposed)
-    : m_block_size(block_size),
-      m_v_transposed(v_transposed) {}
+SplitKVCacheIntoBlocks::SplitKVCacheIntoBlocks(uint32_t block_size) : m_block_size(block_size) {}
 
 bool SplitKVCacheIntoBlocks::run_on_model(const std::shared_ptr<ov::Model>& model) {
     bool model_changed = false;
@@ -83,11 +77,14 @@ bool SplitKVCacheIntoBlocks::run_on_model(const std::shared_ptr<ov::Model>& mode
     for (const auto& param : model->get_parameters()) {
         const std::string& name = param->get_friendly_name();
 
-        const bool is_key = ov::npuw::util::isPastKeyValuesKeyContiguous(name).has_value();
-        const bool is_value = ov::npuw::util::isPastKeyValuesValueContiguous(name).has_value();
+        auto key_layer = ov::npuw::util::isPastKeyValuesKeyContiguous(name);
+        auto value_layer = ov::npuw::util::isPastKeyValuesValueContiguous(name);
+        const bool is_key = key_layer.has_value();
+        const bool is_value = value_layer.has_value();
         if (!is_key && !is_value) {
             continue;  // not a contiguous KV cache parameter
         }
+        LOG_DEBUG("SplitKVCacheIntoBlocks: found " << (is_key ? "key" : "value") << " param '" << name << "'");
 
         // Shape must be 4D and fully static before we can proceed.
         const auto& orig_shape = param->get_partial_shape();
@@ -124,8 +121,12 @@ bool SplitKVCacheIntoBlocks::run_on_model(const std::shared_ptr<ov::Model>& mode
             continue;
         }
 
-        // Pre-compute the concat axis (sequence dimension) once.
-        const int64_t concat_axis = (is_key || (is_value && !m_v_transposed)) ? 2 : 3;
+        // Use the axis from the existing Concat — it already reflects the correct
+        // sequence dimension for this specific layer (handles mixed transposed/non-transposed V).
+        // Normalize negative axis (e.g. -2 → 2 for 4D tensors).
+        const int64_t raw_axis = concat->get_axis();
+        const int64_t rank = static_cast<int64_t>(orig_shape.rank().get_length());
+        const int64_t concat_axis = (raw_axis < 0) ? raw_axis + rank : raw_axis;
 
         params_to_transform.push_back({param, concat, present_kv_input, convert_node, is_key, is_value, concat_axis});
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/split_kvcache_into_blocks.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/split_kvcache_into_blocks.hpp
@@ -4,11 +4,20 @@
 
 #pragma once
 
+#include <memory>
+#include <utility>
+
+#include "openvino/op/concat.hpp"
+#include "openvino/op/parameter.hpp"
 #include "openvino/pass/pass.hpp"
 
 namespace ov {
 namespace npuw {
 namespace pass {
+
+// Walk a parameter's consumers to find the Concat it feeds (directly or via Convert).
+std::pair<std::shared_ptr<ov::op::v0::Concat>, std::shared_ptr<ov::Node>> find_concat_for_param(
+    const std::shared_ptr<ov::op::v0::Parameter>& param);
 
 /**
  * @brief Transformation pass to split KV cache access into block-based pattern
@@ -54,18 +63,16 @@ public:
      * @brief Construct transformation with block configuration
      *
      * @param block_size Number of tokens per block (default: 1024 for efficiency)
-     * @param v_transposed Whether V tensor is transposed (true: [B,H,D,S], false: [B,H,S,D])
      *
      * The number of blocks is automatically calculated from the original past_key shape.
      * If the sequence length is not evenly divisible by block_size, a tail block is created.
      */
-    explicit SplitKVCacheIntoBlocks(uint32_t block_size = 1024, bool v_transposed = true);
+    explicit SplitKVCacheIntoBlocks(uint32_t block_size = 1024);
 
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 
 private:
     uint32_t m_block_size;
-    bool m_v_transposed;
 };
 
 }  // namespace pass

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -52,7 +52,7 @@ const constexpr ov::npuw::s11n::IndicatorType NPUW_GQA_COMPILED_MODEL_INDICATOR 
 const constexpr ov::npuw::s11n::IndicatorType NPUW_FLUX2_COMPILED_MODEL_INDICATOR =
     {char{0x46}, char{0x4c}, char{0x32}, char{0x43}, char{0x4d}, char{0x4f}};
 
-const constexpr char* NPUW_SERIALIZATION_VERSION = "0.29";
+const constexpr char* NPUW_SERIALIZATION_VERSION = "0.30";
 
 // Forward declaration
 namespace intel_npu {

--- a/src/plugins/intel_npu/tests/unit/npuw/duplicate_shared_kv_concat_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/duplicate_shared_kv_concat_test.cpp
@@ -202,7 +202,7 @@ TEST_F(DuplicateSharedKVConcatTest, Integration_SplitThenDuplicate) {
 
     // Step 1: seq=32 → block_0 + block_1 + current_k (3 params, 1 Concat, fan-out unchanged).
     ov::pass::Manager mgr;
-    mgr.register_pass<ov::npuw::pass::SplitKVCacheIntoBlocks>(/*block_size=*/16u, /*v_transposed=*/false);
+    mgr.register_pass<ov::npuw::pass::SplitKVCacheIntoBlocks>(/*block_size=*/16u);
     EXPECT_TRUE(mgr.run_passes(model));
     EXPECT_EQ(model->get_parameters().size(), 3u);
     EXPECT_EQ(count_ops<ov::op::v0::Concat>(model), 1u);

--- a/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/kv_cache_block_manager_test.cpp
@@ -28,7 +28,8 @@ protected:
         device = "CPU";  // Use CPU for unit tests
 
         // Pass nullptr for plugin since CPU device doesn't need it in allocMem
-        manager = std::make_unique<KVCacheBlockManager>(block_size, max_blocks, base_shape, elem_type, device, nullptr);
+        manager =
+            std::make_unique<KVCacheBlockManager>(block_size, max_blocks, base_shape, elem_type, device, nullptr, 2u);
     }
 
     void TearDown() override {
@@ -346,16 +347,16 @@ TEST_F(KVCacheBlockManagerTest, InvalidConstructorParams) {
     const ov::Shape valid_shape{1, 32, 512, 128};
 
     // block_size = 0 must throw
-    EXPECT_THROW(KVCacheBlockManager(0u, 8u, valid_shape, ov::element::f16, "CPU", nullptr), ov::Exception)
+    EXPECT_THROW(KVCacheBlockManager(0u, 8u, valid_shape, ov::element::f16, "CPU", nullptr, 2u), ov::Exception)
         << "block_size=0 must throw";
 
     // max_blocks = 0 must throw
-    EXPECT_THROW(KVCacheBlockManager(512u, 0u, valid_shape, ov::element::f16, "CPU", nullptr), ov::Exception)
+    EXPECT_THROW(KVCacheBlockManager(512u, 0u, valid_shape, ov::element::f16, "CPU", nullptr, 2u), ov::Exception)
         << "max_blocks=0 must throw";
 
     // Shape with no dimension equal to block_size must throw
     const ov::Shape bad_shape{1, 32, 256, 128};  // neither dim[2]=256 nor dim[3]=128 equals 512
-    EXPECT_THROW(KVCacheBlockManager(512u, 8u, bad_shape, ov::element::f16, "CPU", nullptr), ov::Exception)
+    EXPECT_THROW(KVCacheBlockManager(512u, 8u, bad_shape, ov::element::f16, "CPU", nullptr, 2u), ov::Exception)
         << "Shape not containing block_size must throw";
 }
 
@@ -393,6 +394,43 @@ TEST_F(KVCacheBlockManagerTest, NumFreeBlocks) {
         manager->allocate_block();
     }
     EXPECT_EQ(manager->num_free_blocks(), 0u);
+}
+
+TEST_F(KVCacheBlockManagerTest, SeqDimDetection_Dim2) {
+    // base_shape = [1, 32, block_size, 128] → seq is at dim 2
+    EXPECT_EQ(manager->get_seq_dim(), 2u);
+}
+
+TEST(KVCacheBlockManagerSeqDimTest, SeqDimDetection_Dim3) {
+    // Transposed V layout: [1, 8, 256, block_size] → seq is at dim 3
+    uint32_t block_size = 512;
+    ov::Shape transposed_shape{1, 8, 256, block_size};
+    KVCacheBlockManager mgr(block_size, 4, transposed_shape, ov::element::f16, "CPU", nullptr, 3u);
+    EXPECT_EQ(mgr.get_seq_dim(), 3u);
+}
+
+TEST(KVCacheBlockManagerSeqDimTest, SeqDim_AmbiguousShapeWithExplicitAxis) {
+    // Both dim 2 and dim 3 equal block_size — caller must specify the correct axis.
+    uint32_t block_size = 256;
+    ov::Shape ambiguous_shape{1, 8, block_size, block_size};
+    KVCacheBlockManager mgr2(block_size, 4, ambiguous_shape, ov::element::f16, "CPU", nullptr, 2u);
+    EXPECT_EQ(mgr2.get_seq_dim(), 2u);
+    KVCacheBlockManager mgr3(block_size, 4, ambiguous_shape, ov::element::f16, "CPU", nullptr, 3u);
+    EXPECT_EQ(mgr3.get_seq_dim(), 3u);
+}
+
+TEST(KVCacheBlockManagerSeqDimTest, SeqDim_MismatchThrows) {
+    // seq_dim points to a dimension that does NOT equal block_size — must throw.
+    uint32_t block_size = 512;
+    ov::Shape shape{1, 8, 256, block_size};  // seq at dim 3, dim 2 = 256
+    EXPECT_ANY_THROW(KVCacheBlockManager(block_size, 4, shape, ov::element::f16, "CPU", nullptr, 2u));
+}
+
+TEST(KVCacheBlockManagerSeqDimTest, SeqDim_InvalidAxisThrows) {
+    uint32_t block_size = 512;
+    ov::Shape shape{1, 8, block_size, 128};
+    EXPECT_ANY_THROW(KVCacheBlockManager(block_size, 4, shape, ov::element::f16, "CPU", nullptr, 0u));
+    EXPECT_ANY_THROW(KVCacheBlockManager(block_size, 4, shape, ov::element::f16, "CPU", nullptr, 1u));
 }
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_infer_request_variant_switch_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_infer_request_variant_switch_test.cpp
@@ -8,15 +8,17 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <regex>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "executor.hpp"
+#include "infer_request_utils.hpp"
 #include "llm_block_kvcache_strategy.hpp"
-#include "llm_infer_request.hpp"
 #include "llm_compiled_model.hpp"
+#include "llm_infer_request.hpp"
 #include "llm_test_helpers.hpp"
 #include "openvino/openvino.hpp"
 #include "util.hpp"
@@ -38,13 +40,50 @@ struct LLMVariantSwitchTestAccess {
         return compiled->m_is_block_kv_cache;
     }
 
-    static void set_num_stored_tokens(const std::shared_ptr<ov::npuw::LLMCompiledModel>& compiled, uint32_t num_tokens) {
+    static const auto& prefill_kv_seq_dims(const std::shared_ptr<ov::npuw::LLMCompiledModel>& compiled) {
+        return compiled->m_kvcache_desc.kv_seq_dims;
+    }
+
+    static const auto& generate_kv_seq_dims(const std::shared_ptr<ov::npuw::LLMCompiledModel>& compiled) {
+        return compiled->m_kvcache_desc.kv_seq_dims_gen;
+    }
+
+    static void set_num_stored_tokens(const std::shared_ptr<ov::npuw::LLMCompiledModel>& compiled,
+                                      uint32_t num_tokens) {
         compiled->m_kvcache_desc.num_stored_tokens = num_tokens;
     }
 
     static uint32_t kv_dim_for_name(const ov::npuw::LLMInferRequest& req, const std::string& name) {
         const auto& desc = req.m_npuw_llm_compiled_model->m_kvcache_desc;
-        return (ov::npuw::util::isPastValueParam(name) && desc.v_tensors_transposed_gen) ? 3u : desc.dim;
+        return desc.kv_seq_dims_gen.at(name);
+    }
+
+    static void set_kv_seq_dims(const std::shared_ptr<ov::npuw::LLMCompiledModel>& compiled,
+                                const std::string& name,
+                                uint32_t prefill_dim,
+                                uint32_t generate_dim) {
+        compiled->m_kvcache_desc.kv_seq_dims.at(name) = prefill_dim;
+        compiled->m_kvcache_desc.kv_seq_dims_gen.at(name) = generate_dim;
+    }
+
+    static const auto& prefill_request(const ov::npuw::LLMInferRequest& req) {
+        return req.m_prefill_request;
+    }
+
+    static const auto& prefill_out_ports(const ov::npuw::LLMInferRequest& req) {
+        return req.m_prefill_out_ports;
+    }
+
+    static void copy_kvcache(ov::npuw::LLMInferRequest& req) {
+        req.copy_kvcache();
+    }
+
+    static void bind_past_kv(ov::npuw::LLMInferRequest& req) {
+        req.bind_past_kv();
+    }
+
+    static bool past_kv_bound(const ov::npuw::LLMInferRequest& req) {
+        return req.m_past_kv_bound;
     }
 
     static void select_smallest_generate_variant(ov::npuw::LLMInferRequest& req) {
@@ -163,8 +202,9 @@ FakeSubInferRequest::FakeSubInferRequest(std::shared_ptr<const FakeSubCompiledMo
                                           ov::get_tensor_impl(ov::Tensor(input.get_element_type(), input.get_shape())));
     }
     for (const auto& output : get_compiled_model()->outputs()) {
-        ov::ISyncInferRequest::set_tensor(output,
-                                          ov::get_tensor_impl(ov::Tensor(output.get_element_type(), output.get_shape())));
+        ov::ISyncInferRequest::set_tensor(
+            output,
+            ov::get_tensor_impl(ov::Tensor(output.get_element_type(), output.get_shape())));
     }
 }
 
@@ -235,6 +275,121 @@ protected:
     std::shared_ptr<ov::IPlugin> m_plugin;
 };
 
+TEST_F(LLMInferRequestVariantSwitchTest, NonChunkPrefillPreservesKvSequenceDimensions) {
+    VariantSwitchFactory factory;
+    auto compiled = create_compiled_model({}, factory);
+
+    const auto& prefill_dims = LLMVariantSwitchTestAccess::prefill_kv_seq_dims(compiled);
+    const auto& generate_dims = LLMVariantSwitchTestAccess::generate_kv_seq_dims(compiled);
+    EXPECT_FALSE(prefill_dims.empty());
+    EXPECT_EQ(prefill_dims, generate_dims);
+}
+
+TEST(LLMKvCacheCopyTest, TransposesDataWhenSequenceDimensionDiffers) {
+    const ov::Shape src_shape{1, 2, 3, 4};
+    const ov::Shape dst_shape{1, 2, 4, 3};
+    ov::Tensor src(ov::element::i32, src_shape);
+    ov::Tensor dst(ov::element::i32, dst_shape);
+
+    auto* src_data = src.data<int32_t>();
+    for (size_t idx = 0; idx < src.get_size(); ++idx) {
+        src_data[idx] = static_cast<int32_t>(idx);
+    }
+
+    auto src_impl = ov::get_tensor_impl(src);
+    auto dst_impl = ov::get_tensor_impl(dst);
+    ov::npuw::util::copy_tensor_by_dim(src_impl, dst_impl, 2u, 3u);
+
+    const auto* dst_data = dst.data<const int32_t>();
+    for (size_t head = 0; head < src_shape[1]; ++head) {
+        for (size_t seq = 0; seq < src_shape[2]; ++seq) {
+            for (size_t dim = 0; dim < src_shape[3]; ++dim) {
+                const size_t src_idx = (head * src_shape[2] + seq) * src_shape[3] + dim;
+                const size_t dst_idx = (head * dst_shape[2] + dim) * dst_shape[3] + seq;
+                EXPECT_EQ(dst_data[dst_idx], src_data[src_idx]);
+            }
+        }
+    }
+}
+
+TEST_F(LLMInferRequestVariantSwitchTest, CopyKvCacheTransposesAndAlignsShortPrefillOutputToStoredTail) {
+    VariantSwitchFactory factory;
+    auto compiled = create_compiled_model({}, factory);
+    ov::npuw::LLMInferRequest req(compiled);
+
+    const auto& past_names = LLMVariantSwitchTestAccess::kvcache_past_names(req);
+    const auto value_it = std::find_if(past_names.begin(), past_names.end(), ov::npuw::util::isPastValueParam);
+    ASSERT_NE(value_it, past_names.end());
+    const auto& input_name = *value_it;
+    const auto output_name =
+        std::regex_replace(input_name, std::regex(ov::npuw::LLMInferRequest::layer_names::past_key_values), "present");
+
+    auto dst = LLMVariantSwitchTestAccess::kvcache_request(req)->get_tensor(
+        LLMVariantSwitchTestAccess::kvcache_in_ports(req).at(input_name));
+    const uint32_t generate_dim = LLMVariantSwitchTestAccess::generate_kv_seq_dims(compiled).at(input_name);
+    ASSERT_TRUE(generate_dim == 2u || generate_dim == 3u);
+    const uint32_t prefill_dim = generate_dim == 2u ? 3u : 2u;
+    LLMVariantSwitchTestAccess::set_kv_seq_dims(compiled, input_name, prefill_dim, generate_dim);
+
+    constexpr uint32_t stored_tokens = 5u;
+    constexpr uint32_t produced_tokens = 3u;
+    ASSERT_GE(dst->get_shape()[generate_dim], stored_tokens);
+    auto src_shape = dst->get_shape();
+    std::swap(src_shape[2], src_shape[3]);
+    src_shape[prefill_dim] = produced_tokens;
+    auto src = ov::get_tensor_impl(ov::Tensor(dst->get_element_type(), src_shape));
+    fill_tensor_pattern(src, 31u);
+    LLMVariantSwitchTestAccess::prefill_request(req)->set_tensor(
+        LLMVariantSwitchTestAccess::prefill_out_ports(req).at(output_name),
+        src);
+    ov::npuw::util::fill_tensor_bytes(dst, 0u);
+    LLMVariantSwitchTestAccess::set_num_stored_tokens(compiled, stored_tokens);
+
+    auto expected_shape = dst->get_shape();
+    expected_shape[generate_dim] = produced_tokens;
+    auto expected = ov::get_tensor_impl(ov::Tensor(dst->get_element_type(), expected_shape));
+    ov::npuw::util::copy_tensor_by_dim(src, expected, prefill_dim, generate_dim);
+
+    LLMVariantSwitchTestAccess::copy_kvcache(req);
+
+    auto prefix = ov::npuw::util::make_tensor_slice(dst, generate_dim, 0u, stored_tokens - produced_tokens);
+    const auto prefix_bytes = materialize_bytes(prefix);
+    EXPECT_TRUE(std::all_of(prefix_bytes.begin(), prefix_bytes.end(), [](uint8_t value) {
+        return value == 0u;
+    }));
+    auto copied_tail =
+        ov::npuw::util::make_tensor_slice(dst, generate_dim, stored_tokens - produced_tokens, stored_tokens);
+    EXPECT_EQ(materialize_bytes(copied_tail), materialize_bytes(expected));
+}
+
+TEST_F(LLMInferRequestVariantSwitchTest, DifferentPerParameterAxesDisablePrefillGenerateBufferSharing) {
+    VariantSwitchFactory factory;
+    auto compiled = create_compiled_model({}, factory);
+    ov::npuw::LLMInferRequest req(compiled);
+    const auto& name = LLMVariantSwitchTestAccess::kvcache_past_names(req).front();
+    const auto generate_dim = LLMVariantSwitchTestAccess::generate_kv_seq_dims(compiled).at(name);
+    LLMVariantSwitchTestAccess::set_kv_seq_dims(compiled, name, generate_dim == 2u ? 3u : 2u, generate_dim);
+
+    LLMVariantSwitchTestAccess::bind_past_kv(req);
+
+    EXPECT_FALSE(LLMVariantSwitchTestAccess::past_kv_bound(req));
+}
+
+TEST_F(LLMInferRequestVariantSwitchTest, BlockKvFallsBackWhenPrefillAndGenerateAxesDiffer) {
+    VariantSwitchFactory factory;
+    auto compiled = create_compiled_model({{"NPUW_LLM_PREFILL_HINT", "DYNAMIC"},
+                                           {"NPUW_LLM_PREFILL_CHUNK_SIZE", "512"},
+                                           {"NPUW_LLM_PREFILL_ATTENTION_HINT", "PYRAMID"},
+                                           {"NPUW_LLM_GENERATE_ATTENTION_HINT", "DYNAMIC"},
+                                           {"NPUW_LLM_ENABLE_BLOCK_BASED_KV_CACHE", "YES"}},
+                                          factory);
+
+    ASSERT_NE(compiled, nullptr);
+    ASSERT_NE(LLMVariantSwitchTestAccess::prefill_kv_seq_dims(compiled),
+              LLMVariantSwitchTestAccess::generate_kv_seq_dims(compiled));
+    EXPECT_FALSE(LLMVariantSwitchTestAccess::is_block_kv_cache(compiled));
+}
+
 TEST_F(LLMInferRequestVariantSwitchTest, ContinuousKvSwitchMigratesStoredTokensToLargerVariant) {
     VariantSwitchFactory factory;
     auto compiled = create_compiled_model({}, factory);
@@ -252,8 +407,10 @@ TEST_F(LLMInferRequestVariantSwitchTest, ContinuousKvSwitchMigratesStoredTokensT
     for (const auto& name : LLMVariantSwitchTestAccess::kvcache_past_names(req)) {
         auto src = LLMVariantSwitchTestAccess::kvcache_request(req)->get_tensor(
             LLMVariantSwitchTestAccess::kvcache_in_ports(req).at(name));
-        auto src_slice = ov::npuw::util::make_tensor_slice(
-            src, LLMVariantSwitchTestAccess::kv_dim_for_name(req, name), 0u, stored_tokens);
+        auto src_slice = ov::npuw::util::make_tensor_slice(src,
+                                                           LLMVariantSwitchTestAccess::kv_dim_for_name(req, name),
+                                                           0u,
+                                                           stored_tokens);
         fill_tensor_pattern(src_slice, seed);
         expected_kv_bytes.emplace(name, materialize_bytes(src_slice));
         seed = static_cast<uint8_t>(seed + 37u);
@@ -265,8 +422,10 @@ TEST_F(LLMInferRequestVariantSwitchTest, ContinuousKvSwitchMigratesStoredTokensT
     for (const auto& name : LLMVariantSwitchTestAccess::kvcache_past_names(req)) {
         auto dst = LLMVariantSwitchTestAccess::kvcache_request(req)->get_tensor(
             LLMVariantSwitchTestAccess::kvcache_in_ports(req).at(name));
-        auto dst_slice = ov::npuw::util::make_tensor_slice(
-            dst, LLMVariantSwitchTestAccess::kv_dim_for_name(req, name), 0u, stored_tokens);
+        auto dst_slice = ov::npuw::util::make_tensor_slice(dst,
+                                                           LLMVariantSwitchTestAccess::kv_dim_for_name(req, name),
+                                                           0u,
+                                                           stored_tokens);
         EXPECT_EQ(materialize_bytes(dst_slice), expected_kv_bytes.at(name)) << name;
     }
 }
@@ -282,11 +441,11 @@ TEST_F(LLMInferRequestVariantSwitchTest, BlockKvVariantsExposeCompatibleBindings
     ASSERT_NE(compiled, nullptr);
     ASSERT_EQ(LLMVariantSwitchTestAccess::generate_variant_count(compiled), 2u);
     ASSERT_TRUE(LLMVariantSwitchTestAccess::is_block_kv_cache(compiled));
-    auto small_variant = std::dynamic_pointer_cast<FakeSubCompiledModel>(
-        LLMVariantSwitchTestAccess::generate_variant(compiled, 0u));
-    auto large_variant = std::dynamic_pointer_cast<FakeSubCompiledModel>(
-        LLMVariantSwitchTestAccess::generate_variant(compiled,
-                                                     LLMVariantSwitchTestAccess::generate_variant_count(compiled) - 1u));
+    auto small_variant =
+        std::dynamic_pointer_cast<FakeSubCompiledModel>(LLMVariantSwitchTestAccess::generate_variant(compiled, 0u));
+    auto large_variant = std::dynamic_pointer_cast<FakeSubCompiledModel>(LLMVariantSwitchTestAccess::generate_variant(
+        compiled,
+        LLMVariantSwitchTestAccess::generate_variant_count(compiled) - 1u));
     ASSERT_NE(small_variant, nullptr);
     ASSERT_NE(large_variant, nullptr);
 

--- a/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_test.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "pyramid_attention.hpp"
+
 #include <gtest/gtest.h>
 
 #include <map>
@@ -10,6 +12,8 @@
 #include <variant>
 #include <vector>
 
+#include "npuw_transformations/convert_kvcache_to_precision.hpp"
+#include "npuw_transformations/split_kvcache_into_blocks.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
@@ -18,9 +22,6 @@
 #include "openvino/op/result.hpp"
 #include "openvino/op/softmax.hpp"
 #include "openvino/openvino.hpp"
-#include "npuw_transformations/convert_kvcache_to_precision.hpp"
-#include "npuw_transformations/split_kvcache_into_blocks.hpp"
-#include "pyramid_attention.hpp"
 #include "util.hpp"
 
 namespace {
@@ -122,12 +123,11 @@ const ov::npuw::function::PyramidValidationBlockResult& get_block_result(
     return std::get<ov::npuw::function::PyramidValidationBlockResult>(validation);
 }
 // Helper function to apply SplitKVCacheIntoBlocks transformation
-std::shared_ptr<ov::Model> apply_split_kvcache_into_blocks(
-    const std::shared_ptr<ov::Model>& model,
-    uint32_t block_size = 32) {
+std::shared_ptr<ov::Model> apply_split_kvcache_into_blocks(const std::shared_ptr<ov::Model>& model,
+                                                           uint32_t block_size = 32) {
     auto cloned = model->clone();
     // Use v_transposed=false to match test model structure where both key and value use axis 2
-    ov::npuw::pass::SplitKVCacheIntoBlocks(block_size, false).run_on_model(cloned);
+    ov::npuw::pass::SplitKVCacheIntoBlocks(block_size).run_on_model(cloned);
     return cloned;
 }
 // --- Tests for validate_and_setup_pyramid_attention (Contiguous KV Cache) ---
@@ -140,7 +140,7 @@ TEST(PyramidAttentionTest, ValidateSucceedsOnValidAttentionModel) {
 
     auto result = ov::npuw::function::validate_and_setup_pyramid_attention(model);
     ASSERT_TRUE(result.has_value());
-    
+
     const auto& contiguous = get_contiguous_result(*result);
     EXPECT_TRUE(contiguous.is_valid());
     EXPECT_EQ(contiguous.query_length, 1u);
@@ -160,18 +160,19 @@ TEST(PyramidAttentionTest, ValidateExtractsCorrectSequenceDimForSingleLayer) {
 
     ASSERT_TRUE(result.has_value()) << "Validation failed for single-layer model";
     const auto& contiguous = get_contiguous_result(*result);
-    
+
     // Concat axis is 2 (sequence dim)
     auto key_it = contiguous.past_key_sequence_dims.find("past_key_values.0.key");
-    EXPECT_NE(key_it, contiguous.past_key_sequence_dims.end()) 
+    EXPECT_NE(key_it, contiguous.past_key_sequence_dims.end())
         << "Key 'past_key_values.0.key' not found. Map has " << contiguous.past_key_sequence_dims.size() << " entries.";
     if (key_it != contiguous.past_key_sequence_dims.end()) {
         EXPECT_EQ(key_it->second, 2u);
     }
-    
+
     auto val_it = contiguous.past_value_sequence_dims.find("past_key_values.0.value");
     EXPECT_NE(val_it, contiguous.past_value_sequence_dims.end())
-        << "Key 'past_key_values.0.value' not found. Map has " << contiguous.past_value_sequence_dims.size() << " entries.";
+        << "Key 'past_key_values.0.value' not found. Map has " << contiguous.past_value_sequence_dims.size()
+        << " entries.";
     if (val_it != contiguous.past_value_sequence_dims.end()) {
         EXPECT_EQ(val_it->second, 2u);
     }
@@ -181,16 +182,16 @@ TEST(PyramidAttentionTest, DebugRegexPatternMatching) {
     // Verify that our regex patterns match expected parameter names
     EXPECT_TRUE(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.0.key").has_value());
     EXPECT_EQ(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.0.key").value(), 0);
-    
+
     EXPECT_TRUE(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.1.key").has_value());
     EXPECT_EQ(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.1.key").value(), 1);
-    
+
     EXPECT_TRUE(ov::npuw::util::isPastKeyValuesValueContiguous("past_key_values.0.value").has_value());
     EXPECT_EQ(ov::npuw::util::isPastKeyValuesValueContiguous("past_key_values.0.value").value(), 0);
-    
+
     EXPECT_TRUE(ov::npuw::util::isPastKeyValuesValueContiguous("past_key_values.1.value").has_value());
     EXPECT_EQ(ov::npuw::util::isPastKeyValuesValueContiguous("past_key_values.1.value").value(), 1);
-    
+
     // Should NOT match
     EXPECT_FALSE(ov::npuw::util::isPastKeyValuesKeyContiguous("query.0").has_value());
     EXPECT_FALSE(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.0.key_block_0").has_value());
@@ -555,8 +556,7 @@ TEST(PyramidAttentionTest, ProcessPyramidModelAfterI8KVCacheConversion) {
                                                             contiguous.past_key_sequence_dims,
                                                             contiguous.past_value_sequence_dims);
 
-    ASSERT_TRUE(result.has_value())
-        << "process_pyramid_model should succeed after i8 KV cache conversion";
+    ASSERT_TRUE(result.has_value()) << "process_pyramid_model should succeed after i8 KV cache conversion";
 }
 
 TEST(PyramidAttentionTest, ProcessPyramidModelI8IncludesDQParamsInAttentionInputs) {
@@ -667,15 +667,17 @@ TEST(PyramidAttentionTest, DebugBlockModeTransformation) {
         const auto& name = param->get_friendly_name();
         if (name.find("_block_") != std::string::npos) {
             block_params++;
-            if (name.find("_block_0") != std::string::npos) found_block_0 = true;
-            if (name.find("_block_tail") != std::string::npos) found_block_tail = true;
+            if (name.find("_block_0") != std::string::npos)
+                found_block_0 = true;
+            if (name.find("_block_tail") != std::string::npos)
+                found_block_tail = true;
         }
     }
-    
+
     EXPECT_TRUE(found_block_0) << "Block 0 parameters not found after split";
     EXPECT_TRUE(found_block_tail) << "Block tail parameters not found after split";
     EXPECT_GE(block_params, 4u) << "Expected at least 4 block params (2 keys + 2 values), got " << block_params;
-    
+
     // Verify that original contiguous parameters were removed
     for (const auto& param : block_model->get_parameters()) {
         const auto& name = param->get_friendly_name();
@@ -696,7 +698,7 @@ TEST(PyramidAttentionTest, ValidateSucceedsOnBlockModeModel) {
 
     // After block split, model should validate and return PyramidValidationBlockResult
     auto result = ov::npuw::function::validate_and_setup_pyramid_attention(block_model);
-    
+
     ASSERT_TRUE(result.has_value());
     const auto& block_result = get_block_result(*result);
     EXPECT_TRUE(block_result.is_valid());

--- a/src/plugins/intel_npu/tests/unit/npuw/split_kvcache_into_blocks_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/split_kvcache_into_blocks_test.cpp
@@ -57,7 +57,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, TransformKeyParameter) {
 
     // Apply transformation (max_blocks removed, auto-calculated from shape)
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     // Verify: Should have expected_blocks + 1 parameters (blocks + new_token)
@@ -99,7 +99,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, TransformValueParameterTransposed) {
 
     // Apply transformation with v_transposed=true
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     const uint32_t expected_blocks = 64 / block_size;  // 4 blocks
@@ -137,7 +137,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, TransformValueParameterNotTransposed) {
 
     // Apply transformation with v_transposed=false
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, false);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     const uint32_t expected_blocks = 64 / block_size;  // 4 blocks
@@ -177,7 +177,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, AlternativeNaming) {
 
     // Apply transformation
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     // Verify: Should have transformed
@@ -203,7 +203,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, SkipNonKVCacheParameter) {
 
     // Apply transformation
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     // Verify: Parameter count unchanged (not transformed)
@@ -234,7 +234,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, InvalidRank) {
 
     // Apply transformation
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     // Verify: Not transformed due to invalid rank
@@ -267,7 +267,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, MultipleKVParameters) {
 
     // Apply transformation
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     // Verify: Should have (expected_blocks * 2) + 2 parameters (K blocks + V blocks + new_k + new_v)
@@ -303,7 +303,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, TailBlockHandling) {
 
     // Apply transformation
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     // Verify: Should have 5 block parameters + 1 new_token = 6 total
@@ -364,7 +364,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, WithConvertNode) {
 
     // Apply transformation
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     // Verify: Should have 4 block parameters + 1 new_token
@@ -412,6 +412,132 @@ TEST_F(SplitKVCacheIntoBlocksTest, WithConvertNode) {
     EXPECT_TRUE(found_concat);
 }
 
+TEST_F(SplitKVCacheIntoBlocksTest, NegativeConcatAxis) {
+    // Test: Concat with negative axis (-2) must be normalized to the correct positive axis.
+    // Shape [1, 8, 64, 256] with axis=-2 means axis=2 (sequence dim).
+    const uint32_t block_size = 16;
+    const ov::Shape orig_shape{1, 8, 64, 256};
+    const uint32_t expected_blocks = 64 / block_size;  // 4 blocks
+
+    // Build model manually because the helper indexes new_token_shape with positive axis.
+    auto kv_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, orig_shape);
+    kv_param->set_friendly_name("past_key_values.0.key");
+
+    ov::Shape new_token_shape{1, 8, 1, 256};  // axis=2 gets size 1
+    auto new_token = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, new_token_shape);
+    new_token->set_friendly_name("new_token");
+
+    // Create Concat with NEGATIVE axis -2
+    auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{kv_param, new_token}, -2);
+
+    auto result = std::make_shared<ov::op::v0::Result>(concat);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{kv_param, new_token});
+
+    // Apply transformation
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
+    manager.run_passes(model);
+
+    // Verify: Should have expected_blocks + 1 parameters (blocks + new_token)
+    EXPECT_EQ(model->get_parameters().size(), expected_blocks + 1);
+
+    // Verify: Each block parameter has correct shape [1, 8, 16, 256]
+    // The sequence axis (normalized to 2) holds the block_size.
+    uint32_t block_count = 0;
+    for (const auto& param : model->get_parameters()) {
+        if (param->get_friendly_name().find("_block_") != std::string::npos) {
+            block_count++;
+            auto block_shape = param->get_shape();
+            EXPECT_EQ(block_shape[0], 1);
+            EXPECT_EQ(block_shape[1], 8);
+            EXPECT_EQ(block_shape[2], block_size);  // normalized axis=2
+            EXPECT_EQ(block_shape[3], 256);
+        }
+    }
+    EXPECT_EQ(block_count, expected_blocks);
+
+    // Verify: New concat uses the normalized positive axis (2)
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<ov::op::v0::Concat>(op)) {
+            auto c = ov::as_type_ptr<ov::op::v0::Concat>(op);
+            EXPECT_EQ(c->get_axis(), 2);
+            EXPECT_EQ(c->get_input_size(), expected_blocks + 1);
+        }
+    }
+}
+
+TEST_F(SplitKVCacheIntoBlocksTest, MixedConcatAxesAcrossLayers) {
+    // Test: Gemma4-like model where V tensors have DIFFERENT concat axes per layer.
+    // Layer 0 (full_attention):   V shape [1, 1, 64, 512], concat axis=2 (NOT transposed)
+    // Layer 1 (sliding_window):   V shape [1, 8, 256, 64], concat axis=3 (transposed)
+    // The fix uses concat->get_axis() per-layer instead of a global v_transposed flag.
+    const uint32_t block_size = 16;
+
+    // --- Layer 0: V not transposed, seq on axis=2 ---
+    auto val0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 1, 64, 512});
+    val0->set_friendly_name("past_key_values.0.value");
+    auto new_v0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 1, 1, 512});
+    auto concat_v0 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{val0, new_v0}, 2);
+
+    // --- Layer 1: V transposed, seq on axis=3 ---
+    auto val1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 8, 256, 64});
+    val1->set_friendly_name("past_key_values.1.value");
+    auto new_v1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 8, 256, 1});
+    auto concat_v1 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{val1, new_v1}, 3);
+
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{std::make_shared<ov::op::v0::Result>(concat_v0),
+                                                              std::make_shared<ov::op::v0::Result>(concat_v1)},
+                                             ov::ParameterVector{val0, val1, new_v0, new_v1});
+
+    const uint32_t expected_blocks_l0 = 64 / block_size;  // 4 blocks
+    const uint32_t expected_blocks_l1 = 64 / block_size;  // 4 blocks
+
+    // Apply transformation
+    ov::pass::Manager manager;
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
+    manager.run_passes(model);
+
+    // Verify: total params = blocks_l0 + blocks_l1 + 2 new_token params
+    EXPECT_EQ(model->get_parameters().size(), expected_blocks_l0 + expected_blocks_l1 + 2);
+
+    // Verify: Layer 0 blocks have shape [1, 1, block_size, 512] (seq on axis=2)
+    // Verify: Layer 1 blocks have shape [1, 8, 256, block_size] (seq on axis=3)
+    size_t layer0_blocks = 0, layer1_blocks = 0;
+    for (const auto& param : model->get_parameters()) {
+        const auto& name = param->get_friendly_name();
+        if (name.find("_block_") == std::string::npos)
+            continue;
+        const auto& s = param->get_shape();
+        if (name.find("past_key_values.0") != std::string::npos) {
+            layer0_blocks++;
+            EXPECT_EQ(s[0], 1u);
+            EXPECT_EQ(s[1], 1u) << "Layer 0: 1 KV head";
+            EXPECT_EQ(s[2], block_size) << "Layer 0: seq on axis=2";
+            EXPECT_EQ(s[3], 512u) << "Layer 0: head_dim=512";
+        } else if (name.find("past_key_values.1") != std::string::npos) {
+            layer1_blocks++;
+            EXPECT_EQ(s[0], 1u);
+            EXPECT_EQ(s[1], 8u) << "Layer 1: 8 KV heads";
+            EXPECT_EQ(s[2], 256u) << "Layer 1: head_dim=256 (transposed)";
+            EXPECT_EQ(s[3], block_size) << "Layer 1: seq on axis=3";
+        }
+    }
+    EXPECT_EQ(layer0_blocks, expected_blocks_l0);
+    EXPECT_EQ(layer1_blocks, expected_blocks_l1);
+
+    // Verify: Each Concat preserved its own axis
+    size_t concat_count = 0;
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<ov::op::v0::Concat>(op)) {
+            auto c = ov::as_type_ptr<ov::op::v0::Concat>(op);
+            concat_count++;
+            // One concat should have axis=2, the other axis=3
+            EXPECT_TRUE(c->get_axis() == 2 || c->get_axis() == 3);
+        }
+    }
+    EXPECT_EQ(concat_count, 2u);
+}
+
 TEST_F(SplitKVCacheIntoBlocksTest, HeterogeneousKVShapesAcrossLayers) {
     // Test: MoE model with two KV layer groups that have different shapes.
     // Layer 0: [1, 8, 512, 256]  (8 heads, head_dim=256)
@@ -439,7 +565,7 @@ TEST_F(SplitKVCacheIntoBlocksTest, HeterogeneousKVShapesAcrossLayers) {
                                              ov::ParameterVector{key0, key1, new_k0, new_k1});
 
     ov::pass::Manager manager;
-    manager.register_pass<SplitKVCacheIntoBlocks>(block_size, true);
+    manager.register_pass<SplitKVCacheIntoBlocks>(block_size);
     manager.run_passes(model);
 
     // 4 blocks per layer * 2 layers + 2 new_token params = 10


### PR DESCRIPTION
### Details:
Gemma4 uses a hybrid attention architecture: most layers use sliding-window attention (8 KV heads, head_dim=256) while every 6th layer uses full attention (1 KV head, head_dim=512). During model compilation, OptimizeValueTensors successfully transposes V-cache for sliding layers but fails to match full-attention layers (the aten::transpose op degenerates into a Reshape when num_kv_heads=1, so the pattern matcher cannot match it). This results in different layers having different V-cache layouts within the same model.

 Problem: Gemma4 uses two attention types — sliding-window (8 KV heads, V transposed, seq on axis 3) and full-attention (1 KV head, V not transposed, seq on axis 2). The existing code assumed a uniform V layout across all layers via a global  v_transposed flag, causing runtime failures:
  1. SplitKVCacheIntoBlocks used a global flag to compute concat axis, producing wrong block shapes for layers with different V layouts, For Gemma4's full-attention layers whose V remains untransposed (seq at dim=2), using the global flag (dim=3) causes out-of-bounds access or shape mismatch:
  _Non-chunk prefill: Check '*roi_begin <= *max_dim' failed
  Chunk prefill: Check 'src_shape == dst->get_shape()' failed_
  2. copy_kvcache and update_kvcache_for used global pre_kv_dim/gen_kv_dim for tensor slicing, causing out-of-bounds access on layers whose seq dim differs.
  3. copy_outputs_to_blocks asserted num_tokens <= src_seq_len, which fails for sliding-window layers whose prefill output is capped at window size (e.g. 512) while prompt length is larger (e.g. 546).

_Global SDPA in Gemma4 12B:_
<img width="1747" height="514" alt="image" src="https://github.com/user-attachments/assets/2c6a68d9-6f66-4c1e-9c11-012a7c6edd00" />

_Local SDPA in Gemma4 12B:_
<img width="1122" height="497" alt="image" src="https://github.com/user-attachments/assets/2e247940-be6e-4936-b6fa-1f5e094b8bfb" />

### Tickets:
 - *ticket-id*
 - https://jira.devtools.intel.com/browse/EISW-229017

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
