### PR TITLE
[GPU][coverity] prevent reshape axis integer overflow

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -759,7 +759,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
                     }
                 }
 
-                OPENVINO_ASSERT(reshape_axis < output_rank,
+                OPENVINO_ASSERT(reshape_axis >= 0 && static_cast<size_t>(reshape_axis) < output_rank,
                                 "[GPU] Calculated reshape_axis is out of range for along-feature crop propagation.");
 
                 reshape_lower_sizes[reshape_axis] = lower_sizes[crop_axis];

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -740,7 +740,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
                 // axis-mapping so build-time (dyn mask) and runtime (mask +
                 // explicit sizes) paths pick the same reshape axis for patterns
                 // that do not need scaling.
-                size_t reshape_axis = crop_axis;
+                int64_t reshape_axis = static_cast<int64_t>(crop_axis);
                 if (reshape_mode == reshape::reshape_mode::base) {
                     reshape_axis = reshape_ps.size() - 1;
                     ov::Dimension::value_type mul = 1;
@@ -753,7 +753,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
                 } else if (reshape_mode == reshape::reshape_mode::unsqueeze || reshape_mode == reshape::reshape_mode::squeeze) {
                     const auto& output_pattern = reshape_desc->output_pattern;
                     for (size_t i = 0; i < output_pattern.size(); i++) {
-                        if (output_pattern[i] <= static_cast<int64_t>(reshape_axis)) {
+                        if (output_pattern[i] <= reshape_axis) {
                             reshape_axis += reshape_mode == reshape::reshape_mode::unsqueeze ? 1 : -1;
                         }
                     }


### PR DESCRIPTION
### Details
- Change `reshape_axis` from `size_t` to `int64_t`.
- Prevent unsigned integer overflow when decrementing the axis for squeeze reshapes.
- Preserve the existing control flow and axis calculation.

### Safety
The conversion is safe because `reshape_axis` represents a tensor axis and its value is limited by the maximum supported shape rank, which is far below the `int64_t` limit.

A signed type is appropriate because squeeze processing may temporarily decrement the axis below zero. Previously, this operation wrapped to a large unsigned value. The existing bounds assertion still rejects an invalid axis, so valid-input behavior remains unchanged.

### Tickets:
 - 191973

### AI Assistance:
 - AI assistance used: yes
 - AI: fix
 - User: review
