### PR TITLE
[GPU] Fix dynamic_quantize kernel sharing between different IFM sizes

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/dynamic_quantize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/dynamic_quantize.hpp
@@ -24,13 +24,18 @@ struct dynamic_quantize : public primitive_base<dynamic_quantize> {
     /// @param input Input primitive id
     /// @param attrs Quantization attributes
     /// @param input_size Rank of input tensor
+    /// @param innermost_size Length of the innermost input dimension, or 0 if unknown. Quantization groups are
+    ///                       formed along that dimension, so it has to take part in impl caching even when the
+    ///                       input layout keeps it dynamic.
     dynamic_quantize(const primitive_id& id,
            const input_info& input,
            const Attributes& attrs,
-           const size_t input_size = 3)
+           const size_t input_size = 3,
+           const size_t innermost_size = 0)
            : primitive_base(id, {input})
            , attrs(attrs)
-           , input_size(input_size) {
+           , input_size(input_size)
+           , innermost_size(innermost_size) {
         num_outputs = 2;
         if (attrs.quantization_type == ov::op::internal::DynamicQuantize::QuantizationType::Asymmetric &&
             attrs.output_storage_type == ov::op::internal::DynamicQuantize::OutputStorageType::Planar)
@@ -42,6 +47,7 @@ struct dynamic_quantize : public primitive_base<dynamic_quantize> {
 
     Attributes attrs;
     size_t input_size;
+    size_t innermost_size = 0;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
@@ -55,6 +61,7 @@ struct dynamic_quantize : public primitive_base<dynamic_quantize> {
         seed = hash_combine(seed, attrs.precomputed_reduction);
         seed = hash_combine(seed, attrs.precomputed_reduction_dt.hash());
         seed = hash_combine(seed, input_size);
+        seed = hash_combine(seed, innermost_size);
 
         return seed;
     }
@@ -74,7 +81,8 @@ struct dynamic_quantize : public primitive_base<dynamic_quantize> {
                attrs.quantization_type == rhs_casted.attrs.quantization_type &&
                attrs.precomputed_reduction == rhs_casted.attrs.precomputed_reduction &&
                attrs.precomputed_reduction_dt == rhs_casted.attrs.precomputed_reduction_dt &&
-               input_size == rhs_casted.input_size;
+               input_size == rhs_casted.input_size &&
+               innermost_size == rhs_casted.innermost_size;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
@@ -90,6 +98,7 @@ struct dynamic_quantize : public primitive_base<dynamic_quantize> {
         ob << attrs.group_sizes;
         ob << attrs.precomputed_reduction;
         ob << input_size;
+        ob << innermost_size;
     }
 
     void load(BinaryInputBuffer& ib) override {
@@ -105,6 +114,7 @@ struct dynamic_quantize : public primitive_base<dynamic_quantize> {
         ib >> attrs.group_sizes;
         ib >> attrs.precomputed_reduction;
         ib >> input_size;
+        ib >> innermost_size;
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
@@ -7,7 +7,6 @@
 #include "dynamic_quantize/dynamic_quantize_kernel_ref.h"
 #include "dynamic_quantize/dynamic_quantize_kernel_selector.h"
 #include "dynamic_quantize_inst.h"
-#include "fully_connected_inst.h"
 
 namespace cldnn {
 namespace ocl {
@@ -39,12 +38,8 @@ struct dynamic_quantize_impl : typed_primitive_impl_ocl<dynamic_quantize> {
         params.outputs.push_back(convert_data_tensor(impl_param.get_output_layout(1)));
 
         // In Some model, the feature size could be dynamic in input0.
-        // It refers to IFM value of weight of fully connected.
-        auto user_node = impl_param.prog->get_node(impl_param.desc->id).get_users().front();
-        if (user_node != nullptr && user_node->is_type<fully_connected>()) {
-            auto& fc_node = user_node->as<fully_connected>();
-            params.fc_ifm_size = fc_node.weights().get_output_layout().feature();
-        }
+        // It refers to IFM value of weight of fully connected, resolved when the primitive was created.
+        params.fc_ifm_size = primitive->innermost_size;
 
         if (impl_param.output_layouts.size() > 2)
             params.outputs.push_back(convert_data_tensor(impl_param.get_output_layout(2)));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -17,20 +17,31 @@ enum class DynQuanMode {
     PER_TOKEN = 3
 };
 
-static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params& params) {
+// Length of the dimension the quantization groups are formed along. Returns 0 when the layout keeps that
+// dimension dynamic and it could not be resolved from the consuming fully connected either, in which case
+// the group count is unknown and this kernel is not applicable.
+static size_t get_input_f_size(const dynamic_quantize_params& params) {
     size_t input_f = params.inputs[0].Feature().v;
-    size_t input_batch = params.inputs[0].Batch().v;
     // 3D input
-    if (params.outputs[0].GetLayout() == DataLayout::bfyx) {
+    if (params.outputs[0].GetLayout() == DataLayout::bfyx)
         input_f = params.inputs[0].Y().v * params.inputs[0].X().v;
-        input_batch = params.inputs[0].Batch().v * params.inputs[0].Feature().v;
-    }
 
     // In Some model, input_f could be dynamic in input0. It refers to IFM value of weight.
-    if (params.inputs[0].is_dynamic() && input_f == 0) {
-        OPENVINO_ASSERT(params.fc_ifm_size != 0, "[GPU] Invalid fc_ifm_size value");
-        input_f = params.fc_ifm_size;
-    }
+    if (params.inputs[0].is_dynamic() && input_f == 0)
+        return params.fc_ifm_size;
+
+    return input_f;
+}
+
+static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params& params) {
+    size_t input_batch = params.inputs[0].Batch().v;
+    // 3D input
+    if (params.outputs[0].GetLayout() == DataLayout::bfyx)
+        input_batch = params.inputs[0].Batch().v * params.inputs[0].Feature().v;
+
+    // Validate() rejects this kernel when the size cannot be resolved, so it is known to be set here
+    const auto input_f = get_input_f_size(params);
+    OPENVINO_ASSERT(input_f != 0, "[GPU] Invalid fc_ifm_size value");
 
     return {input_batch, input_f};
 }
@@ -202,6 +213,11 @@ bool DynamicQuantizeKernelOpt::Validate(const Params& params) const {
         DO_NOT_USE_THIS_KERNEL(params.layerID);
 
     const auto& dq_params = static_cast<const dynamic_quantize_params&>(params);
+
+    // The group count is baked into the kernel at compile time, so it cannot be built without knowing
+    // the length of the dimension the groups are formed along
+    if (get_input_f_size(dq_params) == 0)
+        DO_NOT_USE_THIS_KERNEL(params.layerID);
 
     if (get_dynamic_quantize_mode(dq_params) == DynQuanMode::PER_TOKEN && dq_params.generate_precomputed_reduction)
         DO_NOT_USE_THIS_KERNEL(params.layerID);

--- a/src/plugins/intel_gpu/src/plugin/ops/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/dynamic_quantize.cpp
@@ -6,9 +6,43 @@
 #include "intel_gpu/plugin/program_builder.hpp"
 #include "intel_gpu/plugin/common_utils.hpp"
 #include "intel_gpu/primitives/dynamic_quantize.hpp"
+#include "intel_gpu/op/fully_connected_compressed.hpp"
 
 
 namespace ov::intel_gpu {
+
+// Quantization groups are formed along the innermost input dimension, so its length drives the kernel's
+// group count. When the input keeps that dimension dynamic, it can still be recovered from the weights of
+// the consuming FullyConnected, whose IFM equals it. Returns 0 when it stays unknown, which makes the opt
+// kernel reject the primitive so that the ref kernel is used instead.
+static size_t get_innermost_size(const std::shared_ptr<ov::op::internal::DynamicQuantize>& op) {
+    const auto& in_shape = op->get_input_partial_shape(0);
+    const auto& innermost_dim = in_shape[in_shape.size() - 1];
+    if (innermost_dim.is_static())
+        return innermost_dim.get_length();
+
+    size_t innermost_size = 0;
+    for (const auto& target_input : op->get_output_target_inputs(0)) {
+        const auto* fc = ov::as_type<const op::FullyConnectedCompressed>(target_input.get_node());
+        if (fc == nullptr || target_input.get_index() != 0)
+            continue;
+
+        // Weights are [N, K] when transposed, [K, N] otherwise
+        const auto& weights_shape = fc->get_input_partial_shape(1);
+        const auto& ifm = weights_shape[weights_shape.size() - (fc->get_transpose_b() ? 1 : 2)];
+        if (!ifm.is_static())
+            continue;
+
+        // Every user consumes the same activations, so they have to agree on the length
+        const auto ifm_size = static_cast<size_t>(ifm.get_length());
+        OPENVINO_ASSERT(innermost_size == 0 || innermost_size == ifm_size,
+                        "[GPU] Users of ", op->get_friendly_name(), " disagree on the innermost size: ",
+                        innermost_size, " vs ", ifm_size);
+        innermost_size = ifm_size;
+    }
+
+    return innermost_size;
+}
 
 static void CreateDynamicQuantizeOp(ProgramBuilder& p, const std::shared_ptr<ov::op::internal::DynamicQuantize>& op) {
     validate_inputs_count(op, {1});
@@ -18,7 +52,8 @@ static void CreateDynamicQuantizeOp(ProgramBuilder& p, const std::shared_ptr<ov:
     auto prim = cldnn::dynamic_quantize(primitive_name,
                                         inputs[0],
                                         op->get_attrs(),
-                                        op->get_input_partial_shape(0).size());
+                                        op->get_input_partial_shape(0).size(),
+                                        get_innermost_size(op));
 
     prim.num_outputs = op->get_output_size();
 

--- a/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
@@ -950,7 +950,9 @@ TEST_P(fc_compressed_int8_bias_prod_unfused_dynamic_onednn, basic) {
         scale,
         dcomp_zp,
         mul_data,
-        dynamic_quantize("dyn_quan", input_info("input"), dq_config, 3),
+        // The input layout keeps every dimension dynamic, so the innermost length has to be passed
+        // explicitly, otherwise the opt kernel cannot tell how many elements a group spans
+        dynamic_quantize("dyn_quan", input_info("input"), dq_config, 3, feature_len),
         fc_prim_dyn_quan,
         eltwise("mul", { input_info("fc_prim"), input_info("mul_data") }, eltwise_mode::prod),
         reorder("reorder_bfyx", input_info("mul"), p.default_format, data_types::f32)

--- a/src/plugins/intel_gpu/tests/unit/module_tests/primitive_comparison_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/primitive_comparison_test.cpp
@@ -10,6 +10,7 @@
 #include <intel_gpu/primitives/fully_connected.hpp>
 #include <intel_gpu/primitives/gather.hpp>
 #include <intel_gpu/primitives/permute.hpp>
+#include <intel_gpu/primitives/dynamic_quantize.hpp>
 
 namespace cldnn {
 // For gtest NE compare, class defines only `==` operator. Required when building using C++20
@@ -109,6 +110,27 @@ TEST(primitive_comparison, permute) {
 
     ASSERT_EQ(permute_prim, permute_prim_eq);
     ASSERT_NE(permute_prim, permute_prim_order);
+}
+
+TEST(primitive_comparison, dynamic_quantize_innermost_size) {
+    dynamic_quantize::Attributes attrs;
+    attrs.quantization_type = ov::op::internal::DynamicQuantize::QuantizationType::Symmetric;
+    attrs.quantization_dt = data_types::i8;
+    attrs.scale_dt = data_types::f16;
+    attrs.zp_dt = data_types::dynamic;
+    attrs.group_sizes = {1, 1, UINT64_MAX};
+    attrs.scales_zp_output_order = {0, 1, 2};
+    attrs.output_storage_type = ov::op::internal::DynamicQuantize::OutputStorageType::Planar;
+
+    auto dq_prim = dynamic_quantize("dq", input_info("input"), attrs, 3, 4096);
+    auto dq_prim_eq = dynamic_quantize("dq_eq", input_info("input_eq"), attrs, 3, 4096);
+    // The innermost dimension drives the group count baked into the kernel, so two primitives that
+    // only differ by it must not compare equal - otherwise they share a kernel built for one of them
+    auto dq_prim_innermost = dynamic_quantize("dq", input_info("input"), attrs, 3, 8192);
+
+    ASSERT_EQ(dq_prim, dq_prim_eq);
+    ASSERT_NE(dq_prim, dq_prim_innermost);
+    ASSERT_NE(dq_prim.hash(), dq_prim_innermost.hash());
 }
 
 TEST(primitive_comparison, reorder_weights) {


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)

- **Symptom**: int4 VLMs produce garbage output on GPU in per-token dyn-quant mode. Reproduced on `gemma-4-31B-it-int4-ov` and `gemma-4-26b-a4b-it-int4-ov`.
- **Root-cause**: Two `dynamic_quantize` nodes with a dynamic innermost dim (`?x?x?`) get identical `kernel_impl_params`, so `add_kernels_source()` drops the second one and both share a single kernel. In per-token mode the group count is baked into the JIT from `fc_ifm_size`, so the shared kernel is correct for only one of them. These models hit it because their sliding/full attention layers feed o_proj FCs with different IFM.
- **How it was resolved**: The resolved innermost length is now carried by the primitive (`dynamic_quantize::innermost_size`) and joins `hash()` / `operator==`, so the two nodes no longer collide. `CreateDynamicQuantizeOp` resolves it once from the static dim, or from the weights IFM of the consuming `FullyConnectedCompressed`.

#### The code and line that caused this issue (if it is not changed directly)

- `intel_gpu/src/graph/impls/ocl/kernels_cache.cpp` - `add_kernels_source()` skips duplicate params
- `dynamic_quantize_kernel_opt.cpp` - `GetJitConstants()` bakes `TOTAL_BLOCK_NUM` from `fc_ifm_size`
- `intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp` - the old `get_users().front()` lookup gave a per-node value that never reached the cache key (#26850)

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)

 - `$ python vlm_test.py gemma-4-31B-it-int4-ov cat.jpg GPU`
- Expected `The picture shows a grey tabby cat ...`, got unrelated tokens.
 - `gemma-4-26b-a4b-it-int4-ov` reproduces the same with `DYNAMIC_QUANTIZATION_GROUP_SIZE=18446744073709551615`.

#### Problematic graph

```
  sliding layer:  SDPA -> Reshape(?x?x?) -> DynamicQuantize -> FC(W: [N, 8192])
  full    layer:  SDPA -> Reshape(?x?x?) -> DynamicQuantize -> FC(W: [N, 16384])
```

- Same layouts on both dq nodes; only the FC weights differ, which was not in the cache key.

#### Checklist

 - [x] Is it a proper fix? (not a workaround) K (the innermost dimension) determines the quantization group count baked into the kernel at compile time, so it is now part of the primitive's hash()/operator==.
 - [x] Did you include test case for this fix, if necessary? `primitive_comparison.dynamic_quantize_innermost_size` — two dynamic_quantize primitives differing only in K must compare unequal and hash differently.
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
`primitive_comparison_test.cpp` — the fix only changes the primitive's hash/comparison, so this is where it belongs. It had no dynamic_quantize case; extended with one.

### Tickets:
 - *191435*

(cherry picked from commit ede92661fafd9b46788a3e5e2bb654beb9f17f30)