### PR TITLE
docs: finalize 2026.3 package links

### DIFF
--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -77,9 +77,9 @@ Step 1: Download and Install the OpenVINO Core Components
                .. code-block:: sh
 
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu26_2026.3.0.dev20260723_x86_64.tgz --output openvino_2026.3.0.tgz
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu26_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
                   tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_ubuntu26_2026.3.0.dev20260723_x86_64 /opt/intel/openvino_2026.3.0
+                  sudo mv openvino_toolkit_ubuntu26_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
 
             .. tab-item:: Ubuntu 24.04
                :sync: ubuntu-24
@@ -87,9 +87,9 @@ Step 1: Download and Install the OpenVINO Core Components
                .. code-block:: sh
 
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu24_2026.3.0.dev20260723_x86_64.tgz --output openvino_2026.3.0.tgz
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu24_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
                   tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_ubuntu24_2026.3.0.dev20260723_x86_64 /opt/intel/openvino_2026.3.0
+                  sudo mv openvino_toolkit_ubuntu24_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
 
             .. tab-item:: Ubuntu 22.04
                :sync: ubuntu-22
@@ -97,9 +97,9 @@ Step 1: Download and Install the OpenVINO Core Components
                .. code-block:: sh
 
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu22_2026.3.0.dev20260723_x86_64.tgz --output openvino_2026.3.0.tgz
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu22_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
                   tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_ubuntu22_2026.3.0.dev20260723_x86_64 /opt/intel/openvino_2026.3.0
+                  sudo mv openvino_toolkit_ubuntu22_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
 
 
             .. tab-item:: RHEL 8
@@ -107,18 +107,18 @@ Step 1: Download and Install the OpenVINO Core Components
 
                .. code-block:: sh
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_rhel8_2026.3.0.dev20260723_x86_64.tgz --output openvino_2026.3.0.tgz
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_rhel8_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
                   tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_rhel8_2026.3.0.dev20260723_x86_64 /opt/intel/openvino_2026.3.0
+                  sudo mv openvino_toolkit_rhel8_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
 
             .. tab-item:: CentOS 8
                :sync: centos-8
 
                .. code-block:: sh
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_centos8_2026.3.0.dev20260723_x86_64.tgz --output openvino_2026.3.0.tgz
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_centos8_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
                   tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_centos8_2026.3.0.dev20260723_x86_64 /opt/intel/openvino_2026.3.0
+                  sudo mv openvino_toolkit_centos8_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
 
 
       .. tab-item:: ARM 64-bit
@@ -126,9 +126,9 @@ Step 1: Download and Install the OpenVINO Core Components
 
          .. code-block:: sh
 
-            curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu22_2026.3.0.dev20260723_arm64.tgz --output openvino_2026.3.0.tgz
+            curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu22_2026.3.0.22451.bd8d6542e3c_arm64.tgz --output openvino_2026.3.0.tgz
             tar -xf openvino_2026.3.0.tgz
-            sudo mv openvino_toolkit_ubuntu22_2026.3.0.dev20260723_arm64 /opt/intel/openvino_2026.3.0
+            sudo mv openvino_toolkit_ubuntu22_2026.3.0.22451.bd8d6542e3c_arm64 /opt/intel/openvino_2026.3.0
 
       .. tab-item:: ARM 32-bit
          :sync: arm-32

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -57,9 +57,9 @@ Step 1: Install OpenVINO Core Components
 
          .. code-block:: sh
 
-            curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/macos/openvino_toolkit_macos_12_6_2026.3.0.dev20260723_arm64.tgz --output openvino_2026.3.0.tgz
+            curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/macos/openvino_toolkit_macos_12_6_2026.3.0.22451.bd8d6542e3c_arm64.tgz --output openvino_2026.3.0.tgz
             tar -xf openvino_2026.3.0.tgz
-            sudo mv openvino_toolkit_macos_12_6_2026.3.0.dev20260723_arm64 /opt/intel/openvino_2026.3.0
+            sudo mv openvino_toolkit_macos_12_6_2026.3.0.22451.bd8d6542e3c_arm64 /opt/intel/openvino_2026.3.0
 
 
 5. (Optional) Install *numpy* Python Library:

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -48,7 +48,7 @@ Step 1: Download and Install OpenVINO Core Components
    .. code-block:: sh
 
       cd <user_home>/Downloads
-      curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/windows/openvino_toolkit_windows_2026.3.0.dev20260723_x86_64.zip --output openvino_2026.3.0.zip
+      curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/windows/openvino_toolkit_windows_2026.3.0.22451.bd8d6542e3c_x86_64.zip --output openvino_2026.3.0.zip
 
    .. note::
 
@@ -67,7 +67,7 @@ Step 1: Download and Install OpenVINO Core Components
    .. code-block:: sh
 
       tar -xf openvino_2026.3.0.zip
-      ren openvino_toolkit_windows_2026.3.0.dev20260723_x86_64 openvino_2026.3.0
+      ren openvino_toolkit_windows_2026.3.0.22451.bd8d6542e3c_x86_64 openvino_2026.3.0
       move openvino_2026.3.0 "C:\Program Files (x86)\Intel"
 
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-genai.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-genai.rst
@@ -75,21 +75,12 @@ Linux
                curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu22_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
                tar -xf openvino_genai_2026.3.0.0.tgz
 
-         .. tab-item:: Ubuntu 20.04
-            :sync: ubuntu-20
-
-            .. code-block:: sh
-
-               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu20_2026.3.0.0_x86_64.tar.gz  --output openvino_genai_2026.3.0.0.tgz
-               tar -xf openvino_genai_2026.3.0.0.tgz
-
-
    .. tab-item:: ARM 64-bit
       :sync: arm-64
 
       .. code-block:: sh
 
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu20_2026.3.0.0_arm64.tar.gz --output openvino_genai_2026.3.0.0.tgz
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu22_2026.3.0.0_arm64.tar.gz --output openvino_genai_2026.3.0.0.tgz
          tar -xf openvino_genai_2026.3.0.0.tgz
 
 
@@ -106,14 +97,6 @@ macOS
 
 .. tab-set::
 
-   .. tab-item:: x86, 64-bit
-      :sync: x86-64
-
-      .. code-block:: sh
-
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/macos/openvino_genai_macos_12_6_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
-         tar -xf openvino_genai_2026.3.0.0.tgz
-
    .. tab-item:: ARM, 64-bit
       :sync: arm-64
 
@@ -127,5 +110,4 @@ Here are the full guides:
 :doc:`Linux <install-openvino-archive-linux>`,
 :doc:`Windows <install-openvino-archive-windows>`, and
 :doc:`macOS <install-openvino-archive-macos>`.
-
 


### PR DESCRIPTION
### Details:
 - *Updates the OpenVINO 2026.3 Runtime and GenAI package links using the final published artifacts.*
 - *The previous URLs were pre-release estimates, but production verification identified the final Runtime build identifiers and several unavailable GenAI platform packages that required correction.*

### Tickets:
 - *no ticket*

### AI Assistance:
 - *AI assistance used: no*
