### PR TITLE
docs: add approved 2026.3 package guidance

### DIFF
--- a/docs/articles_en/get-started/install-openvino/install-openvino-genai.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-genai.rst
@@ -59,6 +59,14 @@ Linux
 
       .. tab-set::
 
+         .. tab-item:: Ubuntu 26.04
+            :sync: ubuntu-26
+
+            .. code-block:: sh
+
+               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu26_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
+               tar -xf openvino_genai_2026.3.0.0.tgz
+
          .. tab-item:: Ubuntu 24.04
             :sync: ubuntu-24
 
@@ -73,6 +81,14 @@ Linux
             .. code-block:: sh
 
                curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu22_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
+               tar -xf openvino_genai_2026.3.0.0.tgz
+
+         .. tab-item:: RHEL 8
+            :sync: rhel-8
+
+            .. code-block:: sh
+
+               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_rhel8_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
                tar -xf openvino_genai_2026.3.0.0.tgz
 
    .. tab-item:: ARM 64-bit
@@ -110,4 +126,3 @@ Here are the full guides:
 :doc:`Linux <install-openvino-archive-linux>`,
 :doc:`Windows <install-openvino-archive-windows>`, and
 :doc:`macOS <install-openvino-archive-macos>`.
-

--- a/docs/dev/build_android.md
+++ b/docs/dev/build_android.md
@@ -9,6 +9,21 @@ This article describes how to build OpenVINO for Android operating systems.
 - [Android SDK Platform Tools](https://developer.android.com/tools/releases/platform-tools) (this guide has been validated with the 35.0.0 release)
 - [Android NDK](https://developer.android.com/ndk/downloads) (this guide has been validated with r28c release)
 
+## Use the prebuilt x86-64 archive
+
+For Android x86-64 targets, you can use the prebuilt OpenVINO 2026.3 Runtime package instead of building OpenVINO from source:
+
+```sh
+mkdir openvino-android
+export OPV_HOME_DIR=${PWD}/openvino-android
+curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_android_2026.3.0.22451.bd8d6542e3c_x86_64.tgz \
+  --output $OPV_HOME_DIR/openvino_toolkit_android_2026.3.0.tgz
+tar -xf $OPV_HOME_DIR/openvino_toolkit_android_2026.3.0.tgz -C $OPV_HOME_DIR
+export OpenVINO_DIR=$OPV_HOME_DIR/openvino_toolkit_android_2026.3.0.22451.bd8d6542e3c_x86_64/runtime/cmake
+```
+
+The archive provides the OpenVINO headers, x86-64 Runtime libraries, CMake configuration, and required oneTBB libraries. For other Android architectures or a custom configuration, build OpenVINO from source as described below. The ADB example later in this guide demonstrates an aarch64 source build and does not apply directly to this x86-64 archive.
+
 ## How to build
 
 ### Create a work directory 


### PR DESCRIPTION
### Details:
 - *Add Ubuntu 26.04 and RHEL 8 GenAI archive tabs to install-openvino-genai.rst*
 - *Add the prebuilt Android x86-64 Runtime archive workflow to docs/dev/build_android.md*

### Tickets:
 - *no ticket*

### AI Assistance:
 - *AI assistance used: no*
