### PR TITLE
[NPU][IE-MDK] Remove VclAllocatorTest library path workaround

### DIFF
--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/vcl_allocator_test.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/vcl_allocator_test.hpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <iostream>
 #include <memory>
 #include <vector>
 
@@ -44,13 +45,6 @@ protected:
         targetDevice = GetParam();
         model = ov::test::utils::make_conv_pool_relu();
         allocator = std::make_shared<::intel_npu::vcl_allocator_2>();
-
-        try {
-            std::string ov_lib_dir = ov::test::utils::getOpenvinoLibDirectory();
-            ::intel_npu::VCLApi::getInstance(ov_lib_dir);
-        } catch (const std::exception&) {
-            GTEST_SKIP() << "Couldn't load compiler library";
-        }
     }
 
     // Helper struct and function to reduce code duplication

--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/vcl_allocator_test.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/vcl_allocator_test.hpp
@@ -7,7 +7,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <iostream>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
### Details:
 - Removes a workaround for retrieving compiler library path

### Tickets:
 - *ticket-id*

### AI Assistance:
 - AI assistance used: no