### PR TITLE
Libcxx22 missing includes

### DIFF
--- a/docs/articles_en/assets/snippets/ov_infer_request.cpp
+++ b/docs/articles_en/assets/snippets/ov_infer_request.cpp
@@ -3,6 +3,7 @@
 //
 
 // ! [ov:include]
+#include <exception>
 #include <openvino/openvino.hpp>
 // ! [ov:include]
 

--- a/samples/cpp/benchmark/throughput_benchmark/main.cpp
+++ b/samples/cpp/benchmark/throughput_benchmark/main.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <condition_variable>
+#include <exception>
 #include <string>
 #include <vector>
 

--- a/samples/cpp/classification_sample_async/main.cpp
+++ b/samples/cpp/classification_sample_async/main.cpp
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 
 #include <condition_variable>
+#include <exception>
 #include <fstream>
 #include <map>
 #include <memory>

--- a/src/bindings/c/src/ov_infer_request.cpp
+++ b/src/bindings/c/src/ov_infer_request.cpp
@@ -3,6 +3,8 @@
 //
 #include "openvino/c/ov_infer_request.h"
 
+#include <exception>
+
 #include "common.h"
 
 void ov_infer_request_free(ov_infer_request_t* infer_request) {

--- a/src/bindings/js/node/src/async_infer_queue.cpp
+++ b/src/bindings/js/node/src/async_infer_queue.cpp
@@ -5,6 +5,7 @@
 #include "node/include/async_infer_queue.hpp"
 
 #include <condition_variable>
+#include <exception>
 #include <mutex>
 #include <queue>
 #include <string>

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -4,6 +4,8 @@
 
 #include "node/include/core_wrap.hpp"
 
+#include <exception>
+
 #include "node/include/addon.hpp"
 #include "node/include/async_reader.hpp"
 #include "node/include/compiled_model.hpp"

--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <initializer_list>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "openvino/util/file_path.hpp"

--- a/src/core/include/openvino/core/any.hpp
+++ b/src/core/include/openvino/core/any.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>

--- a/src/core/include/openvino/runtime/allocator.hpp
+++ b/src/core/include/openvino/runtime/allocator.hpp
@@ -11,6 +11,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <type_traits>
 
 #include "openvino/core/any.hpp"
 #include "openvino/core/core_visibility.hpp"

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <iterator>
 #include <sstream>
 
 #include "compare.hpp"


### PR DESCRIPTION
### Details:
 - Under LLVM 22 libc++ with transitive include removal active (`-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES`) these headers are no longer pulled in indirectly and the build fails. Adds `<type_traits>` (`any.hpp`, `allocator.hpp`, `util/file_util.hpp`), `<iterator>` (`op/constant.cpp`) and `<exception>` where the complete `std::exception_ptr` type is required. One line per file, no functional change.
 - Verified with a full build, clang 22.1.8 + libc++, tests enabled: 0 errors.

### Tickets:
 - *N/A*

### AI Assistance:
 - *AI assistance used: yes*

