### PR TITLE
samples: discover installed gflags and nlohmann-json packages

### DIFF
--- a/samples/cpp/CMakeLists.txt
+++ b/samples/cpp/CMakeLists.txt
@@ -112,6 +112,10 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/common/utils")
     set(gflags_required ON)
 endif()
 
+if(NOT TARGET gflags)
+    find_package(gflags QUIET)
+endif()
+
 if(TARGET gflags)
     set(GFLAGS_TARGET gflags)
 elseif(gflags_required)

--- a/samples/cpp/benchmark_app/CMakeLists.txt
+++ b/samples/cpp/benchmark_app/CMakeLists.txt
@@ -15,6 +15,10 @@ ov_add_sample(NAME ${TARGET_NAME}
 # Required nlohmann_json dependency
 
 if(NOT TARGET nlohmann_json::nlohmann_json)
+    find_package(nlohmann_json QUIET)
+endif()
+
+if(NOT TARGET nlohmann_json::nlohmann_json)
     if(EXISTS "${Samples_SOURCE_DIR}/thirdparty/nlohmann_json")
         # OpenVINO package puts thirdparty to samples dir
         # suppress shadowing names warning


### PR DESCRIPTION
The C++ sample build expects gflags and nlohmann-json targets to have been created by a parent or bundled dependency setup. Standalone sample builds can have valid installed packages but still stop during CMake configuration because those targets do not yet exist.

When the expected targets are absent, try find_package before the existing required-target and bundled-source logic. Parent-provided targets keep precedence, while system package builds can configure the same samples without injecting private dependency targets.