### PR TITLE
[CPU] Fix Loop output shape mismatch on zero iterations

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -686,12 +686,11 @@ void TensorIterator::execute(const dnnl::stream& strm) {
 
     bool continue_cond = initial_cond_check->getStatus() != 0;
     int max_num_iter = trip_count_check->getStatus();
+    const bool has_executed = max_num_iter != 0 && continue_cond;
 
     for (auto& mapper : first_mappers) {
         mapper.second->execute(strm, -1);
     }
-
-    bool has_executed = false;
 
     // use  "i != max_num_iter" only to allow "-1" works like infinite loop
     for (int i = 0; i != max_num_iter && continue_cond; i++) {
@@ -701,7 +700,6 @@ void TensorIterator::execute(const dnnl::stream& strm) {
         }
 
         sub_graph.Infer();
-        has_executed = true;
 
         continue_cond = (continue_cond_check->getStatus() != 0);
 
@@ -725,7 +723,7 @@ void TensorIterator::executeDynamicImpl(const dnnl::stream& strm) {
 
     bool continue_cond = initial_cond_check->getStatus() != 0;
     int max_num_iter = trip_count_check->getStatus();
-    bool has_executed = false;
+    const bool has_executed = max_num_iter != 0 && continue_cond;
 
     for (auto& mapper : first_mappers) {
         mapper.second->execute(strm, -1);
@@ -742,7 +740,6 @@ void TensorIterator::executeDynamicImpl(const dnnl::stream& strm) {
         }
 
         sub_graph.Infer();
-        has_executed = true;
 
         continue_cond = (continue_cond_check->getStatus() != 0);
 
@@ -936,10 +933,8 @@ int TensorIterator::getInitialValueInputPort(const PortMap& outputMapRule) const
     return input_rule->from;
 }
 
-// In case the body has not been executed at all (zero trip count or false initial execution condition)
-// the value of a loop carried dependency is still its initial value, so the output has to be filled from
-// the corresponding node input directly. The body output memory cannot be used here: it has neither a
-// valid shape (it is left undefined, which used to be nullified to zeros) nor valid data.
+// If the body never executed, a loop carried dependency keeps its initial value: fill the output from
+// the corresponding node input directly, since the body output memory has neither a valid shape nor data.
 bool TensorIterator::fillOutputByInitialValue(const dnnl::stream& strm, const PortMap& outputMapRule) {
     const auto initial_value_port = getInitialValueInputPort(outputMapRule);
     if (initial_value_port == -1) {

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -691,6 +691,8 @@ void TensorIterator::execute(const dnnl::stream& strm) {
         mapper.second->execute(strm, -1);
     }
 
+    bool has_executed = false;
+
     // use  "i != max_num_iter" only to allow "-1" works like infinite loop
     for (int i = 0; i != max_num_iter && continue_cond; i++) {
         // copy data to subgraph iteration
@@ -699,6 +701,7 @@ void TensorIterator::execute(const dnnl::stream& strm) {
         }
 
         sub_graph.Infer();
+        has_executed = true;
 
         continue_cond = (continue_cond_check->getStatus() != 0);
 
@@ -710,7 +713,9 @@ void TensorIterator::execute(const dnnl::stream& strm) {
     }
 
     for (auto& mapper : last_mappers) {
-        mapper->execute(strm, -1);
+        // If the body has produced nothing, a loop carried dependency output keeps its initial value
+        const bool useInitialValue = !has_executed && mapper.zeroIterMapper;
+        (useInitialValue ? mapper.zeroIterMapper : mapper.mapper)->execute(strm, -1);
     }
 }
 
@@ -720,6 +725,7 @@ void TensorIterator::executeDynamicImpl(const dnnl::stream& strm) {
 
     bool continue_cond = initial_cond_check->getStatus() != 0;
     int max_num_iter = trip_count_check->getStatus();
+    bool has_executed = false;
 
     for (auto& mapper : first_mappers) {
         mapper.second->execute(strm, -1);
@@ -736,6 +742,7 @@ void TensorIterator::executeDynamicImpl(const dnnl::stream& strm) {
         }
 
         sub_graph.Infer();
+        has_executed = true;
 
         continue_cond = (continue_cond_check->getStatus() != 0);
 
@@ -749,7 +756,7 @@ void TensorIterator::executeDynamicImpl(const dnnl::stream& strm) {
         }
     }
 
-    reshapeAndFillOutput(strm);
+    reshapeAndFillOutput(strm, !has_executed);
 }
 
 /* *==============* Prepare reorders, edges between body and TI *==============* */
@@ -778,8 +785,18 @@ void TensorIterator::prepareOutputPorts() {
         auto& from_mem = output_mem[map_rule.to];
 
         if (map_rule.axis == -1) {
-            last_mappers.emplace_back(
-                std::make_shared<BackEdgePortHelper>(context->getParamsCache(), from_mem, to_mem));
+            LastPortMapper mappers{std::make_shared<BackEdgePortHelper>(context->getParamsCache(), from_mem, to_mem),
+                                   nullptr};
+
+            // a loop carried dependency output falls back to its initial value in case of zero iterations
+            const auto initial_value_port = getInitialValueInputPort(map_rule);
+            if (initial_value_port != -1) {
+                mappers.zeroIterMapper = std::make_shared<BackEdgePortHelper>(context->getParamsCache(),
+                                                                              getSrcMemoryAtPort(initial_value_port),
+                                                                              to_mem);
+            }
+
+            last_mappers.emplace_back(std::move(mappers));
         } else {
             after_mappers.emplace_back(std::make_shared<PortIteratorHelper>(context->getParamsCache(),
                                                                             from_mem,
@@ -893,9 +910,67 @@ void TensorIterator::reshapeSubgraphInput() {
     }
 }
 
-void TensorIterator::reshapeAndFillOutput(const dnnl::stream& strm) {
+// Returns the external input port which holds the initial value of the loop carried dependency the given
+// output port is bound to, i.e. the merged input the body output of this port is connected back to.
+// -1 is returned in case the given output port is not a loop carried dependency.
+int TensorIterator::getInitialValueInputPort(const PortMap& outputMapRule) const {
+    if (outputMapRule.axis != -1) {
+        return -1;
+    }
+
+    const auto back_edge = std::find_if(backEdges.begin(), backEdges.end(), [&](const PortMap& rule) {
+        return rule.from == outputMapRule.to;
+    });
+    if (back_edge == backEdges.end()) {
+        return -1;
+    }
+
+    // back edges are created for merged inputs only, so the corresponding input port map is not iterable
+    const auto input_rule = std::find_if(inputPortMap.begin(), inputPortMap.end(), [&](const PortMap& rule) {
+        return rule.to == back_edge->to && rule.axis == -1;
+    });
+    if (input_rule == inputPortMap.end()) {
+        return -1;
+    }
+
+    return input_rule->from;
+}
+
+// In case the body has not been executed at all (zero trip count or false initial execution condition)
+// the value of a loop carried dependency is still its initial value, so the output has to be filled from
+// the corresponding node input directly. The body output memory cannot be used here: it has neither a
+// valid shape (it is left undefined, which used to be nullified to zeros) nor valid data.
+bool TensorIterator::fillOutputByInitialValue(const dnnl::stream& strm, const PortMap& outputMapRule) {
+    const auto initial_value_port = getInitialValueInputPort(outputMapRule);
+    if (initial_value_port == -1) {
+        return false;
+    }
+
+    auto from_mem = getSrcMemoryAtPort(initial_value_port);
+    const auto& newDims = from_mem->getStaticDims();
+
+    const auto baseDesc = getBaseMemDescAtOutputPort(outputMapRule.from);
+    if (baseDesc->getShape().getRank() != newDims.size()) {
+        return false;
+    }
+
+    auto to_mems = getToMemories(this, outputMapRule.from);
+    const bool hasZeroDims = std::count(std::begin(newDims), std::end(newDims), 0) > 0;
+    redefineToMemories(to_mems, baseDesc->cloneWithNewDims(newDims, hasZeroDims));
+
+    BackEdgePortHelper mapper(context->getParamsCache(), from_mem, to_mems.front());
+    mapper.execute(strm, -1);
+
+    return true;
+}
+
+void TensorIterator::reshapeAndFillOutput(const dnnl::stream& strm, const bool zeroIterations) {
     for (auto map_rule : outputPortMap) {
         if (map_rule.axis == -1) {
+            if (zeroIterations && fillOutputByInitialValue(strm, map_rule)) {
+                continue;
+            }
+
             auto to_mems = getToMemories(this, map_rule.from);
             auto& from_mem = output_mem[map_rule.to];
 

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -714,8 +714,8 @@ void TensorIterator::execute(const dnnl::stream& strm) {
 
     for (auto& mapper : last_mappers) {
         // If the body has produced nothing, a loop carried dependency output keeps its initial value
-        const bool useInitialValue = !has_executed && mapper.zeroIterMapper;
-        (useInitialValue ? mapper.zeroIterMapper : mapper.mapper)->execute(strm, -1);
+        const bool use_initial_value = !has_executed && mapper.zeroIterMapper;
+        (use_initial_value ? mapper.zeroIterMapper : mapper.mapper)->execute(strm, -1);
     }
 }
 
@@ -947,16 +947,16 @@ bool TensorIterator::fillOutputByInitialValue(const dnnl::stream& strm, const Po
     }
 
     auto from_mem = getSrcMemoryAtPort(initial_value_port);
-    const auto& newDims = from_mem->getStaticDims();
+    const auto& new_dims = from_mem->getStaticDims();
 
-    const auto baseDesc = getBaseMemDescAtOutputPort(outputMapRule.from);
-    if (baseDesc->getShape().getRank() != newDims.size()) {
+    const auto base_desc = getBaseMemDescAtOutputPort(outputMapRule.from);
+    if (base_desc->getShape().getRank() != new_dims.size()) {
         return false;
     }
 
     auto to_mems = getToMemories(this, outputMapRule.from);
-    const bool hasZeroDims = std::count(std::begin(newDims), std::end(newDims), 0) > 0;
-    redefineToMemories(to_mems, baseDesc->cloneWithNewDims(newDims, hasZeroDims));
+    const bool has_zero_dims = std::count(std::begin(new_dims), std::end(new_dims), 0) > 0;
+    redefineToMemories(to_mems, base_desc->cloneWithNewDims(new_dims, has_zero_dims));
 
     BackEdgePortHelper mapper(context->getParamsCache(), from_mem, to_mems.front());
     mapper.execute(strm, -1);

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.h
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.h
@@ -196,13 +196,8 @@ private:
     std::unordered_map<std::pair<int, int>, std::shared_ptr<PortMapHelper>, PortMapHasher>
         first_mappers;  /// < Applied once before loop
 
-    /**
-     * Pair of helpers to fill one node output port when the loop is over.
-     * 'mapper' takes the value produced by the body on the last executed iteration, while
-     * 'zeroIterMapper' takes the initial value of the corresponding loop carried dependency
-     * (merged input) and is used when the body has not been executed at all. It stays empty
-     * for the output ports which are not loop carried dependencies.
-     */
+    /// Fills one output port once the loop is over: 'mapper' uses the last executed iteration's value, while
+    /// 'zeroIterMapper' (set only for loop carried dependencies) falls back to the initial merged input value.
     struct LastPortMapper {
         std::shared_ptr<PortMapHelper> mapper;
         std::shared_ptr<PortMapHelper> zeroIterMapper;

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.h
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.h
@@ -167,8 +167,13 @@ private:
 
     /* Dynamic support */
     void reshapeSubgraphInput();
-    void reshapeAndFillOutput(const dnnl::stream& strm);
+    void reshapeAndFillOutput(const dnnl::stream& strm, bool zeroIterations);
     bool checkForInputAndBodyShapesInequality() const;
+
+    /* Zero iterations support */
+    int getInitialValueInputPort(const PortMap& outputMapRule) const;
+    bool fillOutputByInitialValue(const dnnl::stream& strm, const PortMap& outputMapRule);
+
     int getNumIteration(const std::vector<PortMap>& inputPortMap, const std::vector<PortMap>& outputPortMap) const;
     void prepareParamsImpl(bool compileStage);
 
@@ -191,10 +196,22 @@ private:
     std::unordered_map<std::pair<int, int>, std::shared_ptr<PortMapHelper>, PortMapHasher>
         first_mappers;  /// < Applied once before loop
 
-    std::vector<std::shared_ptr<PortMapHelper>> last_mappers,  /// < Applied once after loop
-        before_mappers,                                        /// < Applied before each iteration
-        after_mappers,                                         /// < Applied after each iteration
-        back_mappers;                                          /// < Applied before each iteration for dynamic shapes
+    /**
+     * Pair of helpers to fill one node output port when the loop is over.
+     * 'mapper' takes the value produced by the body on the last executed iteration, while
+     * 'zeroIterMapper' takes the initial value of the corresponding loop carried dependency
+     * (merged input) and is used when the body has not been executed at all. It stays empty
+     * for the output ports which are not loop carried dependencies.
+     */
+    struct LastPortMapper {
+        std::shared_ptr<PortMapHelper> mapper;
+        std::shared_ptr<PortMapHelper> zeroIterMapper;
+    };
+    std::vector<LastPortMapper> last_mappers;  /// < Applied once after loop
+
+    std::vector<std::shared_ptr<PortMapHelper>> before_mappers,  /// < Applied before each iteration
+        after_mappers,                                           /// < Applied after each iteration
+        back_mappers;                                            /// < Applied before each iteration for dynamic shapes
 
     std::shared_ptr<PortChecker> trip_count_check,  /// < Perform check of trip count value. value >= -1
         initial_cond_check,   /// < Perform check of initial continue condition value. value [0, 1]

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/loop.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/loop.cpp
@@ -456,7 +456,8 @@ protected:
 };
 
 using LoopZeroIterationsParams = typename std::tuple<int64_t,  // TripCount
-                                                     bool>;    // Execution condition
+                                                     bool,     // Execution condition
+                                                     bool>;    // Static shapes
 
 // Loop which may not execute its body at all: either the trip count is zero or the initial execution
 // condition is false. A loop carried dependency output (a body output which is connected back to a merged
@@ -464,7 +465,10 @@ using LoopZeroIterationsParams = typename std::tuple<int64_t,  // TripCount
 // to be taken from the corresponding node input. Otherwise the output shape is nullified to zeros and the
 // following eltwise fails on shape infer.
 //
-//    Parameter(input, dynamic)   Parameter(exec_cond)
+// With static shapes and a constant execution condition the node itself is fully static, exercising
+// TensorIterator::execute() instead of executeDynamicImpl().
+//
+//    Parameter(input)   Parameter or Constant(exec_cond)
 //        |             \                 /
 //        |              Loop(trip_count, exec_cond)   body: Add(body_param, 1.f) --+
 //        |                    |                                 ^                 |
@@ -476,26 +480,41 @@ class LoopZeroIterationsCPUTest : public testing::WithParamInterface<LoopZeroIte
                                   virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<LoopZeroIterationsParams>& obj) {
-        const auto& [trip_count, exec_cond] = obj.param;
+        const auto& [trip_count, exec_cond, static_shapes] = obj.param;
         std::ostringstream result;
-        result << "trip_count=" << trip_count << "_exec_cond=" << exec_cond;
+        result << "trip_count=" << trip_count << "_exec_cond=" << exec_cond << "_static_shapes=" << static_shapes;
         return result.str();
     }
 
 protected:
     void SetUp() override {
-        const auto& [trip_count, exec_cond] = this->GetParam();
+        const auto& [trip_count, exec_cond, static_shapes] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         // the body is executed only if both the trip count and the execution condition allow it
         executed_iterations = exec_cond ? trip_count : 0;
 
-        InputShape input_shape = {{-1, -1, -1}, {{2, 3, 4}, {1, 5, 5}}};  // infer more than once
-        InputShape exec_cond_shape = {{1}, {{1}, {1}}};
-        init_input_shapes({input_shape, exec_cond_shape});
+        if (static_shapes) {
+            init_input_shapes({{{2, 3, 4}, {{2, 3, 4}}}});
+        } else {
+            InputShape input_shape = {{-1, -1, -1}, {{2, 3, 4}, {1, 5, 5}}};  // infer more than once
+            InputShape exec_cond_shape = {{1}, {{1}, {1}}};
+            init_input_shapes({input_shape, exec_cond_shape});
+        }
 
         auto input = std::make_shared<ov::op::v0::Parameter>(netType, inputDynamicShapes[0]);
-        // the execution condition is a parameter to keep the loop output shape dynamic
-        auto exec_condition = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, inputDynamicShapes[1]);
+        ov::ParameterVector params = {input};
+
+        // a constant execution condition (with static shapes) keeps the node static; a parameter one
+        // keeps the loop output shape dynamic
+        ov::Output<ov::Node> exec_condition;
+        if (static_shapes) {
+            exec_condition = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{1}, exec_cond);
+        } else {
+            auto exec_condition_param =
+                std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, inputDynamicShapes[1]);
+            params.push_back(exec_condition_param);
+            exec_condition = exec_condition_param;
+        }
         auto trip_count_input = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, trip_count);
 
         // Body: the loop carried value is incremented by 1 on each iteration
@@ -515,13 +534,11 @@ protected:
         // the consumer of the loop output is the actual victim of a wrong output shape
         auto add = std::make_shared<ov::op::v1::Add>(loop_out, input);
         auto result = std::make_shared<ov::op::v0::Result>(add);
-        function = std::make_shared<ov::Model>(ov::ResultVector{result},
-                                               ov::ParameterVector{input, exec_condition},
-                                               "loop_zero_iterations");
+        function = std::make_shared<ov::Model>(ov::ResultVector{result}, params, "loop_zero_iterations");
     }
 
     void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
-        const auto& [trip_count, exec_cond] = this->GetParam();
+        const auto& [trip_count, exec_cond, static_shapes] = this->GetParam();
         inputs.clear();
         const auto& funcInputs = function->inputs();
 
@@ -531,9 +548,11 @@ protected:
         inputs.insert({funcInputs[0].get_node_shared_ptr(),
                        ov::test::utils::create_and_fill_tensor(netType, targetInputStaticShapes[0], in_data)});
 
-        ov::Tensor exec_cond_tensor(ov::element::boolean, targetInputStaticShapes[1]);
-        *exec_cond_tensor.data<bool>() = exec_cond;
-        inputs.insert({funcInputs[1].get_node_shared_ptr(), exec_cond_tensor});
+        if (!static_shapes) {
+            ov::Tensor exec_cond_tensor(ov::element::boolean, targetInputStaticShapes[1]);
+            *exec_cond_tensor.data<bool>() = exec_cond;
+            inputs.insert({funcInputs[1].get_node_shared_ptr(), exec_cond_tensor});
+        }
     }
 
     // the reference implementation of Loop does not support zero iterations at all (it throws), so the
@@ -779,11 +798,21 @@ INSTANTIATE_TEST_SUITE_P(smoke_LoopForConcat,
                          LoopLayerCPUTest::getTestCaseName);
 
 // trip_count == 0 and exec_cond == false both lead to zero iterations, exec_cond == true with a non zero
-// trip count is the control case where the body is really executed
+// trip count is the control case where the body is really executed. Dynamic shapes drive executeDynamicImpl().
 INSTANTIATE_TEST_SUITE_P(smoke_LoopZeroIterations,
                          LoopZeroIterationsCPUTest,
                          ::testing::Combine(::testing::Values(static_cast<int64_t>(0), static_cast<int64_t>(3)),
-                                            ::testing::Values(false, true)),
+                                            ::testing::Values(false, true),
+                                            ::testing::Values(false)),
+                         LoopZeroIterationsCPUTest::getTestCaseName);
+
+// zero trip count with a constant exec_cond and static shapes keeps the node static, exercising execute()
+// instead of executeDynamicImpl()
+INSTANTIATE_TEST_SUITE_P(smoke_LoopZeroIterationsStatic,
+                         LoopZeroIterationsCPUTest,
+                         ::testing::Combine(::testing::Values(static_cast<int64_t>(0)),
+                                            ::testing::Values(true),
+                                            ::testing::Values(true)),
                          LoopZeroIterationsCPUTest::getTestCaseName);
 
 }  // namespace

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/loop.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/loop.cpp
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "openvino/op/loop.hpp"
+
 #include "common_test_utils/node_builders/constant.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "common_test_utils/test_enums.hpp"
@@ -10,30 +11,24 @@
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/less.hpp"
-#include "openvino/op/loop.hpp"
 #include "openvino/op/slice.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
 
 using namespace ov::test::utils;
 
 namespace ov {
 namespace test {
 
-enum LOOP_IN_TYPE {
-    INVARIANT,
-    MERGED
-};
+enum LOOP_IN_TYPE { INVARIANT, MERGED };
 
-using LoopParams = typename std::tuple<
-        InputLayerType,                                                    // TripCount is a constant?
-        int64_t,                                                           // TripCount, -1 means infinity
-        bool,                                                              // Execution condition
-        std::vector<InputShape>,                                           // InputShapes
-        std::vector<LOOP_IN_TYPE>,                                         // Type
-        ElementType>;                                                      // Input element type
+using LoopParams = typename std::tuple<InputLayerType,             // TripCount is a constant?
+                                       int64_t,                    // TripCount, -1 means infinity
+                                       bool,                       // Execution condition
+                                       std::vector<InputShape>,    // InputShapes
+                                       std::vector<LOOP_IN_TYPE>,  // Type
+                                       ElementType>;               // Input element type
 
-
-class LoopLayerCPUTest : public testing::WithParamInterface<LoopParams>,
-                         virtual public SubgraphBaseTest {
+class LoopLayerCPUTest : public testing::WithParamInterface<LoopParams>, virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<LoopParams>& obj) {
         const auto& [trip_count_type, trip_count, exec_cond, shapes, types, netType] = obj.param;
@@ -54,7 +49,7 @@ public:
         result << "exec_cond=" << exec_cond << "_";
         result << "netType=" << netType;
         return result.str();
-}
+    }
 
 protected:
     void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
@@ -68,7 +63,8 @@ protected:
             ov::test::utils::InputGenerateData in_data;
             in_data.start_from = 1;
             in_data.range = 10;
-            ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), funcInput.get_shape(), in_data);
+            ov::Tensor tensor =
+                ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), funcInput.get_shape(), in_data);
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
             i++;
         }
@@ -80,7 +76,9 @@ protected:
             in_data.start_from = 0;
             in_data.range = 15;
             in_data.resolution = 32768;
-            ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], in_data);
+            ov::Tensor tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                        targetInputStaticShapes[i],
+                                                                        in_data);
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
         }
     }
@@ -98,7 +96,7 @@ protected:
         // Body parameters
         const std::vector<ov::PartialShape> body_params_shapes(shapes.size(), ov::PartialShape::dynamic());
         ov::ParameterVector body_params;
-        for (const auto &pshape : body_params_shapes) {
+        for (const auto& pshape : body_params_shapes) {
             body_params.emplace_back(std::make_shared<ov::op::v0::Parameter>(netType, pshape));
         }
 
@@ -123,8 +121,7 @@ protected:
             Zo = std::make_shared<ov::op::v1::Add>(body_params[i], Zo);
         }
 
-        auto body = std::make_shared<ov::Model>(ov::OutputVector{body_condition_const, Zo},
-                                                       body_params);
+        auto body = std::make_shared<ov::Model>(ov::OutputVector{body_condition_const, Zo}, body_params);
 
         auto loop = std::make_shared<ov::op::v5::Loop>(trip_count_input, exec_condition);
         loop->set_function(body);
@@ -175,8 +172,8 @@ protected:
         }
         // Body parameters
         const std::vector<ov::PartialShape> body_params_shapes(shapes.size(), ov::PartialShape::dynamic());
-        ov::ParameterVector body_params = { std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{}) };
-        for (const auto &pshape : body_params_shapes) {
+        ov::ParameterVector body_params = {std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{})};
+        for (const auto& pshape : body_params_shapes) {
             body_params.emplace_back(std::make_shared<ov::op::v0::Parameter>(inType, pshape));
         }
 
@@ -215,7 +212,7 @@ protected:
 
         auto result0 = std::make_shared<ov::op::v0::Result>(out0);
         auto result1 = std::make_shared<ov::op::v0::Result>(out1);
-        function = std::make_shared<ov::Model>(ov::ResultVector{ result0, result1 }, params, "loop");
+        function = std::make_shared<ov::Model>(ov::ResultVector{result0, result1}, params, "loop");
     }
 };
 
@@ -243,7 +240,7 @@ protected:
         // Body parameters
         const std::vector<ov::PartialShape> body_params_shapes(shapes.size(), ov::PartialShape::dynamic());
         ov::ParameterVector body_params;
-        for (const auto &pshape : body_params_shapes) {
+        for (const auto& pshape : body_params_shapes) {
             body_params.emplace_back(std::make_shared<ov::op::v0::Parameter>(inType, pshape));
         }
 
@@ -374,10 +371,12 @@ class StaticLoopDynamicSubgraphCPUTest : public SubgraphBaseTest {
         auto body_condition_const = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{1}, true);
 
         // Body parameters
-        ov::ParameterVector body_params = {std::make_shared<ov::op::v0::Parameter>(netType, ov::PartialShape{25, 1, -1})};
+        ov::ParameterVector body_params = {
+            std::make_shared<ov::op::v0::Parameter>(netType, ov::PartialShape{25, 1, -1})};
 
         // Body
-        auto broadcast_target_shape = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{25, 1, 256});
+        auto broadcast_target_shape =
+            std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{25, 1, 256});
         auto broadcast_axis_mapping = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, 0);
         auto broadcast = std::make_shared<ov::op::v3::Broadcast>(body_params[0], broadcast_target_shape);
         auto body = std::make_shared<ov::Model>(ov::OutputVector{body_condition_const, broadcast}, body_params);
@@ -411,7 +410,9 @@ class StaticLoopDynamicSubgraphCPUTest : public SubgraphBaseTest {
                 in_data.start_from = 0;
                 in_data.range = 2560;
                 in_data.resolution = 256;
-                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], in_data);
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[i],
+                                                                 in_data);
             }
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
         }
@@ -454,6 +455,105 @@ protected:
     }
 };
 
+using LoopZeroIterationsParams = typename std::tuple<int64_t,  // TripCount
+                                                     bool>;    // Execution condition
+
+// Loop which may not execute its body at all: either the trip count is zero or the initial execution
+// condition is false. A loop carried dependency output (a body output which is connected back to a merged
+// input) keeps the initial value of that merged input in such a case, so both its shape and its data have
+// to be taken from the corresponding node input. Otherwise the output shape is nullified to zeros and the
+// following eltwise fails on shape infer.
+//
+//    Parameter(input, dynamic)   Parameter(exec_cond)
+//        |             \                 /
+//        |              Loop(trip_count, exec_cond)   body: Add(body_param, 1.f) --+
+//        |                    |                                 ^                 |
+//        |                    |                                 +--- back edge ---+
+//        +-------- Add -------+
+//                   |
+//                 Result
+class LoopZeroIterationsCPUTest : public testing::WithParamInterface<LoopZeroIterationsParams>,
+                                  virtual public SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<LoopZeroIterationsParams>& obj) {
+        const auto& [trip_count, exec_cond] = obj.param;
+        std::ostringstream result;
+        result << "trip_count=" << trip_count << "_exec_cond=" << exec_cond;
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        const auto& [trip_count, exec_cond] = this->GetParam();
+        targetDevice = ov::test::utils::DEVICE_CPU;
+        // the body is executed only if both the trip count and the execution condition allow it
+        executed_iterations = exec_cond ? trip_count : 0;
+
+        InputShape input_shape = {{-1, -1, -1}, {{2, 3, 4}, {1, 5, 5}}};  // infer more than once
+        InputShape exec_cond_shape = {{1}, {{1}, {1}}};
+        init_input_shapes({input_shape, exec_cond_shape});
+
+        auto input = std::make_shared<ov::op::v0::Parameter>(netType, inputDynamicShapes[0]);
+        // the execution condition is a parameter to keep the loop output shape dynamic
+        auto exec_condition = std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, inputDynamicShapes[1]);
+        auto trip_count_input = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, trip_count);
+
+        // Body: the loop carried value is incremented by 1 on each iteration
+        auto body_param = std::make_shared<ov::op::v0::Parameter>(netType, ov::PartialShape{-1, -1, -1});
+        auto body_condition_const = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{1}, true);
+        auto increment = std::make_shared<ov::op::v0::Constant>(netType, ov::Shape{1}, std::vector<float>{1.f});
+        auto body_add = std::make_shared<ov::op::v1::Add>(body_param, increment);
+        auto body = std::make_shared<ov::Model>(ov::OutputVector{body_condition_const, body_add},
+                                                ov::ParameterVector{body_param});
+
+        auto loop = std::make_shared<ov::op::v5::Loop>(trip_count_input, exec_condition);
+        loop->set_function(body);
+        loop->set_special_body_ports(ov::op::v5::Loop::SpecialBodyPorts{-1, 0});
+        loop->set_merged_input(body_param, input, body_add);
+        auto loop_out = loop->get_iter_value(body_add, -1);
+
+        // the consumer of the loop output is the actual victim of a wrong output shape
+        auto add = std::make_shared<ov::op::v1::Add>(loop_out, input);
+        auto result = std::make_shared<ov::op::v0::Result>(add);
+        function = std::make_shared<ov::Model>(ov::ResultVector{result},
+                                               ov::ParameterVector{input, exec_condition},
+                                               "loop_zero_iterations");
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        const auto& [trip_count, exec_cond] = this->GetParam();
+        inputs.clear();
+        const auto& funcInputs = function->inputs();
+
+        ov::test::utils::InputGenerateData in_data;
+        in_data.start_from = 0;
+        in_data.range = 10;
+        inputs.insert({funcInputs[0].get_node_shared_ptr(),
+                       ov::test::utils::create_and_fill_tensor(netType, targetInputStaticShapes[0], in_data)});
+
+        ov::Tensor exec_cond_tensor(ov::element::boolean, targetInputStaticShapes[1]);
+        *exec_cond_tensor.data<bool>() = exec_cond;
+        inputs.insert({funcInputs[1].get_node_shared_ptr(), exec_cond_tensor});
+    }
+
+    // the reference implementation of Loop does not support zero iterations at all (it throws), so the
+    // expected values are calculated here: out = (input + executed_iterations) + input
+    std::vector<ov::Tensor> calculate_refs() override {
+        const auto& input = inputs.at(function->get_parameters().front());
+        ov::Tensor expected(input.get_element_type(), input.get_shape());
+
+        const auto* src = input.data<float>();
+        auto* dst = expected.data<float>();
+        for (size_t i = 0; i < input.get_size(); i++) {
+            dst[i] = src[i] + (src[i] + static_cast<float>(executed_iterations));
+        }
+
+        return {expected};
+    }
+
+    const ElementType netType = ov::element::f32;
+    int64_t executed_iterations = 0;
+};
 
 TEST_P(LoopLayerCPUTest, CompareWithRefs) {
     run();
@@ -483,218 +583,208 @@ TEST_F(LoopZeroDimBackEdgeCPUTest, smoke_ZeroDimBackEdgeNoCrash) {
     EXPECT_EQ(output_shape, expected_shape);
 }
 
+TEST_P(LoopZeroIterationsCPUTest, CompareWithRefs) {
+    run();
+}
+
 namespace {
 
-const std::vector<ElementType> inputPrecisions = {
-        ElementType::f32,
-        ElementType::bf16,
-        ElementType::i8
-};
+const std::vector<ElementType> inputPrecisions = {ElementType::f32, ElementType::bf16, ElementType::i8};
 
-std::vector<InputLayerType> trip_count_type { InputLayerType::CONSTANT, InputLayerType::PARAMETER };
-std::vector<int64_t> trip_count { 0, 1, 5 };
-std::vector<bool> exec_cond { true, false };
+std::vector<InputLayerType> trip_count_type{InputLayerType::CONSTANT, InputLayerType::PARAMETER};
+std::vector<int64_t> trip_count{0, 1, 5};
+std::vector<bool> exec_cond{true, false};
 
 // dim[axis] = 1 because loop supports concatenation only with stride = part_size = 1
 // the first loop suit test is with output concatenation
 std::vector<std::vector<InputShape>> inputs = {
-    {  //first test suit
-        {   //dynamic shape for first input
-            {-1, 1, -1},
-            { // target static shapes
-                {10, 1, 10},
-                {1, 1, 1},
-                {1, 1, 1},
-                {5, 1, 3}
-            }
-        },
-        {   //dynamic shape for second input
-            {-1, -1, -1},
-            { // target static shapes
-                {1, 1, 1},
-                {5, 1, 2},
-                {5, 1, 2},
-                {5, 1, 3}
-            }
-        },
-        {   //dynamic shape for third input
-            {-1, 1, -1},
-            { // target static shapes
-                {10, 1, 10},
-                {5, 1, 2},
-                {5, 1, 2},
-                {5, 1, 3}
-            }
-        }
-    },
+    { // first test suit
+     {// dynamic shape for first input
+      {-1, 1, -1},
+      {// target static shapes
+       {10, 1, 10},
+       {1, 1, 1},
+       {1, 1, 1},
+       {5, 1, 3}}},
+     {// dynamic shape for second input
+      {-1, -1, -1},
+      {// target static shapes
+       {1, 1, 1},
+       {5, 1, 2},
+       {5, 1, 2},
+       {5, 1, 3}}},
+     {// dynamic shape for third input
+      {-1, 1, -1},
+      {// target static shapes
+       {10, 1, 10},
+       {5, 1, 2},
+       {5, 1, 2},
+       {5, 1, 3}}}},
 
-    {  //second test suit
-        {   //dynamic shape for first input
-            {{1, 10}, 1, {1, 10}},
-            { // target static shapes
-                {8, 1, 8},
-                {1, 1, 1},
-                {1, 1, 1},
-                {1, 1, 1}
-            }
-        },
-        {   //dynamic shape for second input
-            {{1, 8}, 1, {1, 8}},
-            { // target static shapes
-                {8, 1, 8},
-                {1, 1, 1},
-                {1, 1, 1},
-                {5, 1, 3}
-            }
-        },
-        {   //dynamic shape for third input
-            {{1, 10}, -1, {1, 10}},
-            { // target static shapes
-                {8, 1, 8},
-                {1, 1, 1},
-                {1, 1, 1},
-                {5, 1, 3}
-            }
-        }
-    },
+    { // second test suit
+     {// dynamic shape for first input
+      {{1, 10}, 1, {1, 10}},
+      {// target static shapes
+       {8, 1, 8},
+       {1, 1, 1},
+       {1, 1, 1},
+       {1, 1, 1}}},
+     {// dynamic shape for second input
+      {{1, 8}, 1, {1, 8}},
+      {// target static shapes
+       {8, 1, 8},
+       {1, 1, 1},
+       {1, 1, 1},
+       {5, 1, 3}}},
+     {// dynamic shape for third input
+      {{1, 10}, -1, {1, 10}},
+      {// target static shapes
+       {8, 1, 8},
+       {1, 1, 1},
+       {1, 1, 1},
+       {5, 1, 3}}}},
 };
-std::vector<LOOP_IN_TYPE> types = {
-        LOOP_IN_TYPE::INVARIANT, LOOP_IN_TYPE::INVARIANT, LOOP_IN_TYPE::MERGED
-};
+std::vector<LOOP_IN_TYPE> types = {LOOP_IN_TYPE::INVARIANT, LOOP_IN_TYPE::INVARIANT, LOOP_IN_TYPE::MERGED};
 
-INSTANTIATE_TEST_SUITE_P(smoke_LoopForCommon, LoopLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(trip_count_type),
-                                 ::testing::ValuesIn(trip_count),
-                                 ::testing::ValuesIn(exec_cond),
-                                 ::testing::ValuesIn(inputs),
-                                 ::testing::Values(types),
-                                 ::testing::ValuesIn(inputPrecisions)),
+INSTANTIATE_TEST_SUITE_P(smoke_LoopForCommon,
+                         LoopLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(trip_count_type),
+                                            ::testing::ValuesIn(trip_count),
+                                            ::testing::ValuesIn(exec_cond),
+                                            ::testing::ValuesIn(inputs),
+                                            ::testing::Values(types),
+                                            ::testing::ValuesIn(inputPrecisions)),
                          LoopLayerCPUTest::getTestCaseName);
 
-std::vector<std::vector<InputShape>> inputs_2 = {
-    {  //first test suit
-        {   //dynamic shape
-            {-1, -1},
-            { // target static shapes
-                {10, 10},
-                {1, 1},
-                {1, 1},
-                {5, 3}
-            }
-        },
-    },
+std::vector<std::vector<InputShape>> inputs_2 = {{
+                                                     // first test suit
+                                                     {// dynamic shape
+                                                      {-1, -1},
+                                                      {// target static shapes
+                                                       {10, 10},
+                                                       {1, 1},
+                                                       {1, 1},
+                                                       {5, 3}}},
+                                                 },
 
-    {  //second test suit
-        {   //dynamic shape
-            {{1, 10}, {1, 10}},
-            { // target static shapes
-                {5, 2},
-                {2, 5},
-                {5, 5},
-                {5, 5}
-            }
-        },
-    }
-};
+                                                 {
+                                                     // second test suit
+                                                     {// dynamic shape
+                                                      {{1, 10}, {1, 10}},
+                                                      {// target static shapes
+                                                       {5, 2},
+                                                       {2, 5},
+                                                       {5, 5},
+                                                       {5, 5}}},
+                                                 }};
 
-INSTANTIATE_TEST_SUITE_P(smoke_LoopWhileCommon, LoopWhileLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::Values(trip_count_type[0]),
-                                 ::testing::Values(-1),
-                                 ::testing::Values(true),
-                                 ::testing::ValuesIn(inputs_2),
-                                 ::testing::Values(std::vector<LOOP_IN_TYPE>{}),
-                                 ::testing::ValuesIn(inputPrecisions)),
+INSTANTIATE_TEST_SUITE_P(smoke_LoopWhileCommon,
+                         LoopWhileLayerCPUTest,
+                         ::testing::Combine(::testing::Values(trip_count_type[0]),
+                                            ::testing::Values(-1),
+                                            ::testing::Values(true),
+                                            ::testing::ValuesIn(inputs_2),
+                                            ::testing::Values(std::vector<LOOP_IN_TYPE>{}),
+                                            ::testing::ValuesIn(inputPrecisions)),
                          LoopWhileLayerCPUTest::getTestCaseName);
 
 std::vector<std::vector<InputShape>> inputs_3 = {
-        {  // first test suit
-            {
-                {-1, -1, -1},
-                { // target static shapes
-                     {10, 1, 10},
-                     {1, 10, 1},
-                     {1, 10, 1},
-                     {2, 2, 2},
-                }
-            },
-        },
-        {  // second test suit
-            {
-                {{0, 10}, {0, 10}, {0, 10}},
-                { // target static shapes
-                     {10, 5, 10},
-                     {1, 10, 1},
-                     {1, 10, 1},
-                     {2, 1, 2},
-                }
-            },
-        },
+    {
+        // first test suit
+        {{-1, -1, -1},
+         {
+             // target static shapes
+             {10, 1, 10},
+             {1, 10, 1},
+             {1, 10, 1},
+             {2, 2, 2},
+         }},
+    },
+    {
+        // second test suit
+        {{{0, 10}, {0, 10}, {0, 10}},
+         {
+             // target static shapes
+             {10, 5, 10},
+             {1, 10, 1},
+             {1, 10, 1},
+             {2, 1, 2},
+         }},
+    },
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_LoopForDiffShapesConcat, LoopForDiffShapesLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(trip_count_type),
-                                 ::testing::ValuesIn(trip_count),
-                                 ::testing::ValuesIn(exec_cond),
-                                 ::testing::ValuesIn(inputs_3),
-                                 ::testing::Values(std::vector<LOOP_IN_TYPE>{}),
-                                 ::testing::ValuesIn(inputPrecisions)),
+INSTANTIATE_TEST_SUITE_P(smoke_LoopForDiffShapesConcat,
+                         LoopForDiffShapesLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(trip_count_type),
+                                            ::testing::ValuesIn(trip_count),
+                                            ::testing::ValuesIn(exec_cond),
+                                            ::testing::ValuesIn(inputs_3),
+                                            ::testing::Values(std::vector<LOOP_IN_TYPE>{}),
+                                            ::testing::ValuesIn(inputPrecisions)),
                          LoopLayerCPUTest::getTestCaseName);
 
 std::vector<std::vector<InputShape>> inputs_4 = {
-        {  // first test suit
-            {  // first input
-                {-1, 10, 10},
-                { // target static shapes
-                    {10, 10, 10},
-                    {5, 10, 10},
-                    {5, 10, 10},
-                    {8, 10, 10},
-                }
-            },
-            {  // second input
-                {-1, 10, 10},
-                { // target static shapes
-                    {0, 10, 10},
-                    {0, 10, 10},
-                    {0, 10, 10},
-                    {0, 10, 10},
-                }
-            },
-        },
-        {  // second test suit
-            {  // first input
-                {{0, 10}, 10, 10},
-                { // target static shapes
-                    {10, 10, 10},
-                    {5, 10, 10},
-                    {5, 10, 10},
-                    {8, 10, 10},
-                }
-            },
-            {  // second input
-                {-1, 10, 10},
-                { // target static shapes
-                    {0, 10, 10},
-                    {0, 10, 10},
-                    {0, 10, 10},
-                    {0, 10, 10},
-                }
-            },
-        },
+    {
+        // first test suit
+        {// first input
+         {-1, 10, 10},
+         {
+             // target static shapes
+             {10, 10, 10},
+             {5, 10, 10},
+             {5, 10, 10},
+             {8, 10, 10},
+         }},
+        {// second input
+         {-1, 10, 10},
+         {
+             // target static shapes
+             {0, 10, 10},
+             {0, 10, 10},
+             {0, 10, 10},
+             {0, 10, 10},
+         }},
+    },
+    {
+        // second test suit
+        {// first input
+         {{0, 10}, 10, 10},
+         {
+             // target static shapes
+             {10, 10, 10},
+             {5, 10, 10},
+             {5, 10, 10},
+             {8, 10, 10},
+         }},
+        {// second input
+         {-1, 10, 10},
+         {
+             // target static shapes
+             {0, 10, 10},
+             {0, 10, 10},
+             {0, 10, 10},
+             {0, 10, 10},
+         }},
+    },
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_LoopForConcat, LoopForConcatLayerCPUTest,
-                         ::testing::Combine(
-                                 ::testing::ValuesIn(trip_count_type),
-                                 ::testing::ValuesIn(trip_count),
-                                 ::testing::ValuesIn(exec_cond),
-                                 ::testing::ValuesIn(inputs_4),
-                                 ::testing::Values(std::vector<LOOP_IN_TYPE>{}),
-                                 ::testing::ValuesIn(inputPrecisions)),
+INSTANTIATE_TEST_SUITE_P(smoke_LoopForConcat,
+                         LoopForConcatLayerCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(trip_count_type),
+                                            ::testing::ValuesIn(trip_count),
+                                            ::testing::ValuesIn(exec_cond),
+                                            ::testing::ValuesIn(inputs_4),
+                                            ::testing::Values(std::vector<LOOP_IN_TYPE>{}),
+                                            ::testing::ValuesIn(inputPrecisions)),
                          LoopLayerCPUTest::getTestCaseName);
+
+// trip_count == 0 and exec_cond == false both lead to zero iterations, exec_cond == true with a non zero
+// trip count is the control case where the body is really executed
+INSTANTIATE_TEST_SUITE_P(smoke_LoopZeroIterations,
+                         LoopZeroIterationsCPUTest,
+                         ::testing::Combine(::testing::Values(static_cast<int64_t>(0), static_cast<int64_t>(3)),
+                                            ::testing::Values(false, true)),
+                         LoopZeroIterationsCPUTest::getTestCaseName);
 
 }  // namespace
 }  // namespace test


### PR DESCRIPTION

### Details:
 - *Fixes a shape mismatch crash when a Loop (opset5) executes zero
  iterations: a loop-carried output (a body output fed back via a
  merged input) used to fall back to the body's never-executed output
  memory and get its shape nullified to [0,0,0], breaking downstream
  Eltwise-like shape inference. It now forwards the shape and data of
  the merged input's initial value instead, mirroring the equivalent
  GPU plugin fix.*
 - *Covers both the static (`execute()`) and dynamic
  (`executeDynamicImpl()`/`reshapeAndFillOutput()`) shape paths.*
 - *Adds `LoopZeroIterationsCPUTest` covering trip_count=0 and
  false execution_condition, with a manually computed reference*

### Tickets:
 - *CVS-191389*

