### PR TITLE
[PyOV] Add `__slots__` to `OVDict`

### DIFF
--- a/src/bindings/python/src/openvino/utils/data_helpers/wrappers.py
+++ b/src/bindings/python/src/openvino/utils/data_helpers/wrappers.py
@@ -66,6 +66,8 @@ class OVDict(Mapping):
         # or alternatively:
         out1, out2, out3, _ = request.infer(inputs).to_tuple()
     """
+    __slots__ = ("_dict", "_names", "__weakref__")
+
     def __init__(self, _dict: dict[ConstOutput, np.ndarray]) -> None:
         self._dict = _dict
         self._names: Optional[dict[ConstOutput, set[str]]] = None


### PR DESCRIPTION
### Details:
 - More info on `__slots__`: https://wiki.python.org/moin/UsingSlots
 - The only applicable class in PyAPI is `OVDict`, since an instance of it is being created every infer call
 - The benefits in lower memory consumption will range from negligible to noticeable depending on the user's pipeline
 - The change also reduces constructor latency (by ~25%) and attribute read (by ~8%), but the absolute gains are expressed in microseconds, so they can be ignored
 - While it's not a revolutionary improvement, it's another step towards reducing the Python API overhead during inference
 - Memory usage measurements:

| N results | Before (KB) | After (KB) | Saved (KB) |
|----------:|------------:|-----------:|-----------:|
| 1 | 1.4 | 0.8 | 0.6 |
| 10 | 2.6 | 0.9 | 1.6 |
| 100 | 22.3 | 5.9 | 16.4 |
| 1,000 | 219.9 | 55.9 | 164.0 |
| 10,000 | 2193 | 552 | 1641 |
| 100,000 | 21876 | 5470 | 16406 |
| 500,000 | 109539 | 27508 | 82031 |

### Tickets:
 - CVS-192236
