### PR TITLE
docs: fix data table text overflow

### DIFF
--- a/docs/openvino_sphinx_theme/openvino_sphinx_theme/directives/code.py
+++ b/docs/openvino_sphinx_theme/openvino_sphinx_theme/directives/code.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import os.path
 from sphinx.directives.code import LiteralInclude, LiteralIncludeReader, container_wrapper
 from sphinx.util import logging

--- a/docs/openvino_sphinx_theme/openvino_sphinx_theme/directives/code.py
+++ b/docs/openvino_sphinx_theme/openvino_sphinx_theme/directives/code.py
@@ -178,8 +178,7 @@ class DataTable(Directive):
                 csv_table_html += '<tr class="' + parity + '">'
                 for value in row:
                     csv_table_html += '<td><p>%s</p></td>' % value
-            csv_table_html += '</tr>\n</tbody>'
-            csv_table_html += "</tr>"
+                csv_table_html += '</tr>\n'
             csv_table_html += '</tbody></table>'
         csv_node.append(nodes.raw(csv_table_html, csv_table_html, format="html"))
 

--- a/docs/sphinx_setup/_static/css/openVinoDataTables.css
+++ b/docs/sphinx_setup/_static/css/openVinoDataTables.css
@@ -25,6 +25,11 @@ table.dataTable {
     width: 100%;
 }
 
+table.dataTable tbody td {
+    overflow-wrap: anywhere;
+    word-break: normal;
+}
+
 .dt-container {
     background-color: white !important;
     padding: .5rem !important;


### PR DESCRIPTION
### Details:
 - *Long model names overflowed into adjacent columns because the fixed-width table did not allow text to wrap. I added a rule that wraps long identifiers within their cells. I also corrected malformed HTML row tags produced by the shared table directive. Tables now remain readable at narrower screen widths and have valid, more reliable HTML structure.*
 - *See: [the current state](https://github.com/user-attachments/assets/5b1ce54d-9c23-4760-bf1a-b38cc44b1515) and the [fixed state, tested locally](https://github.com/user-attachments/assets/4f8da035-5fe5-4aea-aa35-0eae301d6d2f).*

### Tickets:
 - *no ticket*

### AI Assistance:
 - *AI assistance used: no*
