### PR TITLE
[GPU] Fix in-place crop padding propagation through reshape

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -608,13 +608,15 @@ bool crop_in_place_optimization::optimize(crop_node& node) {
     //  |_low_pad_|__data_size__|___|<-upper pad
     if (!node.is_dynamic() && can_crop_be_optimized_along_feature(crop_layout, input_layout)) {
         std::pair<const program_node*, layout> user_info;
-        update_in_place_crop_padding_along_feature(node,
-                                                   crop_layout,
-                                                   input_layout,
-                                                   user_info,
-                                                   crop_params->input_offsets[0],
-                                                   node.get_primitive()->axis,
-                                                   false);
+        if (!update_in_place_crop_padding_along_feature(node,
+                                                        crop_layout,
+                                                        input_layout,
+                                                        user_info,
+                                                        crop_params->input_offsets[0],
+                                                        node.get_primitive()->axis,
+                                                        false)) {
+            return false;
+        }
     } else if (can_crop_be_optimized_simple_data_format(crop_layout, input_layout)) {
         std::pair<const program_node*, layout> user_info;
         if (node.get_users().front()->is_type<reshape>()) {
@@ -643,7 +645,7 @@ bool crop_in_place_optimization::optimize(crop_node& node) {
     return false;
 }
 
-void crop_in_place_optimization::update_in_place_crop_padding_along_feature(const program_node& node,
+bool crop_in_place_optimization::update_in_place_crop_padding_along_feature(const program_node& node,
                                                                             layout& crop_layout,
                                                                             layout& input_layout,
                                                                             std::pair<const program_node*, layout>& user_info,
@@ -655,7 +657,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
         padding::DynamicDimsMask info_dynamic_pad;
         info_dynamic_pad[crop_axis] = true;
         crop_layout.data_padding._dynamic_dims_mask = info_dynamic_pad;
-        return;
+        return true;
     }
 
     const auto& crop_size = crop_layout.get_tensor();
@@ -740,17 +742,20 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
                 // axis-mapping so build-time (dyn mask) and runtime (mask +
                 // explicit sizes) paths pick the same reshape axis for patterns
                 // that do not need scaling.
-                int64_t reshape_axis = static_cast<int64_t>(crop_axis);
+                ov::Dimension::value_type divider = 1;
+                int64_t reshape_axis = static_cast<int64_t>(reshape_ps.size());
                 if (reshape_mode == reshape::reshape_mode::base) {
-                    reshape_axis = reshape_ps.size() - 1;
-                    ov::Dimension::value_type mul = 1;
                     for (size_t i = reshape_ps.size(); i > 1; i--) {
-                        if (reshape_ps[i - 1].is_dynamic() || mul == crop_dim_val)
+                        const auto& dim = reshape_ps[i - 1];
+                        if (dim.is_dynamic() || divider * dim.get_length() == crop_dim_val)
                             break;
-                        mul *= reshape_ps[i - 1].get_length();
-                        reshape_axis = i - 1;
+
+                        divider *= dim.get_length();
+                        reshape_axis = static_cast<int64_t>(i - 1);
                     }
+                    reshape_axis -= 1;
                 } else if (reshape_mode == reshape::reshape_mode::unsqueeze || reshape_mode == reshape::reshape_mode::squeeze) {
+                    reshape_axis = crop_axis;
                     const auto& output_pattern = reshape_desc->output_pattern;
                     for (size_t i = 0; i < output_pattern.size(); i++) {
                         if (output_pattern[i] <= reshape_axis) {
@@ -762,9 +767,15 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
                 OPENVINO_ASSERT(reshape_axis >= 0 && static_cast<size_t>(reshape_axis) < output_rank,
                                 "[GPU] Calculated reshape_axis is out of range for along-feature crop propagation.");
 
-                reshape_lower_sizes[reshape_axis] = lower_sizes[crop_axis];
-                reshape_upper_sizes[reshape_axis] = upper_sizes[crop_axis];
-                reshape_dyn_pad_mask[reshape_axis] = true;
+                if (divider > 1 &&
+                    (lower_sizes[crop_axis] % divider != 0 || upper_sizes[crop_axis] % divider != 0)) {
+                    return false;
+                }
+
+                const auto reshape_axis_idx = static_cast<size_t>(reshape_axis);
+                reshape_lower_sizes[reshape_axis_idx] = lower_sizes[crop_axis] / divider;
+                reshape_upper_sizes[reshape_axis_idx] = upper_sizes[crop_axis] / divider;
+                reshape_dyn_pad_mask[reshape_axis_idx] = true;
             }
 
             user_info.second.data_padding = padding(reshape_lower_sizes, reshape_upper_sizes, reshape_dyn_pad_mask);
@@ -772,6 +783,7 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
     } else {
         crop_layout.data_padding = padding(lower_sizes, upper_sizes);
     }
+    return true;
 }
 
 bool crop_in_place_optimization::update_in_place_crop_padding_simple_data_format(layout& crop_layout,
@@ -1006,13 +1018,15 @@ void prepare_buffer_fusing::run(program& p) {
             auto crop_params = node.get_kernel_impl_params();
             if (!node.is_dynamic() && crop_in_place_optimization::can_crop_be_optimized_along_feature(crop_layout, pred_layout)) {
                 std::pair<const program_node*, layout> user_info;
-                crop_in_place_optimization::update_in_place_crop_padding_along_feature(node,
-                                                                                       crop_layout,
-                                                                                       pred_layout,
-                                                                                       user_info,
-                                                                                       crop_params->input_offsets[0],
-                                                                                       node.get_primitive()->axis,
-                                                                                       false);
+                if (!crop_in_place_optimization::update_in_place_crop_padding_along_feature(node,
+                                                                                            crop_layout,
+                                                                                            pred_layout,
+                                                                                            user_info,
+                                                                                            crop_params->input_offsets[0],
+                                                                                            node.get_primitive()->axis,
+                                                                                            false)) {
+                    return;
+                }
             } else if (crop_in_place_optimization::can_crop_be_optimized_simple_data_format(crop_layout, pred_layout)) {
                 std::pair<const program_node*, layout> user_info;
                 if (node.get_users().front()->is_type<reshape>()) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.h
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.h
@@ -83,7 +83,7 @@ struct crop_in_place_optimization : pattern_match_optimization_typed<crop_in_pla
     //                  update_in_place_crop_padding_simple_data_format and
     //                  avoids relying on reshape's calc_output_layouts (which
     //                  resets padding to empty for reshape_mode::base).
-    static void update_in_place_crop_padding_along_feature(const program_node& node,
+    static bool update_in_place_crop_padding_along_feature(const program_node& node,
                                                            layout& crop_layout,
                                                            layout& pred_layout,
                                                            std::pair<const program_node*, layout>& user_info,

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2020,7 +2020,13 @@ void primitive_inst::do_runtime_in_place_crop() {
                             continue;
                         }
                     }
-                    crop_in_place_optimization::update_in_place_crop_padding_along_feature(u->get_node(), crop_layout, pred_layout, user_info, offsets, crop_axis, true);
+                    if (!crop_in_place_optimization::update_in_place_crop_padding_along_feature(
+                            u->get_node(), crop_layout, pred_layout, user_info, offsets, crop_axis, true)) {
+                        u->set_can_be_optimized(false);
+                        GPU_DEBUG_TRACE_DETAIL << "[In place crop] " << u->id()
+                                               << " cannot be optimized due to padding indivisibility" << std::endl;
+                        continue;
+                    }
                     // Install the padded crop layout and propagate the reshape
                     // output padding computed by the helper. Assigning the
                     // reshape output layout directly (mirroring the

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -2576,6 +2576,80 @@ TEST(prepare_buffer_fusing, in_place_crop_along_feature_runtime_updates_reshape_
     assert_reshape_padded("reshape2", 2);
 }
 
+TEST(prepare_buffer_fusing, in_place_crop_along_feature_reshape_scales_feature_padding) {
+    auto& engine = get_test_engine();
+    tests::random_generator rg(GET_SUITE_NAME);
+
+    constexpr int64_t tokens = 4;
+    constexpr int64_t qkv_parts = 3;
+    constexpr int64_t num_heads = 16;
+    constexpr int64_t head_size = 96;
+    constexpr int64_t hidden_size = num_heads * head_size;
+    constexpr int64_t qkv_size = qkv_parts * hidden_size;
+
+    const layout input_layout_dynamic{ov::PartialShape{-1, qkv_size}, data_types::f16, format::bfyx};
+    auto input_mem = engine.allocate_memory({{tokens, qkv_size}, data_types::f16, format::bfyx});
+    auto axis_mem = engine.allocate_memory({{}, data_types::i64, format::bfyx});
+    auto split_lengths_mem = engine.allocate_memory({{qkv_parts}, data_types::i64, format::bfyx});
+    auto scale_mem = engine.allocate_memory({{1}, data_types::f16, format::bfyx});
+
+    const auto input_data = rg.generate_random_1d<ov::float16>(tokens * qkv_size, -1.f, 1.f);
+    set_values(input_mem, input_data);
+    set_values<int64_t>(axis_mem, {1});
+    set_values<int64_t>(split_lengths_mem, {hidden_size, hidden_size, hidden_size});
+    set_values<ov::float16>(scale_mem, {ov::float16(1.f)});
+
+    topology topo(
+        input_layout("input", input_layout_dynamic),
+        data("axis", axis_mem),
+        data("split_lengths", split_lengths_mem),
+        data("scale", scale_mem),
+        crop("value_split",
+             {input_info("input"), input_info("axis"), input_info("split_lengths")},
+             tensor(1),
+             tensor(0),
+             crop_ngraph_op_mode::variadic_split,
+             2,
+             1),
+        reshape("value_view",
+                input_info("value_split"),
+                false,
+                {1, -1, num_heads, head_size},
+                ov::PartialShape{1, -1, num_heads, head_size},
+                reshape::reshape_mode::base),
+        eltwise("value", {input_info("value_view"), input_info("scale")}, eltwise_mode::prod),
+        reorder("result", input_info("value"), format::bfyx, data_types::f16));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    network net(engine, topo, config);
+    net.set_input_data("input", input_mem);
+    const auto outputs = net.execute();
+
+    ASSERT_TRUE(net.get_primitive("value_split")->can_be_optimized());
+
+    const auto& value_layout = net.get_primitive("value_view")->get_output_layout();
+    const auto& value_padding = value_layout.data_padding;
+    ASSERT_TRUE(value_padding._dynamic_dims_mask[2]);
+    ASSERT_EQ(value_padding._lower_size[2], 2 * num_heads);
+    ASSERT_EQ(value_padding._upper_size[2], 0);
+    ASSERT_EQ(static_cast<int64_t>(value_layout.get_pitches()[1]), qkv_size);
+    ASSERT_EQ(static_cast<int64_t>(value_layout.get_linear_offset()), 2 * hidden_size);
+
+    const auto output_mem = outputs.at("result").get_memory();
+    mem_lock<ov::float16, mem_lock_type::read> output_data(output_mem, get_test_stream());
+    ASSERT_EQ(output_data.size(), static_cast<size_t>(tokens * hidden_size));
+    for (int64_t token = 0; token < tokens; token++) {
+        for (int64_t feature = 0; feature < hidden_size; feature++) {
+            const auto output_idx = static_cast<size_t>(token * hidden_size + feature);
+            const auto input_idx = static_cast<size_t>(token * qkv_size + 2 * hidden_size + feature);
+            ASSERT_EQ(output_data[output_idx], input_data[input_idx]) << "Mismatch at token " << token << ", feature " << feature;
+        }
+    }
+}
+
 // =============================================================================
 // UNIT TEST: build-time and runtime must agree on which axis carries the
 //            dyn-pad mask for the TransposeSplitMatcher pattern.


### PR DESCRIPTION
### Description of the issue (symptom, root cause, how it was resolved)

- This is a regression introduced by https://github.com/openvinotoolkit/openvino/pull/36246.
- In-place crop padding was propagated through reshape without conversion to the corresponding reshape-axis units.
- This caused incorrect offsets and pitches for packed QKV views and could result in incorrect output or `CL_OUT_OF_RESOURCES`.
- The fix converts padding using the trailing reshape dimensions and disables in-place optimization when the padding cannot be represented exactly.
- The validation is applied at both graph preparation and runtime.

#### The code and line that caused this issue (if it is not changed directly)

- `crop_in_place_optimization::update_in_place_crop_padding_along_feature()`
- `src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp`

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)

```bash
./ov_gpu_unit_tests \
    --gtest_filter=prepare_buffer_fusing.in_place_crop_along_feature_reshape_scales_feature_padding
```
Skipped tests require VLSDPA CM/JIT support unavailable in the test environment.

#### Problematic graph

```text
Packed QKV [L, 3 * H * S]
    -> Split/Crop Q, K, V
    -> Reshape [1, L, H, S]
    -> SDPA/VLSDPA
```

The affected views require:

```text
linear offset = split_index * H * S
token pitch   = 3 * H * S
```

#### Checklist

- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
  - Reviewed the existing in-place crop/reshape and PR #36246 VLSDPA pitch tests.