### PR TITLE
[GPU] Add implicit GEMM convolution kernel for 1D large-tap small-IC shapes

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -194,17 +194,6 @@ private:
                                               const layout& output_layout,
                                               const layout& weights_layout,
                                               std::shared_ptr<const convolution> conv);
-    // True for the small-input-feature, very-many-tap 1D convolutions that
-    // ConvolutionKernel_1d_small_ic_gemm handles as an implicit GEMM. Blocked
-    // layouts pad the feature dimension up to their block size, throwing away 15 of
-    // every 16 MACs at IC == 1; a planar layout lets that kernel merge IC and the
-    // taps into one reduction axis instead. Kept deliberately narrow so it cannot
-    // divert a shape the blocked kernels are good at. Its shape bounds come from the
-    // kernel class, so the two gates widen together.
-    static bool convolution_1d_small_ic_gemm_opt(const layout& input_layout,
-                                                 const layout& output_layout,
-                                                 const layout& weights_layout,
-                                                 std::shared_ptr<const convolution> conv);
     bool convolution_bs_fs_yx_bsv32_fsv32_opt(const layout &input_layout,
                                               const layout& output_layout,
                                               const layout& weights_layout,

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -194,6 +194,17 @@ private:
                                               const layout& output_layout,
                                               const layout& weights_layout,
                                               std::shared_ptr<const convolution> conv);
+    // True for the small-input-feature, very-many-tap 1D convolutions that
+    // ConvolutionKernel_1d_small_ic_gemm handles as an implicit GEMM. Blocked
+    // layouts pad the feature dimension up to their block size, throwing away 15 of
+    // every 16 MACs at IC == 1; a planar layout lets that kernel merge IC and the
+    // taps into one reduction axis instead. Kept deliberately narrow so it cannot
+    // divert a shape the blocked kernels are good at. Its shape bounds come from the
+    // kernel class, so the two gates widen together.
+    static bool convolution_1d_small_ic_gemm_opt(const layout& input_layout,
+                                                 const layout& output_layout,
+                                                 const layout& weights_layout,
+                                                 std::shared_ptr<const convolution> conv);
     bool convolution_bs_fs_yx_bsv32_fsv32_opt(const layout &input_layout,
                                               const layout& output_layout,
                                               const layout& weights_layout,

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -47,12 +47,6 @@
 #include "lstm_seq_inst.h"
 #include "group_normalization_inst.h"
 #include "to_string_utils.h"
-#include "activation_inst.h"
-#include "intel_gpu/plugin/common_utils.hpp"
-// For the shape bounds shared with convolution_1d_small_ic_gemm_opt(), so the
-// graph-side gate and the kernel's Validate() cannot drift apart.
-#include "convolution/convolution_kernel_1d_small_ic_gemm.h"
-#include <tuple>
 #include <vector>
 #include <memory>
 #include <utility>
@@ -805,94 +799,6 @@ bool layout_optimizer::convolution_bs_fs_yx_bsv16_fsv16_opt(const layout& input_
     return (int8_sup || fp16_ver || fp32_ver) && correct_feature && correct_batch && single_group;
 }
 
-// Whether every fused op on this node would reach the kernel through
-// convolution_params::activations rather than fused_ops. Kernels declaring no
-// supported fused ops - ConvolutionKernel_1d_small_ic_gemm among them - still handle
-// those, since they apply params.activations in their epilogue.
-//
-// Mirrors use_legacy_fused_ops() in impls/ocl/kernel_selector_helper.cpp, minus
-// its plain-format test (this runs while deciding whether to make the format plain,
-// so asking whether it already is would be circular) and its legacy_fusion_list
-// test (convolution is in that list).
-static bool can_use_legacy_activations_only(const program_node& node) {
-    const auto& fused = node.get_fused_primitives();
-    if (fused.empty())
-        return true;
-    if (fused.size() != 1)
-        return false;
-    return fused[0].is_type<activation>() && fused[0].deps.empty();
-}
-
-bool layout_optimizer::convolution_1d_small_ic_gemm_opt(const layout& input_layout,
-                                                        const layout& output_layout,
-                                                        const layout& weights_layout,
-                                                        std::shared_ptr<const convolution> conv) {
-    // Mirrors ConvolutionKernel_1d_small_ic_gemm::Validate(), and must agree with
-    // it: returning true for a node the kernel then rejects leaves it on a slower
-    // planar kernel than the blocked one it came from - worse than not diverting it.
-    //
-    // The shape bounds are read off the kernel class so widening its gate widens
-    // this one too. The remaining conditions cannot be shared that way: they are the
-    // same checks over cldnn::layout instead of convolution_params, which the ocl
-    // impl has not built yet at this point.
-    using kernel_selector::ConvolutionKernel_1d_small_ic_gemm;
-    constexpr auto max_input_features = static_cast<int64_t>(ConvolutionKernel_1d_small_ic_gemm::max_input_features);
-    constexpr auto min_taps = static_cast<int64_t>(ConvolutionKernel_1d_small_ic_gemm::min_taps);
-
-    if (conv->groups != 1 || conv->transposed || conv->deformable_mode)
-        return false;
-
-    if (input_layout.is_dynamic() || output_layout.is_dynamic() || weights_layout.is_dynamic())
-        return false;
-
-    // 4D only: the kernel handles a single spatial axis, mapped onto X or Y.
-    if (input_layout.get_rank() != 4 || output_layout.get_rank() != 4)
-        return false;
-    if (weights_layout.spatial(2) != 1)
-        return false;
-
-    if (input_layout.feature() > max_input_features)
-        return false;
-
-    // Only the dtypes the kernel declares in its ParamsKey.
-    const auto supported_dts = {data_types::f16, data_types::f32, data_types::u8, data_types::i8};
-    if (!one_of(input_layout.data_type, supported_dts) || !one_of(output_layout.data_type, supported_dts) ||
-        !one_of(weights_layout.data_type, supported_dts))
-        return false;
-
-    // The long axis is whichever spatial axis carries the taps; the kernel
-    // collapses the other away entirely, so it must be degenerate everywhere,
-    // paddings included.
-    //
-    // This picks the same physical axis as the kernel's long_axis_is_x(), but the
-    // booleans are not comparable: the kernel sees params after
-    // convolution_impl::get_kernel_params swapped X and Y, so for a 1D convolution
-    // along Y it reads true where this reads false. Each only selects which axis to
-    // look at within its own frame.
-    const bool long_axis_is_x = weights_layout.spatial(0) >= weights_layout.spatial(1);
-    const size_t long_idx = long_axis_is_x ? 0 : 1;
-    const size_t short_idx = long_axis_is_x ? 1 : 0;
-
-    if (weights_layout.spatial(long_idx) < min_taps)
-        return false;
-
-    if (weights_layout.spatial(short_idx) != 1 || input_layout.spatial(short_idx) != 1 ||
-        output_layout.spatial(short_idx) != 1)
-        return false;
-
-    // padding_begin/_end are in ov order, so use the same get_xyz() the ocl impl
-    // uses to fill convolution_params. For a 1D convolution it puts the single
-    // spatial value on Y and leaves X at the default, matching how such a shape
-    // lands in a bfyx tensor.
-    uint32_t pad_begin[3] = {};
-    uint32_t pad_end[3] = {};
-    std::tie(pad_begin[0], pad_begin[1], pad_begin[2]) =
-        ov::intel_gpu::get_xyz<ov::CoordinateDiff, uint32_t>(conv->padding_begin, 0);
-    std::tie(pad_end[0], pad_end[1], pad_end[2]) =
-        ov::intel_gpu::get_xyz<ov::CoordinateDiff, uint32_t>(conv->padding_end, 0);
-    return pad_begin[short_idx] == 0 && pad_end[short_idx] == 0 && pad_begin[2] == 0 && pad_end[2] == 0;
-}
-
 bool layout_optimizer::convolution_fs_b_yx_fsv32_opt(const layout& input_layout,
                                                      const layout& output_layout,
                                                      const layout& weights_layout,
@@ -1202,6 +1108,13 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
     bool onednn_valid_post_ops = get_post_ops_count(node) <= 32;
     bool use_onednn_impls = contains_onednn_impls_optimization_attribute(&node) && input_layout.data_type != data_types::f32;
 
+    // convolution_gpu_1d_small_ic_gemm declares no fused ops, but a single
+    // dependency-free activation still reaches it through convolution_params::activations
+    // (see use_legacy_fused_ops()). Anything else fused would make it reject the node.
+    const auto& fused_prims = node.get_fused_primitives();
+    const bool activation_only_fusion = fused_prims.empty() ||
+        (fused_prims.size() == 1 && fused_prims[0].is_type<activation>() && fused_prims[0].deps.empty());
+
     // Use planar bfyx format for dynamic convolutions with explicit padding in clDNN
     if (node.is_dynamic() && output_layout.get_partial_shape().size() == 4 && node.use_explicit_padding() && !i8_u8_input &&
         (!use_onednn_impls || !onednn_valid_post_ops || node.has_padded_dependency())) {
@@ -1229,16 +1142,10 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
                 expected_format = cldnn::format::b_fs_yx_fsv32;
             else
                 expected_format = cldnn::format::b_fs_zyx_fsv32;
-        } else if (convolution_1d_small_ic_gemm_opt(input_layout, output_layout, weights_layout, prim) &&
-                   can_use_legacy_activations_only(node)) {
-            // Planar, so ConvolutionKernel_1d_small_ic_gemm can run this as an
-            // implicit GEMM. Every blocked format below pads the feature dimension
-            // up to its block size, wasting 15 of every 16 MACs at IC == 1.
-            //
-            // After the onednn branches on purpose: a node onednn will implement
-            // anyway gains nothing from a planar layout and would only pay for a
-            // reorder. Those are the nodes whose format is already set through
-            // get_preferred_output_fmt above, plus the int8 case just before this.
+        } else if (input_layout.get_rank() == 4 && input_layout.feature() == 1 &&
+                   input_layout.spatial(0) == 1 && weights_layout.spatial(0) == 1 &&
+                   weights_layout.spatial(1) >= 256 && activation_only_fusion) {
+            // Use bfyx format for 1d conv with feature size 1 and 1d kernel size >= 256
             expected_format = cldnn::format::bfyx;
         } else if (i8_u8_input) {
             if (((_optimization_attributes.b_fs_yx_fsv16_network != 0) &&

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -47,6 +47,12 @@
 #include "lstm_seq_inst.h"
 #include "group_normalization_inst.h"
 #include "to_string_utils.h"
+#include "activation_inst.h"
+#include "intel_gpu/plugin/common_utils.hpp"
+// For the shape bounds shared with convolution_1d_small_ic_gemm_opt(), so the
+// graph-side gate and the kernel's Validate() cannot drift apart.
+#include "convolution/convolution_kernel_1d_small_ic_gemm.h"
+#include <tuple>
 #include <vector>
 #include <memory>
 #include <utility>
@@ -799,6 +805,94 @@ bool layout_optimizer::convolution_bs_fs_yx_bsv16_fsv16_opt(const layout& input_
     return (int8_sup || fp16_ver || fp32_ver) && correct_feature && correct_batch && single_group;
 }
 
+// Whether every fused op on this node would reach the kernel through
+// convolution_params::activations rather than fused_ops. Kernels declaring no
+// supported fused ops - ConvolutionKernel_1d_small_ic_gemm among them - still handle
+// those, since they apply params.activations in their epilogue.
+//
+// Mirrors use_legacy_fused_ops() in impls/ocl/kernel_selector_helper.cpp, minus
+// its plain-format test (this runs while deciding whether to make the format plain,
+// so asking whether it already is would be circular) and its legacy_fusion_list
+// test (convolution is in that list).
+static bool can_use_legacy_activations_only(const program_node& node) {
+    const auto& fused = node.get_fused_primitives();
+    if (fused.empty())
+        return true;
+    if (fused.size() != 1)
+        return false;
+    return fused[0].is_type<activation>() && fused[0].deps.empty();
+}
+
+bool layout_optimizer::convolution_1d_small_ic_gemm_opt(const layout& input_layout,
+                                                        const layout& output_layout,
+                                                        const layout& weights_layout,
+                                                        std::shared_ptr<const convolution> conv) {
+    // Mirrors ConvolutionKernel_1d_small_ic_gemm::Validate(), and must agree with
+    // it: returning true for a node the kernel then rejects leaves it on a slower
+    // planar kernel than the blocked one it came from - worse than not diverting it.
+    //
+    // The shape bounds are read off the kernel class so widening its gate widens
+    // this one too. The remaining conditions cannot be shared that way: they are the
+    // same checks over cldnn::layout instead of convolution_params, which the ocl
+    // impl has not built yet at this point.
+    using kernel_selector::ConvolutionKernel_1d_small_ic_gemm;
+    constexpr auto max_input_features = static_cast<int64_t>(ConvolutionKernel_1d_small_ic_gemm::max_input_features);
+    constexpr auto min_taps = static_cast<int64_t>(ConvolutionKernel_1d_small_ic_gemm::min_taps);
+
+    if (conv->groups != 1 || conv->transposed || conv->deformable_mode)
+        return false;
+
+    if (input_layout.is_dynamic() || output_layout.is_dynamic() || weights_layout.is_dynamic())
+        return false;
+
+    // 4D only: the kernel handles a single spatial axis, mapped onto X or Y.
+    if (input_layout.get_rank() != 4 || output_layout.get_rank() != 4)
+        return false;
+    if (weights_layout.spatial(2) != 1)
+        return false;
+
+    if (input_layout.feature() > max_input_features)
+        return false;
+
+    // Only the dtypes the kernel declares in its ParamsKey.
+    const auto supported_dts = {data_types::f16, data_types::f32, data_types::u8, data_types::i8};
+    if (!one_of(input_layout.data_type, supported_dts) || !one_of(output_layout.data_type, supported_dts) ||
+        !one_of(weights_layout.data_type, supported_dts))
+        return false;
+
+    // The long axis is whichever spatial axis carries the taps; the kernel
+    // collapses the other away entirely, so it must be degenerate everywhere,
+    // paddings included.
+    //
+    // This picks the same physical axis as the kernel's long_axis_is_x(), but the
+    // booleans are not comparable: the kernel sees params after
+    // convolution_impl::get_kernel_params swapped X and Y, so for a 1D convolution
+    // along Y it reads true where this reads false. Each only selects which axis to
+    // look at within its own frame.
+    const bool long_axis_is_x = weights_layout.spatial(0) >= weights_layout.spatial(1);
+    const size_t long_idx = long_axis_is_x ? 0 : 1;
+    const size_t short_idx = long_axis_is_x ? 1 : 0;
+
+    if (weights_layout.spatial(long_idx) < min_taps)
+        return false;
+
+    if (weights_layout.spatial(short_idx) != 1 || input_layout.spatial(short_idx) != 1 ||
+        output_layout.spatial(short_idx) != 1)
+        return false;
+
+    // padding_begin/_end are in ov order, so use the same get_xyz() the ocl impl
+    // uses to fill convolution_params. For a 1D convolution it puts the single
+    // spatial value on Y and leaves X at the default, matching how such a shape
+    // lands in a bfyx tensor.
+    uint32_t pad_begin[3] = {};
+    uint32_t pad_end[3] = {};
+    std::tie(pad_begin[0], pad_begin[1], pad_begin[2]) =
+        ov::intel_gpu::get_xyz<ov::CoordinateDiff, uint32_t>(conv->padding_begin, 0);
+    std::tie(pad_end[0], pad_end[1], pad_end[2]) =
+        ov::intel_gpu::get_xyz<ov::CoordinateDiff, uint32_t>(conv->padding_end, 0);
+    return pad_begin[short_idx] == 0 && pad_end[short_idx] == 0 && pad_begin[2] == 0 && pad_end[2] == 0;
+}
+
 bool layout_optimizer::convolution_fs_b_yx_fsv32_opt(const layout& input_layout,
                                                      const layout& output_layout,
                                                      const layout& weights_layout,
@@ -1135,6 +1229,17 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
                 expected_format = cldnn::format::b_fs_yx_fsv32;
             else
                 expected_format = cldnn::format::b_fs_zyx_fsv32;
+        } else if (convolution_1d_small_ic_gemm_opt(input_layout, output_layout, weights_layout, prim) &&
+                   can_use_legacy_activations_only(node)) {
+            // Planar, so ConvolutionKernel_1d_small_ic_gemm can run this as an
+            // implicit GEMM. Every blocked format below pads the feature dimension
+            // up to its block size, wasting 15 of every 16 MACs at IC == 1.
+            //
+            // After the onednn branches on purpose: a node onednn will implement
+            // anyway gains nothing from a planar layout and would only pay for a
+            // reorder. Those are the nodes whose format is already set through
+            // get_preferred_output_fmt above, plus the int8 case just before this.
+            expected_format = cldnn::format::bfyx;
         } else if (i8_u8_input) {
             if (((_optimization_attributes.b_fs_yx_fsv16_network != 0) &&
                 convolution_b_fs_yx_fsv16_opt(input_layout, output_layout, weights_layout, prim))) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_1d_small_ic_gemm.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_1d_small_ic_gemm.cl
@@ -1,0 +1,257 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "include/batch_headers/fetch_data.cl"
+#include "include/batch_headers/fetch_weights.cl"
+
+// Implicit-GEMM 1D convolution for a small input feature count and a large tap
+// count. See convolution_kernel_1d_small_ic_gemm.h for the rationale.
+//
+// The convolution is treated as C = A * B with
+//
+//   A: weights, M x K, M = OC,               K = IC * TAPS
+//   B: im2col,  K x N, N = BATCH * OUT_LEN
+//
+// Neither is reordered or materialized. A K index decomposes into
+// (input feature, tap) and an N index into (batch, output position); the input
+// element a (k, n) pair refers to is
+//
+//   input[batch][ic][n_pos * STRIDE + tap * DILATION - PAD_BEGIN]
+//
+// computed while staging tiles into SLM. Out-of-range positions are zero-filled
+// there, so the accumulation loop is branch-free.
+//
+// Jit constants supplied by the host:
+//   TAPS, OUT_LEN, GEMM_M, GEMM_N, GEMM_K
+//   TILE_M, TILE_N, TILE_K, SIMD, N_PER_LANE
+//   STRIDE_L, DILATION_L, PAD_BEGIN_L, IN_LEN
+//   ACCUMULATOR_TYPE, ACTIVATION_TYPE
+//   B_IN_BOUNDS, B_VEC (see below)
+
+// The long spatial axis is X or Y depending on whether the plugin's XY swap
+// applied. The host picks the long one and sets LONG_AXIS_IS_X accordingly, so
+// the index macros below stay correct either way.
+#if LONG_AXIS_IS_X
+    #define INPUT_AT(b, ic, pos)  INPUT0_GET_INDEX(b, ic, 0, pos)
+    #define OUTPUT_AT(b, oc, pos) OUTPUT_GET_INDEX(b, oc, 0, pos)
+    #define WEIGHTS_AT(oc, ic, tap) GET_FILTER_INDEX(FILTER, 0, oc, ic, 0, tap)
+#else
+    #define INPUT_AT(b, ic, pos)  INPUT0_GET_INDEX(b, ic, pos, 0)
+    #define OUTPUT_AT(b, oc, pos) OUTPUT_GET_INDEX(b, oc, pos, 0)
+    #define WEIGHTS_AT(oc, ic, tap) GET_FILTER_INDEX(FILTER, 0, oc, ic, tap, 0)
+#endif
+
+// One work-group computes a TILE_M x TILE_N tile but is only one sub-group (SIMD
+// work items) wide: each lane owns N_PER_LANE output columns and all TILE_M rows
+// in registers. TILE_N == SIMD * N_PER_LANE.
+#define WG_SIZE (SIMD)
+
+// Vector load of B_VEC consecutive input elements. Only used on the B_IN_BOUNDS
+// path, where the host has checked long-axis pitch 1 and DILATION_L == 1, so a run
+// of consecutive taps is contiguous.
+#define B_VEC_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, B_VEC)
+#define B_VLOAD(ptr) CAT(vload, B_VEC)(0, ptr)
+
+REQD_SUB_GROUP_SIZE(SIMD)
+__attribute__((reqd_work_group_size(WG_SIZE, 1, 1)))
+KERNEL(convolution_gpu_1d_small_ic_gemm)(
+    OPTIONAL_SHAPE_INFO_ARG
+    const __global INPUT0_TYPE *conv_input,
+    __global OUTPUT_TYPE *output,
+    const __global FILTER_TYPE *weights
+#if BIAS_TERM
+    , const __global BIAS_TYPE *biases
+#endif
+#if ASYMMETRIC_WEIGHTS_QUANTIZATION
+    , const __global WEIGHTS_ZERO_POINTS_TYPE *weights_zp
+#endif
+#if ASYMMETRIC_DATA_QUANTIZATION
+    , const __global ACTIVATIONS_ZERO_POINTS_TYPE *activations_zp
+#endif
+#if COMPENSATION_TERM
+    , const __global COMPENSATION_TYPE *comp
+#endif
+)
+{
+    const uint lid = get_local_id(0);
+
+    // Tile origin in the GEMM index space.
+    const uint n_base = (uint)get_group_id(0) * TILE_N;
+    const uint m_base = (uint)get_group_id(1) * TILE_M;
+
+    // SLM staging buffer for one K slice of A. B is per-lane and stays in
+    // registers - see B_VLOAD above.
+    __local ACCUMULATOR_TYPE a_tile[TILE_M][TILE_K];
+
+    // TILE_M rows x N_PER_LANE columns per lane. Both extents are compile-time
+    // constants and every access below is at a constant index, so this stays in the
+    // register file instead of spilling to scratch.
+    ACCUMULATOR_TYPE acc[N_PER_LANE][TILE_M];
+    __attribute__((opencl_unroll_hint))
+    for (uint j = 0; j < N_PER_LANE; ++j)
+        __attribute__((opencl_unroll_hint))
+        for (uint i = 0; i < TILE_M; ++i)
+            acc[j][i] = (ACCUMULATOR_TYPE)0;
+
+    // This lane's output columns, i.e. its (batch, output position) pairs. They are
+    // SIMD apart rather than adjacent so that at a given j the sub-group's lanes
+    // cover consecutive columns, keeping the B loads and the stores coalesced.
+    uint n_batch[N_PER_LANE];
+    uint n_pos[N_PER_LANE];
+    bool n_valid[N_PER_LANE];
+    __attribute__((opencl_unroll_hint))
+    for (uint j = 0; j < N_PER_LANE; ++j) {
+        const uint n = n_base + j * SIMD + lid;
+        n_batch[j] = n / OUT_LEN;
+        n_pos[j] = n % OUT_LEN;
+        n_valid[j] = (n < GEMM_N);
+    }
+
+    for (uint k_base = 0; k_base < GEMM_K; k_base += TILE_K) {
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // --- Stage A (weights): TILE_M x TILE_K, strided over the WG. ---
+        for (uint idx = lid; idx < TILE_M * TILE_K; idx += WG_SIZE) {
+            const uint am = idx / TILE_K;
+            const uint ak = idx % TILE_K;
+            const uint m = m_base + am;
+            const uint k = k_base + ak;
+
+            ACCUMULATOR_TYPE w = (ACCUMULATOR_TYPE)0;
+            if (m < GEMM_M && k < GEMM_K) {
+                // k -> (input feature, tap)
+                const uint k_ic = k / TAPS;
+                const uint k_tap = k % TAPS;
+                const uint w_idx = WEIGHTS_AT(m, k_ic, k_tap);
+                w = TO_ACCUMULATOR_TYPE(weights[w_idx]);
+#if ASYMMETRIC_WEIGHTS_QUANTIZATION
+                w -= TO_ACCUMULATOR_TYPE(weights_zp[m]);
+#endif
+            }
+            a_tile[am][ak] = w;
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // --- Stage B (im2col column block) and accumulate. ---
+        // A lane is the only reader of its own K slices, so B never goes to SLM.
+        // Staging and accumulation are fused so B lives in a few registers rather
+        // than a TILE_K array, which would be dynamically indexed and spill.
+        //
+        // Loop order is (k outer, column inner) so each SLM read of a_tile[i][k] is
+        // reused by all N_PER_LANE columns - the whole reason for the 2D tile.
+        // Reversing the loops would read A N_PER_LANE times as often.
+#if B_IN_BOUNDS
+        // Fast path: every position this tile touches is in range and a K run is
+        // contiguous, so B is read with unguarded vector loads - TILE_K scalar
+        // gathers become a handful of wide ones. The host proves all of that for the
+        // whole iteration space before setting B_IN_BOUNDS; see GetJitConstants.
+        {
+            const uint k_ic = k_base / TAPS;
+            const uint k_tap = k_base % TAPS;
+
+            const __global INPUT0_TYPE* src[N_PER_LANE];
+            __attribute__((opencl_unroll_hint))
+            for (uint j = 0; j < N_PER_LANE; ++j) {
+                const uint pos = n_pos[j] * STRIDE_L + k_tap * DILATION_L - PAD_BEGIN_L;
+                src[j] = conv_input + INPUT_AT(n_batch[j], k_ic, pos);
+            }
+#if ASYMMETRIC_DATA_QUANTIZATION
+            const ACCUMULATOR_TYPE azp = TO_ACCUMULATOR_TYPE(activations_zp[k_ic]);
+#endif
+            for (uint bk = 0; bk < TILE_K; bk += B_VEC) {
+                B_VEC_TYPE raw[N_PER_LANE];
+                __attribute__((opencl_unroll_hint))
+                for (uint j = 0; j < N_PER_LANE; ++j)
+                    raw[j] = B_VLOAD(src[j] + bk);
+
+                __attribute__((opencl_unroll_hint))
+                for (uint e = 0; e < B_VEC; ++e) {
+                    ACCUMULATOR_TYPE bv[N_PER_LANE];
+                    __attribute__((opencl_unroll_hint))
+                    for (uint j = 0; j < N_PER_LANE; ++j) {
+                        bv[j] = TO_ACCUMULATOR_TYPE(raw[j][e]);
+#if ASYMMETRIC_DATA_QUANTIZATION
+                        bv[j] -= azp;
+#endif
+                    }
+
+                    __attribute__((opencl_unroll_hint))
+                    for (uint i = 0; i < TILE_M; ++i) {
+                        const ACCUMULATOR_TYPE av = a_tile[i][bk + e];
+                        __attribute__((opencl_unroll_hint))
+                        for (uint j = 0; j < N_PER_LANE; ++j)
+                            acc[j][i] = fma(av, bv[j], acc[j][i]);
+                    }
+                }
+            }
+        }
+#else
+        // General path: guard every element. Used when padding, dilation, a ragged
+        // tile or an indivisible TAPS can put a position out of range.
+        for (uint bk = 0; bk < TILE_K; ++bk) {
+            const uint k = k_base + bk;
+
+            ACCUMULATOR_TYPE bv[N_PER_LANE];
+            __attribute__((opencl_unroll_hint))
+            for (uint j = 0; j < N_PER_LANE; ++j) {
+                bv[j] = (ACCUMULATOR_TYPE)0;
+                if (n_valid[j] && k < GEMM_K) {
+                    const uint k_ic = k / TAPS;
+                    const uint k_tap = k % TAPS;
+                    const int pos = (int)(n_pos[j] * STRIDE_L + k_tap * DILATION_L) - (int)PAD_BEGIN_L;
+                    if (pos >= 0 && pos < (int)IN_LEN) {
+                        const uint in_idx = INPUT_AT(n_batch[j], k_ic, (uint)pos);
+                        bv[j] = TO_ACCUMULATOR_TYPE(conv_input[in_idx]);
+#if ASYMMETRIC_DATA_QUANTIZATION
+                        bv[j] -= TO_ACCUMULATOR_TYPE(activations_zp[k_ic]);
+#endif
+                    }
+                }
+            }
+
+            __attribute__((opencl_unroll_hint))
+            for (uint i = 0; i < TILE_M; ++i) {
+                const ACCUMULATOR_TYPE av = a_tile[i][bk];
+                __attribute__((opencl_unroll_hint))
+                for (uint j = 0; j < N_PER_LANE; ++j)
+                    acc[j][i] = fma(av, bv[j], acc[j][i]);
+            }
+        }
+#endif
+    }
+
+    // --- Epilogue: bias, activation, store. ---
+    // The M loop is outermost so that, for a fixed i, the lanes at a given j write
+    // consecutive output elements.
+    __attribute__((opencl_unroll_hint))
+    for (uint i = 0; i < TILE_M; ++i) {
+        const uint m = m_base + i;
+        if (m >= GEMM_M)
+            continue;
+
+        __attribute__((opencl_unroll_hint))
+        for (uint j = 0; j < N_PER_LANE; ++j) {
+            if (!n_valid[j])
+                continue;
+
+            ACTIVATION_TYPE res = TO_ACTIVATION_TYPE(acc[j][i]);
+            // No compensation term on purpose: it is the precomputed
+            // -sum(azp * w) for kernels that cannot subtract the activation zero
+            // point per element, but this one already did while staging B, so
+            // applying it would double-count. convolution_gpu_ref also takes the
+            // argument and ignores it.
+#if BIAS_TERM
+            res += TO_ACTIVATION_TYPE(biases[m]);
+#endif
+            const uint dst = OUTPUT_AT(n_batch[j], m, n_pos[j]);
+            output[dst] = TO_OUTPUT_TYPE(ACTIVATION_TYPED(res, ACTIVATION_PARAMS_TYPED));
+        }
+    }
+}
+
+#undef WG_SIZE
+#undef INPUT_AT
+#undef OUTPUT_AT
+#undef WEIGHTS_AT

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_1d_small_ic_gemm.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_1d_small_ic_gemm.cl
@@ -5,51 +5,38 @@
 #include "include/batch_headers/fetch_data.cl"
 #include "include/batch_headers/fetch_weights.cl"
 
-// Implicit-GEMM 1D convolution for a small input feature count and a large tap
-// count. See convolution_kernel_1d_small_ic_gemm.h for the rationale.
+// Implicit-GEMM 1D convolution, C = A * B with
 //
-// The convolution is treated as C = A * B with
-//
-//   A: weights, M x K, M = OC,               K = IC * TAPS
+//   A: weights, M x K, M = OC,               K = IC * FILTER_LEN
 //   B: im2col,  K x N, N = BATCH * OUT_LEN
 //
-// Neither is reordered or materialized. A K index decomposes into
-// (input feature, tap) and an N index into (batch, output position); the input
-// element a (k, n) pair refers to is
+// Neither is reordered or materialized: a K index decomposes into
+// (input feature, filter position) and an N index into (batch, output position),
+// so the input element a (k, n) pair refers to is
 //
-//   input[batch][ic][n_pos * STRIDE + tap * DILATION - PAD_BEGIN]
+//   input[batch][ic][n_pos * STRIDE + fpos * DILATION - PAD_BEGIN]
 //
-// computed while staging tiles into SLM. Out-of-range positions are zero-filled
-// there, so the accumulation loop is branch-free.
-//
-// Jit constants supplied by the host:
-//   TAPS, OUT_LEN, GEMM_M, GEMM_N, GEMM_K
-//   TILE_M, TILE_N, TILE_K, SIMD, N_PER_LANE
-//   STRIDE_L, DILATION_L, PAD_BEGIN_L, IN_LEN
-//   ACCUMULATOR_TYPE, ACTIVATION_TYPE
-//   B_IN_BOUNDS, B_VEC (see below)
+// resolved while staging tiles. Out-of-range positions are zero-filled there, so
+// the accumulation loop is branch-free. See convolution_kernel_1d_small_ic_gemm.h.
 
-// The long spatial axis is X or Y depending on whether the plugin's XY swap
-// applied. The host picks the long one and sets LONG_AXIS_IS_X accordingly, so
-// the index macros below stay correct either way.
+// The host picks the long spatial axis and sets LONG_AXIS_IS_X, so these stay
+// correct whether or not the plugin's XY swap applied.
 #if LONG_AXIS_IS_X
     #define INPUT_AT(b, ic, pos)  INPUT0_GET_INDEX(b, ic, 0, pos)
     #define OUTPUT_AT(b, oc, pos) OUTPUT_GET_INDEX(b, oc, 0, pos)
-    #define WEIGHTS_AT(oc, ic, tap) GET_FILTER_INDEX(FILTER, 0, oc, ic, 0, tap)
+    #define WEIGHTS_AT(oc, ic, fpos) GET_FILTER_INDEX(FILTER, 0, oc, ic, 0, fpos)
 #else
     #define INPUT_AT(b, ic, pos)  INPUT0_GET_INDEX(b, ic, pos, 0)
     #define OUTPUT_AT(b, oc, pos) OUTPUT_GET_INDEX(b, oc, pos, 0)
-    #define WEIGHTS_AT(oc, ic, tap) GET_FILTER_INDEX(FILTER, 0, oc, ic, tap, 0)
+    #define WEIGHTS_AT(oc, ic, fpos) GET_FILTER_INDEX(FILTER, 0, oc, ic, fpos, 0)
 #endif
 
-// One work-group computes a TILE_M x TILE_N tile but is only one sub-group (SIMD
-// work items) wide: each lane owns N_PER_LANE output columns and all TILE_M rows
-// in registers. TILE_N == SIMD * N_PER_LANE.
+// A work-group computes a TILE_M x TILE_N tile but is only one sub-group wide:
+// each lane owns N_PER_LANE columns and all TILE_M rows in registers.
 #define WG_SIZE (SIMD)
 
-// Vector load of B_VEC consecutive input elements. Only used on the B_IN_BOUNDS
-// path, where the host has checked long-axis pitch 1 and DILATION_L == 1, so a run
-// of consecutive taps is contiguous.
+// Vector load of B_VEC consecutive input elements, only valid on the B_IN_BOUNDS
+// path where the host has proved a run of filter positions is contiguous.
 #define B_VEC_TYPE MAKE_VECTOR_TYPE(INPUT0_TYPE, B_VEC)
 #define B_VLOAD(ptr) CAT(vload, B_VEC)(0, ptr)
 
@@ -80,13 +67,11 @@ KERNEL(convolution_gpu_1d_small_ic_gemm)(
     const uint n_base = (uint)get_group_id(0) * TILE_N;
     const uint m_base = (uint)get_group_id(1) * TILE_M;
 
-    // SLM staging buffer for one K slice of A. B is per-lane and stays in
-    // registers - see B_VLOAD above.
+    // One K slice of A. B is per-lane and stays in registers.
     __local ACCUMULATOR_TYPE a_tile[TILE_M][TILE_K];
 
-    // TILE_M rows x N_PER_LANE columns per lane. Both extents are compile-time
-    // constants and every access below is at a constant index, so this stays in the
-    // register file instead of spilling to scratch.
+    // Both extents are compile-time constants and every access below is at a
+    // constant index, so this stays in registers instead of spilling.
     ACCUMULATOR_TYPE acc[N_PER_LANE][TILE_M];
     __attribute__((opencl_unroll_hint))
     for (uint j = 0; j < N_PER_LANE; ++j)
@@ -94,9 +79,8 @@ KERNEL(convolution_gpu_1d_small_ic_gemm)(
         for (uint i = 0; i < TILE_M; ++i)
             acc[j][i] = (ACCUMULATOR_TYPE)0;
 
-    // This lane's output columns, i.e. its (batch, output position) pairs. They are
-    // SIMD apart rather than adjacent so that at a given j the sub-group's lanes
-    // cover consecutive columns, keeping the B loads and the stores coalesced.
+    // This lane's output columns. SIMD apart rather than adjacent, so that at a
+    // given j the sub-group covers consecutive columns and stays coalesced.
     uint n_batch[N_PER_LANE];
     uint n_pos[N_PER_LANE];
     bool n_valid[N_PER_LANE];
@@ -120,10 +104,10 @@ KERNEL(convolution_gpu_1d_small_ic_gemm)(
 
             ACCUMULATOR_TYPE w = (ACCUMULATOR_TYPE)0;
             if (m < GEMM_M && k < GEMM_K) {
-                // k -> (input feature, tap)
-                const uint k_ic = k / TAPS;
-                const uint k_tap = k % TAPS;
-                const uint w_idx = WEIGHTS_AT(m, k_ic, k_tap);
+                // k -> (input feature, filter position)
+                const uint k_ic = k / FILTER_LEN;
+                const uint k_fpos = k % FILTER_LEN;
+                const uint w_idx = WEIGHTS_AT(m, k_ic, k_fpos);
                 w = TO_ACCUMULATOR_TYPE(weights[w_idx]);
 #if ASYMMETRIC_WEIGHTS_QUANTIZATION
                 w -= TO_ACCUMULATOR_TYPE(weights_zp[m]);
@@ -135,26 +119,22 @@ KERNEL(convolution_gpu_1d_small_ic_gemm)(
         barrier(CLK_LOCAL_MEM_FENCE);
 
         // --- Stage B (im2col column block) and accumulate. ---
-        // A lane is the only reader of its own K slices, so B never goes to SLM.
         // Staging and accumulation are fused so B lives in a few registers rather
-        // than a TILE_K array, which would be dynamically indexed and spill.
-        //
-        // Loop order is (k outer, column inner) so each SLM read of a_tile[i][k] is
-        // reused by all N_PER_LANE columns - the whole reason for the 2D tile.
-        // Reversing the loops would read A N_PER_LANE times as often.
+        // than a dynamically indexed TILE_K array, which would spill. Loop order is
+        // (k outer, column inner) so each SLM read of A is reused by all N_PER_LANE
+        // columns - the whole reason for the 2D tile.
 #if B_IN_BOUNDS
-        // Fast path: every position this tile touches is in range and a K run is
-        // contiguous, so B is read with unguarded vector loads - TILE_K scalar
-        // gathers become a handful of wide ones. The host proves all of that for the
-        // whole iteration space before setting B_IN_BOUNDS; see GetJitConstants.
+        // Fast path: every position is in range and a K run is contiguous, so
+        // TILE_K scalar gathers become a handful of wide loads. The host proves this
+        // for the whole iteration space; see GetJitConstants.
         {
-            const uint k_ic = k_base / TAPS;
-            const uint k_tap = k_base % TAPS;
+            const uint k_ic = k_base / FILTER_LEN;
+            const uint k_fpos = k_base % FILTER_LEN;
 
             const __global INPUT0_TYPE* src[N_PER_LANE];
             __attribute__((opencl_unroll_hint))
             for (uint j = 0; j < N_PER_LANE; ++j) {
-                const uint pos = n_pos[j] * STRIDE_L + k_tap * DILATION_L - PAD_BEGIN_L;
+                const uint pos = n_pos[j] * STRIDE_L + k_fpos * DILATION_L - PAD_BEGIN_L;
                 src[j] = conv_input + INPUT_AT(n_batch[j], k_ic, pos);
             }
 #if ASYMMETRIC_DATA_QUANTIZATION
@@ -188,8 +168,8 @@ KERNEL(convolution_gpu_1d_small_ic_gemm)(
             }
         }
 #else
-        // General path: guard every element. Used when padding, dilation, a ragged
-        // tile or an indivisible TAPS can put a position out of range.
+        // General path: guard every element. Used when padding, dilation or a ragged
+        // tile can put a position out of range.
         for (uint bk = 0; bk < TILE_K; ++bk) {
             const uint k = k_base + bk;
 
@@ -198,9 +178,9 @@ KERNEL(convolution_gpu_1d_small_ic_gemm)(
             for (uint j = 0; j < N_PER_LANE; ++j) {
                 bv[j] = (ACCUMULATOR_TYPE)0;
                 if (n_valid[j] && k < GEMM_K) {
-                    const uint k_ic = k / TAPS;
-                    const uint k_tap = k % TAPS;
-                    const int pos = (int)(n_pos[j] * STRIDE_L + k_tap * DILATION_L) - (int)PAD_BEGIN_L;
+                    const uint k_ic = k / FILTER_LEN;
+                    const uint k_fpos = k % FILTER_LEN;
+                    const int pos = (int)(n_pos[j] * STRIDE_L + k_fpos * DILATION_L) - (int)PAD_BEGIN_L;
                     if (pos >= 0 && pos < (int)IN_LEN) {
                         const uint in_idx = INPUT_AT(n_batch[j], k_ic, (uint)pos);
                         bv[j] = TO_ACCUMULATOR_TYPE(conv_input[in_idx]);
@@ -223,8 +203,8 @@ KERNEL(convolution_gpu_1d_small_ic_gemm)(
     }
 
     // --- Epilogue: bias, activation, store. ---
-    // The M loop is outermost so that, for a fixed i, the lanes at a given j write
-    // consecutive output elements.
+    // M outermost so that, for a fixed i, the lanes at a given j write consecutive
+    // output elements.
     __attribute__((opencl_unroll_hint))
     for (uint i = 0; i < TILE_M; ++i) {
         const uint m = m_base + i;
@@ -237,11 +217,9 @@ KERNEL(convolution_gpu_1d_small_ic_gemm)(
                 continue;
 
             ACTIVATION_TYPE res = TO_ACTIVATION_TYPE(acc[j][i]);
-            // No compensation term on purpose: it is the precomputed
-            // -sum(azp * w) for kernels that cannot subtract the activation zero
-            // point per element, but this one already did while staging B, so
-            // applying it would double-count. convolution_gpu_ref also takes the
-            // argument and ignores it.
+            // No compensation term on purpose: this kernel already subtracted the
+            // activation zero point per element while staging B, so applying the
+            // precomputed -sum(azp * w) would double-count.
 #if BIAS_TERM
             res += TO_ACTIVATION_TYPE(biases[m]);
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_1d_small_ic_gemm.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_1d_small_ic_gemm.cpp
@@ -1,0 +1,260 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "convolution_kernel_1d_small_ic_gemm.h"
+#include "kernel_selector_utils.h"
+#include "common_tools.h"
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace kernel_selector {
+namespace {
+
+// Tile shape of the implicit GEMM.
+//
+// A lane owns n_per_lane output columns, so TILE_N = simd * n_per_lane while the
+// work-group stays one sub-group wide. That is what pays for the inner loop's
+// memory traffic: one SLM read of A feeds n_per_lane FMAs instead of one. (A
+// lane's columns are simd apart, not adjacent, to keep loads and stores
+// coalesced - see the kernel.)
+//
+// n_per_lane is 2, not 4: TILE_N=64 covers fewer shapes on the B_IN_BOUNDS fast
+// path (gemm_n must be a multiple) and halves the accumulator to 32 registers.
+constexpr size_t simd = 16;
+constexpr size_t n_per_lane = 2;
+constexpr size_t tile_m = 16;
+constexpr size_t tile_n = simd * n_per_lane;
+constexpr size_t tile_k = 32;
+
+// SLM per work-group: the A staging buffer only. B stays in registers, since a
+// lane stages the K slice of its own output column and is its only reader. The
+// accumulator is fp32 for every dtype (see GetJitConstants), hence the 4 bytes.
+constexpr size_t slm_bytes_per_wg = tile_m * tile_k * 4;
+
+// Width of the vector load used to stage B on the unguarded path. Must divide
+// tile_k. OpenCL only defines vloadN for N in {2,3,4,8,16}.
+constexpr size_t b_vec = 8;
+static_assert(tile_k % b_vec == 0, "B_VEC must divide TILE_K");
+
+}  // namespace
+
+ParamsKey ConvolutionKernel_1d_small_ic_gemm::GetSupportedKey() const {
+    ParamsKey k;
+    k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::F32);
+    k.EnableInputDataType(Datatype::INT8);
+    k.EnableInputDataType(Datatype::UINT8);
+
+    k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::F32);
+    k.EnableOutputDataType(Datatype::INT8);
+    k.EnableOutputDataType(Datatype::UINT8);
+
+    k.EnableInputWeightsType(WeightsType::F16);
+    k.EnableInputWeightsType(WeightsType::F32);
+    k.EnableInputWeightsType(WeightsType::INT8);
+    k.EnableInputWeightsType(WeightsType::UINT8);
+
+    k.EnableDifferentTypes();
+    k.EnableDifferentInputWeightsTypes();
+
+    k.EnableInputLayout(DataLayout::bfyx);
+    k.EnableOutputLayout(DataLayout::bfyx);
+
+    k.EnableTensorOffset();
+    k.EnableTensorPitches();
+    k.EnableDilation();
+    k.EnableBiasPerFeature();
+    k.EnableNonBiasTerm();
+    k.EnableBatching();
+
+    k.EnableQuantization(QuantizationType::SYMMETRIC);
+    k.EnableQuantization(QuantizationType::ASYMMETRIC_DATA);
+    k.EnableQuantization(QuantizationType::ASYMMETRIC_WEIGHTS);
+    k.EnableQuantization(QuantizationType::ASYMMETRIC_DATA_AND_WEIGHTS);
+
+    // Deliberately no EnableDynamicShapesSupport(): see Validate().
+    return k;
+}
+
+DeviceFeaturesKey ConvolutionKernel_1d_small_ic_gemm::get_required_device_features_key(const Params& params) const {
+    return get_common_subgroups_device_features_key(params);
+}
+
+WeightsLayout ConvolutionKernel_1d_small_ic_gemm::GetPreferredWeightsLayout(const convolution_params&) const {
+    // [OC][IC][taps] is already contiguous as [OC][IC * taps], exactly the A
+    // matrix this kernel wants, so the default layout avoids a weights reorder.
+    return WeightsLayout::oiyx;
+}
+
+bool ConvolutionKernel_1d_small_ic_gemm::Validate(const Params& p) const {
+    if (!Parent::Validate(p)) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    const auto& params = static_cast<const convolution_params&>(p);
+
+    // Shape-agnostic execution is out of scope. Convolution has no dynamic onednn
+    // impl either, and the ocl dynamic path is a narrow auto_pad == EXPLICIT
+    // fallback (see registry/convolution_impls.cpp), so a dynamic variant would
+    // never be selected for a real model while costing the tile-size constant
+    // folding this kernel depends on.
+    if (params.is_shape_agnostic || params.has_dynamic_tensors()) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    if (params.groups != 1 || params.transposed || params.deformable_mode) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    const auto& in = params.inputs[0];
+    const auto& out = params.outputs[0];
+
+    // 1D only, and the long axis has to be the same one everywhere: the kernel
+    // indexes input, output and weights through a single LONG_AXIS_IS_X switch, so
+    // every short-axis extent must be degenerate, or the axis the host picked from
+    // filterSize would disagree with the tensors.
+    //
+    // padding_end is deliberately not checked: the XY swap updates filterSize,
+    // padding_begin, stride and dilation but leaves padding_end alone (see
+    // convolution_impl::get_kernel_params), so after a swap it refers to the other
+    // axis. This kernel never reads it - the output length comes from the output
+    // tensor and the trailing boundary from the in-range test on the staged
+    // position.
+    const bool long_x = long_axis_is_x(params);
+    const size_t short_filter = long_x ? params.filterSize.y : params.filterSize.x;
+    const size_t short_in = long_x ? in.Y().v : in.X().v;
+    const size_t short_out = long_x ? out.Y().v : out.X().v;
+    const size_t short_pad_begin = long_x ? params.padding_begin.y : params.padding_begin.x;
+
+    const bool is_1d = in.Z().v == 1 && out.Z().v == 1 && params.filterSize.z == 1 && short_filter == 1 &&
+                       short_in == 1 && short_out == 1 && short_pad_begin == 0;
+    if (!is_1d) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    if (in.Feature().v > max_input_features) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    if (get_taps(params) < min_taps) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    // The staging buffers must fit in the device's SLM budget.
+    if (slm_bytes_per_wg > params.engineInfo.maxLocalMemSize) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    if (!IsSIMDSizeSupported(params.engineInfo, simd)) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    return true;
+}
+
+JitConstants ConvolutionKernel_1d_small_ic_gemm::GetJitConstants(const convolution_params& params,
+                                                                const DispatchData& dispatchData) const {
+    JitConstants jit = Parent::GetJitConstants(params, dispatchData);
+
+    const auto& in = params.inputs[0];
+    const auto& out = params.outputs[0];
+
+    // Read every long-axis value off the same axis so the kernel is correct
+    // whether or not the XY swap happened; Validate() has already checked that the
+    // short axis is degenerate.
+    const bool long_x = long_axis_is_x(params);
+    const size_t taps = get_taps(params);
+    const size_t in_len = long_x ? in.X().v : in.Y().v;
+    const size_t out_len = long_x ? out.X().v : out.Y().v;
+    const size_t stride_l = long_x ? params.stride.x : params.stride.y;
+    const size_t dilation_l = long_x ? params.dilation.x : params.dilation.y;
+    const size_t pad_begin_l = long_x ? params.padding_begin.x : params.padding_begin.y;
+
+    const size_t gemm_m = out.Feature().v;
+    const size_t gemm_n = out.Batch().v * out_len;
+    const size_t gemm_k = in.Feature().v * taps;
+
+    // Whether the kernel may stage B with unguarded vector loads. That path has no
+    // per-element fallback, so each of its assumptions is proved here for the whole
+    // iteration space rather than assumed:
+    //
+    //  - no left padding and the highest position read (last tap of the last
+    //    output) still inside the input, so no bounds test is needed;
+    //  - a K run is contiguous: dilation 1 and long-axis pitch 1 make consecutive
+    //    taps consecutive elements. This holds in practice (DataTensor::SwapXY sets
+    //    y.pitch = 1, and X is bfyx's innermost axis otherwise) but is checked;
+    //  - tile_k divides taps, so a tile never straddles a k / taps boundary and the
+    //    input feature is constant within it;
+    //  - tile_n divides gemm_n, so every lane has a valid column;
+    //  - b_vec divides tile_k, so the vector loop covers the tile exactly.
+    //
+    // last_pos is written without subtraction so it cannot wrap.
+    const size_t last_pos = (out_len - 1) * stride_l + (taps - 1) * dilation_l;
+    const size_t long_pitch = long_x ? in.X().pitch : in.Y().pitch;
+    const bool b_in_bounds = pad_begin_l == 0 && dilation_l == 1 && long_pitch == 1 && last_pos < in_len &&
+                             taps % tile_k == 0 && gemm_n % tile_n == 0 && tile_k % b_vec == 0;
+
+    jit.AddConstants({
+        MakeJitConstant("B_IN_BOUNDS", b_in_bounds),
+        MakeJitConstant("B_VEC", b_vec),
+        MakeJitConstant("N_PER_LANE", n_per_lane),
+        MakeJitConstant("TAPS", taps),
+        MakeJitConstant("IN_LEN", in_len),
+        MakeJitConstant("OUT_LEN", out_len),
+        MakeJitConstant("STRIDE_L", stride_l),
+        MakeJitConstant("DILATION_L", dilation_l),
+        MakeJitConstant("PAD_BEGIN_L", pad_begin_l),
+        MakeJitConstant("GEMM_M", gemm_m),
+        MakeJitConstant("GEMM_N", gemm_n),
+        MakeJitConstant("GEMM_K", gemm_k),
+        MakeJitConstant("TILE_M", tile_m),
+        MakeJitConstant("TILE_N", tile_n),
+        MakeJitConstant("TILE_K", tile_k),
+        MakeJitConstant("SIMD", simd),
+        // Which axis the long one landed on, so the kernel's index macros pick
+        // the matching argument order. Consistent with get_taps().
+        MakeJitConstant("LONG_AXIS_IS_X", long_x),
+    });
+
+    // fp32 accumulation for every dtype, including int8: this keeps one code path.
+    const Datatype accumulator_dt = Datatype::F32;
+    const Datatype activation_dt = Datatype::F32;
+
+    jit.Merge(MakeTypeJitConstants(accumulator_dt, "ACCUMULATOR"));
+    jit.Merge(MakeTypeJitConstants(activation_dt, "ACTIVATION"));
+    jit.Merge(MakeActivationJitConstants(params.activations, activation_dt, "_TYPED"));
+
+    return jit;
+}
+
+ConvolutionKernel_1d_small_ic_gemm::Parent::DispatchData ConvolutionKernel_1d_small_ic_gemm::SetDefault(
+    const convolution_params& params,
+    int autoTuneIndex) const {
+    DispatchData dispatchData = Parent::SetDefault(params, autoTuneIndex);
+
+    const auto& out = params.outputs[0];
+    const size_t out_len = long_axis_is_x(params) ? out.X().v : out.Y().v;
+
+    const size_t gemm_m = out.Feature().v;
+    const size_t gemm_n = out.Batch().v * out_len;
+
+    dispatchData.gws = {CeilDiv(gemm_n, tile_n) * simd, CeilDiv(gemm_m, tile_m), 1};
+    dispatchData.lws = {simd, 1, 1};
+
+    return dispatchData;
+}
+
+KernelsPriority ConvolutionKernel_1d_small_ic_gemm::GetKernelsPriority(const Params& /*params*/) const {
+    // Must beat convolution_gpu_bfyx_os_iyx_osv16, which is picked for these
+    // shapes today and reaches only a few percent of peak on them.
+    return FORCE_PRIORITY_2;
+}
+
+KernelsData ConvolutionKernel_1d_small_ic_gemm::GetKernelsData(const Params& params) const {
+    return GetTunedKernelsDataByIndex(params);
+}
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_1d_small_ic_gemm.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_1d_small_ic_gemm.cpp
@@ -12,29 +12,21 @@
 namespace kernel_selector {
 namespace {
 
-// Tile shape of the implicit GEMM.
-//
-// A lane owns n_per_lane output columns, so TILE_N = simd * n_per_lane while the
-// work-group stays one sub-group wide. That is what pays for the inner loop's
-// memory traffic: one SLM read of A feeds n_per_lane FMAs instead of one. (A
-// lane's columns are simd apart, not adjacent, to keep loads and stores
-// coalesced - see the kernel.)
-//
-// n_per_lane is 2, not 4: TILE_N=64 covers fewer shapes on the B_IN_BOUNDS fast
-// path (gemm_n must be a multiple) and halves the accumulator to 32 registers.
+// Tile shape of the implicit GEMM. A lane owns n_per_lane output columns, so one
+// SLM read of A feeds n_per_lane FMAs. n_per_lane is 2, not 4: TILE_N=64 covers
+// fewer shapes on the B_IN_BOUNDS path and doubles the accumulator.
 constexpr size_t simd = 16;
 constexpr size_t n_per_lane = 2;
 constexpr size_t tile_m = 16;
 constexpr size_t tile_n = simd * n_per_lane;
 constexpr size_t tile_k = 32;
 
-// SLM per work-group: the A staging buffer only. B stays in registers, since a
-// lane stages the K slice of its own output column and is its only reader. The
-// accumulator is fp32 for every dtype (see GetJitConstants), hence the 4 bytes.
+// SLM per work-group: the A staging buffer only, B stays in registers. 4 bytes
+// because the accumulator is fp32 for every dtype (see GetJitConstants).
 constexpr size_t slm_bytes_per_wg = tile_m * tile_k * 4;
 
-// Width of the vector load used to stage B on the unguarded path. Must divide
-// tile_k. OpenCL only defines vloadN for N in {2,3,4,8,16}.
+// Width of the vector load used to stage B. OpenCL only defines vloadN for N in
+// {2,3,4,8,16}.
 constexpr size_t b_vec = 8;
 static_assert(tile_k % b_vec == 0, "B_VEC must divide TILE_K");
 
@@ -84,8 +76,8 @@ DeviceFeaturesKey ConvolutionKernel_1d_small_ic_gemm::get_required_device_featur
 }
 
 WeightsLayout ConvolutionKernel_1d_small_ic_gemm::GetPreferredWeightsLayout(const convolution_params&) const {
-    // [OC][IC][taps] is already contiguous as [OC][IC * taps], exactly the A
-    // matrix this kernel wants, so the default layout avoids a weights reorder.
+    // Already contiguous as [OC][IC * filter length], i.e. the A matrix, so no
+    // weights reorder is needed.
     return WeightsLayout::oiyx;
 }
 
@@ -96,11 +88,7 @@ bool ConvolutionKernel_1d_small_ic_gemm::Validate(const Params& p) const {
 
     const auto& params = static_cast<const convolution_params&>(p);
 
-    // Shape-agnostic execution is out of scope. Convolution has no dynamic onednn
-    // impl either, and the ocl dynamic path is a narrow auto_pad == EXPLICIT
-    // fallback (see registry/convolution_impls.cpp), so a dynamic variant would
-    // never be selected for a real model while costing the tile-size constant
-    // folding this kernel depends on.
+    // Static shapes only: the shape is folded into the jit constants below.
     if (params.is_shape_agnostic || params.has_dynamic_tensors()) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
@@ -112,34 +100,27 @@ bool ConvolutionKernel_1d_small_ic_gemm::Validate(const Params& p) const {
     const auto& in = params.inputs[0];
     const auto& out = params.outputs[0];
 
-    // 1D only, and the long axis has to be the same one everywhere: the kernel
-    // indexes input, output and weights through a single LONG_AXIS_IS_X switch, so
-    // every short-axis extent must be degenerate, or the axis the host picked from
-    // filterSize would disagree with the tensors.
-    //
-    // padding_end is deliberately not checked: the XY swap updates filterSize,
-    // padding_begin, stride and dilation but leaves padding_end alone (see
-    // convolution_impl::get_kernel_params), so after a swap it refers to the other
-    // axis. This kernel never reads it - the output length comes from the output
-    // tensor and the trailing boundary from the in-range test on the staged
-    // position.
+    if (in.Feature().v > max_input_features) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    if (get_filter_len(params) < min_filter_len) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
+    // 1D only: the kernel indexes every tensor through a single LONG_AXIS_IS_X
+    // switch, so all axes but the long one must be degenerate and unpadded.
+    // padding_end is not checked - the XY swap leaves it referring to the other axis
+    // (see convolution_impl::get_kernel_params) and this kernel never reads it.
     const bool long_x = long_axis_is_x(params);
     const size_t short_filter = long_x ? params.filterSize.y : params.filterSize.x;
     const size_t short_in = long_x ? in.Y().v : in.X().v;
     const size_t short_out = long_x ? out.Y().v : out.X().v;
     const size_t short_pad_begin = long_x ? params.padding_begin.y : params.padding_begin.x;
 
-    const bool is_1d = in.Z().v == 1 && out.Z().v == 1 && params.filterSize.z == 1 && short_filter == 1 &&
-                       short_in == 1 && short_out == 1 && short_pad_begin == 0;
+    const bool is_1d = short_filter == 1 && short_in == 1 && short_out == 1 && short_pad_begin == 0 &&
+                       params.filterSize.z == 1 && in.Z().v == 1 && out.Z().v == 1;
     if (!is_1d) {
-        DO_NOT_USE_THIS_KERNEL(p.layerID);
-    }
-
-    if (in.Feature().v > max_input_features) {
-        DO_NOT_USE_THIS_KERNEL(p.layerID);
-    }
-
-    if (get_taps(params) < min_taps) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
@@ -162,11 +143,9 @@ JitConstants ConvolutionKernel_1d_small_ic_gemm::GetJitConstants(const convoluti
     const auto& in = params.inputs[0];
     const auto& out = params.outputs[0];
 
-    // Read every long-axis value off the same axis so the kernel is correct
-    // whether or not the XY swap happened; Validate() has already checked that the
-    // short axis is degenerate.
+    // Read every value off the long axis, so the XY swap does not matter.
     const bool long_x = long_axis_is_x(params);
-    const size_t taps = get_taps(params);
+    const size_t filter_len = get_filter_len(params);
     const size_t in_len = long_x ? in.X().v : in.Y().v;
     const size_t out_len = long_x ? out.X().v : out.Y().v;
     const size_t stride_l = long_x ? params.stride.x : params.stride.y;
@@ -175,33 +154,23 @@ JitConstants ConvolutionKernel_1d_small_ic_gemm::GetJitConstants(const convoluti
 
     const size_t gemm_m = out.Feature().v;
     const size_t gemm_n = out.Batch().v * out_len;
-    const size_t gemm_k = in.Feature().v * taps;
+    const size_t gemm_k = in.Feature().v * filter_len;
 
-    // Whether the kernel may stage B with unguarded vector loads. That path has no
-    // per-element fallback, so each of its assumptions is proved here for the whole
-    // iteration space rather than assumed:
-    //
-    //  - no left padding and the highest position read (last tap of the last
-    //    output) still inside the input, so no bounds test is needed;
-    //  - a K run is contiguous: dilation 1 and long-axis pitch 1 make consecutive
-    //    taps consecutive elements. This holds in practice (DataTensor::SwapXY sets
-    //    y.pitch = 1, and X is bfyx's innermost axis otherwise) but is checked;
-    //  - tile_k divides taps, so a tile never straddles a k / taps boundary and the
-    //    input feature is constant within it;
-    //  - tile_n divides gemm_n, so every lane has a valid column;
-    //  - b_vec divides tile_k, so the vector loop covers the tile exactly.
-    //
-    // last_pos is written without subtraction so it cannot wrap.
-    const size_t last_pos = (out_len - 1) * stride_l + (taps - 1) * dilation_l;
+    // The unguarded vector loads for B have no per-element fallback, so every
+    // position must be provably in range (no left padding, last read inside the
+    // input) and a K run contiguous (dilation 1, unit pitch), with tile_k and tile_n
+    // dividing the filter length and gemm_n so no tile is ragged. last_pos avoids
+    // subtraction so it cannot wrap.
+    const size_t last_pos = (out_len - 1) * stride_l + (filter_len - 1) * dilation_l;
     const size_t long_pitch = long_x ? in.X().pitch : in.Y().pitch;
     const bool b_in_bounds = pad_begin_l == 0 && dilation_l == 1 && long_pitch == 1 && last_pos < in_len &&
-                             taps % tile_k == 0 && gemm_n % tile_n == 0 && tile_k % b_vec == 0;
+                             filter_len % tile_k == 0 && gemm_n % tile_n == 0 && tile_k % b_vec == 0;
 
     jit.AddConstants({
         MakeJitConstant("B_IN_BOUNDS", b_in_bounds),
         MakeJitConstant("B_VEC", b_vec),
         MakeJitConstant("N_PER_LANE", n_per_lane),
-        MakeJitConstant("TAPS", taps),
+        MakeJitConstant("FILTER_LEN", filter_len),
         MakeJitConstant("IN_LEN", in_len),
         MakeJitConstant("OUT_LEN", out_len),
         MakeJitConstant("STRIDE_L", stride_l),
@@ -214,12 +183,10 @@ JitConstants ConvolutionKernel_1d_small_ic_gemm::GetJitConstants(const convoluti
         MakeJitConstant("TILE_N", tile_n),
         MakeJitConstant("TILE_K", tile_k),
         MakeJitConstant("SIMD", simd),
-        // Which axis the long one landed on, so the kernel's index macros pick
-        // the matching argument order. Consistent with get_taps().
         MakeJitConstant("LONG_AXIS_IS_X", long_x),
     });
 
-    // fp32 accumulation for every dtype, including int8: this keeps one code path.
+    // fp32 accumulation for every dtype, including int8, to keep one code path.
     const Datatype accumulator_dt = Datatype::F32;
     const Datatype activation_dt = Datatype::F32;
 
@@ -248,8 +215,8 @@ ConvolutionKernel_1d_small_ic_gemm::Parent::DispatchData ConvolutionKernel_1d_sm
 }
 
 KernelsPriority ConvolutionKernel_1d_small_ic_gemm::GetKernelsPriority(const Params& /*params*/) const {
-    // Must beat convolution_gpu_bfyx_os_iyx_osv16, which is picked for these
-    // shapes today and reaches only a few percent of peak on them.
+    // Must beat convolution_gpu_bfyx_os_iyx_osv16, which is picked for these shapes
+    // today and reaches only a few percent of peak.
     return FORCE_PRIORITY_2;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_1d_small_ic_gemm.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_1d_small_ic_gemm.h
@@ -11,19 +11,11 @@
 
 namespace kernel_selector {
 
-// Implicit-GEMM convolution for 1D convolutions with a single input feature and
-// a large tap count, e.g. IC=1, taps=2048, OC=1025.
-//
-// The blocked-layout kernels pad the feature dimension up to the block size (16),
-// so an IC=1 convolution wastes 15/16 of every MAC it issues. This kernel merges
-// IC and the taps into one reduction axis instead, giving
-//
-//   M = OC, N = batch * output_length, K = IC * taps
-//
-// so there is no feature padding and K is large enough to amortize the tile
-// loads. The im2col matrix is never materialized: K maps back to
-// (input feature, tap) and N to (batch, output position) on the fly while
-// loading tiles into SLM.
+// Implicit-GEMM convolution for a 1D convolution with a single input feature and a
+// large filter, e.g. IC=1, filter length 2048, OC=1025. IC and the filter are
+// merged into one reduction axis - M = OC, N = batch * output length,
+// K = IC * filter length - so the feature dimension is not padded up to a blocked
+// block size. The im2col matrix is never materialized.
 class ConvolutionKernel_1d_small_ic_gemm : public ConvolutionKernelBase {
 public:
     using Parent = ConvolutionKernelBase;
@@ -35,35 +27,26 @@ public:
     ParamsKey GetSupportedKey() const override;
     DeviceFeaturesKey get_required_device_features_key(const Params& params) const override;
 
-    // 1 because that is the only value measured, not a limit of the formulation:
-    // the kernel decomposes K into (input feature, tap) and is correct for any IC.
-    // At IC > 1 the competitor is ConvolutionKernel_bfyx_to_bfyx_f16, whose input
-    // is planar and pays no padding cost, so widening needs a benchmark against it
-    // plus kernel-side accuracy coverage. Until then
-    // convolution_1d_small_ic_gemm_f32.rejects_input_features_above_max repeats
-    // this bound as a literal so widening cannot pass silently.
+    // The formulation is correct for any IC; 1 is the only value measured. Widening
+    // needs a benchmark against ConvolutionKernel_bfyx_to_bfyx_f16.
     static constexpr size_t max_input_features = 1;
-    // K = IC * taps has to be large enough that loading a K tile pays for itself.
-    static constexpr size_t min_taps = 256;
+    // K = IC * filter length has to be large enough that loading a K tile pays off.
+    static constexpr size_t min_filter_len = 256;
 
 protected:
     WeightsLayout GetPreferredWeightsLayout(const convolution_params&) const override;
-    // Boundary conditions are handled by the tile loads, so the input does not
-    // have to be pre-padded into a larger buffer.
+    // The tile loads handle boundaries, so the input needs no pre-padded buffer.
     bool NeedPaddedInput() const override { return false; }
     JitConstants GetJitConstants(const convolution_params& params, const DispatchData& dispatchData) const override;
     bool Validate(const Params& p) const override;
     DispatchData SetDefault(const convolution_params& arg, int autoTuneIndex = -1) const override;
 
-    // The plugin swaps X and Y so a 1D convolution's long axis lands on X (see
-    // convolution_impl::get_kernel_params), consistently across the tensors,
-    // filterSize, padding, stride and dilation. Picking whichever axis is
-    // non-degenerate makes the kernel independent of whether the swap happened;
-    // Validate() rejects anything where the two disagree.
+    // The plugin may swap X and Y (see convolution_impl::get_kernel_params), so pick
+    // the axis by filter extent rather than assuming one.
     static bool long_axis_is_x(const convolution_params& params) {
         return params.filterSize.x >= params.filterSize.y;
     }
-    static size_t get_taps(const convolution_params& params) {
+    static size_t get_filter_len(const convolution_params& params) {
         return long_axis_is_x(params) ? params.filterSize.x : params.filterSize.y;
     }
 };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_1d_small_ic_gemm.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_1d_small_ic_gemm.h
@@ -1,0 +1,71 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "convolution_kernel_base.h"
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace kernel_selector {
+
+// Implicit-GEMM convolution for 1D convolutions with a single input feature and
+// a large tap count, e.g. IC=1, taps=2048, OC=1025.
+//
+// The blocked-layout kernels pad the feature dimension up to the block size (16),
+// so an IC=1 convolution wastes 15/16 of every MAC it issues. This kernel merges
+// IC and the taps into one reduction axis instead, giving
+//
+//   M = OC, N = batch * output_length, K = IC * taps
+//
+// so there is no feature padding and K is large enough to amortize the tile
+// loads. The im2col matrix is never materialized: K maps back to
+// (input feature, tap) and N to (batch, output position) on the fly while
+// loading tiles into SLM.
+class ConvolutionKernel_1d_small_ic_gemm : public ConvolutionKernelBase {
+public:
+    using Parent = ConvolutionKernelBase;
+    ConvolutionKernel_1d_small_ic_gemm() : Parent("convolution_gpu_1d_small_ic_gemm") {}
+    ~ConvolutionKernel_1d_small_ic_gemm() override = default;
+
+    KernelsData GetKernelsData(const Params& params) const override;
+    KernelsPriority GetKernelsPriority(const Params& params) const override;
+    ParamsKey GetSupportedKey() const override;
+    DeviceFeaturesKey get_required_device_features_key(const Params& params) const override;
+
+    // 1 because that is the only value measured, not a limit of the formulation:
+    // the kernel decomposes K into (input feature, tap) and is correct for any IC.
+    // At IC > 1 the competitor is ConvolutionKernel_bfyx_to_bfyx_f16, whose input
+    // is planar and pays no padding cost, so widening needs a benchmark against it
+    // plus kernel-side accuracy coverage. Until then
+    // convolution_1d_small_ic_gemm_f32.rejects_input_features_above_max repeats
+    // this bound as a literal so widening cannot pass silently.
+    static constexpr size_t max_input_features = 1;
+    // K = IC * taps has to be large enough that loading a K tile pays for itself.
+    static constexpr size_t min_taps = 256;
+
+protected:
+    WeightsLayout GetPreferredWeightsLayout(const convolution_params&) const override;
+    // Boundary conditions are handled by the tile loads, so the input does not
+    // have to be pre-padded into a larger buffer.
+    bool NeedPaddedInput() const override { return false; }
+    JitConstants GetJitConstants(const convolution_params& params, const DispatchData& dispatchData) const override;
+    bool Validate(const Params& p) const override;
+    DispatchData SetDefault(const convolution_params& arg, int autoTuneIndex = -1) const override;
+
+    // The plugin swaps X and Y so a 1D convolution's long axis lands on X (see
+    // convolution_impl::get_kernel_params), consistently across the tensors,
+    // filterSize, padding, stride and dilation. Picking whichever axis is
+    // non-degenerate makes the kernel independent of whether the swap happened;
+    // Validate() rejects anything where the two disagree.
+    static bool long_axis_is_x(const convolution_params& params) {
+        return params.filterSize.x >= params.filterSize.y;
+    }
+    static size_t get_taps(const convolution_params& params) {
+        return long_axis_is_x(params) ? params.filterSize.x : params.filterSize.y;
+    }
+};
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_selector.cpp
@@ -6,6 +6,7 @@
 #include "convolution_kernel_ref.h"
 #include "convolution_kernel_bfyx_1x1_opt.h"
 #include "convolution_kernel_bfyx_gemm_like.h"
+#include "convolution_kernel_1d_small_ic_gemm.h"
 #include "convolution_kernel_bfyx_direct_10_12_16.h"
 #include "convolution_kernel_bfyx_os_iyx_osv16.h"
 #include "convolution_kernel_bfyx_os_iyx_osv32.h"
@@ -76,6 +77,7 @@ convolution_kernel_selector::convolution_kernel_selector() {
 
     // bfyx fp
     Attach<convolution_kernel_bfyx_1x1_opt>();
+    Attach<ConvolutionKernel_1d_small_ic_gemm>();
     Attach<ConvolutionKernel_bfyx_GEMMLike>();
     Attach<ConvolutionKernel_bfyx_Direct_10_10_12>();
     Attach<ConvolutionKernel_bfyx_os_iyx_osv16>();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -13302,478 +13302,172 @@ TEST(convolution_gpu_bfyx_f16, dynamic_fused_input_scalar_and_non_scalar_fp32) {
 
 // ---------------------------------------------------------------------------
 // convolution_gpu_1d_small_ic_gemm
-//
-// The 1D large-tap / small-IC convolution kernel, which maps such convolutions
-// onto an implicit GEMM with K = IC * taps instead of padding IC up to a blocked
-// feature size.
-//
-// Every test forces the kernel through force_implementations, so no other kernel
-// can silently satisfy an expectation: kernel_selector throws when a forced kernel
-// rejects the params. Reference values come from reference_conv_1d() below, which
-// accumulates in fp32 for every dtype to match the kernel, and is itself validated
-// against convolution_gpu_ref by the *_vs_ref_kernel suite.
+// Each case runs the same topology twice - once forced onto this kernel, once onto
+// convolution_gpu_ref - and compares, so no reference values live here.
 // ---------------------------------------------------------------------------
 
-static constexpr const char* conv_1d_small_ic_gemm_kernel = "convolution_gpu_1d_small_ic_gemm";
-
-// Used by the *_vs_ref_kernel suite to validate reference_conv_1d() independently
-// of the kernel under test; without it a bug shared by both would go unnoticed.
-static constexpr const char* conv_1d_reference_kernel = "convolution_gpu_ref";
-
-// Shape of a 1D convolution laid out as bfyx with the long axis on Y
-// (x == 1), which is how the plugin canonicalizes 3D conv inputs.
-struct conv_1d_shape {
+// Laid out as bfyx with the long axis on Y (x == 1), as the plugin canonicalizes 3D conv.
+struct conv_1d_case {
+    const char* name;
+    data_types dt;  // input dtype; weights are i8 when this is u8/i8
     size_t batch;
-    size_t in_features;   // IC
-    size_t in_length;     // input length along the long axis
-    size_t out_features;  // OC
-    size_t taps;          // filter size along the long axis
+    size_t in_features;
+    size_t in_length;
+    size_t out_features;
+    size_t filter_len;
     size_t stride;
     size_t dilation;
     size_t pad_begin;
     size_t pad_end;
-
-    // Extent of the filter over the input after dilation.
-    size_t extent() const { return dilation * (taps - 1) + 1; }
-
-    bool is_valid() const { return in_length + pad_begin + pad_end >= extent(); }
-
-    size_t out_length() const {
-        // Guarded because the subtraction is unsigned: an over-long filter would
-        // wrap and produce an absurd allocation instead of a clear failure.
-        OPENVINO_ASSERT(is_valid(), "[TEST] invalid 1D conv shape: padded input length ",
-                        in_length + pad_begin + pad_end, " < filter extent ", extent());
-        return (in_length + pad_begin + pad_end - extent()) / stride + 1;
-    }
+    bool with_bias;
+    bool with_zp;  // int8 only: asymmetric data and weights zero points
 };
 
-// Reference convolution over flat fp32 buffers laid out as input [b][ic][ol_in],
-// weights [oc][ic][tap], output [b][oc][ol_out]. fp32 accumulation matches the
-// kernel, and pre-converting inputs to fp32 lets one routine serve f32/f16/u8/i8.
-static std::vector<float> reference_conv_1d(const conv_1d_shape& s,
-                                            const std::vector<float>& input,
-                                            const std::vector<float>& weights,
-                                            const std::vector<float>& bias,
-                                            const std::vector<float>& data_zp,
-                                            const std::vector<float>& weights_zp) {
-    const size_t ol = s.out_length();
-    std::vector<float> output(s.batch * s.out_features * ol, 0.f);
-
-    for (size_t b = 0; b < s.batch; ++b) {
-        for (size_t oc = 0; oc < s.out_features; ++oc) {
-            const float w_zp = weights_zp.empty() ? 0.f : weights_zp[oc];
-            for (size_t o = 0; o < ol; ++o) {
-                float acc = 0.f;
-                for (size_t ic = 0; ic < s.in_features; ++ic) {
-                    const float a_zp = data_zp.empty() ? 0.f : data_zp[ic];
-                    for (size_t t = 0; t < s.taps; ++t) {
-                        const int64_t pos = static_cast<int64_t>(o * s.stride + t * s.dilation) -
-                                            static_cast<int64_t>(s.pad_begin);
-                        if (pos < 0 || pos >= static_cast<int64_t>(s.in_length))
-                            continue;
-                        const float in_val =
-                            input[(b * s.in_features + ic) * s.in_length + static_cast<size_t>(pos)] - a_zp;
-                        const float w_val = weights[(oc * s.in_features + ic) * s.taps + t] - w_zp;
-                        acc += in_val * w_val;
-                    }
-                }
-                if (!bias.empty())
-                    acc += bias[oc];
-                output[(b * s.out_features + oc) * ol + o] = acc;
-            }
-        }
-    }
-    return output;
-}
+static bool conv_1d_is_int8(data_types dt) { return dt == data_types::u8 || dt == data_types::i8; }
 
 template <typename T>
-std::vector<T> conv_1d_to_typed(const std::vector<float>& src) {
+static void conv_1d_set(memory::ptr mem, const std::vector<float>& src) {
     std::vector<T> dst(src.size());
     std::transform(src.begin(), src.end(), dst.begin(), [](float v) { return static_cast<T>(v); });
-    return dst;
+    set_values(mem, dst);
 }
 
-template <typename T>
-std::vector<float> conv_1d_to_float(const std::vector<T>& src) {
-    std::vector<float> dst(src.size());
-    std::transform(src.begin(), src.end(), dst.begin(), [](T v) { return static_cast<float>(v); });
-    return dst;
+static void conv_1d_set_values(memory::ptr mem, const std::vector<float>& src) {
+    const auto dt = mem->get_layout().data_type;
+    if (dt == data_types::f32) conv_1d_set<float>(mem, src);
+    else if (dt == data_types::f16) conv_1d_set<ov::float16>(mem, src);
+    else if (dt == data_types::u8) conv_1d_set<uint8_t>(mem, src);
+    else conv_1d_set<int8_t>(mem, src);
 }
 
-static ExecutionConfig conv_1d_forced_config(const engine& eng, const char* forced_kernel) {
-    ExecutionConfig config = get_test_default_config(eng);
+// Runs the case with dt for input and weights, forced onto forced_kernel. Seeded from
+// the case name, so two calls for one case see identical data.
+static std::vector<float> run_conv_1d(const conv_1d_case& c, data_types dt, const char* forced_kernel) {
+    auto& engine = get_test_engine();
+    tests::random_generator rg(std::string(c.name));
+
+    const bool int8 = conv_1d_is_int8(dt);
+    const int lo = (dt == data_types::u8) ? 0 : -8;
+    // Multiples of 1/8 in [-1, 1]: exact in f16 and their products exact in f32, so an
+    // f32 accumulation over K is exact. int8 values are integers, exact either way.
+    auto gen = [&](size_t n, int int_lo, int int_hi) {
+        if (!int8)
+            return rg.generate_random_1d<float>(n, -1, 1, 8);
+        const auto v = rg.generate_random_1d<int>(n, int_lo, int_hi, 1);
+        return std::vector<float>(v.begin(), v.end());
+    };
+    auto i32 = [](size_t v) { return static_cast<int32_t>(v); };
+    auto make_layout = [&](data_types t, size_t b, size_t f, size_t y) {
+        return layout{t, format::bfyx, tensor(i32(b), i32(f), 1, i32(y))};
+    };
+    auto add_data = [&](topology& t, const std::string& id, const layout& l, const std::vector<float>& v) {
+        auto mem = engine.allocate_memory(l);
+        conv_1d_set_values(mem, v);
+        t.add(data(id, mem));
+    };
+
+    auto input_mem = engine.allocate_memory(make_layout(dt, c.batch, c.in_features, c.in_length));
+    conv_1d_set_values(input_mem, gen(c.batch * c.in_features * c.in_length, lo, (dt == data_types::u8) ? 15 : 7));
+    topology topo;
+    topo.add(input_layout("input", input_mem->get_layout()));
+    add_data(topo, "weights", make_layout(int8 ? data_types::i8 : dt, c.out_features, c.in_features, c.filter_len),
+             gen(c.out_features * c.in_features * c.filter_len, -4, 4));
+    std::string bias_id, a_zp_id, w_zp_id;
+    if (c.with_bias) {
+        bias_id = "bias";
+        add_data(topo, bias_id, make_layout(int8 ? data_types::f32 : dt, 1, c.out_features, 1),
+                 gen(c.out_features, -8, 8));
+    }
+    if (c.with_zp) {
+        a_zp_id = "a_zp";
+        add_data(topo, a_zp_id, make_layout(dt, 1, c.in_features, 1), gen(c.in_features, lo, lo + 4));
+        w_zp_id = "w_zp";
+        add_data(topo, w_zp_id, make_layout(data_types::i8, c.out_features, 1, 1), gen(c.out_features, -2, 2));
+    }
+    const ov::Strides stride{c.stride, 1}, dilation{c.dilation, 1};
+    const ov::CoordinateDiff pad_begin{static_cast<std::ptrdiff_t>(c.pad_begin), 0},
+                             pad_end{static_cast<std::ptrdiff_t>(c.pad_end), 0};
+    if (int8) {
+        topo.add(convolution("conv", input_info("input"), "weights", bias_id, w_zp_id, a_zp_id, "", 1, stride,
+                             dilation, pad_begin, pad_end, false, data_types::f32));
+    } else {
+        topo.add(convolution("conv", input_info("input"), "weights", bias_id, 1, stride, dilation, pad_begin,
+                             pad_end, false));
+    }
+    topo.add(reorder("out", input_info("conv"), format::bfyx, data_types::f32));
+
     ov::intel_gpu::ImplementationDesc conv_impl = {format::bfyx, forced_kernel, impl_types::ocl};
+    ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv", conv_impl}}));
     config.set_property(ov::intel_gpu::optimize_data(true));
-    return config;
+    config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"out"}));
+
+    network net(engine, topo, config);
+    net.set_input_data("input", input_mem);
+    auto out_mem = net.execute().at("out").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> ptr(out_mem, get_test_stream());
+    return std::vector<float>(ptr.data(), ptr.data() + ptr.size());
 }
 
-// Runs one float (f32/f16) case and compares against the fp32 reference.
-template <typename T>
-void run_conv_1d_float_case(const conv_1d_shape& s, data_types dt, float rel_err, bool with_bias,
-                            int seed_offset = 0,
-                            const char* forced_kernel = conv_1d_small_ic_gemm_kernel) {
-    auto& engine = get_test_engine();
-    if (dt == data_types::f16 && !engine.get_device_info().supports_fp16) {
+// One entry per code path, in conv_1d_case field order.
+const std::vector<conv_1d_case> conv_1d_cases = {
+    // Filter length at min_filter_len, OC 3 and out_length 23 below their tiles: every leftover path at once.
+    {"min_filter_len", data_types::f32, 1, 1, 300, 3, 256, 2, 1, 0, 0, true, false},
+    // K = 2048 at the model layer's stride, so a K tile never straddles a filter boundary.
+    {"large_k", data_types::f32, 1, 1, 3742, 17, 2048, 242, 1, 0, 0, true, false},
+    // OC 273 = 17 * TILE_M + 1: M ragged over many tiles.
+    {"oc_leftover", data_types::f32, 1, 1, 300, 273, 256, 2, 1, 0, 0, true, false},
+    // Dilation and padding on the guarded path; dilated extent 511.
+    {"dilation_and_padding", data_types::f32, 2, 1, 800, 17, 256, 32, 2, 13, 5, true, false},
+    // Maximum overlap, and the one stride where a dropped stride still lands in range.
+    {"stride_1", data_types::f32, 2, 1, 300, 17, 256, 1, 1, 0, 0, true, false},
+    // Unguarded vector loads: no padding, dilation 1, TILE_K | filter_len, TILE_N | batch * out_length (2 * 32).
+    {"fast", data_types::f32, 2, 1, 318, 17, 256, 2, 1, 0, 0, true, false},
+    // out_length 33 vs TILE_N 32: the second tile has one valid column, so j = 0 is partially valid. No bias too.
+    {"ragged_n_no_bias", data_types::f32, 1, 1, 320, 17, 256, 2, 1, 0, 0, false, false},
+    // K = 2048, where an f16 accumulator would fail well outside tolerance.
+    {"f16_large_k", data_types::f16, 1, 1, 3742, 17, 2048, 242, 1, 0, 0, true, false},
+    // f16 on the fast path, which stages B through f16 vector loads.
+    {"f16_fast", data_types::f16, 2, 1, 318, 17, 256, 2, 1, 0, 0, true, false},
+    // Zero points are subtracted while staging, so the compensation term is ignored - these catch a double-count.
+    {"u8_zp", data_types::u8, 2, 1, 300, 17, 256, 32, 1, 0, 0, true, true},
+    {"i8_fast_zp", data_types::i8, 2, 1, 318, 17, 256, 2, 1, 0, 0, true, true},
+};
+
+class convolution_1d_small_ic_gemm : public ::testing::TestWithParam<conv_1d_case> {};
+
+TEST_P(convolution_1d_small_ic_gemm, vs_ref_kernel) {
+    const auto& c = GetParam();
+    if (c.dt == data_types::f16 && !get_test_engine().get_device_info().supports_fp16) {
         GTEST_SKIP() << "The test is skipped (cl_khr_fp16 is not supported).";
     }
 
-    tests::random_generator rg(GET_SUITE_NAME + std::to_string(seed_offset));
+    // convolution_gpu_ref accumulates in the input dtype, so an f16 reference would be
+    // the inaccurate side; it runs in f32, leaving only this kernel's output rounding.
+    const auto ref_dt = conv_1d_is_int8(c.dt) ? c.dt : data_types::f32;
+    const auto expected = run_conv_1d(c, ref_dt, "convolution_gpu_ref");
+    const auto actual = run_conv_1d(c, c.dt, "convolution_gpu_1d_small_ic_gemm");
 
-    const size_t ol = s.out_length();
-    // Values are multiples of 1/8 in [-1, 1], exact in f16, and their products are
-    // exact multiples of 1/64. So the fp32 accumulation over K terms is exact and
-    // the reference is the exact mathematical result; the tolerance then only has
-    // to cover the rounding of the f16 output.
-    auto input_f = rg.generate_random_1d<float>(s.batch * s.in_features * s.in_length, -1, 1, 8);
-    auto weights_f = rg.generate_random_1d<float>(s.out_features * s.in_features * s.taps, -1, 1, 8);
-    std::vector<float> bias_f;
-    if (with_bias)
-        bias_f = rg.generate_random_1d<float>(s.out_features, -1, 1, 8);
-
-    auto ref = reference_conv_1d(s, input_f, weights_f, bias_f, {}, {});
-
-    auto input_mem = engine.allocate_memory(
-        {dt, format::bfyx, tensor(static_cast<int32_t>(s.batch), static_cast<int32_t>(s.in_features), 1,
-                                  static_cast<int32_t>(s.in_length))});
-    auto weights_mem = engine.allocate_memory(
-        {dt, format::bfyx, tensor(static_cast<int32_t>(s.out_features), static_cast<int32_t>(s.in_features), 1,
-                                  static_cast<int32_t>(s.taps))});
-    set_values(input_mem, conv_1d_to_typed<T>(input_f));
-    set_values(weights_mem, conv_1d_to_typed<T>(weights_f));
-
-    topology topo;
-    topo.add(input_layout("input", input_mem->get_layout()));
-    topo.add(data("weights", weights_mem));
-
-    if (with_bias) {
-        auto bias_mem = engine.allocate_memory(
-            {dt, format::bfyx, tensor(1, static_cast<int32_t>(s.out_features), 1, 1)});
-        set_values(bias_mem, conv_1d_to_typed<T>(bias_f));
-        topo.add(data("bias", bias_mem));
-        topo.add(convolution("conv", input_info("input"), "weights", "bias", 1,
-                             {s.stride, 1}, {s.dilation, 1},
-                             {static_cast<std::ptrdiff_t>(s.pad_begin), 0},
-                             {static_cast<std::ptrdiff_t>(s.pad_end), 0}, false));
-    } else {
-        topo.add(convolution("conv", input_info("input"), "weights", no_bias, 1,
-                             {s.stride, 1}, {s.dilation, 1},
-                             {static_cast<std::ptrdiff_t>(s.pad_begin), 0},
-                             {static_cast<std::ptrdiff_t>(s.pad_end), 0}, false));
-    }
-    topo.add(reorder("out", input_info("conv"), format::bfyx, data_types::f32));
-
-    auto config = conv_1d_forced_config(engine, forced_kernel);
-    config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"out"}));
-
-    network net(engine, topo, config);
-    net.set_input_data("input", input_mem);
-    auto outputs = net.execute();
-
-    auto out_mem = outputs.at("out").get_memory();
-    cldnn::mem_lock<float, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
-
-    ASSERT_EQ(out_mem->get_layout().batch(), static_cast<int32_t>(s.batch));
-    ASSERT_EQ(out_mem->get_layout().feature(), static_cast<int32_t>(s.out_features));
-    ASSERT_EQ(out_mem->get_layout().spatial(1), static_cast<int32_t>(ol));
-    ASSERT_EQ(out_mem->get_layout().spatial(0), 1);
-    ASSERT_EQ(ref.size(), out_ptr.size());
-
-    for (size_t i = 0; i < ref.size(); ++i) {
-        ASSERT_TRUE(are_equal(ref[i], out_ptr[i], rel_err))
-            << "mismatch at flat index " << i << " (dt=" << dt << ", OC=" << s.out_features
-            << ", taps=" << s.taps << ", stride=" << s.stride << ")";
+    ASSERT_EQ(expected.size(), actual.size());
+    const float tolerance = (c.dt == data_types::f16) ? 5e-4f : 1e-4f;
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_TRUE(are_equal(expected[i], actual[i], tolerance)) << "mismatch at flat index " << i;
     }
 }
 
-// Runs one int8 case. Weights are i8, the input u8 or i8, the output fp32 - as in
-// the model under investigation, so the fp32 accumulator is directly observable.
-template <typename InputT>
-void run_conv_1d_int8_case(const conv_1d_shape& s, data_types in_dt, bool with_data_zp, bool with_weights_zp,
-                           int seed_offset = 0,
-                           const char* forced_kernel = conv_1d_small_ic_gemm_kernel) {
-    auto& engine = get_test_engine();
-    tests::random_generator rg(GET_SUITE_NAME + std::to_string(seed_offset));
+INSTANTIATE_TEST_SUITE_P(convolution_gpu_1d_small_ic_gemm,
+                         convolution_1d_small_ic_gemm,
+                         ::testing::ValuesIn(conv_1d_cases),
+                         [](const testing::TestParamInfo<conv_1d_case>& info) {
+                             return std::string(info.param.name);
+                         });
 
-    const size_t ol = s.out_length();
-    const int in_min = (in_dt == data_types::u8) ? 0 : -8;
-    const int in_max = (in_dt == data_types::u8) ? 15 : 7;
-
-    // k = 1 yields plain integers in [min, max], without the fractional-resolution
-    // division the generator applies for float types.
-    auto input_i = rg.generate_random_1d<int>(s.batch * s.in_features * s.in_length, in_min, in_max, 1);
-    auto weights_i = rg.generate_random_1d<int>(s.out_features * s.in_features * s.taps, -4, 4, 1);
-    auto bias_f = rg.generate_random_1d<float>(s.out_features, -8, 8, 8);
-
-    std::vector<float> data_zp_f;
-    std::vector<float> weights_zp_f;
-    if (with_data_zp)
-        data_zp_f = conv_1d_to_float(rg.generate_random_1d<int>(s.in_features, in_min, in_min + 4, 1));
-    if (with_weights_zp)
-        weights_zp_f = conv_1d_to_float(rg.generate_random_1d<int>(s.out_features, -2, 2, 1));
-
-    auto input_f = conv_1d_to_float(input_i);
-    auto weights_f = conv_1d_to_float(weights_i);
-    auto ref = reference_conv_1d(s, input_f, weights_f, bias_f, data_zp_f, weights_zp_f);
-
-    auto input_mem = engine.allocate_memory(
-        {in_dt, format::bfyx, tensor(static_cast<int32_t>(s.batch), static_cast<int32_t>(s.in_features), 1,
-                                     static_cast<int32_t>(s.in_length))});
-    auto weights_mem = engine.allocate_memory(
-        {data_types::i8, format::bfyx, tensor(static_cast<int32_t>(s.out_features),
-                                              static_cast<int32_t>(s.in_features), 1,
-                                              static_cast<int32_t>(s.taps))});
-    auto bias_mem = engine.allocate_memory(
-        {data_types::f32, format::bfyx, tensor(1, static_cast<int32_t>(s.out_features), 1, 1)});
-
-    set_values(input_mem, conv_1d_to_typed<InputT>(input_f));
-    set_values(weights_mem, conv_1d_to_typed<int8_t>(weights_f));
-    set_values(bias_mem, bias_f);
-
-    topology topo;
-    topo.add(input_layout("input", input_mem->get_layout()));
-    topo.add(data("weights", weights_mem));
-    topo.add(data("bias", bias_mem));
-
-    std::string a_zp_id;
-    std::string w_zp_id;
-    if (with_data_zp) {
-        a_zp_id = "a_zp";
-        auto a_zp_mem = engine.allocate_memory(
-            {in_dt, format::bfyx, tensor(1, static_cast<int32_t>(s.in_features), 1, 1)});
-        set_values(a_zp_mem, conv_1d_to_typed<InputT>(data_zp_f));
-        topo.add(data(a_zp_id, a_zp_mem));
-    }
-    if (with_weights_zp) {
-        w_zp_id = "w_zp";
-        auto w_zp_mem = engine.allocate_memory(
-            {data_types::i8, format::bfyx, tensor(static_cast<int32_t>(s.out_features), 1, 1, 1)});
-        set_values(w_zp_mem, conv_1d_to_typed<int8_t>(weights_zp_f));
-        topo.add(data(w_zp_id, w_zp_mem));
-    }
-
-    topo.add(convolution("conv", input_info("input"), "weights", "bias", w_zp_id, a_zp_id, "", 1,
-                         {s.stride, 1}, {s.dilation, 1},
-                         {static_cast<std::ptrdiff_t>(s.pad_begin), 0},
-                         {static_cast<std::ptrdiff_t>(s.pad_end), 0}, false, data_types::f32));
-    topo.add(reorder("out", input_info("conv"), format::bfyx, data_types::f32));
-
-    auto config = conv_1d_forced_config(engine, forced_kernel);
-    config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"out"}));
-
-    network net(engine, topo, config);
-    net.set_input_data("input", input_mem);
-    auto outputs = net.execute();
-
-    auto out_mem = outputs.at("out").get_memory();
-    cldnn::mem_lock<float, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
-
-    ASSERT_EQ(out_mem->get_layout().spatial(1), static_cast<int32_t>(ol));
-    ASSERT_EQ(ref.size(), out_ptr.size());
-
-    // int8 operands are exact in fp32 and so is the accumulator, so the result is
-    // bit-exact up to fp32 addition ordering.
-    for (size_t i = 0; i < ref.size(); ++i) {
-        ASSERT_NEAR(ref[i], out_ptr[i], 1e-3f)
-            << "mismatch at flat index " << i << " (in_dt=" << in_dt << ", a_zp=" << with_data_zp
-            << ", w_zp=" << with_weights_zp << ")";
-    }
-}
-
-// Smallest accepted shape: taps sits exactly on min_taps, and OC = 3 and
-// out_length = 23 are both below their tile sizes, so every leftover path is
-// exercised at once.
-constexpr conv_1d_shape conv_1d_shape_min_taps{/*batch*/ 1, /*IC*/ 1, /*L*/ 300, /*OC*/ 3, /*taps*/ 256,
-                                               /*stride*/ 2, /*dilation*/ 1, /*pad_begin*/ 0, /*pad_end*/ 0};
-
-// Same tap/stride ratio as the model layer (overlap factor 8.46x) but small
-// enough to run in a unit test. K = 2048.
-constexpr conv_1d_shape conv_1d_shape_reduced_real{1, 1, 4964, 65, 2048, 242, 1, 0, 0};
-
-// OC = 1025 is not a multiple of 16, so the OC leftover path is mandatory.
-constexpr conv_1d_shape conv_1d_shape_oc_leftover{1, 1, 2664, 1025, 2048, 242, 1, 0, 0};
-
-// Small OC leftover (17 = 16 + 1) with a short filter.
-constexpr conv_1d_shape conv_1d_shape_oc_leftover_small{2, 1, 300, 17, 256, 32, 1, 0, 0};
-
-// Dilation doubles the filter extent to 2 * (256 - 1) + 1 = 511, so this needs a
-// longer input than conv_1d_shape_oc_leftover_small - hence a separate shape.
-constexpr conv_1d_shape conv_1d_shape_dilated{2, 1, 1200, 17, 256, 32, 2, 0, 0};
-
-// Takes the unguarded vector-load path for staging B, which the kernel selects
-// only when every access is provably in range: no left padding, dilation 1, the
-// last tap of the last output inside the input, taps a multiple of TILE_K, and
-// batch * out_length a multiple of TILE_N.
-//
-// The real model layer meets all of those but none of the shapes above do (their
-// out_length is not a multiple of TILE_N), so the fast path would otherwise go
-// untested. out_length is 32: (318 - 256) / 2 + 1. OC = 17 covers the OC leftover
-// path here too, and batch = 2 makes GEMM_N span several tiles while keeping every
-// fast-path condition satisfied (2 * 32 = 64).
-constexpr conv_1d_shape conv_1d_shape_fast_wide{2, 1, 318, 17, 256, 2, 1, 0, 0};
-
-// A ragged N tail past the first tile. out_length is 33, so with TILE_N = 32 the
-// second of two tiles holds a single valid column: the lane at j = 0 is partially
-// valid and every lane at j = 1 is invalid. Since a lane owns N_PER_LANE columns a
-// tile can be partially valid in two ways, and the shapes above only reach the
-// other one. OC = 17 makes M ragged at the same time.
-constexpr conv_1d_shape conv_1d_shape_ragged_n{1, 1, 320, 17, 256, 2, 1, 0, 0};
-
-// ---------------------------------------------------------------------------
-// Self-check: validate reference_conv_1d() against convolution_gpu_ref. These pin
-// down the expected values independently of the kernel under test, so a failure in
-// the suites below is unambiguously a kernel bug and not a reference bug.
-//
-// One shape per B-staging path is enough, since that is where the reference and the
-// kernel could agree on a shared indexing bug. conv_1d_shape_oc_leftover_small also
-// carries padding, a stride and both zero points, so one f32 and one int8 case pin
-// down the guarded path.
-// ---------------------------------------------------------------------------
-
-TEST(convolution_1d_small_ic_gemm_vs_ref_kernel, f32_guarded) {
-    conv_1d_shape s = conv_1d_shape_oc_leftover_small;
-    s.pad_begin = 13;
-    s.pad_end = 5;
-    run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true, 0, conv_1d_reference_kernel);
-}
-
-TEST(convolution_1d_small_ic_gemm_vs_ref_kernel, f32_fast) {
-    run_conv_1d_float_case<float>(conv_1d_shape_fast_wide, data_types::f32, 1e-4f, /*with_bias*/ true, 0,
-                                  conv_1d_reference_kernel);
-}
-
-TEST(convolution_1d_small_ic_gemm_vs_ref_kernel, u8s8f32_asymmetric_data_and_weights) {
-    run_conv_1d_int8_case<uint8_t>(conv_1d_shape_oc_leftover_small, data_types::u8, /*a_zp*/ true, /*w_zp*/ true, 0,
-                                   conv_1d_reference_kernel);
-}
-
-// IC > 1 deliberately, even though Validate() rejects it today: the K = IC * taps
-// decomposition is correct for any IC and the bound is meant to be raisable. Pinning
-// the values now, against a kernel with no IC gate, means raising it later does not
-// also require deriving fresh reference values. Only the reference is exercised here
-// - a wider gate would still need accuracy coverage on the kernel itself.
-TEST(convolution_1d_small_ic_gemm_vs_ref_kernel, f32_input_features_2_to_4) {
-    for (size_t ic = 2; ic <= 4; ++ic) {
-        conv_1d_shape s = conv_1d_shape_oc_leftover_small;
-        s.in_features = ic;
-        run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true, static_cast<int>(ic),
-                                      conv_1d_reference_kernel);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// f32 - the only dtype the model uses, so the shape coverage lives here.
-// ---------------------------------------------------------------------------
-
-// Smallest accepted shape, and every leftover path at once: OC = 3 < TILE_M and
-// out_length = 23 < TILE_N.
-TEST(convolution_1d_small_ic_gemm_f32, min_taps_leftovers) {
-    run_conv_1d_float_case<float>(conv_1d_shape_min_taps, data_types::f32, 1e-4f, /*with_bias*/ true);
-}
-
-// The model layer's proportions, and the shape that matters for performance.
-TEST(convolution_1d_small_ic_gemm_f32, reduced_real_shape) {
-    run_conv_1d_float_case<float>(conv_1d_shape_reduced_real, data_types::f32, 1e-4f, /*with_bias*/ true);
-}
-
-// OC = 1025 as in the model: M ragged against TILE_M = 16 over many tiles.
-TEST(convolution_1d_small_ic_gemm_f32, oc_leftover_1025) {
-    run_conv_1d_float_case<float>(conv_1d_shape_oc_leftover, data_types::f32, 1e-4f, /*with_bias*/ true);
-}
-
-// Padding, dilation and batch > 1 together on the guarded path: DILATION_L != 1 is
-// one of the conditions that rules out the fast path.
-TEST(convolution_1d_small_ic_gemm_f32, dilation_and_padding) {
-    conv_1d_shape s = conv_1d_shape_dilated;
-    s.pad_begin = 13;
-    s.pad_end = 5;
-    run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true);
-}
-
-// stride == 1 is the maximum-overlap end of the range, and the one value where a
-// stride the kernel failed to apply still lands in range - so a mix-up shows up as
-// wrong values rather than a crash. The shapes above cover strides 2, 32 and 242.
-TEST(convolution_1d_small_ic_gemm_f32, stride_1) {
-    conv_1d_shape s = conv_1d_shape_oc_leftover_small;
-    s.stride = 1;
-    run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true);
-}
-
-// The unguarded vector-load path, which every case above avoids. _fast_wide covers
-// the no-bias epilogue and an OC leftover on it too.
-TEST(convolution_1d_small_ic_gemm_f32, fast) {
-    run_conv_1d_float_case<float>(conv_1d_shape_fast_wide, data_types::f32, 1e-4f, /*with_bias*/ true);
-}
-
-TEST(convolution_1d_small_ic_gemm_f32, fast_no_bias) {
-    run_conv_1d_float_case<float>(conv_1d_shape_fast_wide, data_types::f32, 1e-4f, /*with_bias*/ false);
-}
-
-// Only this shape reaches the partially-valid tile where j = 0 is valid and j = 1
-// is not.
-TEST(convolution_1d_small_ic_gemm_f32, ragged_n) {
-    run_conv_1d_float_case<float>(conv_1d_shape_ragged_n, data_types::f32, 1e-4f, /*with_bias*/ true);
-}
-
-// The IC bound is selection policy, not correctness: the kernel outranks the
-// blocked ones at FORCE_PRIORITY_2, so the bound has to live in Validate() rather
-// than in the priority, and this asserts it is enforced there.
-//
-// The bound is repeated as a literal rather than read from max_input_features on
-// purpose. Following the constant would make this test pass automatically on a
-// widened gate, which is the case it exists to catch: widening also needs a
-// benchmark against convolution_gpu_bfyx_to_bfyx_f16 and kernel-side accuracy
-// coverage. The accepted end of the range is covered by every other test here.
-TEST(convolution_1d_small_ic_gemm_f32, rejects_input_features_above_max) {
-    constexpr size_t max_input_features = 1;
-    conv_1d_shape s = conv_1d_shape_oc_leftover_small;
-    s.in_features = max_input_features + 1;
+// The IC bound is selection policy, so it lives in Validate(). Repeated as a literal
+// rather than read from max_input_features, so widening it cannot pass silently.
+TEST(convolution_1d_small_ic_gemm_gate, rejects_input_features_above_max) {
+    conv_1d_case c = conv_1d_cases[0];
+    c.in_features = 2;
     // kernel_selector throws when the forced kernel rejects the params.
-    ASSERT_ANY_THROW(run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true))
-        << "kernel unexpectedly accepted IC = " << s.in_features
-        << "; if max_input_features was raised deliberately, add a benchmark and "
-           "kernel-side accuracy coverage for the new range, then update this test";
-}
-
-// ---------------------------------------------------------------------------
-// f16 and int8
-//
-// These share one code path with f32 - the accumulator and epilogue are fp32 for
-// every dtype and only the final store differs - so the shape coverage above is not
-// repeated. What is left per dtype is that the store converts correctly and that
-// fp32 accumulation really is used.
-// ---------------------------------------------------------------------------
-
-// The reference is exact (see run_conv_1d_float_case), so the only error allowed is
-// one rounding of the f16 output: 2^-11 ~= 4.9e-4. Anything more means the kernel
-// did not accumulate in fp32, which K = 2048 makes fail comfortably.
-constexpr float conv_1d_f16_out_round_rel_err = 5e-4f;
-
-TEST(convolution_1d_small_ic_gemm_f16, reduced_real_shape) {
-    run_conv_1d_float_case<ov::float16>(conv_1d_shape_reduced_real, data_types::f16,
-                                        conv_1d_f16_out_round_rel_err, /*with_bias*/ true);
-}
-
-TEST(convolution_1d_small_ic_gemm_f16, fast) {
-    run_conv_1d_float_case<ov::float16>(conv_1d_shape_fast_wide, data_types::f16,
-                                        conv_1d_f16_out_round_rel_err, /*with_bias*/ true);
-}
-
-// int8 exercises what f32 and f16 do not: the zero-point subtractions. The
-// activation zero point is subtracted per element while staging B and the weights
-// one while staging A, so the compensation term is deliberately ignored - these two
-// cases are what would catch a double-count.
-TEST(convolution_1d_small_ic_gemm_int8, u8s8f32_asymmetric_data_and_weights) {
-    run_conv_1d_int8_case<uint8_t>(conv_1d_shape_oc_leftover_small, data_types::u8, /*a_zp*/ true, /*w_zp*/ true);
-}
-
-TEST(convolution_1d_small_ic_gemm_int8, i8s8f32_fast_asymmetric_data_and_weights) {
-    run_conv_1d_int8_case<int8_t>(conv_1d_shape_fast_wide, data_types::i8, /*a_zp*/ true, /*w_zp*/ true);
-}
-
-// Full model shape. Disabled because the buffers are large: N=32, OC=1025,
-// L=49964 -> ~800 MB of fp32 output.
-TEST(convolution_1d_small_ic_gemm_full_shape, DISABLED_f32_layer9) {
-    constexpr conv_1d_shape s{32, 1, 49964, 1025, 2048, 242, 1, 0, 0};
-    run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true);
+    ASSERT_ANY_THROW(run_conv_1d(c, c.dt, "convolution_gpu_1d_small_ic_gemm"))
+        << "kernel accepted IC = " << c.in_features;
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -13299,3 +13299,481 @@ TEST(convolution_gpu_bfyx_f16, dynamic_fused_input_scalar_and_non_scalar_fp32) {
     ASSERT_NE(std::find(conv_info->c_fused_ids.begin(), conv_info->c_fused_ids.end(), "add"), conv_info->c_fused_ids.end());
     ASSERT_NE(conv_info->kernel_id.find("convolution_gpu_bfyx_f16_1x1"), std::string::npos);
 }
+
+// ---------------------------------------------------------------------------
+// convolution_gpu_1d_small_ic_gemm
+//
+// The 1D large-tap / small-IC convolution kernel, which maps such convolutions
+// onto an implicit GEMM with K = IC * taps instead of padding IC up to a blocked
+// feature size.
+//
+// Every test forces the kernel through force_implementations, so no other kernel
+// can silently satisfy an expectation: kernel_selector throws when a forced kernel
+// rejects the params. Reference values come from reference_conv_1d() below, which
+// accumulates in fp32 for every dtype to match the kernel, and is itself validated
+// against convolution_gpu_ref by the *_vs_ref_kernel suite.
+// ---------------------------------------------------------------------------
+
+static constexpr const char* conv_1d_small_ic_gemm_kernel = "convolution_gpu_1d_small_ic_gemm";
+
+// Used by the *_vs_ref_kernel suite to validate reference_conv_1d() independently
+// of the kernel under test; without it a bug shared by both would go unnoticed.
+static constexpr const char* conv_1d_reference_kernel = "convolution_gpu_ref";
+
+// Shape of a 1D convolution laid out as bfyx with the long axis on Y
+// (x == 1), which is how the plugin canonicalizes 3D conv inputs.
+struct conv_1d_shape {
+    size_t batch;
+    size_t in_features;   // IC
+    size_t in_length;     // input length along the long axis
+    size_t out_features;  // OC
+    size_t taps;          // filter size along the long axis
+    size_t stride;
+    size_t dilation;
+    size_t pad_begin;
+    size_t pad_end;
+
+    // Extent of the filter over the input after dilation.
+    size_t extent() const { return dilation * (taps - 1) + 1; }
+
+    bool is_valid() const { return in_length + pad_begin + pad_end >= extent(); }
+
+    size_t out_length() const {
+        // Guarded because the subtraction is unsigned: an over-long filter would
+        // wrap and produce an absurd allocation instead of a clear failure.
+        OPENVINO_ASSERT(is_valid(), "[TEST] invalid 1D conv shape: padded input length ",
+                        in_length + pad_begin + pad_end, " < filter extent ", extent());
+        return (in_length + pad_begin + pad_end - extent()) / stride + 1;
+    }
+};
+
+// Reference convolution over flat fp32 buffers laid out as input [b][ic][ol_in],
+// weights [oc][ic][tap], output [b][oc][ol_out]. fp32 accumulation matches the
+// kernel, and pre-converting inputs to fp32 lets one routine serve f32/f16/u8/i8.
+static std::vector<float> reference_conv_1d(const conv_1d_shape& s,
+                                            const std::vector<float>& input,
+                                            const std::vector<float>& weights,
+                                            const std::vector<float>& bias,
+                                            const std::vector<float>& data_zp,
+                                            const std::vector<float>& weights_zp) {
+    const size_t ol = s.out_length();
+    std::vector<float> output(s.batch * s.out_features * ol, 0.f);
+
+    for (size_t b = 0; b < s.batch; ++b) {
+        for (size_t oc = 0; oc < s.out_features; ++oc) {
+            const float w_zp = weights_zp.empty() ? 0.f : weights_zp[oc];
+            for (size_t o = 0; o < ol; ++o) {
+                float acc = 0.f;
+                for (size_t ic = 0; ic < s.in_features; ++ic) {
+                    const float a_zp = data_zp.empty() ? 0.f : data_zp[ic];
+                    for (size_t t = 0; t < s.taps; ++t) {
+                        const int64_t pos = static_cast<int64_t>(o * s.stride + t * s.dilation) -
+                                            static_cast<int64_t>(s.pad_begin);
+                        if (pos < 0 || pos >= static_cast<int64_t>(s.in_length))
+                            continue;
+                        const float in_val =
+                            input[(b * s.in_features + ic) * s.in_length + static_cast<size_t>(pos)] - a_zp;
+                        const float w_val = weights[(oc * s.in_features + ic) * s.taps + t] - w_zp;
+                        acc += in_val * w_val;
+                    }
+                }
+                if (!bias.empty())
+                    acc += bias[oc];
+                output[(b * s.out_features + oc) * ol + o] = acc;
+            }
+        }
+    }
+    return output;
+}
+
+template <typename T>
+std::vector<T> conv_1d_to_typed(const std::vector<float>& src) {
+    std::vector<T> dst(src.size());
+    std::transform(src.begin(), src.end(), dst.begin(), [](float v) { return static_cast<T>(v); });
+    return dst;
+}
+
+template <typename T>
+std::vector<float> conv_1d_to_float(const std::vector<T>& src) {
+    std::vector<float> dst(src.size());
+    std::transform(src.begin(), src.end(), dst.begin(), [](T v) { return static_cast<float>(v); });
+    return dst;
+}
+
+static ExecutionConfig conv_1d_forced_config(const engine& eng, const char* forced_kernel) {
+    ExecutionConfig config = get_test_default_config(eng);
+    ov::intel_gpu::ImplementationDesc conv_impl = {format::bfyx, forced_kernel, impl_types::ocl};
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv", conv_impl}}));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    return config;
+}
+
+// Runs one float (f32/f16) case and compares against the fp32 reference.
+template <typename T>
+void run_conv_1d_float_case(const conv_1d_shape& s, data_types dt, float rel_err, bool with_bias,
+                            int seed_offset = 0,
+                            const char* forced_kernel = conv_1d_small_ic_gemm_kernel) {
+    auto& engine = get_test_engine();
+    if (dt == data_types::f16 && !engine.get_device_info().supports_fp16) {
+        GTEST_SKIP() << "The test is skipped (cl_khr_fp16 is not supported).";
+    }
+
+    tests::random_generator rg(GET_SUITE_NAME + std::to_string(seed_offset));
+
+    const size_t ol = s.out_length();
+    // Values are multiples of 1/8 in [-1, 1], exact in f16, and their products are
+    // exact multiples of 1/64. So the fp32 accumulation over K terms is exact and
+    // the reference is the exact mathematical result; the tolerance then only has
+    // to cover the rounding of the f16 output.
+    auto input_f = rg.generate_random_1d<float>(s.batch * s.in_features * s.in_length, -1, 1, 8);
+    auto weights_f = rg.generate_random_1d<float>(s.out_features * s.in_features * s.taps, -1, 1, 8);
+    std::vector<float> bias_f;
+    if (with_bias)
+        bias_f = rg.generate_random_1d<float>(s.out_features, -1, 1, 8);
+
+    auto ref = reference_conv_1d(s, input_f, weights_f, bias_f, {}, {});
+
+    auto input_mem = engine.allocate_memory(
+        {dt, format::bfyx, tensor(static_cast<int32_t>(s.batch), static_cast<int32_t>(s.in_features), 1,
+                                  static_cast<int32_t>(s.in_length))});
+    auto weights_mem = engine.allocate_memory(
+        {dt, format::bfyx, tensor(static_cast<int32_t>(s.out_features), static_cast<int32_t>(s.in_features), 1,
+                                  static_cast<int32_t>(s.taps))});
+    set_values(input_mem, conv_1d_to_typed<T>(input_f));
+    set_values(weights_mem, conv_1d_to_typed<T>(weights_f));
+
+    topology topo;
+    topo.add(input_layout("input", input_mem->get_layout()));
+    topo.add(data("weights", weights_mem));
+
+    if (with_bias) {
+        auto bias_mem = engine.allocate_memory(
+            {dt, format::bfyx, tensor(1, static_cast<int32_t>(s.out_features), 1, 1)});
+        set_values(bias_mem, conv_1d_to_typed<T>(bias_f));
+        topo.add(data("bias", bias_mem));
+        topo.add(convolution("conv", input_info("input"), "weights", "bias", 1,
+                             {s.stride, 1}, {s.dilation, 1},
+                             {static_cast<std::ptrdiff_t>(s.pad_begin), 0},
+                             {static_cast<std::ptrdiff_t>(s.pad_end), 0}, false));
+    } else {
+        topo.add(convolution("conv", input_info("input"), "weights", no_bias, 1,
+                             {s.stride, 1}, {s.dilation, 1},
+                             {static_cast<std::ptrdiff_t>(s.pad_begin), 0},
+                             {static_cast<std::ptrdiff_t>(s.pad_end), 0}, false));
+    }
+    topo.add(reorder("out", input_info("conv"), format::bfyx, data_types::f32));
+
+    auto config = conv_1d_forced_config(engine, forced_kernel);
+    config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"out"}));
+
+    network net(engine, topo, config);
+    net.set_input_data("input", input_mem);
+    auto outputs = net.execute();
+
+    auto out_mem = outputs.at("out").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
+
+    ASSERT_EQ(out_mem->get_layout().batch(), static_cast<int32_t>(s.batch));
+    ASSERT_EQ(out_mem->get_layout().feature(), static_cast<int32_t>(s.out_features));
+    ASSERT_EQ(out_mem->get_layout().spatial(1), static_cast<int32_t>(ol));
+    ASSERT_EQ(out_mem->get_layout().spatial(0), 1);
+    ASSERT_EQ(ref.size(), out_ptr.size());
+
+    for (size_t i = 0; i < ref.size(); ++i) {
+        ASSERT_TRUE(are_equal(ref[i], out_ptr[i], rel_err))
+            << "mismatch at flat index " << i << " (dt=" << dt << ", OC=" << s.out_features
+            << ", taps=" << s.taps << ", stride=" << s.stride << ")";
+    }
+}
+
+// Runs one int8 case. Weights are i8, the input u8 or i8, the output fp32 - as in
+// the model under investigation, so the fp32 accumulator is directly observable.
+template <typename InputT>
+void run_conv_1d_int8_case(const conv_1d_shape& s, data_types in_dt, bool with_data_zp, bool with_weights_zp,
+                           int seed_offset = 0,
+                           const char* forced_kernel = conv_1d_small_ic_gemm_kernel) {
+    auto& engine = get_test_engine();
+    tests::random_generator rg(GET_SUITE_NAME + std::to_string(seed_offset));
+
+    const size_t ol = s.out_length();
+    const int in_min = (in_dt == data_types::u8) ? 0 : -8;
+    const int in_max = (in_dt == data_types::u8) ? 15 : 7;
+
+    // k = 1 yields plain integers in [min, max], without the fractional-resolution
+    // division the generator applies for float types.
+    auto input_i = rg.generate_random_1d<int>(s.batch * s.in_features * s.in_length, in_min, in_max, 1);
+    auto weights_i = rg.generate_random_1d<int>(s.out_features * s.in_features * s.taps, -4, 4, 1);
+    auto bias_f = rg.generate_random_1d<float>(s.out_features, -8, 8, 8);
+
+    std::vector<float> data_zp_f;
+    std::vector<float> weights_zp_f;
+    if (with_data_zp)
+        data_zp_f = conv_1d_to_float(rg.generate_random_1d<int>(s.in_features, in_min, in_min + 4, 1));
+    if (with_weights_zp)
+        weights_zp_f = conv_1d_to_float(rg.generate_random_1d<int>(s.out_features, -2, 2, 1));
+
+    auto input_f = conv_1d_to_float(input_i);
+    auto weights_f = conv_1d_to_float(weights_i);
+    auto ref = reference_conv_1d(s, input_f, weights_f, bias_f, data_zp_f, weights_zp_f);
+
+    auto input_mem = engine.allocate_memory(
+        {in_dt, format::bfyx, tensor(static_cast<int32_t>(s.batch), static_cast<int32_t>(s.in_features), 1,
+                                     static_cast<int32_t>(s.in_length))});
+    auto weights_mem = engine.allocate_memory(
+        {data_types::i8, format::bfyx, tensor(static_cast<int32_t>(s.out_features),
+                                              static_cast<int32_t>(s.in_features), 1,
+                                              static_cast<int32_t>(s.taps))});
+    auto bias_mem = engine.allocate_memory(
+        {data_types::f32, format::bfyx, tensor(1, static_cast<int32_t>(s.out_features), 1, 1)});
+
+    set_values(input_mem, conv_1d_to_typed<InputT>(input_f));
+    set_values(weights_mem, conv_1d_to_typed<int8_t>(weights_f));
+    set_values(bias_mem, bias_f);
+
+    topology topo;
+    topo.add(input_layout("input", input_mem->get_layout()));
+    topo.add(data("weights", weights_mem));
+    topo.add(data("bias", bias_mem));
+
+    std::string a_zp_id;
+    std::string w_zp_id;
+    if (with_data_zp) {
+        a_zp_id = "a_zp";
+        auto a_zp_mem = engine.allocate_memory(
+            {in_dt, format::bfyx, tensor(1, static_cast<int32_t>(s.in_features), 1, 1)});
+        set_values(a_zp_mem, conv_1d_to_typed<InputT>(data_zp_f));
+        topo.add(data(a_zp_id, a_zp_mem));
+    }
+    if (with_weights_zp) {
+        w_zp_id = "w_zp";
+        auto w_zp_mem = engine.allocate_memory(
+            {data_types::i8, format::bfyx, tensor(static_cast<int32_t>(s.out_features), 1, 1, 1)});
+        set_values(w_zp_mem, conv_1d_to_typed<int8_t>(weights_zp_f));
+        topo.add(data(w_zp_id, w_zp_mem));
+    }
+
+    topo.add(convolution("conv", input_info("input"), "weights", "bias", w_zp_id, a_zp_id, "", 1,
+                         {s.stride, 1}, {s.dilation, 1},
+                         {static_cast<std::ptrdiff_t>(s.pad_begin), 0},
+                         {static_cast<std::ptrdiff_t>(s.pad_end), 0}, false, data_types::f32));
+    topo.add(reorder("out", input_info("conv"), format::bfyx, data_types::f32));
+
+    auto config = conv_1d_forced_config(engine, forced_kernel);
+    config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{"out"}));
+
+    network net(engine, topo, config);
+    net.set_input_data("input", input_mem);
+    auto outputs = net.execute();
+
+    auto out_mem = outputs.at("out").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
+
+    ASSERT_EQ(out_mem->get_layout().spatial(1), static_cast<int32_t>(ol));
+    ASSERT_EQ(ref.size(), out_ptr.size());
+
+    // int8 operands are exact in fp32 and so is the accumulator, so the result is
+    // bit-exact up to fp32 addition ordering.
+    for (size_t i = 0; i < ref.size(); ++i) {
+        ASSERT_NEAR(ref[i], out_ptr[i], 1e-3f)
+            << "mismatch at flat index " << i << " (in_dt=" << in_dt << ", a_zp=" << with_data_zp
+            << ", w_zp=" << with_weights_zp << ")";
+    }
+}
+
+// Smallest accepted shape: taps sits exactly on min_taps, and OC = 3 and
+// out_length = 23 are both below their tile sizes, so every leftover path is
+// exercised at once.
+constexpr conv_1d_shape conv_1d_shape_min_taps{/*batch*/ 1, /*IC*/ 1, /*L*/ 300, /*OC*/ 3, /*taps*/ 256,
+                                               /*stride*/ 2, /*dilation*/ 1, /*pad_begin*/ 0, /*pad_end*/ 0};
+
+// Same tap/stride ratio as the model layer (overlap factor 8.46x) but small
+// enough to run in a unit test. K = 2048.
+constexpr conv_1d_shape conv_1d_shape_reduced_real{1, 1, 4964, 65, 2048, 242, 1, 0, 0};
+
+// OC = 1025 is not a multiple of 16, so the OC leftover path is mandatory.
+constexpr conv_1d_shape conv_1d_shape_oc_leftover{1, 1, 2664, 1025, 2048, 242, 1, 0, 0};
+
+// Small OC leftover (17 = 16 + 1) with a short filter.
+constexpr conv_1d_shape conv_1d_shape_oc_leftover_small{2, 1, 300, 17, 256, 32, 1, 0, 0};
+
+// Dilation doubles the filter extent to 2 * (256 - 1) + 1 = 511, so this needs a
+// longer input than conv_1d_shape_oc_leftover_small - hence a separate shape.
+constexpr conv_1d_shape conv_1d_shape_dilated{2, 1, 1200, 17, 256, 32, 2, 0, 0};
+
+// Takes the unguarded vector-load path for staging B, which the kernel selects
+// only when every access is provably in range: no left padding, dilation 1, the
+// last tap of the last output inside the input, taps a multiple of TILE_K, and
+// batch * out_length a multiple of TILE_N.
+//
+// The real model layer meets all of those but none of the shapes above do (their
+// out_length is not a multiple of TILE_N), so the fast path would otherwise go
+// untested. out_length is 32: (318 - 256) / 2 + 1. OC = 17 covers the OC leftover
+// path here too, and batch = 2 makes GEMM_N span several tiles while keeping every
+// fast-path condition satisfied (2 * 32 = 64).
+constexpr conv_1d_shape conv_1d_shape_fast_wide{2, 1, 318, 17, 256, 2, 1, 0, 0};
+
+// A ragged N tail past the first tile. out_length is 33, so with TILE_N = 32 the
+// second of two tiles holds a single valid column: the lane at j = 0 is partially
+// valid and every lane at j = 1 is invalid. Since a lane owns N_PER_LANE columns a
+// tile can be partially valid in two ways, and the shapes above only reach the
+// other one. OC = 17 makes M ragged at the same time.
+constexpr conv_1d_shape conv_1d_shape_ragged_n{1, 1, 320, 17, 256, 2, 1, 0, 0};
+
+// ---------------------------------------------------------------------------
+// Self-check: validate reference_conv_1d() against convolution_gpu_ref. These pin
+// down the expected values independently of the kernel under test, so a failure in
+// the suites below is unambiguously a kernel bug and not a reference bug.
+//
+// One shape per B-staging path is enough, since that is where the reference and the
+// kernel could agree on a shared indexing bug. conv_1d_shape_oc_leftover_small also
+// carries padding, a stride and both zero points, so one f32 and one int8 case pin
+// down the guarded path.
+// ---------------------------------------------------------------------------
+
+TEST(convolution_1d_small_ic_gemm_vs_ref_kernel, f32_guarded) {
+    conv_1d_shape s = conv_1d_shape_oc_leftover_small;
+    s.pad_begin = 13;
+    s.pad_end = 5;
+    run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true, 0, conv_1d_reference_kernel);
+}
+
+TEST(convolution_1d_small_ic_gemm_vs_ref_kernel, f32_fast) {
+    run_conv_1d_float_case<float>(conv_1d_shape_fast_wide, data_types::f32, 1e-4f, /*with_bias*/ true, 0,
+                                  conv_1d_reference_kernel);
+}
+
+TEST(convolution_1d_small_ic_gemm_vs_ref_kernel, u8s8f32_asymmetric_data_and_weights) {
+    run_conv_1d_int8_case<uint8_t>(conv_1d_shape_oc_leftover_small, data_types::u8, /*a_zp*/ true, /*w_zp*/ true, 0,
+                                   conv_1d_reference_kernel);
+}
+
+// IC > 1 deliberately, even though Validate() rejects it today: the K = IC * taps
+// decomposition is correct for any IC and the bound is meant to be raisable. Pinning
+// the values now, against a kernel with no IC gate, means raising it later does not
+// also require deriving fresh reference values. Only the reference is exercised here
+// - a wider gate would still need accuracy coverage on the kernel itself.
+TEST(convolution_1d_small_ic_gemm_vs_ref_kernel, f32_input_features_2_to_4) {
+    for (size_t ic = 2; ic <= 4; ++ic) {
+        conv_1d_shape s = conv_1d_shape_oc_leftover_small;
+        s.in_features = ic;
+        run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true, static_cast<int>(ic),
+                                      conv_1d_reference_kernel);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// f32 - the only dtype the model uses, so the shape coverage lives here.
+// ---------------------------------------------------------------------------
+
+// Smallest accepted shape, and every leftover path at once: OC = 3 < TILE_M and
+// out_length = 23 < TILE_N.
+TEST(convolution_1d_small_ic_gemm_f32, min_taps_leftovers) {
+    run_conv_1d_float_case<float>(conv_1d_shape_min_taps, data_types::f32, 1e-4f, /*with_bias*/ true);
+}
+
+// The model layer's proportions, and the shape that matters for performance.
+TEST(convolution_1d_small_ic_gemm_f32, reduced_real_shape) {
+    run_conv_1d_float_case<float>(conv_1d_shape_reduced_real, data_types::f32, 1e-4f, /*with_bias*/ true);
+}
+
+// OC = 1025 as in the model: M ragged against TILE_M = 16 over many tiles.
+TEST(convolution_1d_small_ic_gemm_f32, oc_leftover_1025) {
+    run_conv_1d_float_case<float>(conv_1d_shape_oc_leftover, data_types::f32, 1e-4f, /*with_bias*/ true);
+}
+
+// Padding, dilation and batch > 1 together on the guarded path: DILATION_L != 1 is
+// one of the conditions that rules out the fast path.
+TEST(convolution_1d_small_ic_gemm_f32, dilation_and_padding) {
+    conv_1d_shape s = conv_1d_shape_dilated;
+    s.pad_begin = 13;
+    s.pad_end = 5;
+    run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true);
+}
+
+// stride == 1 is the maximum-overlap end of the range, and the one value where a
+// stride the kernel failed to apply still lands in range - so a mix-up shows up as
+// wrong values rather than a crash. The shapes above cover strides 2, 32 and 242.
+TEST(convolution_1d_small_ic_gemm_f32, stride_1) {
+    conv_1d_shape s = conv_1d_shape_oc_leftover_small;
+    s.stride = 1;
+    run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true);
+}
+
+// The unguarded vector-load path, which every case above avoids. _fast_wide covers
+// the no-bias epilogue and an OC leftover on it too.
+TEST(convolution_1d_small_ic_gemm_f32, fast) {
+    run_conv_1d_float_case<float>(conv_1d_shape_fast_wide, data_types::f32, 1e-4f, /*with_bias*/ true);
+}
+
+TEST(convolution_1d_small_ic_gemm_f32, fast_no_bias) {
+    run_conv_1d_float_case<float>(conv_1d_shape_fast_wide, data_types::f32, 1e-4f, /*with_bias*/ false);
+}
+
+// Only this shape reaches the partially-valid tile where j = 0 is valid and j = 1
+// is not.
+TEST(convolution_1d_small_ic_gemm_f32, ragged_n) {
+    run_conv_1d_float_case<float>(conv_1d_shape_ragged_n, data_types::f32, 1e-4f, /*with_bias*/ true);
+}
+
+// The IC bound is selection policy, not correctness: the kernel outranks the
+// blocked ones at FORCE_PRIORITY_2, so the bound has to live in Validate() rather
+// than in the priority, and this asserts it is enforced there.
+//
+// The bound is repeated as a literal rather than read from max_input_features on
+// purpose. Following the constant would make this test pass automatically on a
+// widened gate, which is the case it exists to catch: widening also needs a
+// benchmark against convolution_gpu_bfyx_to_bfyx_f16 and kernel-side accuracy
+// coverage. The accepted end of the range is covered by every other test here.
+TEST(convolution_1d_small_ic_gemm_f32, rejects_input_features_above_max) {
+    constexpr size_t max_input_features = 1;
+    conv_1d_shape s = conv_1d_shape_oc_leftover_small;
+    s.in_features = max_input_features + 1;
+    // kernel_selector throws when the forced kernel rejects the params.
+    ASSERT_ANY_THROW(run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true))
+        << "kernel unexpectedly accepted IC = " << s.in_features
+        << "; if max_input_features was raised deliberately, add a benchmark and "
+           "kernel-side accuracy coverage for the new range, then update this test";
+}
+
+// ---------------------------------------------------------------------------
+// f16 and int8
+//
+// These share one code path with f32 - the accumulator and epilogue are fp32 for
+// every dtype and only the final store differs - so the shape coverage above is not
+// repeated. What is left per dtype is that the store converts correctly and that
+// fp32 accumulation really is used.
+// ---------------------------------------------------------------------------
+
+// The reference is exact (see run_conv_1d_float_case), so the only error allowed is
+// one rounding of the f16 output: 2^-11 ~= 4.9e-4. Anything more means the kernel
+// did not accumulate in fp32, which K = 2048 makes fail comfortably.
+constexpr float conv_1d_f16_out_round_rel_err = 5e-4f;
+
+TEST(convolution_1d_small_ic_gemm_f16, reduced_real_shape) {
+    run_conv_1d_float_case<ov::float16>(conv_1d_shape_reduced_real, data_types::f16,
+                                        conv_1d_f16_out_round_rel_err, /*with_bias*/ true);
+}
+
+TEST(convolution_1d_small_ic_gemm_f16, fast) {
+    run_conv_1d_float_case<ov::float16>(conv_1d_shape_fast_wide, data_types::f16,
+                                        conv_1d_f16_out_round_rel_err, /*with_bias*/ true);
+}
+
+// int8 exercises what f32 and f16 do not: the zero-point subtractions. The
+// activation zero point is subtracted per element while staging B and the weights
+// one while staging A, so the compensation term is deliberately ignored - these two
+// cases are what would catch a double-count.
+TEST(convolution_1d_small_ic_gemm_int8, u8s8f32_asymmetric_data_and_weights) {
+    run_conv_1d_int8_case<uint8_t>(conv_1d_shape_oc_leftover_small, data_types::u8, /*a_zp*/ true, /*w_zp*/ true);
+}
+
+TEST(convolution_1d_small_ic_gemm_int8, i8s8f32_fast_asymmetric_data_and_weights) {
+    run_conv_1d_int8_case<int8_t>(conv_1d_shape_fast_wide, data_types::i8, /*a_zp*/ true, /*w_zp*/ true);
+}
+
+// Full model shape. Disabled because the buffers are large: N=32, OC=1025,
+// L=49964 -> ~800 MB of fp32 output.
+TEST(convolution_1d_small_ic_gemm_full_shape, DISABLED_f32_layer9) {
+    constexpr conv_1d_shape s{32, 1, 49964, 1025, 2048, 242, 1, 0, 0};
+    run_conv_1d_float_case<float>(s, data_types::f32, 1e-4f, /*with_bias*/ true);
+}


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - **Symptom**: on a 1D convolution with `input [32,1,49964]`, `weights [1025,1,2048]`, stride 242, the selected kernel `convolution_gpu_bfyx_os_iyx_osv16` reaches only 0.45 TFLOPS on PTLH — **5.8% of the 7.68 TFLOPS FP32 vector peak**.
 - **Root cause**: no existing kernel fits IC=1 with a 2048-long filter. The blocked kernels pad the feature dimension up to the block size (16), wasting 15 of every 16 MACs; `os_iyx_osv16` wastes nothing but tiles over output spatial, which leaves the hardware idle at this IC.
 - **Fix**: added `ConvolutionKernel_1d_small_ic_gemm`, which merges IC and the filter into one reduction axis and runs the layer as an implicit GEMM (`M=OC, N=batch*out_len, K=IC*filter_len`) — no feature padding, and K large enough to amortize tile loads. The `im2col` matrix is never materialized. `layout_optimizer::get_expected_format()` gets one `else if` that keeps such nodes planar so the kernel can be selected; the shape conditions themselves live in the kernel's `Validate()`, not in the graph. The format gate is deliberately narrow (4D, IC=1, degenerate X axis, filter length >= 256, no fusion other than a single dependency-free activation) so no shape the blocked kernels are good at is diverted.
 - Output is bit-exact vs the previously selected kernel (max_abs 0, cos 1.0).

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv16.cpp` — the kernel selected for these shapes before this PR. Not modified; the new kernel outranks it at `FORCE_PRIORITY_2`.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - Customer model, not attached. Reproducible with the unit tests:
 - `$ ./ov_gpu_unit_tests --gtest_filter=*1d_small_ic_gemm*`

#### Problematic graph
```mermaid
graph TD
I[/"<b>input0</b><br/>Type: f32<br/>Layout: bs_fs_yx_bsv16<br/>Shape: 32x1x49964x1<br/>Pad: nopad"/]
W[/"<b>weights</b><br/>Type: f32<br/>Layout: is_os_yx_isv16_osv16<br/>Shape: 1025x1x2048x1<br/>Pad: nopad"/]

C{"<b>conv</b><br/>Type: f32<br/>Layout: bs_fs_yx_bsv16_fsv16<br/>Shape: 32x1025x199x1<br/>Pad: nopad<br/>gen9_common_conv_fwd_data_f32"}

I --> C
W --> C
```
#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary? — 12 tests: 11 shapes covering one code path each (min_filter_len, large_k, oc_leftover, dilation_and_padding, stride_1, fast, ragged_n_no_bias, f16_large_k, f16_fast, u8_zp, i8_fast_zp) plus rejects_input_features_above_max for the IC gate. Each case runs the same topology twice — once forced onto this kernel, once onto convolution_gpu_ref — and compares, so there are no hand-written reference values to be wrong. The f16 reference is run in f32 because convolution_gpu_ref accumulates in the input dtype, which leaves the tolerance covering only this kernel's output rounding and so still catches a non-fp32 accumulator.
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? — Reviewed intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp and extended it rather than adding a new file, matching the style of the existing convolution_gpu_* suites.

### Ticket
- *185927*