### PR TITLE
[PyOV] Update pytz and dependency review

### DIFF
--- a/.github/dependency_review.yml
+++ b/.github/dependency_review.yml
@@ -23,4 +23,6 @@ vulnerability-check: true
 allow-dependencies-licenses:
   - 'pkg:pypi/PyGithub@2.2.0'
   - 'pkg:pypi/psycopg2-binary'
+  - 'pkg:pypi/pytz@2026.3.post1' # MIT license, but dependency review flags it as MIT AND ZPL-2.1: https://github.com/stub42/pytz/blob/release_2026.2/LICENSE.txt
+  
   - 'pkg:npm/@sinclair/typebox@0.34.49' # It has only an MIT license, but the dependency check actions reports it as MIT AND Zlib, see https://github.com/sinclairzx81/sinclair-typebox?tab=License-1-ov-file

--- a/.github/dependency_review.yml
+++ b/.github/dependency_review.yml
@@ -23,5 +23,4 @@ vulnerability-check: true
 allow-dependencies-licenses:
   - 'pkg:pypi/PyGithub@2.2.0'
   - 'pkg:pypi/psycopg2-binary'
-  - 'pkg:pypi/pytz@2026.2' # MIT license, but dependency review flags it as MIT AND ZPL-2.1: https://github.com/stub42/pytz/blob/release_2026.2/LICENSE.txt
   - 'pkg:npm/@sinclair/typebox@0.34.49' # It has only an MIT license, but the dependency check actions reports it as MIT AND Zlib, see https://github.com/sinclairzx81/sinclair-typebox?tab=License-1-ov-file

--- a/.github/dependency_review.yml
+++ b/.github/dependency_review.yml
@@ -23,6 +23,6 @@ vulnerability-check: true
 allow-dependencies-licenses:
   - 'pkg:pypi/PyGithub@2.2.0'
   - 'pkg:pypi/psycopg2-binary'
-  - 'pkg:pypi/pytz@2026.3.post1' # MIT license, but dependency review flags it as MIT AND ZPL-2.1: https://github.com/stub42/pytz/blob/release_2026.2/LICENSE.txt
+  - 'pkg:pypi/pytz@2026.3.post1' # MIT license, but dependency review flags it as MIT AND ZPL-2.1: https://github.com/stub42/pytz/blob/release_2026.3.post1/LICENSE.txt
   
   - 'pkg:npm/@sinclair/typebox@0.34.49' # It has only an MIT license, but the dependency check actions reports it as MIT AND Zlib, see https://github.com/sinclairzx81/sinclair-typebox?tab=License-1-ov-file

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -29,7 +29,7 @@ pytest==9.1.1
 pytest-html==4.2.0
 pytest-metadata==3.1.1
 py>=1.11.0
-pytz==2026.2
+pytz==2026.3.post1
 pyyaml==6.0.3
 requests==2.34.2
 six==1.17.0


### PR DESCRIPTION
### Details:
 - Update pytz
 - Dependency review skip is still needed for pytz:
> The following dependencies have incompatible licenses:
  docs/requirements.txt » pytz@2026.3.post1 – License: MIT AND ZPL-2.1
  Error: Dependency review detected incompatible licenses.

### AI Assistance:
 - *AI assistance used: no *
