### PR TITLE
[NPU] Remove old interperter and mlir_runtime name

### DIFF
--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vm/npu_vm_runtime_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vm/npu_vm_runtime_api.hpp
@@ -54,7 +54,6 @@ public:
 
     // Inspects the blob header to select the appropriate runtime library and calls initialize().
     // Selects "openvino_intel_npu_vm_runtime" for NPUByte blobs, "openvino_intel_npu_mlir_runtime" otherwise.
-    // Falls back to legacy runtime library names if the new names are not available.
     static void initializeFromBlob(const void* data, size_t size);
 
     static const std::shared_ptr<NPUVMRuntimeApi>& getInstance();

--- a/src/plugins/intel_npu/src/utils/src/vm/npu_vm_runtime_api.cpp
+++ b/src/plugins/intel_npu/src/utils/src/vm/npu_vm_runtime_api.cpp
@@ -12,37 +12,21 @@
 namespace intel_npu {
 
 namespace {
-constexpr std::string_view NEW_MLIR_RUNTIME_NAME = "openvino_intel_npu_mlir_runtime";
-constexpr std::string_view OLD_MLIR_RUNTIME_NAME = "npu_mlir_runtime";
-constexpr std::string_view NEW_VM_RUNTIME_NAME = "openvino_intel_npu_vm_runtime";
-constexpr std::string_view OLD_VM_RUNTIME_NAME = "npu_interpreter_runtime";
+constexpr std::string_view MLIR_RUNTIME_NAME = "openvino_intel_npu_mlir_runtime";
+constexpr std::string_view VM_RUNTIME_NAME = "openvino_intel_npu_vm_runtime";
 
-std::string g_libName{NEW_MLIR_RUNTIME_NAME};
+std::string g_libName{MLIR_RUNTIME_NAME};
 bool g_instanceCreated{false};
 }  // namespace
 
 NPUVMRuntimeApi::NPUVMRuntimeApi(std::string_view libName) {
-    const std::string_view baseName = libName.empty() ? NEW_MLIR_RUNTIME_NAME : libName;
+    const std::string_view baseName = libName.empty() ? MLIR_RUNTIME_NAME : libName;
     try {
         auto libPath =
             ov::util::make_plugin_library_name(ov::util::get_ov_lib_path(), std::string(baseName) + OV_BUILD_POSTFIX);
         this->lib = ov::util::load_shared_object(libPath);
     } catch (const std::runtime_error& error) {
-        // Temporary compatibility for packages built before the runtime library rename.
-        const std::string_view fallbackName = baseName == NEW_MLIR_RUNTIME_NAME ? OLD_MLIR_RUNTIME_NAME
-                                              : baseName == NEW_VM_RUNTIME_NAME ? OLD_VM_RUNTIME_NAME
-                                                                                : std::string_view{};
-        if (fallbackName.empty()) {
-            OPENVINO_THROW(error.what());
-        }
-
-        try {
-            auto fallbackLibPath = ov::util::make_plugin_library_name(ov::util::get_ov_lib_path(),
-                                                                      std::string(fallbackName) + OV_BUILD_POSTFIX);
-            this->lib = ov::util::load_shared_object(fallbackLibPath);
-        } catch (const std::runtime_error& fallbackError) {
-            OPENVINO_THROW(error.what(), "; fallback failed: ", fallbackError.what());
-        }
+        OPENVINO_THROW("Failed to load NPU runtime library '", baseName, "': ", error.what());
     }
 
     try {
@@ -51,7 +35,7 @@ NPUVMRuntimeApi::NPUVMRuntimeApi(std::string_view libName) {
         nvm_symbols_list();
 #undef nvm_symbol_statement
     } catch (const std::runtime_error& error) {
-        OPENVINO_THROW(error.what());
+        OPENVINO_THROW("Failed to resolve required symbol in NPU runtime library '", baseName, "': ", error.what());
     }
 
 #define nvm_symbol_statement(symbol)                                                              \
@@ -68,12 +52,12 @@ void NPUVMRuntimeApi::initializeFromBlob(const void* data, size_t size) {
     const size_t headerSize = std::min(size, size_t{20});
     const std::string_view header(static_cast<const char*>(data), headerSize);
     const std::string_view libName =
-        (header.find("NPUByte\x00") != std::string_view::npos) ? NEW_VM_RUNTIME_NAME : NEW_MLIR_RUNTIME_NAME;
+        (header.find("NPUByte\x00") != std::string_view::npos) ? VM_RUNTIME_NAME : MLIR_RUNTIME_NAME;
     initialize(libName);
 }
 
 void NPUVMRuntimeApi::initialize(std::string_view libName) {
-    const std::string resolvedName{libName.empty() ? NEW_MLIR_RUNTIME_NAME : libName};
+    const std::string resolvedName{libName.empty() ? MLIR_RUNTIME_NAME : libName};
     if (g_instanceCreated) {
         if (g_libName != resolvedName) {
             OPENVINO_THROW("NPUVMRuntimeApi is already initialized with '",

--- a/src/plugins/intel_npu/tests/functional/behavior/dynamic_host_pipeline/infer_with_host_compile.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/dynamic_host_pipeline/infer_with_host_compile.cpp
@@ -778,7 +778,7 @@ TEST_P(InferWithDefaultHostCompileTests, CompileDynamicModelWithNoHostCompileMod
     auto model = createModelByName(selectedModelName);
 
     ov::CompiledModel compiledModel;
-    // Compilation shall pass since load of npu_mlir_runtime is deffered with NPU_CREATE_EXECUTOR=0
+    // Compilation shall pass since load of openvino_intel_npu_mlir_runtime is deffered with NPU_CREATE_EXECUTOR=0
     OV_ASSERT_NO_THROW(compiledModel = core->compile_model(model, target_device, configuration));
 
     std::stringstream modelStream;


### PR DESCRIPTION
### Details:
 - Deprecate and remove the old interpreter, mlir_runtime reference, and fallback mechanism.
    - npu_interpreter_runtime-> openvino_intel_npu_vm_runtime
    - npu_mlir_runtime -> openvino_intel_npu_mlir_runtime

### Tickets:
 - *CVS-190805*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
