### PR TITLE
[GPU] Add BF16 support to concatenation OCL kernels

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -102,6 +102,7 @@ attach_concatenation_impl::attach_concatenation_impl() {
         data_types::i8,
         data_types::u8,
         data_types::f16,
+        data_types::bf16,
         data_types::f32,
         data_types::i32,
         data_types::i64,
@@ -128,6 +129,7 @@ attach_concatenation_impl::attach_concatenation_impl() {
         data_types::i8,
         data_types::u8,
         data_types::f16,
+        data_types::bf16,
         data_types::f32,
         data_types::i32,
         data_types::i64
@@ -160,6 +162,7 @@ attach_concatenation_impl::attach_concatenation_impl() {
 
     keys.emplace(data_types::f32, format::b_fs_yx_fsv16);
     keys.emplace(data_types::f16, format::b_fs_yx_fsv16);
+    keys.emplace(data_types::bf16, format::b_fs_yx_fsv16);
     keys.emplace(data_types::u8, format::b_fs_yx_fsv16);
     keys.emplace(data_types::i8, format::b_fs_yx_fsv16);
 
@@ -168,8 +171,10 @@ attach_concatenation_impl::attach_concatenation_impl() {
 
     keys.emplace(data_types::i8, format::b_fs_yx_fsv32);
     keys.emplace(data_types::u8, format::b_fs_yx_fsv32);
+    keys.emplace(data_types::bf16, format::b_fs_yx_fsv32);
 
     keys.emplace(data_types::f16, format::fs_b_yx_fsv32);
+    keys.emplace(data_types::bf16, format::fs_b_yx_fsv32);
 
     implementation_map<concatenation>::add(impl_types::ocl,
                                            typed_primitive_impl_ocl<concatenation>::create<concatenation_impl>,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_b_fs_yx_fsv32.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_b_fs_yx_fsv32.cl
@@ -35,7 +35,7 @@ KERNEL(concatenation_gpu_b_fs_yx_fsv32)(
 
     const uint input_offset = INPUT0_GET_INDEX(b, fs * FSV, y, x);
 
-    MAKE_VECTOR_TYPE(INPUT0_TYPE, 2) in = DT_INPUT_BLOCK_READ2(input, input_offset);
+    MAKE_VECTOR_TYPE(INPUT0_COMPUTE_TYPE, 2) in = DECODE_INPUT0_COMPUTE_VECTOR_TYPE(DT_INPUT_BLOCK_READ2(input, input_offset), 2);
 
     in = ACTIVATION(in, ACTIVATION_PARAMS);
 
@@ -44,14 +44,14 @@ KERNEL(concatenation_gpu_b_fs_yx_fsv32)(
 
     // Full feature block: use block write for maximum throughput
     if (fs * FSV + FSV <= INPUT0_FEATURE_NUM) {
-        DT_OUTPUT_BLOCK_WRITE2(output, dst_index, in);
+        DT_OUTPUT_BLOCK_WRITE2(output, dst_index, TO_OUTPUT_VECTOR_TYPE(in, 2));
     } else {
         // Last partial feature block: write only valid features
         if (sglid + fs * FSV < INPUT0_FEATURE_NUM) {
-            output[dst_index + sglid] = in.s0;
+            output[dst_index + sglid] = TO_OUTPUT_TYPE(in.s0);
         }
         if (sglid + SUB_GROUP_SIZE + fs * FSV < INPUT0_FEATURE_NUM) {
-            output[dst_index + SUB_GROUP_SIZE + sglid] = in.s1;
+            output[dst_index + SUB_GROUP_SIZE + sglid] = TO_OUTPUT_TYPE(in.s1);
         }
     }
 #else
@@ -59,10 +59,10 @@ KERNEL(concatenation_gpu_b_fs_yx_fsv32)(
     const uint dst_feature = fs * FSV + output_offset_in_concat_axis + sglid;
 
     if (sglid + SUB_GROUP_SIZE + fs * FSV < INPUT0_FEATURE_NUM) {
-        output[OUTPUT_GET_INDEX(b, dst_feature, y, x)] = in.s0;
-        output[OUTPUT_GET_INDEX(b, dst_feature + SUB_GROUP_SIZE, y, x)] = in.s1;
+        output[OUTPUT_GET_INDEX(b, dst_feature, y, x)] = TO_OUTPUT_TYPE(in.s0);
+        output[OUTPUT_GET_INDEX(b, dst_feature + SUB_GROUP_SIZE, y, x)] = TO_OUTPUT_TYPE(in.s1);
     } else if (sglid + fs * FSV < INPUT0_FEATURE_NUM) {
-        output[OUTPUT_GET_INDEX(b, dst_feature, y, x)] = in.s0;
+        output[OUTPUT_GET_INDEX(b, dst_feature, y, x)] = TO_OUTPUT_TYPE(in.s0);
     }
 #endif
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_blocked.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_blocked.cl
@@ -11,7 +11,9 @@
 
 #define INPUT_VEC_TYPE                          MAKE_VECTOR_TYPE(INPUT0_TYPE, TILE_XY)
 #define OUTPUT_VEC_TYPE                         MAKE_VECTOR_TYPE(OUTPUT_TYPE, TILE_XY)
-#define TO_OUTPUT_VEC_TYPE(x)                   CAT(convert_, OUTPUT_VEC_TYPE)(x)
+// Use the jitter-provided vector conversion which encodes BF16 output from FP32 compute values.
+// For non-BF16 output types it expands to convert_<OUTPUT_TYPE><TILE_XY>(x) - same as before.
+#define TO_OUTPUT_VEC_TYPE(x)                   TO_OUTPUT_VECTOR_TYPE(x, TILE_XY)
 #define INPUT_BLOCK_READ(ptr, offset)           MAKE_VECTOR_TYPE(DT_INPUT_BLOCK_READ, TILE_XY)(ptr, offset)
 #define OUTPUT_BLOCK_WRITE(ptr, offset, val)    MAKE_VECTOR_TYPE(DT_OUTPUT_BLOCK_WRITE, TILE_XY)(ptr, offset, val)
 
@@ -47,12 +49,12 @@ KERNEL (concatenation_gpu_blocked)(
                         || (f_block * IC_BLOCK + IC_BLOCK <= INPUT0_FEATURE_NUM);
 
     if (do_block_write) {
-        OUTPUT_VEC_TYPE res = TO_OUTPUT_VEC_TYPE(ACTIVATION(src, ACTIVATION_PARAMS));
+        OUTPUT_VEC_TYPE res = TO_OUTPUT_VEC_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_VECTOR_TYPE(src, TILE_XY), ACTIVATION_PARAMS));
         OUTPUT_BLOCK_WRITE(output, dst_index, res);
     } else {
         if (lid < INPUT0_FEATURE_NUM % IC_BLOCK) {
             unroll_for(uint tx = 0; tx < TILE_XY; ++tx) {
-                OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(((INPUT0_TYPE*)&src)[tx], ACTIVATION_PARAMS));
+                OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(((INPUT0_TYPE*)&src)[tx]), ACTIVATION_PARAMS));
                 output[dst_index + tx * IC_BLOCK + lid] = res;
             }
         }
@@ -83,12 +85,12 @@ KERNEL (concatenation_gpu_blocked)(
             ((INPUT0_TYPE*)&src_al2)[tx] = _sub_group_shuffle_down(((INPUT0_TYPE*)&src2)[tx], ((INPUT0_TYPE*)&src3)[tx], (IC_BLOCK - MISALIGNMENT));
     #endif
         }
-        OUTPUT_VEC_TYPE res_al0 = TO_OUTPUT_VEC_TYPE(ACTIVATION(src_al0, ACTIVATION_PARAMS));
+        OUTPUT_VEC_TYPE res_al0 = TO_OUTPUT_VEC_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_VECTOR_TYPE(src_al0, TILE_XY), ACTIVATION_PARAMS));
         OUTPUT_BLOCK_WRITE(output, dst_index, res_al0);
     #if TILE_F == 4
-        OUTPUT_VEC_TYPE res_al1 = TO_OUTPUT_VEC_TYPE(ACTIVATION(src_al1, ACTIVATION_PARAMS));
+        OUTPUT_VEC_TYPE res_al1 = TO_OUTPUT_VEC_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_VECTOR_TYPE(src_al1, TILE_XY), ACTIVATION_PARAMS));
         OUTPUT_BLOCK_WRITE(output, dst_index + 1 * OUTPUT_FEATURE_PITCH * IC_BLOCK, res_al1);
-        OUTPUT_VEC_TYPE res_al2 = TO_OUTPUT_VEC_TYPE(ACTIVATION(src_al2, ACTIVATION_PARAMS));
+        OUTPUT_VEC_TYPE res_al2 = TO_OUTPUT_VEC_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_VECTOR_TYPE(src_al2, TILE_XY), ACTIVATION_PARAMS));
         OUTPUT_BLOCK_WRITE(output, dst_index + 2 * OUTPUT_FEATURE_PITCH * IC_BLOCK, res_al2);
     #endif
         uint lid_f_offset = lid;
@@ -103,7 +105,7 @@ KERNEL (concatenation_gpu_blocked)(
 
         dst_index = OUTPUT_GET_INDEX(b, (f_block*IC_BLOCK + lid_f_offset + output_offset_in_concat_axis), y, x);
         unroll_for(uint tx = 0; tx < TILE_XY; ++tx) {
-            OUTPUT_TYPE res_unal = TO_OUTPUT_TYPE(ACTIVATION(((INPUT0_TYPE*)&src_unal)[tx], ACTIVATION_PARAMS));
+            OUTPUT_TYPE res_unal = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(((INPUT0_TYPE*)&src_unal)[tx]), ACTIVATION_PARAMS));
             output[dst_index + tx * IC_BLOCK] = res_unal;
         }
     } else
@@ -119,7 +121,7 @@ KERNEL (concatenation_gpu_blocked)(
             if (do_leftover_write) {
                 unroll_for(uint tx = 0; tx < TILE_XY; ++tx) {
                     INPUT0_TYPE src = input[input_offset + lid + tx * IC_BLOCK + fw * INPUT0_FEATURE_PITCH * IC_BLOCK];
-                    OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(src, ACTIVATION_PARAMS));
+                    OUTPUT_TYPE res = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(src), ACTIVATION_PARAMS));
                     output[dst_index + tx * IC_BLOCK + fw * OUTPUT_FEATURE_PITCH * IC_BLOCK] = res;
                 }
             }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_depth_bfyx_no_pitch.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_depth_bfyx_no_pitch.cl
@@ -46,13 +46,14 @@ KERNEL(concatenation_gpu_depth_bfyx_no_pitch)(__global INPUT0_TYPE* input, __glo
     if(element_group_offset + align_offset + WORK_GROUP_SIZE * ELEMENTS_PER_WORK_ITEM < INPUT0_ELEMENTS_COUNT)
     {
         MAKE_VECTOR_TYPE(INPUT0_TYPE, 8) in = DT_INPUT_BLOCK_READ8(input, input_offset + align_offset);
-        DT_OUTPUT_BLOCK_WRITE8(output, output_offset + align_offset, ACTIVATION(in, ACTIVATION_PARAMS));
+        DT_OUTPUT_BLOCK_WRITE8(output, output_offset + align_offset,
+            TO_OUTPUT_VECTOR_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_VECTOR_TYPE(in, 8), ACTIVATION_PARAMS), 8));
 
         //Fill the values that were missed upon adding align_offset
         if((align_offset != 0) && (element_offset + output_batch_offset < group_start_pos + align_offset))
         {
             for(uint i = 0; i < align_offset; i++)
-                output[output_offset + i] = ACTIVATION(input[input_offset + i], ACTIVATION_PARAMS);
+                output[output_offset + i] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(input[input_offset + i]), ACTIVATION_PARAMS));
         }
     }
     else
@@ -64,7 +65,7 @@ KERNEL(concatenation_gpu_depth_bfyx_no_pitch)(__global INPUT0_TYPE* input, __glo
             if(element_offset + i >= INPUT0_ELEMENTS_COUNT)
                 return;
 
-            output[output_offset + element_offset_in_workitem] = ACTIVATION(input[input_offset + element_offset_in_workitem], ACTIVATION_PARAMS);
+            output[output_offset + element_offset_in_workitem] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(input[input_offset + element_offset_in_workitem]), ACTIVATION_PARAMS));
             element_offset_in_workitem++;
         }
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_fs_b_yx_fsv32.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_fs_b_yx_fsv32.cl
@@ -41,20 +41,20 @@ KERNEL (concatenation_gpu_fs_b_yx_fsv32)(__global INPUT0_TYPE* input,
     input_offset += b * INPUT0_SIZE_X_WITH_PADDING * INPUT0_SIZE_Y_WITH_PADDING * FSV;
     input_offset += fs * INPUT0_SIZE_X_WITH_PADDING * INPUT0_SIZE_Y_WITH_PADDING * FSV * INPUT0_BATCH_NUM;
 
-    MAKE_VECTOR_TYPE(INPUT0_TYPE, 2) in = DT_INPUT_BLOCK_READ2(input, input_offset);
+    MAKE_VECTOR_TYPE(INPUT0_COMPUTE_TYPE, 2) in = DECODE_INPUT0_COMPUTE_VECTOR_TYPE(DT_INPUT_BLOCK_READ2(input, input_offset), 2);
 
     in = ACTIVATION(in, ACTIVATION_PARAMS);
 #if ALIGNED
     const uint dst_index = OUTPUT_GET_INDEX(b, output_offset_in_concat_axis + fs * FSV, y, x);
-    DT_OUTPUT_BLOCK_WRITE2(output, dst_index, in);
+    DT_OUTPUT_BLOCK_WRITE2(output, dst_index, TO_OUTPUT_VECTOR_TYPE(in, 2));
 #else
     const uint dst_feature = fs * FSV + output_offset_in_concat_axis + sglid;
     if (dst_feature + SUB_GROUP_SIZE < OUTPUT_FEATURE_NUM) {
-        output[OUTPUT_GET_INDEX(b, dst_feature, y, x)] = in.s0;
-        output[OUTPUT_GET_INDEX(b, dst_feature + SUB_GROUP_SIZE, y, x)] = in.s1;
+        output[OUTPUT_GET_INDEX(b, dst_feature, y, x)] = TO_OUTPUT_TYPE(in.s0);
+        output[OUTPUT_GET_INDEX(b, dst_feature + SUB_GROUP_SIZE, y, x)] = TO_OUTPUT_TYPE(in.s1);
     } else {
         if (dst_feature < OUTPUT_FEATURE_NUM) {
-            output[OUTPUT_GET_INDEX(b, dst_feature, y, x)] = in.s0;
+            output[OUTPUT_GET_INDEX(b, dst_feature, y, x)] = TO_OUTPUT_TYPE(in.s0);
         }
     }
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_ref.cl
@@ -32,7 +32,7 @@ KERNEL(concatenation_gpu_ref)(
         uint input_offset = GET_INDEX(INPUT0, INPUT_DIMS_ORDER);
         uint output_offset = GET_INDEX(OUTPUT, OUTPUT_DIMS_ORDER);
 
-        INPUT0_TYPE result = input[input_offset];
+        INPUT0_COMPUTE_TYPE result = DECODE_INPUT0_COMPUTE_TYPE(input[input_offset]);
 
 #if HAS_FUSED_OPS
         FUSED_OPS;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_simple_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_simple_ref.cl
@@ -59,7 +59,7 @@ KERNEL (concatenation_gpu_ref)(
     uint input_offset  = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, v, u, w, z, y, x);
     uint output_offset = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR out_b, out_f, out_v, out_u, out_w, out_z, out_y, out_x);
 
-    INPUT0_TYPE result = input[input_offset];
+    INPUT0_COMPUTE_TYPE result = DECODE_INPUT0_COMPUTE_TYPE(input[input_offset]);
 
 #if HAS_FUSED_OPS
     FUSED_OPS;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv16.cpp
@@ -16,6 +16,7 @@ size_t getTileXY(const concatenation_params& params) {
     if (params.isAligned) {
         switch (input.GetDType()) {
         case Datatype::F16:
+        case Datatype::BF16:
         case Datatype::INT8:
         case Datatype::UINT8:
             tileXY = 4;
@@ -29,6 +30,7 @@ size_t getTileXY(const concatenation_params& params) {
             tileXY = 2;
             break;
         case Datatype::F16:
+        case Datatype::BF16:
             tileXY = 4;
             break;
         case Datatype::INT8:
@@ -58,6 +60,8 @@ ParamsKey ConcatenationKernel_b_fs_yx_fsv16::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT8);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_b_fs_yx_fsv32.cpp
@@ -20,6 +20,8 @@ ParamsKey ConcatenationKernel_b_fs_yx_fsv32::GetSupportedKey() const {
     k.EnableOutputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableInputLayout(DataLayout::b_fs_yx_fsv32);
     k.EnableOutputLayout(DataLayout::b_fs_yx_fsv32);
     k.EnableTensorOffset();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_depth_bfyx_no_pitch.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_depth_bfyx_no_pitch.cpp
@@ -12,8 +12,10 @@ ParamsKey ConcatenationKernel_depth_bfyx_no_pitch::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableInputLayout(DataLayout::bf);
     k.EnableOutputLayout(DataLayout::bfyx);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_fs_b_yx_fsv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_fs_b_yx_fsv32.cpp
@@ -17,6 +17,8 @@ ParamsKey ConcatenationKernel_fs_b_yx_fsv32::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableInputLayout(DataLayout::fs_b_yx_fsv32);
     k.EnableOutputLayout(DataLayout::fs_b_yx_fsv32);
     k.EnableTensorOffset();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.cpp
@@ -12,6 +12,7 @@ namespace kernel_selector {
 ParamsKey ConcatenationKernelRef::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::UINT8);
@@ -19,6 +20,7 @@ ParamsKey ConcatenationKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::INT64);
     k.EnableInputDataType(Datatype::F8E4M3);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_simple_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_simple_ref.cpp
@@ -11,12 +11,14 @@ namespace kernel_selector {
 ParamsKey ConcatenationKernel_simple_Ref::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT64);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
@@ -20,6 +20,7 @@ std::vector<std::vector<ov::Shape>> inShapes = {
 };
 std::vector<ov::element::Type> netPrecisions = {ov::element::f32,
                                                 ov::element::f16,
+                                                ov::element::bf16,
                                                 ov::element::i64};
 
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -158,13 +158,16 @@ TEST(concat_cpu, disable_usm) {
 }
 
 void start_concat_test_dynamic(impl_types impl_type = impl_types::any);
-void start_concat_test_dynamic(impl_types impl_type) {
-    auto& engine = get_test_engine();
 
-    layout layout0_dyn = {{1, -1, -1, -1}, data_types::f32, format::bfyx};
-    layout layout1_dyn = {{1, -1,  3, -1}, data_types::f32, format::bfyx};
-    layout layout2_dyn = {{1,  3,  3, -1}, data_types::f32, format::bfyx};
-    layout layout3_dyn = {{1, -1, -1, -1}, data_types::f32, format::bfyx};
+template <typename T>
+void start_concat_test_dynamic_typed(impl_types impl_type = impl_types::any) {
+    auto& engine = get_test_engine();
+    const auto dt = ov::element::from<T>();
+
+    layout layout0_dyn = {{1, -1, -1, -1}, dt, format::bfyx};
+    layout layout1_dyn = {{1, -1,  3, -1}, dt, format::bfyx};
+    layout layout2_dyn = {{1,  3,  3, -1}, dt, format::bfyx};
+    layout layout3_dyn = {{1, -1, -1, -1}, dt, format::bfyx};
 
     topology topology(
             input_layout("input0", layout0_dyn),
@@ -174,7 +177,7 @@ void start_concat_test_dynamic(impl_types impl_type) {
             concatenation("concat",
                           { input_info("input0"), input_info("input1"), input_info("input2"), input_info("input3") },
                           1,
-                          data_types::f32)
+                          dt)
     );
 
     ExecutionConfig config = get_test_default_config(engine);
@@ -196,26 +199,27 @@ void start_concat_test_dynamic(impl_types impl_type) {
         int counter = 0;
 
         {
-            cldnn::mem_lock<float> ptr0(input0, get_test_stream());
-            cldnn::mem_lock<float> ptr1(input1, get_test_stream());
-            cldnn::mem_lock<float> ptr2(input2, get_test_stream());
-            cldnn::mem_lock<float> ptr3(input3, get_test_stream());
+            cldnn::mem_lock<T> ptr0(input0, get_test_stream());
+            cldnn::mem_lock<T> ptr1(input1, get_test_stream());
+            cldnn::mem_lock<T> ptr2(input2, get_test_stream());
+            cldnn::mem_lock<T> ptr3(input3, get_test_stream());
 
             for (size_t i = 0; i < input0->count(); i++) {
-                ptr0[i] = counter++;
+                ptr0[i] = static_cast<T>(counter++);
             }
             for (size_t i = 0; i < input1->count(); i++) {
-                ptr1[i] = counter++;
+                ptr1[i] = static_cast<T>(counter++);
             }
             for (size_t i = 0; i < input2->count(); i++) {
-                ptr2[i] = counter++;
+                ptr2[i] = static_cast<T>(counter++);
             }
             for (size_t i = 0; i < input3->count(); i++) {
-                ptr3[i] = counter++;
+                ptr3[i] = static_cast<T>(counter++);
             }
         }
-        std::vector<float> expected_out(input0->count() + input1->count() + input2->count() + input3->count());
-        std::iota(std::begin(expected_out), std::end(expected_out), 0);
+        std::vector<T> expected_out(input0->count() + input1->count() + input2->count() + input3->count());
+        for (size_t i = 0; i < expected_out.size(); ++i)
+            expected_out[i] = static_cast<T>(i);
 
         network->set_input_data("input0", input0);
         network->set_input_data("input1", input1);
@@ -228,7 +232,7 @@ void start_concat_test_dynamic(impl_types impl_type) {
 
         auto output_memory = outputs.at("concat").get_memory();
         auto output_layout = outputs.at("concat").get_layout();
-        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output_memory, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output_memory, get_test_stream());
 
         ov::PartialShape expected_shape = layout0.get_partial_shape();
         expected_shape[1] = layout0.get_partial_shape()[1] +
@@ -244,31 +248,39 @@ void start_concat_test_dynamic(impl_types impl_type) {
     };
 
 
-    run_on_shapes({{1, 3, 3, 2}, data_types::f32, format::bfyx},
-                  {{1, 5, 3, 2}, data_types::f32, format::bfyx},
-                  {{1, 3, 3, 2}, data_types::f32, format::bfyx},
-                  {{1, 1, 3, 2}, data_types::f32, format::bfyx});
+    run_on_shapes({{1, 3, 3, 2}, dt, format::bfyx},
+                  {{1, 5, 3, 2}, dt, format::bfyx},
+                  {{1, 3, 3, 2}, dt, format::bfyx},
+                  {{1, 1, 3, 2}, dt, format::bfyx});
 
-    run_on_shapes({{1, 2, 3, 2}, data_types::f32, format::bfyx},
-                  {{1, 5, 3, 2}, data_types::f32, format::bfyx},
-                  {{1, 3, 3, 2}, data_types::f32, format::bfyx},
-                  {{1, 2, 3, 2}, data_types::f32, format::bfyx});
+    run_on_shapes({{1, 2, 3, 2}, dt, format::bfyx},
+                  {{1, 5, 3, 2}, dt, format::bfyx},
+                  {{1, 3, 3, 2}, dt, format::bfyx},
+                  {{1, 2, 3, 2}, dt, format::bfyx});
 
-    run_on_shapes({{1, 2, 3, 4}, data_types::f32, format::bfyx},
-                  {{1, 5, 3, 4}, data_types::f32, format::bfyx},
-                  {{1, 3, 3, 4}, data_types::f32, format::bfyx},
-                  {{1, 2, 3, 4}, data_types::f32, format::bfyx});
+    run_on_shapes({{1, 2, 3, 4}, dt, format::bfyx},
+                  {{1, 5, 3, 4}, dt, format::bfyx},
+                  {{1, 3, 3, 4}, dt, format::bfyx},
+                  {{1, 2, 3, 4}, dt, format::bfyx});
 
     if (impl_type == impl_types::cpu) {
-        run_on_shapes({{1, 2, 3, 4}, data_types::f32, format::bfyx},
-                    {{1, 0, 3, 4}, data_types::f32, format::bfyx},
-                    {{1, 3, 3, 4}, data_types::f32, format::bfyx},
-                    {{1, 8, 3, 4}, data_types::f32, format::bfyx});
+        run_on_shapes({{1, 2, 3, 4}, dt, format::bfyx},
+                    {{1, 0, 3, 4}, dt, format::bfyx},
+                    {{1, 3, 3, 4}, dt, format::bfyx},
+                    {{1, 8, 3, 4}, dt, format::bfyx});
     }
+}
+
+void start_concat_test_dynamic(impl_types impl_type) {
+    start_concat_test_dynamic_typed<float>(impl_type);
 }
 
 TEST(concat_gpu, dynamic_4d_f) {
     start_concat_test_dynamic();
+}
+
+TEST(concat_gpu, dynamic_4d_bf16) {
+    start_concat_test_dynamic_typed<ov::bfloat16>();
 }
 
 TEST(concat_cpu_impl, dynamic_4d_f) {
@@ -1102,6 +1114,8 @@ public:
         auto out_mem = outputs.at("concat").get_memory();
         cldnn::mem_lock<Type, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
 
+        ASSERT_EQ(out_mem->get_layout().format, fmt) << "concat output was reordered away from the requested format";
+
         for (size_t bi = 0; bi < batch_num; bi++) {
             size_t f_sum = 0;
             for (size_t in_i = 0; in_i < in_features.size(); in_i++) {
@@ -1188,6 +1202,8 @@ public:
         auto out_mem = outputs.at("concat").get_memory();
         cldnn::mem_lock<Type, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
 
+        ASSERT_EQ(out_mem->get_layout().format, fmt) << "concat output was reordered away from the requested format";
+
         for (size_t bi = 0; bi < batch_num; bi++) {
             for (size_t fi = 0; fi < in_feature; fi++) {
                 for (size_t yi = 0; yi < input_y; yi++) {
@@ -1262,6 +1278,45 @@ TEST_P(concat_gpu_4d_axis3_f16, bs_fs_yx_bsv16_fsv16) {
 
 INSTANTIATE_TEST_SUITE_P(smoke,
                         concat_gpu_4d_axis3_f16,
+                        ::testing::Values(
+                            TestParamType_concat_axis3(2, 16, 2, { 2, 3 }),
+                            TestParamType_concat_axis3(2, 19, 2, { 2, 3, 2 }),
+                            TestParamType_concat_axis3(2, 32, 2, { 2, 3, 2, 1 }),
+                            TestParamType_concat_axis3(2, 35, 2, { 3, 2, 3, 2 })
+                        ),
+                        concat_axis3_gpu::PrintToStringParamName);
+
+using concat_gpu_4d_bf16 = concat_gpu_4d<ov::bfloat16>;
+
+TEST_P(concat_gpu_4d_bf16, b_fs_yx_fsv16) {
+    ASSERT_NO_FATAL_FAILURE(test(format::b_fs_yx_fsv16));
+}
+
+TEST_P(concat_gpu_4d_bf16, b_fs_yx_fsv32) {
+    ASSERT_NO_FATAL_FAILURE(test(format::b_fs_yx_fsv32));
+}
+
+TEST_P(concat_gpu_4d_bf16, fs_b_yx_fsv32) {
+    ASSERT_NO_FATAL_FAILURE(test(format::fs_b_yx_fsv32));
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_bf16,
+                        concat_gpu_4d_bf16,
+                        concat_gpu_all_params,
+                        concat_gpu::PrintToStringParamName);
+
+using concat_gpu_4d_axis3_bf16 = concat_gpu_4d_axis3<ov::bfloat16>;
+
+TEST_P(concat_gpu_4d_axis3_bf16, b_fs_yx_fsv16) {
+    ASSERT_NO_FATAL_FAILURE(test(format::b_fs_yx_fsv16));
+}
+
+TEST_P(concat_gpu_4d_axis3_bf16, fs_b_yx_fsv32) {
+    ASSERT_NO_FATAL_FAILURE(test(format::fs_b_yx_fsv32));
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_bf16,
+                        concat_gpu_4d_axis3_bf16,
                         ::testing::Values(
                             TestParamType_concat_axis3(2, 16, 2, { 2, 3 }),
                             TestParamType_concat_axis3(2, 19, 2, { 2, 3, 2 }),
@@ -2498,4 +2553,134 @@ TEST(concat_gpu, dynamic_f8e4m3) {
     ASSERT_EQ(output_ptr.size(), expected.size());
     for (size_t i = 0; i < expected.size(); ++i)
         ASSERT_EQ(expected[i], static_cast<float>(output_ptr[i])) << "i=" << i;
+}
+
+// 5D (bfzyx) feature-axis concat and 3-input batch-axis concat, run for both
+// BF16 and FP16 (values are exactly representable in both).
+class concat_2dtype_gpu_test : public ::testing::TestWithParam<data_types> {
+public:
+    void set_data(const memory::ptr& mem, const std::vector<float>& vals) const {
+        if (GetParam() == data_types::bf16) {
+            std::vector<ov::bfloat16> data(vals.begin(), vals.end());
+            set_values(mem, data);
+        } else {
+            std::vector<ov::float16> data(vals.begin(), vals.end());
+            set_values(mem, data);
+        }
+    }
+};
+
+static std::string concat_2dtype_test_name(testing::TestParamInfo<data_types> info) {
+    return info.param == data_types::bf16 ? "bf16" : "f16";
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, concat_2dtype_gpu_test,
+                         ::testing::Values(data_types::bf16, data_types::f16),
+                         concat_2dtype_test_name);
+
+// BF16/F16 Concat: 5D (bfzyx) along feature axis
+TEST_P(concat_2dtype_gpu_test, feature_axis_5d) {
+    const auto dt = GetParam();
+    auto& engine = get_test_engine();
+
+    auto input0 = engine.allocate_memory({dt, format::bfzyx, {1, 2, 2, 3, 2}});
+    auto input1 = engine.allocate_memory({dt, format::bfzyx, {1, 1, 2, 3, 2}});
+
+    std::vector<float> input0_data;
+    std::vector<float> input1_data;
+    for (int i = 0; i < 24; ++i) input0_data.push_back(static_cast<float>(i * 0.5f));
+    for (int i = 0; i < 12; ++i) input1_data.push_back(static_cast<float>(-(i * 0.5f)));
+
+    set_data(input0, input0_data);
+    set_data(input1, input1_data);
+
+    topology topology(
+        input_layout("input0", input0->get_layout()),
+        input_layout("input1", input1->get_layout()),
+        concatenation("concat",
+                      {input_info("input0"), input_info("input1")},
+                      1,
+                      dt),
+        reorder("output", input_info("concat"), format::bfzyx, data_types::f32)
+    );
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input0", input0);
+    network.set_input_data("input1", input1);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
+
+    auto output_memory = outputs.at("output").get_memory();
+    auto output_layout = output_memory->get_layout();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output_memory, get_test_stream());
+
+    ASSERT_EQ(output_layout.format, format::bfzyx);
+    ASSERT_EQ(output_layout.feature(), 3);  // 2 + 1
+    ASSERT_EQ(output_layout.batch(), 1);
+
+    for (size_t i = 0; i < input0_data.size(); ++i) {
+        ASSERT_EQ(output_ptr[i], input0_data[i])
+            << "input0 mismatch at i=" << i;
+    }
+    for (size_t i = 0; i < input1_data.size(); ++i) {
+        ASSERT_EQ(output_ptr[input0_data.size() + i], input1_data[i])
+            << "input1 mismatch at i=" << i;
+    }
+}
+
+// BF16/F16 Concat: 3 inputs along batch axis (axis=0)
+TEST_P(concat_2dtype_gpu_test, batch_axis_3_inputs) {
+    const auto dt = GetParam();
+    auto& engine = get_test_engine();
+
+    auto input0 = engine.allocate_memory({dt, format::bfyx, {2, 4, 3, 3}});
+    auto input1 = engine.allocate_memory({dt, format::bfyx, {1, 4, 3, 3}});
+    auto input2 = engine.allocate_memory({dt, format::bfyx, {3, 4, 3, 3}});
+
+    std::vector<float> input0_data, input1_data, input2_data;
+    for (int i = 0; i < 72; ++i) input0_data.push_back(static_cast<float>(i));
+    for (int i = 0; i < 36; ++i) input1_data.push_back(static_cast<float>(-(i + 1)));
+    for (int i = 0; i < 108; ++i) input2_data.push_back(static_cast<float>((i + 1) * 0.25f));
+
+    set_data(input0, input0_data);
+    set_data(input1, input1_data);
+    set_data(input2, input2_data);
+
+    topology topology(
+        input_layout("input0", input0->get_layout()),
+        input_layout("input1", input1->get_layout()),
+        input_layout("input2", input2->get_layout()),
+        concatenation("concat",
+                      {input_info("input0"), input_info("input1"), input_info("input2")},
+                      0,  // batch axis
+                      dt),
+        reorder("output", input_info("concat"), format::bfyx, data_types::f32)
+    );
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input0", input0);
+    network.set_input_data("input1", input1);
+    network.set_input_data("input2", input2);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "output");
+
+    auto output_memory = outputs.at("output").get_memory();
+    auto output_layout = output_memory->get_layout();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output_memory, get_test_stream());
+
+    ASSERT_EQ(output_layout.batch(), 6);  // 2 + 1 + 3
+    ASSERT_EQ(output_layout.feature(), 4);
+
+    size_t offset = 0;
+    for (auto& src_data : {input0_data, input1_data, input2_data}) {
+        for (size_t i = 0; i < src_data.size(); ++i) {
+            ASSERT_EQ(output_ptr[offset + i], src_data[i])
+                << "Mismatch at offset=" << offset + i;
+        }
+        offset += src_data.size();
+    }
 }


### PR DESCRIPTION
Concatenation is pure data movement; BF16 values are stored as ushort bit patterns in OCL. Decode inputs to FP32 compute type via the jitter-provided DECODE_INPUT0_COMPUTE_TYPE/VECTOR macros and re-encode outputs via TO_OUTPUT_TYPE/TO_OUTPUT_VECTOR_TYPE (which handle BF16 via bf16_utils.cl conversions; identity for other types).

Updated kernels: concatenation_gpu_ref, concatenation_gpu_simple_ref, concatenation_gpu_blocked (b_fs_yx_fsv16), concatenation_gpu_depth_bfyx_no_pitch, concatenation_gpu_b_fs_yx_fsv32, concatenation_gpu_fs_b_yx_fsv32.

### Tickets:
 - CVS-192281

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
