### PR TITLE
[NPUW] PA front-end: 1:1 CPU passthrough for the CB PagedAttention model

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
@@ -46,6 +46,7 @@ INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_CHECK, bool, false, ov::intel_npu::npuw::accu
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_THRESH, double, 0.01, ov::intel_npu::npuw::accuracy, threshold, "NPUW_ACC_THRESH", ROOT, HIDDEN, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_DEVICE, std::string, "", ov::intel_npu::npuw::accuracy, reference_device, "NPUW_ACC_DEVICE", ROOT, HIDDEN, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_GQA, bool, false, ov::intel_npu::npuw::gqa, enabled, "NPUW_GQA", ROOT, EXPOSED, CACHED, ALL)
+INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_PA, bool, false, ov::intel_npu::npuw::pa, enabled, "NPUW_PA", ROOT, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_UNQDQ, bool, false, ov::intel_npu::npuw, unqdq, "NPUW_UNQDQ", ROOT, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_DUMP_FULL, bool, false, ov::intel_npu::npuw::dump, full, "NPUW_DUMP_FULL", ROOT, HIDDEN, UNCACHED, DEV)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_DUMP_SUBS, std::string, "", ov::intel_npu::npuw::dump, subgraphs, "NPUW_DUMP_SUBS", ROOT, HIDDEN, UNCACHED, DEV)

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -24,6 +24,7 @@
 #include "openvino/runtime/internal_properties.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/util/common_util.hpp"
+#include "pa_compiled_model.hpp"
 #include "partitioning/patterns/opt.hpp"
 #include "pipelines/kokoro/kokoro_compiled_model.hpp"
 #include "plugin.hpp"
@@ -298,6 +299,7 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     std::shared_ptr<ov::npuw::ICompiledModel> compiled_model;
     auto use_gqa_key = ov::intel_npu::npuw::gqa::enabled.name();
     auto use_llm_key = ov::intel_npu::npuw::llm::enabled.name();
+    auto use_pa_key = ov::intel_npu::npuw::pa::enabled.name();
     auto use_kokoro_key = ov::intel_npu::npuw::kokoro::enabled.name();
 
     // Drop CACHE_DIR from the config
@@ -312,6 +314,9 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
+    } else if (properties.count(use_pa_key) && properties.at(use_pa_key).as<bool>() == true) {
+        LOG_INFO("ov::npuw::PACompiledModel will be created.");
+        compiled_model = std::make_shared<ov::npuw::PACompiledModel>(model, plugin, config);
     } else if (properties.count(use_kokoro_key) && properties.at(use_kokoro_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::KokoroCompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::KokoroCompiledModel>(model, plugin, config);

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
@@ -1,0 +1,142 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "pa_compiled_model.hpp"
+
+#include <cstdlib>
+#include <string>
+#include <utility>
+
+#include "intel_npu/config/npuw.hpp"
+#include "logging.hpp"
+#include "openvino/runtime/iplugin.hpp"
+#include "openvino/runtime/properties.hpp"
+#include "util.hpp"
+
+ov::npuw::PACompiledModel::PACompiledModel(const std::shared_ptr<ov::Model>& model,
+                                           const std::shared_ptr<const ov::IPlugin>& plugin,
+                                           const ov::AnyMap& properties)
+    : ov::npuw::ICompiledModel(nullptr, plugin) {  // I/O comes from the inner via inputs()/outputs()
+    // The fallback device is an internal development knob, not a config
+    // option - an env var keeps it out of user configs (and blob cache keys).
+    // Only CPU is supported for now: a GPU device would also need the remote
+    // context forwarded for the pipeline's cache allocation.
+    const char* device_env = std::getenv("OPENVINO_NPUW_PA_DEVICE");
+    const std::string device = (device_env != nullptr && device_env[0] != '\0') ? device_env : "CPU";
+    OPENVINO_ASSERT(device == "CPU",
+                    "The PagedAttention fallback device is CPU for now, got OPENVINO_NPUW_PA_DEVICE=",
+                    device);
+
+    // Sanity: this must be the model the CB pipeline deploys -- PA control
+    // inputs plus a paged KV cache.
+    bool has_past_lens = false, has_cache = false;
+    for (const auto& input : model->inputs()) {
+        const auto& name = input.get_any_name();
+        has_past_lens |= (name == "past_lens");
+        has_cache |= ov::npuw::util::is_pa_kv_cache_name(name);
+    }
+    OPENVINO_ASSERT(has_past_lens && has_cache,
+                    "PACompiledModel expects the continuous-batching PA model "
+                    "(past_lens + key_cache/value_cache inputs)");
+
+    // The 1:1 part: the model is compiled exactly as received. NPUW_*,
+    // NPU_USE_NPUW and NPU_* keys are this plugin's configuration and must not
+    // reach the executing device (which would reject them as unsupported);
+    // everything else (e.g. KV_CACHE_PRECISION, performance hints) is the
+    // executing device's business and is forwarded.
+    ov::AnyMap inner_config;
+    for (const auto& [key, value] : properties) {
+        if (ov::npuw::util::starts_with(key, "NPU")) {
+            continue;
+        }
+        inner_config.emplace(key, value);
+    }
+
+    LOG_INFO("PA: compiling the dynamic PA model 1:1 on " << device);
+    m_compiled_model = plugin->get_core()->compile_model(model, device, inner_config);
+    OPENVINO_ASSERT(m_compiled_model != nullptr, "PACompiledModel requires a valid inner compiled model");
+}
+
+const std::vector<ov::Output<const ov::Node>>& ov::npuw::PACompiledModel::inputs() const {
+    return m_compiled_model->inputs();
+}
+
+const std::vector<ov::Output<const ov::Node>>& ov::npuw::PACompiledModel::outputs() const {
+    return m_compiled_model->outputs();
+}
+
+void ov::npuw::PACompiledModel::export_model(std::ostream&) const {
+    OPENVINO_THROW_NOT_IMPLEMENTED("PACompiledModel does not support export_model()");
+}
+
+std::shared_ptr<const ov::Model> ov::npuw::PACompiledModel::get_runtime_model() const {
+    return m_compiled_model->get_runtime_model();
+}
+
+void ov::npuw::PACompiledModel::set_property(const ov::AnyMap& properties) {
+    // The PA-level options are fixed at compile time; catching them here gives
+    // a clear error instead of the executing device's "unsupported property".
+    for (const auto& [key, value] : properties) {
+        if (ov::npuw::util::starts_with(key, "NPU")) {
+            OPENVINO_THROW("PACompiledModel: '", key, "' cannot be changed after the model is compiled");
+        }
+    }
+    m_compiled_model->set_property(properties);
+}
+
+ov::Any ov::npuw::PACompiledModel::get_property(const std::string& name) const {
+    // The PA-level key is answered here; everything else is the executing
+    // device's business (notably ov::execution_devices, which the CB pipeline
+    // queries to pick its block size).
+    if (name == std::string(::intel_npu::NPUW_PA::key())) {
+        return true;
+    }
+    if (name == ov::supported_properties.name()) {
+        // Keep the property surface self-consistent: the inner device's list
+        // plus the PA key answered above.
+        auto props = m_compiled_model->get_property(name).as<std::vector<ov::PropertyName>>();
+        props.emplace_back(std::string(::intel_npu::NPUW_PA::key()), ov::PropertyMutability::RO);
+        return props;
+    }
+    return m_compiled_model->get_property(name);
+}
+
+std::shared_ptr<ov::ISyncInferRequest> ov::npuw::PACompiledModel::create_sync_infer_request() const {
+    auto self = std::static_pointer_cast<const ov::ICompiledModel>(shared_from_this());
+    auto inner_request = m_compiled_model->create_infer_request();
+    OPENVINO_ASSERT(inner_request != nullptr, "PACompiledModel requires a valid inner infer request");
+    return std::make_shared<PAInferRequest>(self, std::move(inner_request));
+}
+
+ov::npuw::PAInferRequest::PAInferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
+                                         ov::SoPtr<ov::IAsyncInferRequest> inner_request)
+    : ov::ISyncInferRequest(compiled_model),
+      m_inner_request(std::move(inner_request)) {}
+
+void ov::npuw::PAInferRequest::infer() {
+    m_inner_request->infer();
+}
+
+ov::SoPtr<ov::ITensor> ov::npuw::PAInferRequest::get_tensor(const ov::Output<const ov::Node>& port) const {
+    return m_inner_request->get_tensor(port);
+}
+
+void ov::npuw::PAInferRequest::set_tensor(const ov::Output<const ov::Node>& port,
+                                          const ov::SoPtr<ov::ITensor>& tensor) {
+    m_inner_request->set_tensor(port, tensor);
+}
+
+void ov::npuw::PAInferRequest::check_tensors() const {
+    // Tensors live in the inner request, so the base-class check over this
+    // level's (empty) tensor storage must not run. The inner request performs
+    // the same element-type/shape validation on its own tensors during infer().
+}
+
+std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::PAInferRequest::query_state() const {
+    return m_inner_request->query_state();
+}
+
+std::vector<ov::ProfilingInfo> ov::npuw::PAInferRequest::get_profiling_info() const {
+    return m_inner_request->get_profiling_info();
+}

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+
+#include "npuw/compiled_model.hpp"
+
+namespace ov::npuw {
+
+// The front-end for the dynamic, stateless PagedAttention model deployed by
+// the GenAI continuous-batching pipeline. The model is compiled 1:1 on the PA
+// fallback device (CPU; the internal OPENVINO_NPUW_PA_DEVICE env var exists
+// for development), NPU*-prefixed properties are held at this level while
+// everything else is forwarded to the executing device.
+//
+// The exposed ports are the inner compiled model's own ports, so the cache
+// geometry the pipeline's KVCacheManager reads off them (element types,
+// block shapes) is the device-resolved truth with no copying involved.
+class PACompiledModel final : public ov::npuw::ICompiledModel {
+public:
+    PACompiledModel(const std::shared_ptr<ov::Model>& model,
+                    const std::shared_ptr<const ov::IPlugin>& plugin,
+                    const ov::AnyMap& properties);
+
+    // The wrapper adds no I/O of its own -- it exposes the inner model's ports.
+    const std::vector<ov::Output<const ov::Node>>& inputs() const override;
+    const std::vector<ov::Output<const ov::Node>>& outputs() const override;
+
+    void export_model(std::ostream& stream) const override;
+    std::shared_ptr<const ov::Model> get_runtime_model() const override;
+
+    void set_property(const ov::AnyMap& properties) override;
+    ov::Any get_property(const std::string& name) const override;
+
+private:
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
+
+    ov::SoPtr<ov::ICompiledModel> m_compiled_model;
+};
+
+// 1:1 forwarding request. The ports are shared with the inner request (see
+// PACompiledModel), so every call delegates without translation, and the
+// request holds no state of its own -- it provides exactly the guarantees of
+// using the inner request directly.
+class PAInferRequest final : public ov::ISyncInferRequest {
+public:
+    PAInferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
+                   ov::SoPtr<ov::IAsyncInferRequest> inner_request);
+
+    void infer() override;
+
+    ov::SoPtr<ov::ITensor> get_tensor(const ov::Output<const ov::Node>& port) const override;
+    void set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) override;
+    void check_tensors() const override;
+
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override;
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override;
+
+private:
+    ov::SoPtr<ov::IAsyncInferRequest> m_inner_request;
+};
+
+}  // namespace ov::npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -951,6 +951,11 @@ bool ov::npuw::util::starts_with_past_lincache(const std::string& input_name) {
     return ov::npuw::util::starts_with(input_name, past_lin_conv_cache) ||
            ov::npuw::util::starts_with(input_name, past_lin_ssm_cache);
 }
+
+bool ov::npuw::util::is_pa_kv_cache_name(const std::string& input_name) {
+    return ov::npuw::util::starts_with(input_name, "key_cache.") ||
+           ov::npuw::util::starts_with(input_name, "value_cache.");
+}
 void ov::npuw::util::fill_tensor_bytes(ov::SoPtr<ov::ITensor> tensor, uint8_t fill_val) {
     auto* tensor_data = reinterpret_cast<uint8_t*>(tensor->data());
     const size_t byte_size = tensor->get_byte_size();

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -226,6 +226,11 @@ bool matchLinCacheString(const std::string& input, const std::string& past_or_pr
 
 bool starts_with_past_lincache(const std::string& input_name);
 
+// Matches the paged KV cache inputs of the PagedAttention model deployed by
+// the GenAI continuous-batching pipeline (key_cache.N / value_cache.N, named
+// by the SDPAToPagedAttention transformation).
+bool is_pa_kv_cache_name(const std::string& input_name);
+
 // Structure to hold SDPA pattern nodes.
 // After SplitKVCacheIntoBlocks the single past_key / past_value parameter is
 // replaced by N block parameters, so both param-node fields are vectors.

--- a/src/plugins/intel_npu/src/plugin/sources.cmake
+++ b/src/plugins/intel_npu/src/plugin/sources.cmake
@@ -143,6 +143,8 @@ set(NPUW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/orc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/orc.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/orc/schema_npuw.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_compiled_model.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_compiled_model.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/compiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/compiler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/graph.cpp

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -48,6 +48,7 @@ ov_add_test_target(
             # npuw core
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/gqa_compiled_model.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model_utils.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
@@ -130,6 +130,7 @@ std::vector<Case> make_cases() {
         double_case<::intel_npu::NPUW_ACC_THRESH>("NPUW_ACC_THRESH", "0.25", 0.25),
         string_case<::intel_npu::NPUW_ACC_DEVICE>("NPUW_ACC_DEVICE", "CPU", "CPU"),
         bool_case<::intel_npu::NPUW_GQA>("NPUW_GQA", "YES", true),
+        bool_case<::intel_npu::NPUW_PA>("NPUW_PA", "YES", true),
         bool_case<::intel_npu::NPUW_UNQDQ>("NPUW_UNQDQ", "YES", true),
         bool_case<::intel_npu::NPUW_LLM>("NPUW_LLM", "YES", true),
         numeric_case<::intel_npu::NPUW_LLM_BATCH_DIM>("NPUW_LLM_BATCH_DIM", "1", uint32_t{1}),


### PR DESCRIPTION
### Details:

First change of a short series adding a PagedAttention front-end to NPUW: the minimal, runnable unit that lets the GenAI `ContinuousBatchingPipeline` deploy its dynamic, stateless PA model through the NPU plugin as a **1:1 passthrough on CPU**. Dispatch-contract validation, chunked execution over semi-static variants, and NPUW partitioning of those variants follow as separate changes of the series.

What is in here:

- The `NPUW_PA` option (off by default), covered by the options smoke test. The PA fallback device is deliberately *not* a config option, so it cannot end up in anyone's config or cache key: the internal `OPENVINO_NPUW_PA_DEVICE` env var exists for development. It is pinned to `CPU` for now — a GPU fallback would also need the remote context forwarded for the pipeline's cache allocation, which comes later in the series together with actual GPU evidence.
- The `ICompiledModel::create()` entry hook: `NPU_USE_NPUW=YES` + `NPUW_PA=YES` selects `ov::npuw::PACompiledModel`.
- `PACompiledModel`: compiles the PA model 1:1 on the fallback device. `NPU`-prefixed properties are held at the NPUW level; everything else (e.g. `KV_CACHE_PRECISION`, performance hints) is forwarded to the executing device.
- **The exposed ports are the inner compiled model's own ports** (`inputs()`/`outputs()` forward; the base is constructed with no model, as the runtime officially allows). The pipeline's `KVCacheManager` reads cache precision and block geometry off these ports, so what it sees is the device-resolved truth by construction — no geometry stamping, no model mutation, no port translation anywhere.
- `PAInferRequest`: a pure 1:1 forwarder. Since the ports are shared with the inner request, `get_tensor`/`set_tensor`/`infer`/`query_state` all delegate directly, and the request holds no state of its own.
- `get_property` answers `NPUW_PA` and keeps `supported_properties` self-consistent; everything else (notably `ov::execution_devices`) is the executing device's business. `set_property` rejects post-compile changes to plugin-level keys with a clear error.
- `export_model` is not supported; `get_runtime_model` forwards to the inner compiled model.

### Validation:

- `ov_npu_unit_tests` green (1504 tests at this change).
- End-to-end greedy parity: `ContinuousBatchingPipeline` on plain `CPU` vs `NPU` + `NPU_USE_NPUW/NPUW_PA` (PA device CPU), Qwen3-0.6B int4, across a short, a >128-token and a >1024-token prompt — **token-identical on all three**.

### Tickets:
- CVS-190137
