### PR TITLE
Pa/02 infer request

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw_option_defs.inc
@@ -46,6 +46,7 @@ INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_CHECK, bool, false, ov::intel_npu::npuw::accu
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_THRESH, double, 0.01, ov::intel_npu::npuw::accuracy, threshold, "NPUW_ACC_THRESH", ROOT, HIDDEN, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_ACC_DEVICE, std::string, "", ov::intel_npu::npuw::accuracy, reference_device, "NPUW_ACC_DEVICE", ROOT, HIDDEN, UNCACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_GQA, bool, false, ov::intel_npu::npuw::gqa, enabled, "NPUW_GQA", ROOT, EXPOSED, CACHED, ALL)
+INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_PA, bool, false, ov::intel_npu::npuw::pa, enabled, "NPUW_PA", ROOT, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_UNQDQ, bool, false, ov::intel_npu::npuw, unqdq, "NPUW_UNQDQ", ROOT, EXPOSED, CACHED, ALL)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_DUMP_FULL, bool, false, ov::intel_npu::npuw::dump, full, "NPUW_DUMP_FULL", ROOT, HIDDEN, UNCACHED, DEV)
 INTEL_NPU_NPUW_SIMPLE_OPT(NPUW_DUMP_SUBS, std::string, "", ov::intel_npu::npuw::dump, subgraphs, "NPUW_DUMP_SUBS", ROOT, HIDDEN, UNCACHED, DEV)

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -24,6 +24,7 @@
 #include "openvino/runtime/internal_properties.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/util/common_util.hpp"
+#include "pa_compiled_model.hpp"
 #include "partitioning/patterns/opt.hpp"
 #include "pipelines/kokoro/kokoro_compiled_model.hpp"
 #include "plugin.hpp"
@@ -298,6 +299,7 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     std::shared_ptr<ov::npuw::ICompiledModel> compiled_model;
     auto use_gqa_key = ov::intel_npu::npuw::gqa::enabled.name();
     auto use_llm_key = ov::intel_npu::npuw::llm::enabled.name();
+    auto use_pa_key = ov::intel_npu::npuw::pa::enabled.name();
     auto use_kokoro_key = ov::intel_npu::npuw::kokoro::enabled.name();
 
     // Drop CACHE_DIR from the config
@@ -312,6 +314,9 @@ std::shared_ptr<ov::npuw::ICompiledModel> ov::npuw::ICompiledModel::create(
     } else if (properties.count(use_llm_key) && properties.at(use_llm_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::LLMCompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::LLMCompiledModel>(model, plugin, config);
+    } else if (properties.count(use_pa_key) && properties.at(use_pa_key).as<bool>() == true) {
+        LOG_INFO("ov::npuw::PACompiledModel will be created.");
+        compiled_model = std::make_shared<ov::npuw::PACompiledModel>(model, plugin, config);
     } else if (properties.count(use_kokoro_key) && properties.at(use_kokoro_key).as<bool>() == true) {
         LOG_INFO("ov::npuw::KokoroCompiledModel will be created.");
         compiled_model = std::make_shared<ov::npuw::KokoroCompiledModel>(model, plugin, config);

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
@@ -1,0 +1,156 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "pa_compiled_model.hpp"
+
+#include <cstdlib>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "intel_npu/config/npuw.hpp"
+#include "logging.hpp"
+#include "openvino/runtime/iplugin.hpp"
+#include "openvino/runtime/properties.hpp"
+#include "util.hpp"
+
+namespace {
+
+bool is_kv_cache_name(const std::string& name) {
+    return ov::npuw::util::starts_with(name, "key_cache.") || ov::npuw::util::starts_with(name, "value_cache.");
+}
+
+}  // anonymous namespace
+
+ov::npuw::PACompiledModel::PreparedState ov::npuw::PACompiledModel::prepare(
+    const std::shared_ptr<ov::Model>& model,
+    const std::shared_ptr<const ov::IPlugin>& plugin,
+    const ov::AnyMap& properties) {
+    // The fallback device is an internal development knob, not a config
+    // option - an env var keeps it out of user configs (and blob cache keys).
+    const char* device_env = std::getenv("OPENVINO_NPUW_PA_DEVICE");
+    std::string device = (device_env != nullptr && device_env[0] != '\0') ? device_env : "CPU";
+    // NPU cannot take the PA op itself (dynamic shapes, no PA kernel).
+    OPENVINO_ASSERT(!ov::npuw::util::starts_with(device, "NPU"),
+                    "OPENVINO_NPUW_PA_DEVICE must be the PagedAttention fallback device (CPU or GPU), got ",
+                    device);
+
+    LOG_INFO("PA: compiling the dynamic PA model 1:1 on " << device);
+
+    // Sanity: this must be the model the CB pipeline deploys -- PA control
+    // inputs plus a paged KV cache.
+    bool has_past_lens = false, has_cache = false;
+    for (const auto& input : model->inputs()) {
+        const auto& name = input.get_any_name();
+        has_past_lens |= (name == "past_lens");
+        has_cache |= is_kv_cache_name(name);
+    }
+    OPENVINO_ASSERT(has_past_lens && has_cache,
+                    "PACompiledModel expects the continuous-batching PA model "
+                    "(past_lens + key_cache/value_cache inputs)");
+
+    // The 1:1 part: the model is compiled exactly as received. NPUW_*,
+    // NPU_USE_NPUW and NPU_* keys are this plugin's configuration and must not
+    // reach the executing device (which would reject them as unsupported);
+    // everything else (e.g. KV_CACHE_PRECISION, performance hints) is the
+    // executing device's business and is forwarded.
+    ov::AnyMap inner_config;
+    for (const auto& [key, value] : properties) {
+        if (ov::npuw::util::starts_with(key, "NPU")) {
+            continue;
+        }
+        inner_config.emplace(key, value);
+    }
+    auto compiled = plugin->get_core()->compile_model(model, device, inner_config);
+    OPENVINO_ASSERT(compiled != nullptr, "PACompiledModel requires a valid inner compiled model");
+
+    // Stamp the device-resolved KV cache element types and shapes back onto
+    // the model's cache Parameters. The source PA model declares them fully
+    // dynamic (even the element type); the CB pipeline's KVCacheManager reads
+    // cache precision and block geometry from *this* compiled model's ports,
+    // so they must expose what the device actually decided.
+    std::unordered_map<std::string, ov::Output<const ov::Node>> inner_inputs;
+    for (const auto& input : compiled->inputs()) {
+        inner_inputs.emplace(input.get_any_name(), input);
+    }
+    for (const auto& param : model->get_parameters()) {
+        const auto& name = param->get_output_tensor(0).get_any_name();
+        if (!is_kv_cache_name(name)) {
+            continue;
+        }
+        auto it = inner_inputs.find(name);
+        OPENVINO_ASSERT(it != inner_inputs.end(), "PA: inner compiled model lost the '", name, "' input");
+        param->set_element_type(it->second.get_element_type());
+        param->set_partial_shape(it->second.get_partial_shape());
+    }
+    model->validate_nodes_and_infer_types();
+
+    return PreparedState{model, std::move(compiled), std::move(device)};
+}
+
+ov::npuw::PACompiledModel::PACompiledModel(const std::shared_ptr<ov::Model>& model,
+                                           const std::shared_ptr<const ov::IPlugin>& plugin,
+                                           const ov::AnyMap& properties)
+    : PACompiledModel(prepare(model, plugin, properties), plugin) {}
+
+ov::npuw::PACompiledModel::PACompiledModel(PreparedState prepared, const std::shared_ptr<const ov::IPlugin>& plugin)
+    : ov::npuw::ICompiledModel(prepared.model, plugin),
+      m_device(std::move(prepared.device)),
+      m_compiled_model(std::move(prepared.compiled)) {
+    // The device fixes the KV cache geometry at compile time; remember the
+    // block size for validating block-table coverage per dispatch.
+    for (const auto& input : m_compiled_model->inputs()) {
+        if (input.get_any_name() == "key_cache.0") {
+            const auto& shape = input.get_partial_shape();
+            // [num_blocks (dyn), kv_heads, block_size, head_size]
+            if (shape.rank().is_static() && shape.rank().get_length() == 4 && shape[2].is_static()) {
+                m_block_size = static_cast<std::size_t>(shape[2].get_length());
+            }
+            break;
+        }
+    }
+    LOG_INFO("PA: KV block_size fixed by " << m_device << ": " << m_block_size);
+}
+
+void ov::npuw::PACompiledModel::export_model(std::ostream&) const {
+    OPENVINO_THROW_NOT_IMPLEMENTED("PACompiledModel does not support export_model()");
+}
+
+std::shared_ptr<const ov::Model> ov::npuw::PACompiledModel::get_runtime_model() const {
+    return m_compiled_model->get_runtime_model();
+}
+
+void ov::npuw::PACompiledModel::set_property(const ov::AnyMap& properties) {
+    // The PA-level options are fixed at compile time; catching them here gives
+    // a clear error instead of the executing device's "unsupported property".
+    for (const auto& [key, value] : properties) {
+        if (ov::npuw::util::starts_with(key, "NPU")) {
+            OPENVINO_THROW("PACompiledModel: '", key, "' cannot be changed after the model is compiled");
+        }
+    }
+    m_compiled_model->set_property(properties);
+}
+
+ov::Any ov::npuw::PACompiledModel::get_property(const std::string& name) const {
+    // The PA-level key is answered here; everything else is the executing
+    // device's business (notably ov::execution_devices, which the CB pipeline
+    // queries to pick its block size).
+    if (name == std::string(::intel_npu::NPUW_PA::key())) {
+        return true;
+    }
+    if (name == ov::supported_properties.name()) {
+        // Keep the property surface self-consistent: the inner device's list
+        // plus the PA key answered above.
+        auto props = m_compiled_model->get_property(name).as<std::vector<ov::PropertyName>>();
+        props.emplace_back(std::string(::intel_npu::NPUW_PA::key()), ov::PropertyMutability::RO);
+        return props;
+    }
+    return m_compiled_model->get_property(name);
+}
+
+std::shared_ptr<ov::ISyncInferRequest> ov::npuw::PACompiledModel::create_sync_infer_request() const {
+    // The PA dispatcher (per-dispatch contract validation and execution)
+    // arrives with the next change in this series.
+    OPENVINO_THROW_NOT_IMPLEMENTED("PACompiledModel does not create infer requests yet");
+}

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
@@ -4,6 +4,7 @@
 
 #include "pa_compiled_model.hpp"
 
+#include <algorithm>
 #include <cstdlib>
 #include <string>
 #include <unordered_map>
@@ -19,6 +20,22 @@ namespace {
 
 bool is_kv_cache_name(const std::string& name) {
     return ov::npuw::util::starts_with(name, "key_cache.") || ov::npuw::util::starts_with(name, "value_cache.");
+}
+
+// The PA control tensors are small i32/i64 vectors -- widen to i64 for checks.
+std::vector<int64_t> as_i64_vec(const ov::SoPtr<ov::ITensor>& tensor) {
+    const auto n = tensor->get_size();
+    std::vector<int64_t> out(n);
+    if (tensor->get_element_type() == ov::element::i32) {
+        const auto* data = tensor->data<int32_t>();
+        std::copy_n(data, n, out.begin());
+    } else if (tensor->get_element_type() == ov::element::i64) {
+        const auto* data = tensor->data<int64_t>();
+        std::copy_n(data, n, out.begin());
+    } else {
+        OPENVINO_THROW("PA: unexpected element type ", tensor->get_element_type(), " for a control tensor");
+    }
+    return out;
 }
 
 }  // anonymous namespace
@@ -150,7 +167,156 @@ ov::Any ov::npuw::PACompiledModel::get_property(const std::string& name) const {
 }
 
 std::shared_ptr<ov::ISyncInferRequest> ov::npuw::PACompiledModel::create_sync_infer_request() const {
-    // The PA dispatcher (per-dispatch contract validation and execution)
-    // arrives with the next change in this series.
-    OPENVINO_THROW_NOT_IMPLEMENTED("PACompiledModel does not create infer requests yet");
+    auto self = std::static_pointer_cast<const PACompiledModel>(shared_from_this());
+    return std::make_shared<ov::npuw::PAInferRequest>(std::move(self));
+}
+
+ov::npuw::PAInferRequest::PAInferRequest(std::shared_ptr<const PACompiledModel> compiled_model)
+    : ov::ISyncInferRequest(compiled_model),
+      m_compiled_model(std::move(compiled_model)) {
+    m_inner_request = m_compiled_model->m_compiled_model->create_infer_request();
+    OPENVINO_ASSERT(m_inner_request != nullptr, "PA infer request requires a valid inner request");
+    for (const auto& input : m_inner_request->get_compiled_model()->inputs()) {
+        m_inner_inputs.emplace(input.get_any_name(), input);
+    }
+
+    // Map outer ports to inner ports by tensor name, once. Matching by name
+    // (not by position) keeps the forwarding correct even if the executing
+    // device reorders ports, and gives O(1) lookups on the dispatch hot path.
+    std::unordered_map<std::string, ov::Output<const ov::Node>> inner_outputs;
+    for (const auto& output : m_inner_request->get_compiled_model()->outputs()) {
+        inner_outputs.emplace(output.get_any_name(), output);
+    }
+    const auto map_ports = [this](const auto& outer_ports, const auto& inner_by_name) {
+        for (const auto& outer : outer_ports) {
+            auto it = inner_by_name.find(outer.get_any_name());
+            OPENVINO_ASSERT(it != inner_by_name.end(),
+                            "PA: inner compiled model has no port named '",
+                            outer.get_any_name(),
+                            "'");
+            m_port_map.emplace(outer.get_node(), it->second);
+        }
+    };
+    map_ports(m_compiled_model->inputs(), m_inner_inputs);
+    map_ports(m_compiled_model->outputs(), inner_outputs);
+}
+
+const ov::Output<const ov::Node>& ov::npuw::PAInferRequest::map_port_locked(
+    const ov::Output<const ov::Node>& port) const {
+    auto it = m_port_map.find(port.get_node());
+    OPENVINO_ASSERT(it != m_port_map.end(), "Unknown PA infer request port: ", port.get_any_name());
+    return it->second;
+}
+
+ov::npuw::PAInferRequest::Dispatch ov::npuw::PAInferRequest::validate_dispatch_locked() {
+    const auto get = [&](const char* name) {
+        auto it = m_inner_inputs.find(name);
+        OPENVINO_ASSERT(it != m_inner_inputs.end(), "PA model has no '", name, "' input");
+        return m_inner_request->get_tensor(it->second);
+    };
+
+    const auto expect = [&](bool cond, const char* what) {
+        OPENVINO_ASSERT(cond, "PA dispatch #", m_dispatch_idx, " violates the PA model expectations: ", what);
+    };
+
+    Dispatch d;
+    d.past_lens = as_i64_vec(get("past_lens"));
+    d.subsequence_begins = as_i64_vec(get("subsequence_begins"));
+    const auto& past = d.past_lens;
+    const auto& sub = d.subsequence_begins;
+    const auto mcl_vec = as_i64_vec(get("max_context_len"));
+    expect(!mcl_vec.empty(), "max_context_len is not set");
+    const auto mcl = mcl_vec.front();
+    d.n_seqs = static_cast<int64_t>(past.size());
+    // subsequence_begins is the source of truth for the flat token dimension.
+    // input_ids is absent on embedding-input models (inputs_embeds), so it is
+    // only cross-checked when present; position_ids may be multi-dimensional
+    // (M-RoPE), so its token count is the last shape dim.
+    d.n_tokens = sub.empty() ? int64_t{0} : sub.back();
+
+    if (m_inner_inputs.count("input_ids") > 0) {
+        expect(static_cast<int64_t>(get("input_ids")->get_size()) == d.n_tokens,
+               "input_ids size != subsequence_begins token count");
+    }
+    const auto& pos_shape = get("position_ids")->get_shape();
+    expect(!pos_shape.empty() && static_cast<int64_t>(pos_shape.back()) == d.n_tokens,
+           "position_ids last dim != subsequence_begins token count");
+    expect(static_cast<int64_t>(sub.size()) == d.n_seqs + 1, "subsequence_begins size != past_lens size + 1");
+    expect(sub.front() == 0, "subsequence_begins does not start at 0");
+    expect(std::is_sorted(sub.begin(), sub.end()) && std::adjacent_find(sub.begin(), sub.end()) == sub.end(),
+           "subsequence_begins is not strictly increasing");
+
+    // The shared block table. Cache-eviction models carry per-layer
+    // block_indices.<L> inputs instead; those dispatches run 1:1 and only the
+    // common controls above are validated.
+    const bool has_block_table = m_inner_inputs.count("block_indices") > 0;
+    if (has_block_table) {
+        d.block_indices = as_i64_vec(get("block_indices"));
+        d.block_indices_begins = as_i64_vec(get("block_indices_begins"));
+        const auto& bib = d.block_indices_begins;
+        expect(static_cast<int64_t>(bib.size()) == d.n_seqs + 1, "block_indices_begins size != past_lens size + 1");
+        expect(bib.front() == 0 && bib.back() == static_cast<int64_t>(d.block_indices.size()) &&
+                   std::is_sorted(bib.begin(), bib.end()),
+               "block_indices_begins is not a prefix-sum over block_indices");
+    }
+
+    // Per-subsequence: the provided blocks must cover past + scheduled tokens,
+    // and max_context_len bounds every context.
+    const auto block_size = static_cast<int64_t>(m_compiled_model->m_block_size);
+    for (int64_t s = 0; s < d.n_seqs; ++s) {
+        const auto ctx_after = past[s] + (sub[s + 1] - sub[s]);
+        expect(past[s] >= 0, "negative past_lens entry");
+        expect(mcl >= ctx_after, "max_context_len < a subsequence's context length");
+        if (has_block_table && block_size > 0) {
+            expect((d.block_indices_begins[s + 1] - d.block_indices_begins[s]) * block_size >= ctx_after,
+                   "block_indices do not cover a subsequence's context");
+        }
+    }
+
+    // Gather contract: sampled_tokens_indices picks which flat token rows get
+    // logits; an empty selection is legal (intermediate prefill chunks).
+    if (m_inner_inputs.count("sampled_tokens_indices") > 0) {
+        d.sampled_tokens_indices = as_i64_vec(get("sampled_tokens_indices"));
+        for (auto idx : d.sampled_tokens_indices) {
+            expect(idx >= 0 && idx < d.n_tokens, "sampled_tokens_indices out of token range");
+        }
+    }
+
+    LOG_VERB("PA dispatch #" << m_dispatch_idx << ": " << d.n_seqs << " subsequence(s), " << d.n_tokens << " token(s), "
+                             << d.sampled_tokens_indices.size() << " sampled");
+    return d;
+}
+
+void ov::npuw::PAInferRequest::infer() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    validate_dispatch_locked();
+    m_inner_request->infer();
+    ++m_dispatch_idx;
+}
+
+ov::SoPtr<ov::ITensor> ov::npuw::PAInferRequest::get_tensor(const ov::Output<const ov::Node>& port) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_inner_request->get_tensor(map_port_locked(port));
+}
+
+void ov::npuw::PAInferRequest::set_tensor(const ov::Output<const ov::Node>& port,
+                                          const ov::SoPtr<ov::ITensor>& tensor) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_inner_request->set_tensor(map_port_locked(port), tensor);
+}
+
+void ov::npuw::PAInferRequest::check_tensors() const {
+    // Tensors live in the inner request, so the base-class check over this
+    // level's (empty) tensor storage must not run. The inner request performs
+    // the same element-type/shape validation on its own tensors during infer().
+}
+
+std::vector<ov::SoPtr<ov::IVariableState>> ov::npuw::PAInferRequest::query_state() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_inner_request->query_state();
+}
+
+std::vector<ov::ProfilingInfo> ov::npuw::PAInferRequest::get_profiling_info() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_inner_request->get_profiling_info();
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
@@ -5,11 +5,62 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "npuw/compiled_model.hpp"
 
 namespace ov::npuw {
+
+class PACompiledModel;
+
+// Dispatches the dynamic, stateless PagedAttention model deployed by the
+// GenAI continuous-batching pipeline. Each dispatch is validated against the
+// PA control-tensor contract (past_lens /
+// subsequence_begins / block_indices(_begins) / max_context_len /
+// sampled_tokens_indices), then forwarded 1:1 to a single inner infer request.
+// Chunked execution over semi-static variants arrives with a later change.
+class PAInferRequest final : public ov::ISyncInferRequest {
+public:
+    explicit PAInferRequest(std::shared_ptr<const PACompiledModel> compiled_model);
+
+    void infer() override;
+
+    ov::SoPtr<ov::ITensor> get_tensor(const ov::Output<const ov::Node>& port) const override;
+    void set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) override;
+    void check_tensors() const override;
+
+    std::vector<ov::SoPtr<ov::IVariableState>> query_state() const override;
+    std::vector<ov::ProfilingInfo> get_profiling_info() const override;
+
+private:
+    // One dispatch's control tensors, parsed and validated.
+    struct Dispatch {
+        std::vector<int64_t> past_lens;
+        std::vector<int64_t> subsequence_begins;
+        std::vector<int64_t> block_indices;
+        std::vector<int64_t> block_indices_begins;
+        std::vector<int64_t> sampled_tokens_indices;
+        int64_t n_tokens = 0;
+        int64_t n_seqs = 0;
+    };
+
+    const ov::Output<const ov::Node>& map_port_locked(const ov::Output<const ov::Node>& port) const;
+    // Validates the control tensors of one dispatch and parses them out.
+    Dispatch validate_dispatch_locked();
+
+    std::shared_ptr<const PACompiledModel> m_compiled_model;
+    mutable std::mutex m_mutex;
+    ov::SoPtr<ov::IAsyncInferRequest> m_inner_request;
+
+    // Inner input ports by tensor name, for reading the control tensors.
+    std::unordered_map<std::string, ov::Output<const ov::Node>> m_inner_inputs;
+    // Outer port (keyed by its node) -> matching inner port, both directions.
+    std::unordered_map<const ov::Node*, ov::Output<const ov::Node>> m_port_map;
+    std::size_t m_dispatch_idx = 0u;
+};
 
 // The front-end for the dynamic, stateless PagedAttention model deployed by
 // the GenAI continuous-batching pipeline. This class settles the plugin-level
@@ -48,6 +99,8 @@ private:
     PACompiledModel(PreparedState prepared, const std::shared_ptr<const ov::IPlugin>& plugin);
 
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
+
+    friend class PAInferRequest;
 
     std::string m_device;
     ov::SoPtr<ov::ICompiledModel> m_compiled_model;

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "npuw/compiled_model.hpp"
+
+namespace ov::npuw {
+
+// The front-end for the dynamic, stateless PagedAttention model deployed by
+// the GenAI continuous-batching pipeline. This class settles the plugin-level
+// seams: the model is compiled 1:1 on the PA fallback device (CPU unless the
+// internal OPENVINO_NPUW_PA_DEVICE env var says otherwise), the
+// NPU*-prefixed properties are held at this level while everything else is
+// forwarded to the executing device, and the device-resolved KV cache
+// geometry is stamped back onto the exposed ports so the pipeline's
+// KVCacheManager reads the real cache precision and block shape.
+class PACompiledModel final : public ov::npuw::ICompiledModel {
+public:
+    PACompiledModel(const std::shared_ptr<ov::Model>& model,
+                    const std::shared_ptr<const ov::IPlugin>& plugin,
+                    const ov::AnyMap& properties);
+
+    void export_model(std::ostream& stream) const override;
+    std::shared_ptr<const ov::Model> get_runtime_model() const override;
+
+    void set_property(const ov::AnyMap& properties) override;
+    ov::Any get_property(const std::string& name) const override;
+
+private:
+    // The inner model is compiled first and the resolved KV cache element
+    // types / shapes are stamped back onto the model's cache Parameters, so
+    // this compiled model's ports expose the real geometry. The CB pipeline's
+    // KVCacheManager reads precision and block shape off these ports.
+    struct PreparedState {
+        std::shared_ptr<ov::Model> model;
+        ov::SoPtr<ov::ICompiledModel> compiled;
+        std::string device;
+    };
+    static PreparedState prepare(const std::shared_ptr<ov::Model>& model,
+                                 const std::shared_ptr<const ov::IPlugin>& plugin,
+                                 const ov::AnyMap& properties);
+
+    PACompiledModel(PreparedState prepared, const std::shared_ptr<const ov::IPlugin>& plugin);
+
+    std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
+
+    std::string m_device;
+    ov::SoPtr<ov::ICompiledModel> m_compiled_model;
+
+    // KV cache block size as fixed by the device at compile time; 0 if the
+    // compiled cache shape is still dynamic in that dimension.
+    std::size_t m_block_size = 0u;
+};
+
+}  // namespace ov::npuw

--- a/src/plugins/intel_npu/src/plugin/sources.cmake
+++ b/src/plugins/intel_npu/src/plugin/sources.cmake
@@ -143,6 +143,8 @@ set(NPUW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/orc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/orc.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/orc/schema_npuw.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_compiled_model.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_compiled_model.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/compiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/compiler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/graph.cpp

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -48,6 +48,7 @@ ov_add_test_target(
             # npuw core
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/gqa_compiled_model.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model_utils.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
@@ -130,6 +130,7 @@ std::vector<Case> make_cases() {
         double_case<::intel_npu::NPUW_ACC_THRESH>("NPUW_ACC_THRESH", "0.25", 0.25),
         string_case<::intel_npu::NPUW_ACC_DEVICE>("NPUW_ACC_DEVICE", "CPU", "CPU"),
         bool_case<::intel_npu::NPUW_GQA>("NPUW_GQA", "YES", true),
+        bool_case<::intel_npu::NPUW_PA>("NPUW_PA", "YES", true),
         bool_case<::intel_npu::NPUW_UNQDQ>("NPUW_UNQDQ", "YES", true),
         bool_case<::intel_npu::NPUW_LLM>("NPUW_LLM", "YES", true),
         numeric_case<::intel_npu::NPUW_LLM_BATCH_DIM>("NPUW_LLM_BATCH_DIM", "1", uint32_t{1}),


### PR DESCRIPTION
- Outer ports are mapped to the inner compiled model's ports by tensor
  name once, in the constructor. Matching by name rather than position
  keeps forwarding correct even if the executing device reorders ports,
  and gives O(1) lookups on the dispatch hot path. get_tensor /
  set_tensor / query_state / get_profiling_info forward through that map;
  check_tensors() is a no-op because the tensors live in the inner
  request, which validates them itself during infer().

- Every dispatch is validated against the PA control-tensor contract
  before it runs: subsequence_begins is the source of truth for the flat
  token count and must be a strictly increasing prefix sum starting at 0;
  input_ids (when present -- absent on embedding-input models) and
  position_ids (last dim, which may be M-RoPE) must agree with it;
  block_indices_begins must be a prefix sum over block_indices; the
  blocks provided per subsequence must cover past + scheduled tokens
  given the device-resolved block size; max_context_len must bound every
  context; and sampled_tokens_indices must stay inside the token range.
  A malformed dispatch otherwise surfaces as a silently wrong logits row
  or an out-of-bounds read inside the PA kernel, which is much harder to
  attribute. Cache-eviction models carry per-layer block_indices.<L>
  inputs and no shared block table; those dispatches validate the common
  controls only. Each dispatch is summarised at the Verbose log level.