### PR TITLE
[GPU] Increase position IDs precision for direct MatMul Sin/Cos

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -12,6 +12,7 @@
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/parameter.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/cos.hpp"
 #include "openvino/op/sin.hpp"
@@ -485,11 +486,115 @@ IncreasePositionIdsPrecisionForGPTOSS::IncreasePositionIdsPrecisionForGPTOSS() {
     this->register_matcher(m, callback);
 }
 
+IncreasePositionIdsPrecisionForDirectMatMulSinCos::IncreasePositionIdsPrecisionForDirectMatMulSinCos() {
+    using namespace ov::pass::pattern;
+
+    auto matmul = wrap_type<ov::op::v0::MatMul>({any_input(), any_input()});
+    auto sin = wrap_type<ov::op::v0::Sin>({matmul});
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto matmul_node = ov::as_type_ptr<ov::op::v0::MatMul>(pattern_map.at(matmul).get_node_shared_ptr());
+        auto sin_node = ov::as_type_ptr<ov::op::v0::Sin>(pattern_map.at(sin).get_node_shared_ptr());
+        std::vector<std::shared_ptr<ov::op::v0::Cos>> cos_nodes;
+
+        if (!matmul_node || !sin_node || transformation_callback(matmul_node))
+            return false;
+
+        auto reaches_position_ids = [](ov::Output<ov::Node> output) {
+            std::set<ov::Node*> visited;
+            while (visited.insert(output.get_node()).second) {
+                const auto node = output.get_node_shared_ptr();
+                if (const auto parameter = ov::as_type_ptr<ov::op::v0::Parameter>(node)) {
+                    return parameter->get_friendly_name() == "position_ids" ||
+                           parameter->output(0).get_names().count("position_ids") != 0;
+                }
+
+                if (ov::is_type<ov::op::v0::Convert>(node) || ov::is_type<ov::op::v1::Reshape>(node) ||
+                    ov::is_type<ov::op::v0::Squeeze>(node) || ov::is_type<ov::op::v0::Unsqueeze>(node) ||
+                    ov::is_type<ov::op::v8::Gather>(node)) {
+                    output = node->input_value(0);
+                    continue;
+                }
+                return false;
+            }
+            return false;
+        };
+
+        std::shared_ptr<ov::op::v0::Convert> position_ids_convert_node;
+        auto position_ids_path = matmul_node->input_value(0);
+        std::set<ov::Node*> visited;
+        while (visited.insert(position_ids_path.get_node()).second) {
+            const auto node = position_ids_path.get_node_shared_ptr();
+            if (const auto convert = ov::as_type_ptr<ov::op::v0::Convert>(node)) {
+                if (convert->input_value(0).get_element_type().is_integral() &&
+                    reaches_position_ids(convert->input_value(0))) {
+                    position_ids_convert_node = convert;
+                    break;
+                }
+            }
+
+            if (ov::is_type<ov::op::v0::Convert>(node) || ov::is_type<ov::op::v1::Reshape>(node) ||
+                ov::is_type<ov::op::v0::Squeeze>(node) || ov::is_type<ov::op::v0::Unsqueeze>(node) ||
+                ov::is_type<ov::op::v8::Gather>(node)) {
+                position_ids_path = node->input_value(0);
+                continue;
+            }
+            break;
+        }
+
+        if (!position_ids_convert_node)
+            return false;
+
+        for (const auto& user : matmul_node->get_users()) {
+            if (auto cos_node = ov::as_type_ptr<ov::op::v0::Cos>(user))
+                cos_nodes.push_back(cos_node);
+        }
+
+        const auto desired_et = ov::element::f32;
+        const auto original_et = matmul_node->get_output_element_type(0);
+        if (cos_nodes.empty() || original_et == desired_et ||
+            !position_ids_convert_node->input_value(0).get_element_type().is_integral())
+            return false;
+
+        auto position_ids_to_f32 =
+            std::make_shared<ov::op::v0::Convert>(position_ids_convert_node->input_value(0), desired_et);
+        position_ids_to_f32->set_friendly_name(position_ids_convert_node->get_friendly_name() + "_increase_precision");
+        ov::copy_runtime_info(position_ids_convert_node, position_ids_to_f32);
+        ov::replace_node(position_ids_convert_node, position_ids_to_f32);
+
+        size_t input_idx = 0;
+        if (!insert_converts_before_if_needed(matmul_node, desired_et, input_idx))
+            return false;
+
+        auto promote_output = [&](const std::shared_ptr<ov::Node>& node) {
+            if (auto type_relaxed = std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(node))
+                type_relaxed->set_overridden_output_type(desired_et);
+            node->validate_and_infer_types();
+        };
+        promote_output(matmul_node);
+        promote_output(sin_node);
+        for (const auto& cos_node : cos_nodes)
+            promote_output(cos_node);
+
+        size_t output_idx = 0;
+        for (const auto& cos_node : cos_nodes)
+            insert_converts_after_if_needed(cos_node, original_et, output_idx);
+        insert_converts_after_if_needed(sin_node, original_et, output_idx);
+        return true;
+    };
+
+    auto m =
+        std::make_shared<ov::pass::pattern::Matcher>(sin, "IncreasePositionIdsPrecisionForDirectMatMulSinCos");
+    this->register_matcher(m, callback);
+}
+
 IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() = default;
 
 bool IncreasePositionIdsPrecision::run_on_model(const std::shared_ptr<ov::Model>& model) {
     ov::pass::SymbolicOptimizations symbolic_optimizations(false, get_pass_config());
     auto symbolic_ctx_manager = symbolic_optimizations.get_manager();
+    symbolic_ctx_manager->register_pass<IncreasePositionIdsPrecisionForDirectMatMulSinCos>();
     symbolic_ctx_manager->register_pass<IncreasePositionIdsPrecisionForRoPE>();
     symbolic_ctx_manager->register_pass<IncreasePositionIdsPrecisionForQwen25VL>();
     symbolic_ctx_manager->register_pass<IncreasePositionIdsPrecisionForQwen3VL>();

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -522,46 +522,46 @@ IncreasePositionIdsPrecisionForDirectMatMulSinCos::IncreasePositionIdsPrecisionF
         };
 
         std::shared_ptr<ov::op::v0::Convert> position_ids_convert_node;
-        auto position_ids_path = matmul_node->input_value(0);
-        std::set<ov::Node*> visited;
-        while (visited.insert(position_ids_path.get_node()).second) {
-            const auto node = position_ids_path.get_node_shared_ptr();
-            if (const auto convert = ov::as_type_ptr<ov::op::v0::Convert>(node)) {
-                if (convert->input_value(0).get_element_type().is_integral() &&
-                    reaches_position_ids(convert->input_value(0))) {
-                    position_ids_convert_node = convert;
-                    break;
+        for (auto position_ids_path : matmul_node->input_values()) {
+            std::set<ov::Node*> visited;
+            while (visited.insert(position_ids_path.get_node()).second) {
+                const auto node = position_ids_path.get_node_shared_ptr();
+                if (const auto convert = ov::as_type_ptr<ov::op::v0::Convert>(node)) {
+                    if (convert->input_value(0).get_element_type().is_integral() &&
+                        reaches_position_ids(convert->input_value(0))) {
+                        position_ids_convert_node = convert;
+                        break;
+                    }
                 }
+
+                if (ov::is_type<ov::op::v0::Convert>(node) || ov::is_type<ov::op::v1::Reshape>(node) ||
+                    ov::is_type<ov::op::v0::Squeeze>(node) || ov::is_type<ov::op::v0::Unsqueeze>(node) ||
+                    ov::is_type<ov::op::v8::Gather>(node)) {
+                    position_ids_path = node->input_value(0);
+                    continue;
+                }
+                break;
             }
 
-            if (ov::is_type<ov::op::v0::Convert>(node) || ov::is_type<ov::op::v1::Reshape>(node) ||
-                ov::is_type<ov::op::v0::Squeeze>(node) || ov::is_type<ov::op::v0::Unsqueeze>(node) ||
-                ov::is_type<ov::op::v8::Gather>(node)) {
-                position_ids_path = node->input_value(0);
-                continue;
-            }
-            break;
+            if (position_ids_convert_node)
+                break;
         }
 
         if (!position_ids_convert_node)
             return false;
 
         for (const auto& user : matmul_node->get_users()) {
-            if (auto cos_node = ov::as_type_ptr<ov::op::v0::Cos>(user))
+            if (auto cos_node = ov::as_type_ptr<ov::op::v0::Cos>(user)) {
                 cos_nodes.push_back(cos_node);
+            } else if (user != sin_node && !ov::is_type<ov::op::util::ShapeOfBase>(user)) {
+                return false;
+            }
         }
 
         const auto desired_et = ov::element::f32;
         const auto original_et = matmul_node->get_output_element_type(0);
-        if (cos_nodes.empty() || original_et == desired_et ||
-            !position_ids_convert_node->input_value(0).get_element_type().is_integral())
+        if (cos_nodes.empty() || original_et == desired_et)
             return false;
-
-        auto position_ids_to_f32 =
-            std::make_shared<ov::op::v0::Convert>(position_ids_convert_node->input_value(0), desired_et);
-        position_ids_to_f32->set_friendly_name(position_ids_convert_node->get_friendly_name() + "_increase_precision");
-        ov::copy_runtime_info(position_ids_convert_node, position_ids_to_f32);
-        ov::replace_node(position_ids_convert_node, position_ids_to_f32);
 
         size_t input_idx = 0;
         if (!insert_converts_before_if_needed(matmul_node, desired_et, input_idx))

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
@@ -38,6 +38,12 @@ public:
     IncreasePositionIdsPrecisionForGPTOSS();
 };
 
+class IncreasePositionIdsPrecisionForDirectMatMulSinCos : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("IncreasePositionIdsPrecisionForDirectMatMulSinCos");
+    IncreasePositionIdsPrecisionForDirectMatMulSinCos();
+};
+
 /**
  * @brief This pass adds additional convert nodes on the position_ids input branch (around MatMul or Multiply operation),
  *        targeting to improve runtime rotary position embeddings calculation for FP16 models.

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
@@ -876,6 +876,65 @@ TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForQwen35) {
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
 
+TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCos) {
+    auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{1, 4});
+    position_ids->set_friendly_name("position_ids");
+    auto position_ids_i32 = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+    auto position_ids_gather = std::make_shared<ov::op::v8::Gather>(
+        position_ids_i32,
+        ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0}),
+        ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0}));
+    auto position_ids_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(
+        position_ids_gather,
+        ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0}));
+    auto position_ids_f16 = std::make_shared<ov::op::v0::Convert>(position_ids_unsqueeze, ov::element::f16);
+    auto frequencies = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{4, 4});
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(position_ids_f16, frequencies);
+    auto sin = std::make_shared<ov::op::v0::Sin>(matmul);
+    auto cos = std::make_shared<ov::op::v0::Cos>(matmul);
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{sin, cos}, ov::ParameterVector{position_ids});
+
+    ov::pass::Manager manager;
+    manager.register_pass<IncreasePositionIdsPrecisionForDirectMatMulSinCos>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(matmul->get_input_element_type(0), ov::element::f32);
+    EXPECT_EQ(matmul->get_input_element_type(1), ov::element::f32);
+    EXPECT_EQ(matmul->get_output_element_type(0), ov::element::f32);
+    EXPECT_EQ(sin->get_output_element_type(0), ov::element::f32);
+    EXPECT_EQ(cos->get_output_element_type(0), ov::element::f32);
+
+    for (const auto& trig_node : {std::static_pointer_cast<ov::Node>(sin),
+                                  std::static_pointer_cast<ov::Node>(cos)}) {
+        ASSERT_EQ(trig_node->get_users().size(), 1);
+        const auto restore_precision =
+            ov::as_type_ptr<ov::op::v0::Convert>(trig_node->get_users().front());
+        ASSERT_NE(restore_precision, nullptr);
+        EXPECT_EQ(restore_precision->get_output_element_type(0), ov::element::f16);
+    }
+}
+
+TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCosIgnoresUnrelatedInput) {
+    auto input_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{1, 4});
+    input_ids->set_friendly_name("input_ids");
+    auto input_ids_f16 = std::make_shared<ov::op::v0::Convert>(input_ids, ov::element::f16);
+    auto frequencies = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{4, 4});
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(input_ids_f16, frequencies);
+    auto sin = std::make_shared<ov::op::v0::Sin>(matmul);
+    auto cos = std::make_shared<ov::op::v0::Cos>(matmul);
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{sin, cos}, ov::ParameterVector{input_ids});
+
+    ov::pass::Manager manager;
+    manager.register_pass<IncreasePositionIdsPrecisionForDirectMatMulSinCos>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(matmul->get_input_element_type(0), ov::element::f16);
+    EXPECT_EQ(matmul->get_input_element_type(1), ov::element::f16);
+    EXPECT_EQ(matmul->get_output_element_type(0), ov::element::f16);
+    EXPECT_EQ(sin->get_output_element_type(0), ov::element::f16);
+    EXPECT_EQ(cos->get_output_element_type(0), ov::element::f16);
+}
+
 TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForGPTOSS) {
     {
         auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ 3, -1, -1 });

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
@@ -876,6 +876,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForQwen35) {
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
 
+// Verifies FP32 promotion for the direct MatMul -> Sin/Cos topology.
 TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCos) {
     auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{1, 4});
     position_ids->set_friendly_name("position_ids");
@@ -892,7 +893,9 @@ TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCos) {
     auto matmul = std::make_shared<ov::op::v0::MatMul>(position_ids_f16, frequencies);
     auto sin = std::make_shared<ov::op::v0::Sin>(matmul);
     auto cos = std::make_shared<ov::op::v0::Cos>(matmul);
-    auto model = std::make_shared<ov::Model>(ov::OutputVector{sin, cos}, ov::ParameterVector{position_ids});
+    auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(matmul, ov::element::i32);
+    auto model =
+        std::make_shared<ov::Model>(ov::OutputVector{sin, cos, shape_of}, ov::ParameterVector{position_ids});
 
     ov::pass::Manager manager;
     manager.register_pass<IncreasePositionIdsPrecisionForDirectMatMulSinCos>();
@@ -903,6 +906,7 @@ TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCos) {
     EXPECT_EQ(matmul->get_output_element_type(0), ov::element::f32);
     EXPECT_EQ(sin->get_output_element_type(0), ov::element::f32);
     EXPECT_EQ(cos->get_output_element_type(0), ov::element::f32);
+    EXPECT_EQ(shape_of->get_output_element_type(0), ov::element::i32);
 
     for (const auto& trig_node : {std::static_pointer_cast<ov::Node>(sin),
                                   std::static_pointer_cast<ov::Node>(cos)}) {
@@ -914,6 +918,29 @@ TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCos) {
     }
 }
 
+// Verifies that position_ids are detected when they feed the right-hand side of MatMul.
+TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCosWithPositionIdsOnRhs) {
+    auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{4, 1});
+    position_ids->set_friendly_name("position_ids");
+    auto position_ids_f16 = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::f16);
+    auto frequencies = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{4, 4});
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(frequencies, position_ids_f16);
+    auto sin = std::make_shared<ov::op::v0::Sin>(matmul);
+    auto cos = std::make_shared<ov::op::v0::Cos>(matmul);
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{sin, cos}, ov::ParameterVector{position_ids});
+
+    ov::pass::Manager manager;
+    manager.register_pass<IncreasePositionIdsPrecisionForDirectMatMulSinCos>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(matmul->get_input_element_type(0), ov::element::f32);
+    EXPECT_EQ(matmul->get_input_element_type(1), ov::element::f32);
+    EXPECT_EQ(matmul->get_output_element_type(0), ov::element::f32);
+    EXPECT_EQ(sin->get_output_element_type(0), ov::element::f32);
+    EXPECT_EQ(cos->get_output_element_type(0), ov::element::f32);
+}
+
+// Verifies that a similarly shaped graph is ignored when its input is not position_ids.
 TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCosIgnoresUnrelatedInput) {
     auto input_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{1, 4});
     input_ids->set_friendly_name("input_ids");
@@ -933,6 +960,51 @@ TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCosIgnoresUnrelatedInput) 
     EXPECT_EQ(matmul->get_output_element_type(0), ov::element::f16);
     EXPECT_EQ(sin->get_output_element_type(0), ov::element::f16);
     EXPECT_EQ(cos->get_output_element_type(0), ov::element::f16);
+}
+
+// Verifies that promoting MatMul does not change another consumer of a shared Convert.
+TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCosPreservesSharedConvertConsumer) {
+    auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{1, 4});
+    position_ids->set_friendly_name("position_ids");
+    auto position_ids_f16 = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::f16);
+    auto frequencies = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{4, 4});
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(position_ids_f16, frequencies);
+    auto sin = std::make_shared<ov::op::v0::Sin>(matmul);
+    auto cos = std::make_shared<ov::op::v0::Cos>(matmul);
+    auto unrelated = std::make_shared<ov::op::v0::Result>(position_ids_f16);
+    auto model =
+        std::make_shared<ov::Model>(ov::OutputVector{sin, cos, unrelated}, ov::ParameterVector{position_ids});
+
+    ov::pass::Manager manager;
+    manager.register_pass<IncreasePositionIdsPrecisionForDirectMatMulSinCos>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(matmul->get_input_element_type(0), ov::element::f32);
+    EXPECT_EQ(unrelated->get_input_element_type(0), ov::element::f16);
+    EXPECT_EQ(unrelated->input_value(0).get_node_shared_ptr(), position_ids_f16);
+}
+
+// Verifies that the transformation is skipped when MatMul has an unrelated value consumer.
+TEST(IncreasePositionIdsPrecisionTest, DirectMatMulSinCosIgnoresExtraMatMulConsumer) {
+    auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{1, 4});
+    position_ids->set_friendly_name("position_ids");
+    auto position_ids_f16 = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::f16);
+    auto frequencies = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{4, 4});
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(position_ids_f16, frequencies);
+    auto sin = std::make_shared<ov::op::v0::Sin>(matmul);
+    auto cos = std::make_shared<ov::op::v0::Cos>(matmul);
+    auto unrelated = std::make_shared<ov::op::v0::Result>(matmul);
+    auto model =
+        std::make_shared<ov::Model>(ov::OutputVector{sin, cos, unrelated}, ov::ParameterVector{position_ids});
+
+    ov::pass::Manager manager;
+    manager.register_pass<IncreasePositionIdsPrecisionForDirectMatMulSinCos>();
+    manager.run_passes(model);
+
+    EXPECT_EQ(matmul->get_input_element_type(0), ov::element::f16);
+    EXPECT_EQ(matmul->get_input_element_type(1), ov::element::f16);
+    EXPECT_EQ(matmul->get_output_element_type(0), ov::element::f16);
+    EXPECT_EQ(unrelated->get_input_element_type(0), ov::element::f16);
 }
 
 TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForGPTOSS) {


### PR DESCRIPTION
### Description of the issue (symptom, root cause, how it was resolved)
- Some RoPE graphs calculate position IDs through a direct `MatMul → Sin/Cos` pattern in FP16, which can reduce accuracy for long sequences.
- The existing position ID precision transformations did not match this graph structure.
- Added a generic transformation that traces the MatMul input back to the `position_ids` parameter, promotes MatMul and Sin/Cos calculations to FP32, and restores the original precision after Sin/Cos.
- Unrelated MatMul/Sin/Cos graphs are excluded by validating the `position_ids` input path.

#### The code and line that caused this issue (if it is not changed directly)
- `IncreasePositionIdsPrecision::run_on_model()`
- `src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp`

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
```bash
./ov_gpu_unit_tests \
    --gtest_filter='IncreasePositionIdsPrecisionTest.DirectMatMulSinCos*'
```

#### Problematic graph
```text
position_ids
  → Convert/Gather/Unsqueeze
  → Convert(f16)
  → MatMul(f16)
  → Sin/Cos(f16)
```

After the transformation:
```text
position_ids
  → Convert/Gather/Unsqueeze
  → Convert(f32)
  → MatMul(f32)
  → Sin/Cos(f32)
  → Convert(f16)
```

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
  - Reviewed the existing `IncreasePositionIdsPrecision` transformation tests. Added focused positive and negative tests because the existing cases do not cover the direct `MatMul → Sin/Cos` pattern.