### PR TITLE
[GPU] Support IncreasePositionIdsPrecisionForGemma4 for PA backend (#…

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -89,6 +89,7 @@ IncreasePositionIdsPrecisionForRoPE::IncreasePositionIdsPrecisionForRoPE() {
         auto matmul_node = ov::as_type_ptr<ov::op::v0::MatMul>(pattern_map.at(gemm_or_matmul).get_node_shared_ptr());
         auto cos_node = ov::as_type_ptr<ov::op::v0::Cos>(pattern_map.at(cos).get_node_shared_ptr());
         auto sin_node = ov::as_type_ptr<ov::op::v0::Sin>(pattern_map.at(sin).get_node_shared_ptr());
+        auto rope_node = pattern_map.at(rope).get_node_shared_ptr();
 
         if (!matmul_node || transformation_callback(matmul_node))
             return false;
@@ -98,13 +99,21 @@ IncreasePositionIdsPrecisionForRoPE::IncreasePositionIdsPrecisionForRoPE() {
         if (original_et == desired_et)
             return false;
 
+        // Step 1: Ensure MatMul inputs are f32
         size_t input_idx = 0;
         bool is_changed = insert_converts_before_if_needed(matmul_node, desired_et, input_idx);
 
+        // Step 2: Insert restore converts only if RoPE expects non-f32 precision.
         if (is_changed) {
             size_t output_idx = 0;
-            insert_converts_after_if_needed(cos_node, original_et, output_idx);
-            insert_converts_after_if_needed(sin_node, original_et, output_idx);
+            auto rope_cos_et = rope_node->get_input_element_type(1);
+            if (rope_cos_et != desired_et) {
+                insert_converts_after_if_needed(cos_node, rope_cos_et, output_idx);
+            }
+            auto rope_sin_et = rope_node->get_input_element_type(2);
+            if (rope_sin_et != desired_et) {
+                insert_converts_after_if_needed(sin_node, rope_sin_et, output_idx);
+            }
         }
         return true;
     };
@@ -476,8 +485,7 @@ IncreasePositionIdsPrecisionForGPTOSS::IncreasePositionIdsPrecisionForGPTOSS() {
     this->register_matcher(m, callback);
 }
 
-
-IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() {}
+IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() = default;
 
 bool IncreasePositionIdsPrecision::run_on_model(const std::shared_ptr<ov::Model>& model) {
     ov::pass::SymbolicOptimizations symbolic_optimizations(false, get_pass_config());

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.hpp
@@ -38,7 +38,6 @@ public:
     IncreasePositionIdsPrecisionForGPTOSS();
 };
 
-
 /**
  * @brief This pass adds additional convert nodes on the position_ids input branch (around MatMul or Multiply operation),
  *        targeting to improve runtime rotary position embeddings calculation for FP16 models.

--- a/src/plugins/intel_gpu/src/plugin/transformations/utils.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024-2026 Intel Corporation
+// Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -36,11 +36,17 @@ inline bool insert_converts_before_if_needed(const std::shared_ptr<ov::Node>& no
 
         auto in_convert = ov::as_type_ptr<ov::op::v0::Convert>(incoming_node);
 
-        if (in_convert && in_convert->get_users().size() == 1 && input_et.bitwidth() <= desired_et.bitwidth()) {
-            auto convert = std::make_shared<ov::op::v0::Convert>(incoming_node->input_value(0), desired_et);
-            convert->set_friendly_name(in_convert->get_friendly_name() + "_increase_precision_" + std::to_string(input_idx));
-            ov::copy_runtime_info(incoming_node, convert);
-            ov::replace_node(incoming_node, convert);
+        if (in_convert && input_et.bitwidth() <= desired_et.bitwidth()) {
+            auto convert = std::make_shared<ov::op::v0::Convert>(in_convert->input_value(0), desired_et);
+            convert->set_friendly_name(node->get_friendly_name() + "_increase_precision_" + std::to_string(input_idx));
+            ov::copy_runtime_info(in_convert, convert);
+            if (in_convert->get_users().size() == 1) {
+                // This node is the only user, so the original Convert can be dropped entirely.
+                ov::replace_node(in_convert, convert);
+            } else {
+                // The original Convert is kept for the remaining users; rewire only this input.
+                input.replace_source_output(convert);
+            }
         } else {
             auto convert = std::make_shared<ov::op::v0::Convert>(incoming_output, desired_et);
             convert->set_friendly_name(incoming_node->get_friendly_name() + "_increase_precision_" + std::to_string(input_idx));

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_precision_test.cpp
@@ -1082,3 +1082,76 @@ TEST(IncreasePrecisionTest, IncreaseRMSInputPrecisionForQwenVLMerger) {
     EXPECT_TRUE(ov::as_type_ptr<ov::op::v0::Convert>(rms_user) != nullptr)
         << "rms_m output should feed into Convert node";
 }
+
+// Gemma4 pattern (latest): MatMul(f16) -> Reshape(transpose) -> Concat -> Sin/Cos -> Reshape(unsqueeze) -> RoPE(f16 cos/sin)
+// The local / global attention RoPEs share a single position_ids Convert, so that Convert has two users.
+TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionForGemma4) {
+    // Builds one RoPE branch on top of the shared position_ids Convert.
+    // theta_idx only makes the frequency constants of the two branches distinct.
+    auto make_rope_branch = [](const ov::Output<ov::Node>& pos_ids_fp,
+                               const ov::Output<ov::Node>& rope_input,
+                               int theta_idx,
+                               bool promoted) {
+        auto freq_const = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 128, 1},
+                                                                 std::vector<float>(128, static_cast<float>(theta_idx + 1)));
+        auto shape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{1, 128, 1});
+        ov::Output<ov::Node> matmul_lhs = std::make_shared<ov::op::v3::Broadcast>(freq_const, shape_const);
+        if (promoted)
+            matmul_lhs = std::make_shared<ov::op::v0::Convert>(matmul_lhs, ov::element::f32);
+
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(matmul_lhs, pos_ids_fp);
+
+        // Reshape (acts as transpose) -> Concat -> Sin/Cos
+        auto reshape_tr_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{-1, 1, 128});
+        auto reshape_transpose = std::make_shared<ov::op::v1::Reshape>(matmul, reshape_tr_const, false);
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{reshape_transpose, reshape_transpose}, 2);
+        ov::Output<ov::Node> cos = std::make_shared<ov::op::v0::Cos>(concat);
+        ov::Output<ov::Node> sin = std::make_shared<ov::op::v0::Sin>(concat);
+
+        // RoPE stays in f16, so the promoted branch needs restore converts
+        if (promoted) {
+            cos = std::make_shared<ov::op::v0::Convert>(cos, ov::element::f16);
+            sin = std::make_shared<ov::op::v0::Convert>(sin, ov::element::f16);
+        }
+
+        // Reshape (acts as unsqueeze) -> RoPE
+        auto reshape_cos_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 1, 1, 256});
+        auto cos_reshape = std::make_shared<ov::op::v1::Reshape>(cos, reshape_cos_const, false);
+        auto reshape_sin_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 1, 1, 256});
+        auto sin_reshape = std::make_shared<ov::op::v1::Reshape>(sin, reshape_sin_const, false);
+
+        return std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_reshape, sin_reshape},
+                                                        ov::op::internal::RoPE::Config());
+    };
+
+    {
+        // position_ids(i64) -> Convert(i32) -> Reshape[?,1,1] -> Convert(f16) -> { MatMul_local, MatMul_global }
+        auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1});
+        auto convert_i32 = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+        auto reshape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{-1, 1, 1});
+        auto reshape_pos = std::make_shared<ov::op::v1::Reshape>(convert_i32, reshape_const, false);
+        auto convert_f16 = std::make_shared<ov::op::v0::Convert>(reshape_pos, ov::element::f16);
+
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
+        auto rope_local = make_rope_branch(convert_f16, rope_input, 0, false);
+        auto rope_global = make_rope_branch(convert_f16, rope_input, 1, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope_local, rope_global}, ov::ParameterVector{position_ids, rope_input});
+        manager.register_pass<IncreasePositionIdsPrecision>();
+    }
+    {
+        auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1});
+        auto convert_i32 = std::make_shared<ov::op::v0::Convert>(position_ids, ov::element::i32);
+        auto reshape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{-1, 1, 1});
+        auto reshape_pos = std::make_shared<ov::op::v1::Reshape>(convert_i32, reshape_const, false);
+        auto convert_f32_local = std::make_shared<ov::op::v0::Convert>(reshape_pos, ov::element::f32);
+        auto convert_f32_global = std::make_shared<ov::op::v0::Convert>(reshape_pos, ov::element::f32);
+
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
+        auto rope_local = make_rope_branch(convert_f32_local, rope_input, 0, true);
+        auto rope_global = make_rope_branch(convert_f32_global, rope_input, 1, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope_local, rope_global}, ov::ParameterVector{position_ids, rope_input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}


### PR DESCRIPTION
This PR is backport PR for https://github.com/openvinotoolkit/openvino/pull/36915 

## Details
**Problem:** The `IncreasePositionIdsPrecisionForGemma4` pass introduced in PR #36896 does not match the rotary embedding graph pattern when using the PA (Paged Attention) backend. Under PA, upstream transformations fold `Transpose` into `Reshape` and `Unsqueeze` into `Reshape` and drop the `Convert` after MatMul, producing a different subgraph shape (`MatMul → Reshape → Concat → Sin/Cos → Reshape → RoPE`) that the original pattern (`MatMul → Convert → Transpose → Concat → Sin/Cos → Unsqueeze → RoPE`) cannot match. As a result, the rotary embedding MatMul remains in FP16 and the infinite repetition loop persists on PA backend.

**Fix**: Removed the model-specific `IncreasePositionIdsPrecisionForGemma4` pass and generalized `IncreasePositionIdsPrecisionForRoPE` to cover the Gemma4 graph, since its pattern already accepts the PA-folded shape:

- Fixed `insert_converts_before_if_needed()` in utils.hpp to handle multi-user `Convert` nodes: when an input `Convert` has more than one user, it now branches a separate Convert from the source of the original (e.g. i32→f32 directly), instead of inserting one after it (e.g. i32→f16→f32). The previous behavior caused mantissa loss due to the intermediate f16 truncation.
- Insert the restore `Convert` after `Sin`/`Cos` based on the `RoPE` node's actual `cos`/`sin` input precision instead of the `MatMul`'s original output type. All supported models expect f16 there, so it is still inserted.
- Removed the `IncreasePositionIdsPrecisionForGemma4` declaration/registration, its registration-order dependency, and the optional `Convert`-after-MatMul path.

## Tickets

- [CVS-187785](https://jira.devtools.intel.com/browse/CVS-187785)

## AI Assistance

- AI assistance used: yes
- AI was used for per-iteration logit comparison analysis, tensor dump comparison scripting, exec graph subgraph extraction, and matcher log interpretation. All code changes were manually reviewed and validated with end-to-end accuracy tests.

