### PR TITLE
[OP] SelectiveSSM and PagedSelectiveSSM operations

### DIFF
--- a/src/core/dev_api/dev_headers.cmake
+++ b/src/core/dev_api/dev_headers.cmake
@@ -28,7 +28,9 @@ set(DEV_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/paged_attention.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/paged_causal_conv1d.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/paged_gated_delta_net.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/openvino/op/paged_selective_ssm.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/rms_norm.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/openvino/op/selective_ssm.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/util/node_util.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/util/slice_plan.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/opsets/opset10_decl.hpp

--- a/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
@@ -13,17 +13,31 @@ namespace ov::op::internal {
 /// Paged variant of the SelectiveSSM (Mamba2 selective state-space, arXiv:2405.21060) recurrence. Processes
 /// tokens from multiple sequences packed into a single batch and manages the recurrent SSM state (a per-head
 /// ``[head_dim, state_size]`` matrix) using a paged block table, enabling non-contiguous memory allocation
-/// across sequences. Per token: ``dA = exp(A * dt)``, ``dtB = dt * B``, ``dBx = dtB (x) x``,
+/// across sequences. Per token: ``dA = exp(A * dt)``, ``dtB = dt * B``, ``dBx = x (x) dtB``,
 /// ``state = state * dA + dBx``, ``output = sum(state * C)``.
 ///
 /// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
 /// ``g = h / heads_per_group``, where ``heads_per_group = num_heads / num_groups``.
 ///
-/// ``recurrent_state_table`` is updated in place. For sequence ``s``, the state is cached every
-/// ``cache_interval[s]`` tokens into the blocks addressed by
-/// ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``;
-/// ``cache_interval[s] <= 0`` disables caching for that sequence. ``num_processed_tokens[s]`` gives the
-/// count of previously processed tokens, used to resume from the correct cached state and block offset.
+/// ``recurrent_state_table`` is updated in place through the logical slots of sequence ``s``, that is
+/// ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``. Slot 0 is the input slot
+/// holding the state after exactly ``num_processed_tokens[s]`` tokens; it is read before any slot is written.
+/// Let ``current = subsequence_begins[s+1] - subsequence_begins[s]``. When ``cache_interval[s] > 0``, with
+/// ``interval = cache_interval[s]`` and ``past = num_processed_tokens[s] % interval``, the state is written in
+/// order to slots ``1 .. write_count``, where ``write_count = (past + current - 1) / interval + 1``: once each
+/// time ``past + t`` reaches a multiple of ``interval`` for the ``t``-th token of the call, and once after the
+/// last token unless that token already is such a boundary. The sequence therefore needs at least
+/// ``write_count + 1`` slots; surplus slots and unreferenced table rows are ignored. ``cache_interval[s] <= 0``
+/// disables caching: only the input slot is required and the table is left unmodified. A sequence with no
+/// tokens reads and writes nothing and needs no slots.
+///
+/// Slot 0 may alias slot 1 to update the state in place; the input state is read first, so the result matches
+/// a non-aliased copy. Across sequences the write set must be disjoint from every other sequence's read and
+/// write sets, while a read-only slot may be shared. The caller owns slot 0: it must hold a valid state before
+/// execution, including when ``num_processed_tokens[s]`` is 0, and zero-initialization and recycled-page
+/// synchronization are caller responsibilities. Metadata values are trusted: both begins arrays start at 0, are
+/// non-decreasing and end at the token and logical-slot counts, ``num_processed_tokens`` is non-negative, and
+/// every block index is below ``num_physical_blocks``.
 /// \ingroup ov_ops_cpp_api
 class OPENVINO_API PagedSelectiveSSM : public ov::op::Op {
 public:
@@ -38,11 +52,11 @@ public:
     /// \param x Input hidden states [batch_size_in_tokens, num_heads, head_dim].
     /// \param C Grouped output projection [batch_size_in_tokens, num_groups, state_size].
     /// \param recurrent_state_table Paged table of recurrent state snapshots, updated in place
-    ///        [num_blocks, num_heads, head_dim, state_size]; an all-zeros tensor before any tokens are cached.
+    ///        [num_physical_blocks, num_heads, head_dim, state_size]; an all-zeros tensor before any tokens are cached.
     /// \param subsequence_begins Start indices of each sequence's tokens in the flattened token batch
     ///        [batch_size_in_sequences + 1], element type i32 or i64.
     /// \param la_block_indices Physical block row indices into recurrent_state_table, concatenated across
-    ///        all sequences [num_blocks], element type i32 or i64.
+    ///        all sequences [num_logical_blocks], element type i32 or i64.
     /// \param la_block_indices_begins Splits la_block_indices among sequences
     ///        [batch_size_in_sequences + 1], element type i32 or i64.
     /// \param num_processed_tokens Number of tokens already processed for each sequence

--- a/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
@@ -19,25 +19,15 @@ namespace ov::op::internal {
 /// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
 /// ``g = h / heads_per_group``, where ``heads_per_group = num_heads / num_groups``.
 ///
-/// ``recurrent_state_table`` is updated in place through the logical slots of sequence ``s``, that is
-/// ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``. Slot 0 is the input slot
-/// holding the state after exactly ``num_processed_tokens[s]`` tokens; it is read before any slot is written.
-/// Let ``current = subsequence_begins[s+1] - subsequence_begins[s]``. When ``cache_interval[s] > 0``, with
-/// ``interval = cache_interval[s]`` and ``past = num_processed_tokens[s] % interval``, the state is written in
-/// order to slots ``1 .. write_count``, where ``write_count = (past + current - 1) / interval + 1``: once each
-/// time ``past + t`` reaches a multiple of ``interval`` for the ``t``-th token of the call, and once after the
-/// last token unless that token already is such a boundary. The sequence therefore needs at least
-/// ``write_count + 1`` slots; surplus slots and unreferenced table rows are ignored. ``cache_interval[s] <= 0``
-/// disables caching: only the input slot is required and the table is left unmodified. A sequence with no
-/// tokens reads and writes nothing and needs no slots.
-///
-/// Slot 0 may alias slot 1 to update the state in place; the input state is read first, so the result matches
-/// a non-aliased copy. Across sequences the write set must be disjoint from every other sequence's read and
-/// write sets, while a read-only slot may be shared. The caller owns slot 0: it must hold a valid state before
-/// execution, including when ``num_processed_tokens[s]`` is 0, and zero-initialization and recycled-page
-/// synchronization are caller responsibilities. Metadata values are trusted: both begins arrays start at 0, are
-/// non-decreasing and end at the token and logical-slot counts, ``num_processed_tokens`` is non-negative, and
-/// every block index is below ``num_physical_blocks``.
+/// For each sequence ``s``, ``recurrent_state_table`` is addressed through its logical slots
+/// ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``. Slot 0 holds the input
+/// state and is read before any slot is written; it may alias slot 1 for an in-place update. When
+/// ``cache_interval[s] > 0``, the state is snapshotted into slots ``1, 2, ...`` every ``cache_interval[s]``
+/// tokens counted from ``num_processed_tokens[s]``, and once more after the last token of the call, so the
+/// sequence needs one slot per snapshot plus slot 0. ``cache_interval[s] <= 0`` disables caching: only slot 0
+/// is required and the table is left unmodified. Write sets must be disjoint across sequences. The caller owns
+/// slot 0 and must pre-populate it before execution; metadata (begins arrays, counts, block indices) is
+/// trusted and not validated against the table.
 /// \ingroup ov_ops_cpp_api
 class OPENVINO_API PagedSelectiveSSM : public ov::op::Op {
 public:

--- a/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov::op::internal {
+/// \note PagedSelectiveSSM op class is under development and subject to change
+///
+/// \brief Operator performing paged SelectiveSSM computation for continuous batching.
+///
+/// Paged variant of the SelectiveSSM (Mamba2 selective state-space, arXiv:2405.21060) recurrence. Processes
+/// tokens from multiple sequences packed into a single batch and manages the recurrent SSM state (a per-head
+/// ``[head_dim, state_size]`` matrix) using a paged block table, enabling non-contiguous memory allocation
+/// across sequences. Per token: ``dA = exp(A * dt)``, ``dtB = dt * B``, ``dBx = dtB (x) x``,
+/// ``state = state * dA + dBx``, ``output = sum(state * C)``.
+///
+/// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
+/// ``g = h / heads_per_group``, where ``heads_per_group = num_heads / num_groups``.
+///
+/// ``recurrent_state_table`` is updated in place. For sequence ``s``, the state is cached every
+/// ``cache_interval[s]`` tokens into the blocks addressed by
+/// ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``;
+/// ``cache_interval[s] <= 0`` disables caching for that sequence. ``num_processed_tokens[s]`` gives the
+/// count of previously processed tokens, used to resume from the correct cached state and block offset.
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API PagedSelectiveSSM : public ov::op::Op {
+public:
+    OPENVINO_OP("PagedSelectiveSSM");
+
+    PagedSelectiveSSM() = default;
+    /// \brief Constructs a PagedSelectiveSSM operation.
+    ///
+    /// \param A (Negative) log-decay rates per head [num_heads].
+    /// \param dt Per-token, per-head time steps used for discretization [batch_size_in_tokens, num_heads].
+    /// \param B Grouped input projection [batch_size_in_tokens, num_groups, state_size].
+    /// \param x Input hidden states [batch_size_in_tokens, num_heads, head_dim].
+    /// \param C Grouped output projection [batch_size_in_tokens, num_groups, state_size].
+    /// \param recurrent_state_table Paged table of recurrent state snapshots, updated in place
+    ///        [num_blocks, num_heads, head_dim, state_size]; an all-zeros tensor before any tokens are cached.
+    /// \param subsequence_begins Start indices of each sequence's tokens in the flattened token batch
+    ///        [batch_size_in_sequences + 1], element type i32 or i64.
+    /// \param la_block_indices Physical block row indices into recurrent_state_table, concatenated across
+    ///        all sequences [num_blocks], element type i32 or i64.
+    /// \param la_block_indices_begins Splits la_block_indices among sequences
+    ///        [batch_size_in_sequences + 1], element type i32 or i64.
+    /// \param num_processed_tokens Number of tokens already processed for each sequence
+    ///        [batch_size_in_sequences], element type i32 or i64.
+    /// \param cache_interval Interval (in tokens) at which the recurrent state is cached for each sequence;
+    ///        a value <= 0 disables caching [batch_size_in_sequences], element type i32 or i64.
+    PagedSelectiveSSM(const Output<Node>& A,
+                      const Output<Node>& dt,
+                      const Output<Node>& B,
+                      const Output<Node>& x,
+                      const Output<Node>& C,
+                      const Output<Node>& recurrent_state_table,
+                      const Output<Node>& subsequence_begins,
+                      const Output<Node>& la_block_indices,
+                      const Output<Node>& la_block_indices_begins,
+                      const Output<Node>& num_processed_tokens,
+                      const Output<Node>& cache_interval);
+
+    /// \brief Constructs a PagedSelectiveSSM operation from input vector.
+    ///
+    /// \param args Input tensor vector (11 inputs in order listed above).
+    explicit PagedSelectiveSSM(const ov::OutputVector& args);
+
+    void validate_and_infer_types() override;
+    bool visit_attributes(AttributeVisitor& visitor) override;
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
+};
+
+}  // namespace ov::op::internal

--- a/src/core/dev_api/openvino/op/selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/selective_ssm.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov::op::internal {
+/// \note SelectiveSSM op class is under development and subject to change
+///
+/// \brief Operator performing the Mamba2 selective state-space recurrence (arXiv:2405.21060).
+///
+/// Discretizes ``A`` (log-decay rates) and ``B`` (input projection) with ``dt`` (time steps) ahead of the
+/// recurrence: ``dA = exp(A * dt)``, ``dtB = dt * B``. Then, for each token ``t``:
+/// ``dBx_t = dtB_t (x) x_t``, ``state_t = state_{t-1} * dA_t + dBx_t``, ``y_t = sum(state_t * C_t)``.
+///
+/// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
+/// ``g = h / heads_per_group``, where ``heads_per_group = num_heads / num_groups``.
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API SelectiveSSM : public ov::op::Op {
+public:
+    OPENVINO_OP("SelectiveSSM");
+
+    SelectiveSSM() = default;
+    /// \brief Constructs a SelectiveSSM operation.
+    ///
+    /// \param A (Negative) log-decay rates per head [num_heads].
+    /// \param dt Per-token, per-head time steps used for discretization [batch_size, seq_len, num_heads].
+    /// \param B Grouped input projection [batch_size, seq_len, num_groups, state_size].
+    /// \param x Input hidden states [batch_size, seq_len, num_heads, head_dim].
+    /// \param C Grouped output projection [batch_size, seq_len, num_groups, state_size].
+    /// \param recurrent_state Initial SSM hidden state [batch_size, num_heads, head_dim, state_size];
+    ///        an all-zeros tensor for a fresh sequence.
+    SelectiveSSM(const Output<Node>& A,
+                 const Output<Node>& dt,
+                 const Output<Node>& B,
+                 const Output<Node>& x,
+                 const Output<Node>& C,
+                 const Output<Node>& recurrent_state);
+
+    /// \brief Constructs a SelectiveSSM operation from input vector.
+    ///
+    /// \param args Input tensor vector in order: A, dt, B, x, C, recurrent_state.
+    explicit SelectiveSSM(const ov::OutputVector& args);
+
+    void validate_and_infer_types() override;
+    bool visit_attributes(AttributeVisitor& visitor) override;
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
+};
+
+}  // namespace ov::op::internal

--- a/src/core/dev_api/openvino/op/selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/selective_ssm.hpp
@@ -12,7 +12,7 @@ namespace ov::op::internal {
 ///
 /// Discretizes ``A`` (log-decay rates) and ``B`` (input projection) with ``dt`` (time steps) ahead of the
 /// recurrence: ``dA = exp(A * dt)``, ``dtB = dt * B``. Then, for each token ``t``:
-/// ``dBx_t = dtB_t (x) x_t``, ``state_t = state_{t-1} * dA_t + dBx_t``, ``y_t = sum(state_t * C_t)``.
+/// ``dBx_t = x_t (x) dtB_t``, ``state_t = state_{t-1} * dA_t + dBx_t``, ``y_t = sum(state_t * C_t)``.
 ///
 /// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
 /// ``g = h / heads_per_group``, where ``heads_per_group = num_heads / num_groups``.

--- a/src/core/shape_inference/CMakeLists.txt
+++ b/src/core/shape_inference/CMakeLists.txt
@@ -100,6 +100,7 @@ target_sources(${TARGET_NAME}
     ${SHAPE_INFER_INCLUDE_DIR}/paged_attention_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/paged_causal_conv1d_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/paged_gated_delta_net_shape_inference.hpp
+    ${SHAPE_INFER_INCLUDE_DIR}/paged_selective_ssm_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/pooling_shape_inference_util.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/prior_box_clustered_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/prior_box_shape_inference.hpp
@@ -130,6 +131,7 @@ target_sources(${TARGET_NAME}
     ${SHAPE_INFER_INCLUDE_DIR}/search_sorted_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/segment_max_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/select_shape_inference.hpp
+    ${SHAPE_INFER_INCLUDE_DIR}/selective_ssm_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/sequence_generator.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/shape_infer_type_utils.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/shape_nodes.hpp

--- a/src/core/shape_inference/include/paged_selective_ssm_shape_inference.hpp
+++ b/src/core/shape_inference/include/paged_selective_ssm_shape_inference.hpp
@@ -9,6 +9,16 @@
 
 namespace ov::op::internal {
 
+template <typename TDim>
+bool merge_paged_selective_ssm_dim(TDim& destination, bool& initialized, const TDim& source) {
+    if (!initialized) {
+        destination = source;
+        initialized = true;
+        return true;
+    }
+    return TDim::merge(destination, destination, source);
+}
+
 template <class T, class TRShape = result_shape_t<T>>
 std::vector<TRShape> shape_infer(const PagedSelectiveSSM* op, const std::vector<T>& input_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 11);
@@ -19,136 +29,132 @@ std::vector<TRShape> shape_infer(const PagedSelectiveSSM* op, const std::vector<
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[3].rank().compatible(3));
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[4].rank().compatible(3));
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[5].rank().compatible(4));
-    for (size_t i = 6; i < 11; ++i) {
-        NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[i].rank().compatible(1));
+    for (size_t input = 6; input < 11; ++input) {
+        NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[input].rank().compatible(1));
     }
 
-    const auto& A_ps = input_shapes[0];
-    const auto& dt_ps = input_shapes[1];
-    const auto& B_ps = input_shapes[2];
-    const auto& x_ps = input_shapes[3];
-    const auto& C_ps = input_shapes[4];
-    const auto& state_ps = input_shapes[5];
-    const auto& subsequence_begins_ps = input_shapes[6];
-    const auto& la_block_indices_ps = input_shapes[7];
-    const auto& la_block_indices_begins_ps = input_shapes[8];
-    const auto& num_processed_tokens_ps = input_shapes[9];
-    const auto& cache_interval_ps = input_shapes[10];
+    const auto& A_shape = input_shapes[0];
+    const auto& dt_shape = input_shapes[1];
+    const auto& B_shape = input_shapes[2];
+    const auto& x_shape = input_shapes[3];
+    const auto& C_shape = input_shapes[4];
+    const auto& state_shape = input_shapes[5];
+    const auto& subsequence_shape = input_shapes[6];
+    const auto& block_indices_begins_shape = input_shapes[8];
+    const auto& processed_shape = input_shapes[9];
+    const auto& interval_shape = input_shapes[10];
+    using DimType = typename T::value_type;
 
-    const auto A_rank_is_static = A_ps.rank().is_static();
-    const auto dt_rank_is_static = dt_ps.rank().is_static();
-    const auto B_rank_is_static = B_ps.rank().is_static();
-    const auto x_rank_is_static = x_ps.rank().is_static();
-    const auto C_rank_is_static = C_ps.rank().is_static();
-    const auto state_rank_is_static = state_ps.rank().is_static();
-    const auto subsequence_begins_rank_is_static = subsequence_begins_ps.rank().is_static();
-    const auto la_block_indices_rank_is_static = la_block_indices_ps.rank().is_static();
-    const auto la_block_indices_begins_rank_is_static = la_block_indices_begins_ps.rank().is_static();
-    const auto num_processed_tokens_rank_is_static = num_processed_tokens_ps.rank().is_static();
-    const auto cache_interval_rank_is_static = cache_interval_ps.rank().is_static();
+    DimType token_dim{};
+    DimType heads_dim{};
+    DimType head_dim{};
+    DimType groups_dim{};
+    DimType state_size_dim{};
 
-    Dimension token_dim, num_heads_dim, head_dim_dim, state_size_dim;
-
+    bool token_initialized = false;
     bool token_ok = true;
-    if (x_rank_is_static)
-        token_ok &= Dimension::merge(token_dim, token_dim, x_ps[0]);
-    if (dt_rank_is_static)
-        token_ok &= Dimension::merge(token_dim, token_dim, dt_ps[0]);
-    if (B_rank_is_static)
-        token_ok &= Dimension::merge(token_dim, token_dim, B_ps[0]);
-    if (C_rank_is_static)
-        token_ok &= Dimension::merge(token_dim, token_dim, C_ps[0]);
+    if (x_shape.rank().is_static())
+        token_ok &= merge_paged_selective_ssm_dim(token_dim, token_initialized, x_shape[0]);
+    if (dt_shape.rank().is_static())
+        token_ok &= merge_paged_selective_ssm_dim(token_dim, token_initialized, dt_shape[0]);
+    if (B_shape.rank().is_static())
+        token_ok &= merge_paged_selective_ssm_dim(token_dim, token_initialized, B_shape[0]);
+    if (C_shape.rank().is_static())
+        token_ok &= merge_paged_selective_ssm_dim(token_dim, token_initialized, C_shape[0]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            token_ok,
                            "The token dimension of `dt`, `B`, `x` and `C` should be the same.");
 
-    bool num_heads_ok = true;
-    if (x_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, x_ps[1]);
-    if (A_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, A_ps[0]);
-    if (dt_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, dt_ps[1]);
-    if (state_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, state_ps[1]);
+    bool heads_initialized = false;
+    bool heads_ok = true;
+    if (x_shape.rank().is_static())
+        heads_ok &= merge_paged_selective_ssm_dim(heads_dim, heads_initialized, x_shape[1]);
+    if (A_shape.rank().is_static())
+        heads_ok &= merge_paged_selective_ssm_dim(heads_dim, heads_initialized, A_shape[0]);
+    if (dt_shape.rank().is_static())
+        heads_ok &= merge_paged_selective_ssm_dim(heads_dim, heads_initialized, dt_shape[1]);
+    if (state_shape.rank().is_static())
+        heads_ok &= merge_paged_selective_ssm_dim(heads_dim, heads_initialized, state_shape[1]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
-                           num_heads_ok,
+                           heads_ok,
                            "The number of heads of `A`, `dt`, `x` and `recurrent_state_table` should be the same.");
 
-    if (B_rank_is_static && C_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               C_ps[1].compatible(B_ps[1]),
-                               "The number of groups of `B` and `C` should be the same.");
-    }
-
+    bool head_dim_initialized = false;
     bool head_dim_ok = true;
-    if (x_rank_is_static)
-        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, x_ps[2]);
-    if (state_rank_is_static)
-        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, state_ps[2]);
+    if (x_shape.rank().is_static())
+        head_dim_ok &= merge_paged_selective_ssm_dim(head_dim, head_dim_initialized, x_shape[2]);
+    if (state_shape.rank().is_static())
+        head_dim_ok &= merge_paged_selective_ssm_dim(head_dim, head_dim_initialized, state_shape[2]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            head_dim_ok,
                            "The head dimension of `x` and `recurrent_state_table` should be the same.");
 
+    bool groups_initialized = false;
+    bool groups_ok = true;
+    if (B_shape.rank().is_static())
+        groups_ok &= merge_paged_selective_ssm_dim(groups_dim, groups_initialized, B_shape[1]);
+    if (C_shape.rank().is_static())
+        groups_ok &= merge_paged_selective_ssm_dim(groups_dim, groups_initialized, C_shape[1]);
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, groups_ok, "The number of groups of `B` and `C` should be the same.");
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           groups_dim.is_dynamic() || groups_dim.get_length() > 0,
+                           "The number of groups must be greater than zero.");
+
+    bool state_size_initialized = false;
     bool state_size_ok = true;
-    if (state_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, state_ps[3]);
-    if (B_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, B_ps[2]);
-    if (C_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, C_ps[2]);
+    if (state_shape.rank().is_static())
+        state_size_ok &= merge_paged_selective_ssm_dim(state_size_dim, state_size_initialized, state_shape[3]);
+    if (B_shape.rank().is_static())
+        state_size_ok &= merge_paged_selective_ssm_dim(state_size_dim, state_size_initialized, B_shape[2]);
+    if (C_shape.rank().is_static())
+        state_size_ok &= merge_paged_selective_ssm_dim(state_size_dim, state_size_initialized, C_shape[2]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            state_size_ok,
                            "The state size of `B`, `C` and `recurrent_state_table` should be the same.");
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           state_size_dim.is_dynamic() || state_size_dim.get_length() > 0,
+                           "The state size must be greater than zero.");
 
-    if (num_heads_dim.is_static() && B_rank_is_static) {
-        const auto& num_groups = B_ps[1];
-        if (num_groups.is_static()) {
-            NODE_SHAPE_INFER_CHECK(
-                op,
-                input_shapes,
-                num_groups.get_length() != 0 && num_heads_dim.get_length() % num_groups.get_length() == 0,
-                "The number of heads should be divisible by the number of groups.");
-        }
-    }
-
-    if (la_block_indices_rank_is_static && state_rank_is_static) {
+    if (heads_dim.is_static() && groups_dim.is_static()) {
         NODE_SHAPE_INFER_CHECK(op,
                                input_shapes,
-                               la_block_indices_ps[0].compatible(state_ps[0]),
-                               "The number of blocks of `la_block_indices` and `recurrent_state_table` should "
-                               "be the same.");
-    }
-    if (subsequence_begins_rank_is_static && la_block_indices_begins_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               subsequence_begins_ps[0].compatible(la_block_indices_begins_ps[0]),
-                               "The number of sequences of `subsequence_begins` and `la_block_indices_begins` "
-                               "should be the same.");
-    }
-    if (num_processed_tokens_rank_is_static && cache_interval_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               num_processed_tokens_ps[0].compatible(cache_interval_ps[0]),
-                               "The number of sequences of `num_processed_tokens` and `cache_interval` should "
-                               "be the same.");
-    }
-    if (subsequence_begins_rank_is_static && num_processed_tokens_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               (subsequence_begins_ps[0] - Dimension(1)).compatible(num_processed_tokens_ps[0]),
-                               "The number of sequences of `subsequence_begins` and `num_processed_tokens` "
-                               "should be the same.");
+                               groups_dim.get_length() != 0 && heads_dim.get_length() % groups_dim.get_length() == 0,
+                               "The number of heads should be divisible by the number of groups.");
     }
 
-    auto output_shapes = std::vector<TRShape>{x_ps};
-    if (x_rank_is_static) {
-        output_shapes[0] = TRShape{token_dim, num_heads_dim, head_dim_dim};
+    if (subsequence_shape.rank().is_static() && block_indices_begins_shape.rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               subsequence_shape[0].compatible(block_indices_begins_shape[0]),
+                               "The sizes of `subsequence_begins` and `la_block_indices_begins` should be the same.");
+    }
+    if (processed_shape.rank().is_static() && interval_shape.rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               processed_shape[0].compatible(interval_shape[0]),
+                               "The sizes of `num_processed_tokens` and `cache_interval` should be the same.");
+    }
+    if (subsequence_shape.rank().is_static() && processed_shape.rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               subsequence_shape[0].is_dynamic() || subsequence_shape[0].get_length() >= 1,
+                               "The size of `subsequence_begins` must be at least one.");
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               (subsequence_shape[0] - DimType(1)).compatible(processed_shape[0]),
+                               "The size of `subsequence_begins` should be one larger than "
+                               "`num_processed_tokens`.");
+    }
+
+    auto output_shapes = std::vector<TRShape>{x_shape};
+    if (x_shape.rank().is_static()) {
+        output_shapes[0] = TRShape{token_dim, heads_dim, head_dim};
     }
     return output_shapes;
 }

--- a/src/core/shape_inference/include/paged_selective_ssm_shape_inference.hpp
+++ b/src/core/shape_inference/include/paged_selective_ssm_shape_inference.hpp
@@ -1,0 +1,156 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/paged_selective_ssm.hpp"
+#include "utils.hpp"
+
+namespace ov::op::internal {
+
+template <class T, class TRShape = result_shape_t<T>>
+std::vector<TRShape> shape_infer(const PagedSelectiveSSM* op, const std::vector<T>& input_shapes) {
+    NODE_VALIDATION_CHECK(op, input_shapes.size() == 11);
+
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[0].rank().compatible(1));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[1].rank().compatible(2));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[2].rank().compatible(3));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[3].rank().compatible(3));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[4].rank().compatible(3));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[5].rank().compatible(4));
+    for (size_t i = 6; i < 11; ++i) {
+        NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[i].rank().compatible(1));
+    }
+
+    const auto& A_ps = input_shapes[0];
+    const auto& dt_ps = input_shapes[1];
+    const auto& B_ps = input_shapes[2];
+    const auto& x_ps = input_shapes[3];
+    const auto& C_ps = input_shapes[4];
+    const auto& state_ps = input_shapes[5];
+    const auto& subsequence_begins_ps = input_shapes[6];
+    const auto& la_block_indices_ps = input_shapes[7];
+    const auto& la_block_indices_begins_ps = input_shapes[8];
+    const auto& num_processed_tokens_ps = input_shapes[9];
+    const auto& cache_interval_ps = input_shapes[10];
+
+    const auto A_rank_is_static = A_ps.rank().is_static();
+    const auto dt_rank_is_static = dt_ps.rank().is_static();
+    const auto B_rank_is_static = B_ps.rank().is_static();
+    const auto x_rank_is_static = x_ps.rank().is_static();
+    const auto C_rank_is_static = C_ps.rank().is_static();
+    const auto state_rank_is_static = state_ps.rank().is_static();
+    const auto subsequence_begins_rank_is_static = subsequence_begins_ps.rank().is_static();
+    const auto la_block_indices_rank_is_static = la_block_indices_ps.rank().is_static();
+    const auto la_block_indices_begins_rank_is_static = la_block_indices_begins_ps.rank().is_static();
+    const auto num_processed_tokens_rank_is_static = num_processed_tokens_ps.rank().is_static();
+    const auto cache_interval_rank_is_static = cache_interval_ps.rank().is_static();
+
+    Dimension token_dim, num_heads_dim, head_dim_dim, state_size_dim;
+
+    bool token_ok = true;
+    if (x_rank_is_static)
+        token_ok &= Dimension::merge(token_dim, token_dim, x_ps[0]);
+    if (dt_rank_is_static)
+        token_ok &= Dimension::merge(token_dim, token_dim, dt_ps[0]);
+    if (B_rank_is_static)
+        token_ok &= Dimension::merge(token_dim, token_dim, B_ps[0]);
+    if (C_rank_is_static)
+        token_ok &= Dimension::merge(token_dim, token_dim, C_ps[0]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           token_ok,
+                           "The token dimension of `dt`, `B`, `x` and `C` should be the same.");
+
+    bool num_heads_ok = true;
+    if (x_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, x_ps[1]);
+    if (A_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, A_ps[0]);
+    if (dt_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, dt_ps[1]);
+    if (state_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, state_ps[1]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           num_heads_ok,
+                           "The number of heads of `A`, `dt`, `x` and `recurrent_state_table` should be the same.");
+
+    if (B_rank_is_static && C_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               C_ps[1].compatible(B_ps[1]),
+                               "The number of groups of `B` and `C` should be the same.");
+    }
+
+    bool head_dim_ok = true;
+    if (x_rank_is_static)
+        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, x_ps[2]);
+    if (state_rank_is_static)
+        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, state_ps[2]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           head_dim_ok,
+                           "The head dimension of `x` and `recurrent_state_table` should be the same.");
+
+    bool state_size_ok = true;
+    if (state_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, state_ps[3]);
+    if (B_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, B_ps[2]);
+    if (C_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, C_ps[2]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           state_size_ok,
+                           "The state size of `B`, `C` and `recurrent_state_table` should be the same.");
+
+    if (num_heads_dim.is_static() && B_rank_is_static) {
+        const auto& num_groups = B_ps[1];
+        if (num_groups.is_static()) {
+            NODE_SHAPE_INFER_CHECK(
+                op,
+                input_shapes,
+                num_groups.get_length() != 0 && num_heads_dim.get_length() % num_groups.get_length() == 0,
+                "The number of heads should be divisible by the number of groups.");
+        }
+    }
+
+    if (la_block_indices_rank_is_static && state_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               la_block_indices_ps[0].compatible(state_ps[0]),
+                               "The number of blocks of `la_block_indices` and `recurrent_state_table` should "
+                               "be the same.");
+    }
+    if (subsequence_begins_rank_is_static && la_block_indices_begins_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               subsequence_begins_ps[0].compatible(la_block_indices_begins_ps[0]),
+                               "The number of sequences of `subsequence_begins` and `la_block_indices_begins` "
+                               "should be the same.");
+    }
+    if (num_processed_tokens_rank_is_static && cache_interval_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               num_processed_tokens_ps[0].compatible(cache_interval_ps[0]),
+                               "The number of sequences of `num_processed_tokens` and `cache_interval` should "
+                               "be the same.");
+    }
+    if (subsequence_begins_rank_is_static && num_processed_tokens_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               (subsequence_begins_ps[0] - Dimension(1)).compatible(num_processed_tokens_ps[0]),
+                               "The number of sequences of `subsequence_begins` and `num_processed_tokens` "
+                               "should be the same.");
+    }
+
+    auto output_shapes = std::vector<TRShape>{x_ps};
+    if (x_rank_is_static) {
+        output_shapes[0] = TRShape{token_dim, num_heads_dim, head_dim_dim};
+    }
+    return output_shapes;
+}
+
+}  // namespace ov::op::internal

--- a/src/core/shape_inference/include/selective_ssm_shape_inference.hpp
+++ b/src/core/shape_inference/include/selective_ssm_shape_inference.hpp
@@ -1,0 +1,130 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/selective_ssm.hpp"
+#include "utils.hpp"
+
+namespace ov::op::internal {
+
+template <class T, class TRShape = result_shape_t<T>>
+std::vector<TRShape> shape_infer(const SelectiveSSM* op, const std::vector<T>& input_shapes) {
+    NODE_VALIDATION_CHECK(op, input_shapes.size() == 6);
+
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[0].rank().compatible(1));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[1].rank().compatible(3));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[2].rank().compatible(4));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[3].rank().compatible(4));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[4].rank().compatible(4));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[5].rank().compatible(4));
+
+    const auto& A_ps = input_shapes[0];
+    const auto& dt_ps = input_shapes[1];
+    const auto& B_ps = input_shapes[2];
+    const auto& x_ps = input_shapes[3];
+    const auto& C_ps = input_shapes[4];
+    const auto& state_ps = input_shapes[5];
+
+    const auto A_rank_is_static = A_ps.rank().is_static();
+    const auto dt_rank_is_static = dt_ps.rank().is_static();
+    const auto B_rank_is_static = B_ps.rank().is_static();
+    const auto x_rank_is_static = x_ps.rank().is_static();
+    const auto C_rank_is_static = C_ps.rank().is_static();
+    const auto state_rank_is_static = state_ps.rank().is_static();
+
+    Dimension batch_dim, seq_len_dim, num_heads_dim, head_dim_dim, state_size_dim;
+
+    bool batch_ok = true;
+    if (x_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, x_ps[0]);
+    if (dt_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, dt_ps[0]);
+    if (B_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, B_ps[0]);
+    if (C_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, C_ps[0]);
+    if (state_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, state_ps[0]);
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, batch_ok, "The batch dimension of all inputs should be the same.");
+
+    bool seq_len_ok = true;
+    if (x_rank_is_static)
+        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, x_ps[1]);
+    if (dt_rank_is_static)
+        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, dt_ps[1]);
+    if (B_rank_is_static)
+        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, B_ps[1]);
+    if (C_rank_is_static)
+        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, C_ps[1]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           seq_len_ok,
+                           "The sequence length of `dt`, `B`, `x` and `C` should be the same.");
+
+    bool num_heads_ok = true;
+    if (x_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, x_ps[2]);
+    if (A_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, A_ps[0]);
+    if (dt_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, dt_ps[2]);
+    if (state_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, state_ps[1]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           num_heads_ok,
+                           "The number of heads of `A`, `dt`, `x` and `recurrent_state` should be the same.");
+
+    bool head_dim_ok = true;
+    if (x_rank_is_static)
+        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, x_ps[3]);
+    if (state_rank_is_static)
+        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, state_ps[2]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           head_dim_ok,
+                           "The head dimension of `x` and `recurrent_state` should be the same.");
+
+    if (B_rank_is_static && C_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               C_ps[2].compatible(B_ps[2]),
+                               "The number of groups of `B` and `C` should be the same.");
+    }
+
+    bool state_size_ok = true;
+    if (state_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, state_ps[3]);
+    if (B_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, B_ps[3]);
+    if (C_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, C_ps[3]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           state_size_ok,
+                           "The state size of `B`, `C` and `recurrent_state` should be the same.");
+
+    if (num_heads_dim.is_static() && B_rank_is_static) {
+        const auto& num_groups = B_ps[2];
+        if (num_groups.is_static()) {
+            NODE_SHAPE_INFER_CHECK(
+                op,
+                input_shapes,
+                num_groups.get_length() != 0 && num_heads_dim.get_length() % num_groups.get_length() == 0,
+                "The number of heads should be divisible by the number of groups.");
+        }
+    }
+
+    auto output_shapes = std::vector<TRShape>{x_ps, state_ps};
+    if (x_rank_is_static) {
+        output_shapes[0] = TRShape{batch_dim, seq_len_dim, num_heads_dim, head_dim_dim};
+    }
+    if (state_rank_is_static) {
+        output_shapes[1] = TRShape{batch_dim, num_heads_dim, head_dim_dim, state_size_dim};
+    }
+    return output_shapes;
+}
+
+}  // namespace ov::op::internal

--- a/src/core/shape_inference/include/selective_ssm_shape_inference.hpp
+++ b/src/core/shape_inference/include/selective_ssm_shape_inference.hpp
@@ -9,6 +9,16 @@
 
 namespace ov::op::internal {
 
+template <typename TDim>
+bool merge_selective_ssm_dim(TDim& destination, bool& initialized, const TDim& source) {
+    if (!initialized) {
+        destination = source;
+        initialized = true;
+        return true;
+    }
+    return TDim::merge(destination, destination, source);
+}
+
 template <class T, class TRShape = result_shape_t<T>>
 std::vector<TRShape> shape_infer(const SelectiveSSM* op, const std::vector<T>& input_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 6);
@@ -20,109 +30,121 @@ std::vector<TRShape> shape_infer(const SelectiveSSM* op, const std::vector<T>& i
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[4].rank().compatible(4));
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[5].rank().compatible(4));
 
-    const auto& A_ps = input_shapes[0];
-    const auto& dt_ps = input_shapes[1];
-    const auto& B_ps = input_shapes[2];
-    const auto& x_ps = input_shapes[3];
-    const auto& C_ps = input_shapes[4];
-    const auto& state_ps = input_shapes[5];
+    const auto& A_shape = input_shapes[0];
+    const auto& dt_shape = input_shapes[1];
+    const auto& B_shape = input_shapes[2];
+    const auto& x_shape = input_shapes[3];
+    const auto& C_shape = input_shapes[4];
+    const auto& state_shape = input_shapes[5];
+    using DimType = typename T::value_type;
 
-    const auto A_rank_is_static = A_ps.rank().is_static();
-    const auto dt_rank_is_static = dt_ps.rank().is_static();
-    const auto B_rank_is_static = B_ps.rank().is_static();
-    const auto x_rank_is_static = x_ps.rank().is_static();
-    const auto C_rank_is_static = C_ps.rank().is_static();
-    const auto state_rank_is_static = state_ps.rank().is_static();
+    DimType batch_dim{};
+    DimType sequence_dim{};
+    DimType heads_dim{};
+    DimType head_dim{};
+    DimType groups_dim{};
+    DimType state_size_dim{};
 
-    Dimension batch_dim, seq_len_dim, num_heads_dim, head_dim_dim, state_size_dim;
-
+    bool batch_initialized = false;
     bool batch_ok = true;
-    if (x_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, x_ps[0]);
-    if (dt_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, dt_ps[0]);
-    if (B_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, B_ps[0]);
-    if (C_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, C_ps[0]);
-    if (state_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, state_ps[0]);
-    NODE_SHAPE_INFER_CHECK(op, input_shapes, batch_ok, "The batch dimension of all inputs should be the same.");
-
-    bool seq_len_ok = true;
-    if (x_rank_is_static)
-        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, x_ps[1]);
-    if (dt_rank_is_static)
-        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, dt_ps[1]);
-    if (B_rank_is_static)
-        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, B_ps[1]);
-    if (C_rank_is_static)
-        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, C_ps[1]);
+    if (x_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, x_shape[0]);
+    if (dt_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, dt_shape[0]);
+    if (B_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, B_shape[0]);
+    if (C_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, C_shape[0]);
+    if (state_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, state_shape[0]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
-                           seq_len_ok,
+                           batch_ok,
+                           "The batch dimension of `dt`, `B`, `x`, `C` and `recurrent_state` should be the same.");
+
+    bool sequence_initialized = false;
+    bool sequence_ok = true;
+    if (x_shape.rank().is_static())
+        sequence_ok &= merge_selective_ssm_dim(sequence_dim, sequence_initialized, x_shape[1]);
+    if (dt_shape.rank().is_static())
+        sequence_ok &= merge_selective_ssm_dim(sequence_dim, sequence_initialized, dt_shape[1]);
+    if (B_shape.rank().is_static())
+        sequence_ok &= merge_selective_ssm_dim(sequence_dim, sequence_initialized, B_shape[1]);
+    if (C_shape.rank().is_static())
+        sequence_ok &= merge_selective_ssm_dim(sequence_dim, sequence_initialized, C_shape[1]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           sequence_ok,
                            "The sequence length of `dt`, `B`, `x` and `C` should be the same.");
 
-    bool num_heads_ok = true;
-    if (x_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, x_ps[2]);
-    if (A_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, A_ps[0]);
-    if (dt_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, dt_ps[2]);
-    if (state_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, state_ps[1]);
+    bool heads_initialized = false;
+    bool heads_ok = true;
+    if (x_shape.rank().is_static())
+        heads_ok &= merge_selective_ssm_dim(heads_dim, heads_initialized, x_shape[2]);
+    if (A_shape.rank().is_static())
+        heads_ok &= merge_selective_ssm_dim(heads_dim, heads_initialized, A_shape[0]);
+    if (dt_shape.rank().is_static())
+        heads_ok &= merge_selective_ssm_dim(heads_dim, heads_initialized, dt_shape[2]);
+    if (state_shape.rank().is_static())
+        heads_ok &= merge_selective_ssm_dim(heads_dim, heads_initialized, state_shape[1]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
-                           num_heads_ok,
+                           heads_ok,
                            "The number of heads of `A`, `dt`, `x` and `recurrent_state` should be the same.");
 
+    bool head_dim_initialized = false;
     bool head_dim_ok = true;
-    if (x_rank_is_static)
-        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, x_ps[3]);
-    if (state_rank_is_static)
-        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, state_ps[2]);
+    if (x_shape.rank().is_static())
+        head_dim_ok &= merge_selective_ssm_dim(head_dim, head_dim_initialized, x_shape[3]);
+    if (state_shape.rank().is_static())
+        head_dim_ok &= merge_selective_ssm_dim(head_dim, head_dim_initialized, state_shape[2]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            head_dim_ok,
                            "The head dimension of `x` and `recurrent_state` should be the same.");
 
-    if (B_rank_is_static && C_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               C_ps[2].compatible(B_ps[2]),
-                               "The number of groups of `B` and `C` should be the same.");
-    }
+    bool groups_initialized = false;
+    bool groups_ok = true;
+    if (B_shape.rank().is_static())
+        groups_ok &= merge_selective_ssm_dim(groups_dim, groups_initialized, B_shape[2]);
+    if (C_shape.rank().is_static())
+        groups_ok &= merge_selective_ssm_dim(groups_dim, groups_initialized, C_shape[2]);
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, groups_ok, "The number of groups of `B` and `C` should be the same.");
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           groups_dim.is_dynamic() || groups_dim.get_length() > 0,
+                           "The number of groups must be greater than zero.");
 
+    bool state_size_initialized = false;
     bool state_size_ok = true;
-    if (state_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, state_ps[3]);
-    if (B_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, B_ps[3]);
-    if (C_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, C_ps[3]);
+    if (state_shape.rank().is_static())
+        state_size_ok &= merge_selective_ssm_dim(state_size_dim, state_size_initialized, state_shape[3]);
+    if (B_shape.rank().is_static())
+        state_size_ok &= merge_selective_ssm_dim(state_size_dim, state_size_initialized, B_shape[3]);
+    if (C_shape.rank().is_static())
+        state_size_ok &= merge_selective_ssm_dim(state_size_dim, state_size_initialized, C_shape[3]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            state_size_ok,
                            "The state size of `B`, `C` and `recurrent_state` should be the same.");
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           state_size_dim.is_dynamic() || state_size_dim.get_length() > 0,
+                           "The state size must be greater than zero.");
 
-    if (num_heads_dim.is_static() && B_rank_is_static) {
-        const auto& num_groups = B_ps[2];
-        if (num_groups.is_static()) {
-            NODE_SHAPE_INFER_CHECK(
-                op,
-                input_shapes,
-                num_groups.get_length() != 0 && num_heads_dim.get_length() % num_groups.get_length() == 0,
-                "The number of heads should be divisible by the number of groups.");
-        }
+    if (heads_dim.is_static() && groups_dim.is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               groups_dim.get_length() != 0 && heads_dim.get_length() % groups_dim.get_length() == 0,
+                               "The number of heads should be divisible by the number of groups.");
     }
 
-    auto output_shapes = std::vector<TRShape>{x_ps, state_ps};
-    if (x_rank_is_static) {
-        output_shapes[0] = TRShape{batch_dim, seq_len_dim, num_heads_dim, head_dim_dim};
+    auto output_shapes = std::vector<TRShape>{x_shape, state_shape};
+    if (x_shape.rank().is_static()) {
+        output_shapes[0] = TRShape{batch_dim, sequence_dim, heads_dim, head_dim};
     }
-    if (state_rank_is_static) {
-        output_shapes[1] = TRShape{batch_dim, num_heads_dim, head_dim_dim, state_size_dim};
+    if (state_shape.rank().is_static()) {
+        output_shapes[1] = TRShape{batch_dim, heads_dim, head_dim, state_size_dim};
     }
     return output_shapes;
 }

--- a/src/core/src/op/paged_selective_ssm.cpp
+++ b/src/core/src/op/paged_selective_ssm.cpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/paged_selective_ssm.hpp"
+
+#include "itt.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/op.hpp"
+#include "paged_selective_ssm_shape_inference.hpp"
+
+namespace ov::op::internal {
+
+PagedSelectiveSSM::PagedSelectiveSSM(const Output<Node>& A,
+                                     const Output<Node>& dt,
+                                     const Output<Node>& B,
+                                     const Output<Node>& x,
+                                     const Output<Node>& C,
+                                     const Output<Node>& recurrent_state_table,
+                                     const Output<Node>& subsequence_begins,
+                                     const Output<Node>& la_block_indices,
+                                     const Output<Node>& la_block_indices_begins,
+                                     const Output<Node>& num_processed_tokens,
+                                     const Output<Node>& cache_interval)
+    : Op({A,
+          dt,
+          B,
+          x,
+          C,
+          recurrent_state_table,
+          subsequence_begins,
+          la_block_indices,
+          la_block_indices_begins,
+          num_processed_tokens,
+          cache_interval}) {
+    constructor_validate_and_infer_types();
+}
+
+PagedSelectiveSSM::PagedSelectiveSSM(const ov::OutputVector& args) : ov::op::Op(args) {
+    constructor_validate_and_infer_types();
+}
+
+void PagedSelectiveSSM::validate_and_infer_types() {
+    OV_OP_SCOPE(PagedSelectiveSSM_validate_and_infer_types);
+    NODE_VALIDATION_CHECK(this, get_input_size() == 11);
+
+    ov::element::Type common_float_type = get_input_element_type(0);
+    const bool float_types_merge =
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(4));
+    NODE_VALIDATION_CHECK(this,
+                          float_types_merge,
+                          "PagedSelectiveSSM expects A, dt, B, x, and C to have the same element type.");
+    NODE_VALIDATION_CHECK(this,
+                          common_float_type.is_dynamic() || common_float_type.is_real(),
+                          "Float inputs must have a floating-point element type.");
+
+    // recurrent_state_table (5) is an in-place state cache and is allowed to use an independent float
+    // element type so plugins can maintain lower-precision state without breaking in-place semantics.
+    const auto& state_et = get_input_element_type(5);
+    NODE_VALIDATION_CHECK(this,
+                          state_et.is_dynamic() || state_et.is_real(),
+                          "Float inputs must have a floating-point element type.");
+    for (size_t i = 6; i < 11; ++i) {
+        const auto& et = get_input_element_type(i);
+        NODE_VALIDATION_CHECK(this,
+                              et.is_dynamic() || et == ov::element::i32 || et == ov::element::i64,
+                              "Integer inputs must have i32 or i64 element type.");
+    }
+
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
+    set_output_type(0, common_float_type, output_shapes[0]);
+}
+
+bool PagedSelectiveSSM::visit_attributes(AttributeVisitor&) {
+    OV_OP_SCOPE(PagedSelectiveSSM_visit_attributes);
+    return true;
+}
+
+std::shared_ptr<ov::Node> PagedSelectiveSSM::clone_with_new_inputs(const ov::OutputVector& new_args) const {
+    OV_OP_SCOPE(PagedSelectiveSSM_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    return std::make_shared<PagedSelectiveSSM>(new_args);
+}
+
+}  // namespace ov::op::internal

--- a/src/core/src/op/paged_selective_ssm.cpp
+++ b/src/core/src/op/paged_selective_ssm.cpp
@@ -42,33 +42,39 @@ PagedSelectiveSSM::PagedSelectiveSSM(const ov::OutputVector& args) : ov::op::Op(
 
 void PagedSelectiveSSM::validate_and_infer_types() {
     OV_OP_SCOPE(PagedSelectiveSSM_validate_and_infer_types);
-    NODE_VALIDATION_CHECK(this, get_input_size() == 11);
+    NODE_VALIDATION_CHECK(this,
+                          get_input_size() == 11,
+                          "PagedSelectiveSSM expects 11 inputs, but it has ",
+                          get_input_size());
 
     ov::element::Type common_float_type = get_input_element_type(0);
-    const bool float_types_merge =
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(4));
+    bool float_types_merge = true;
+    for (size_t input = 1; input < 6; ++input) {
+        float_types_merge &=
+            ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(input));
+    }
     NODE_VALIDATION_CHECK(this,
                           float_types_merge,
-                          "PagedSelectiveSSM expects A, dt, B, x, and C to have the same element type.");
+                          "PagedSelectiveSSM expects inputs A, dt, B, x, C and recurrent_state_table to have the "
+                          "same element type.");
     NODE_VALIDATION_CHECK(this,
-                          common_float_type.is_dynamic() || common_float_type.is_real(),
-                          "Float inputs must have a floating-point element type.");
+                          common_float_type.is_dynamic() || common_float_type == ov::element::f32 ||
+                              common_float_type == ov::element::f16 || common_float_type == ov::element::bf16,
+                          "PagedSelectiveSSM data inputs must have f32, f16, or bf16 element type.");
 
-    // recurrent_state_table (5) is an in-place state cache and is allowed to use an independent float
-    // element type so plugins can maintain lower-precision state without breaking in-place semantics.
-    const auto& state_et = get_input_element_type(5);
-    NODE_VALIDATION_CHECK(this,
-                          state_et.is_dynamic() || state_et.is_real(),
-                          "Float inputs must have a floating-point element type.");
-    for (size_t i = 6; i < 11; ++i) {
-        const auto& et = get_input_element_type(i);
-        NODE_VALIDATION_CHECK(this,
-                              et.is_dynamic() || et == ov::element::i32 || et == ov::element::i64,
-                              "Integer inputs must have i32 or i64 element type.");
+    ov::element::Type common_index_type = get_input_element_type(6);
+    bool index_types_merge = true;
+    for (size_t input = 7; input < 11; ++input) {
+        index_types_merge &=
+            ov::element::Type::merge(common_index_type, common_index_type, get_input_element_type(input));
     }
+    NODE_VALIDATION_CHECK(this,
+                          index_types_merge,
+                          "PagedSelectiveSSM expects all metadata inputs to have the same element type.");
+    NODE_VALIDATION_CHECK(this,
+                          common_index_type.is_dynamic() || common_index_type == ov::element::i32 ||
+                              common_index_type == ov::element::i64,
+                          "PagedSelectiveSSM metadata inputs must have i32 or i64 element type.");
 
     const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
     set_output_type(0, common_float_type, output_shapes[0]);

--- a/src/core/src/op/selective_ssm.cpp
+++ b/src/core/src/op/selective_ssm.cpp
@@ -30,28 +30,20 @@ void SelectiveSSM::validate_and_infer_types() {
     NODE_VALIDATION_CHECK(this, get_input_size() == 6, "SelectiveSSM expects 6 inputs, but it has ", get_input_size());
 
     ov::element::Type common_float_type = get_input_element_type(0);
-    const bool float_types_merge =
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(4));
+    bool float_types_merge = true;
+    for (size_t input = 1; input < 6; ++input) {
+        float_types_merge &=
+            ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(input));
+    }
+    NODE_VALIDATION_CHECK(this, float_types_merge, "SelectiveSSM expects all inputs to have the same element type.");
     NODE_VALIDATION_CHECK(this,
-                          float_types_merge,
-                          "SelectiveSSM expects A, dt, B, x, and C to have the same element type.");
-    NODE_VALIDATION_CHECK(this,
-                          common_float_type.is_dynamic() || common_float_type.is_real(),
-                          "Float inputs must have a floating-point element type.");
-
-    // recurrent_state (5) is an in-place state cache and is allowed to use an independent float
-    // element type so plugins can maintain lower-precision state without breaking in-place semantics.
-    const auto& state_et = get_input_element_type(5);
-    NODE_VALIDATION_CHECK(this,
-                          state_et.is_dynamic() || state_et.is_real(),
-                          "Float inputs must have a floating-point element type.");
+                          common_float_type.is_dynamic() || common_float_type == ov::element::f32 ||
+                              common_float_type == ov::element::f16 || common_float_type == ov::element::bf16,
+                          "SelectiveSSM inputs must have f32, f16, or bf16 element type.");
 
     const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
     set_output_type(0, common_float_type, output_shapes[0]);
-    set_output_type(1, state_et, output_shapes[1]);
+    set_output_type(1, common_float_type, output_shapes[1]);
 }
 
 bool SelectiveSSM::visit_attributes(AttributeVisitor&) {

--- a/src/core/src/op/selective_ssm.cpp
+++ b/src/core/src/op/selective_ssm.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/selective_ssm.hpp"
+
+#include "itt.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/op.hpp"
+#include "selective_ssm_shape_inference.hpp"
+
+namespace ov::op::internal {
+
+SelectiveSSM::SelectiveSSM(const Output<Node>& A,
+                           const Output<Node>& dt,
+                           const Output<Node>& B,
+                           const Output<Node>& x,
+                           const Output<Node>& C,
+                           const Output<Node>& recurrent_state)
+    : Op({A, dt, B, x, C, recurrent_state}) {
+    constructor_validate_and_infer_types();
+}
+
+SelectiveSSM::SelectiveSSM(const ov::OutputVector& args) : ov::op::Op(args) {
+    constructor_validate_and_infer_types();
+}
+
+void SelectiveSSM::validate_and_infer_types() {
+    OV_OP_SCOPE(SelectiveSSM_validate_and_infer_types);
+    NODE_VALIDATION_CHECK(this, get_input_size() == 6, "SelectiveSSM expects 6 inputs, but it has ", get_input_size());
+
+    ov::element::Type common_float_type = get_input_element_type(0);
+    const bool float_types_merge =
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(4));
+    NODE_VALIDATION_CHECK(this,
+                          float_types_merge,
+                          "SelectiveSSM expects A, dt, B, x, and C to have the same element type.");
+    NODE_VALIDATION_CHECK(this,
+                          common_float_type.is_dynamic() || common_float_type.is_real(),
+                          "Float inputs must have a floating-point element type.");
+
+    // recurrent_state (5) is an in-place state cache and is allowed to use an independent float
+    // element type so plugins can maintain lower-precision state without breaking in-place semantics.
+    const auto& state_et = get_input_element_type(5);
+    NODE_VALIDATION_CHECK(this,
+                          state_et.is_dynamic() || state_et.is_real(),
+                          "Float inputs must have a floating-point element type.");
+
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
+    set_output_type(0, common_float_type, output_shapes[0]);
+    set_output_type(1, state_et, output_shapes[1]);
+}
+
+bool SelectiveSSM::visit_attributes(AttributeVisitor&) {
+    OV_OP_SCOPE(SelectiveSSM_visit_attributes);
+    return true;
+}
+
+std::shared_ptr<ov::Node> SelectiveSSM::clone_with_new_inputs(const ov::OutputVector& new_args) const {
+    check_new_args_count(this, new_args);
+    return std::make_shared<SelectiveSSM>(new_args);
+}
+
+}  // namespace ov::op::internal

--- a/src/core/src/sources.cmake
+++ b/src/core/src/sources.cmake
@@ -187,6 +187,7 @@ set(LIBRARY_SRC
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_attention.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_causal_conv1d.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_gated_delta_net.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/paged_selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/parameter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/power.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/prelu.cpp
@@ -229,6 +230,7 @@ set(LIBRARY_SRC
     ${CMAKE_CURRENT_LIST_DIR}/op/search_sorted.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/segment_max.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/select.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/selu.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/shape_of.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/shuffle_channels.cpp

--- a/src/core/tests/type_prop/paged_selective_ssm.cpp
+++ b/src/core/tests/type_prop/paged_selective_ssm.cpp
@@ -75,7 +75,7 @@ TEST(type_prop, paged_selective_ssm_partial_shape_infer) {
     EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
 }
 
-TEST(type_prop, paged_selective_ssm_state_type_may_differ) {
+TEST(type_prop, paged_selective_ssm_state_type_must_match) {
     auto A_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
     auto dt_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 4});
     auto B_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 2, 16});
@@ -88,18 +88,19 @@ TEST(type_prop, paged_selective_ssm_state_type_may_differ) {
     auto processed = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
     auto cache_interval = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
 
-    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(OutputVector{A_p,
-                                                                                   dt_p,
-                                                                                   B_p,
-                                                                                   x_p,
-                                                                                   C_p,
-                                                                                   state_p,
-                                                                                   subseq,
-                                                                                   block_idx,
-                                                                                   block_idx_begins,
-                                                                                   processed,
-                                                                                   cache_interval});
-    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(OutputVector{A_p,
+                                                                                                 dt_p,
+                                                                                                 B_p,
+                                                                                                 x_p,
+                                                                                                 C_p,
+                                                                                                 state_p,
+                                                                                                 subseq,
+                                                                                                 block_idx,
+                                                                                                 block_idx_begins,
+                                                                                                 processed,
+                                                                                                 cache_interval}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("recurrent_state_table to have the same element type."));
 }
 
 TEST(type_prop, paged_selective_ssm_bad_index_type) {
@@ -112,7 +113,35 @@ TEST(type_prop, paged_selective_ssm_bad_index_type) {
                                                            Shape{6, 2, 16},
                                                            Shape{3, 4, 8, 16}),
                     NodeValidationFailure,
-                    testing::HasSubstr("Integer inputs must have i32 or i64 element type."));
+                    testing::HasSubstr("metadata inputs must have i32 or i64 element type."));
+}
+
+TEST(type_prop, paged_selective_ssm_f16_and_bf16_accepted) {
+    for (const auto& et : {element::f16, element::bf16}) {
+        const auto op = make_paged_selective_ssm(et,
+                                                 element::i32,
+                                                 Shape{4},
+                                                 Shape{6, 4},
+                                                 Shape{6, 2, 16},
+                                                 Shape{6, 4, 8},
+                                                 Shape{6, 2, 16},
+                                                 Shape{3, 4, 8, 16});
+
+        EXPECT_EQ(op->get_output_element_type(0), et);
+    }
+}
+
+TEST(type_prop, paged_selective_ssm_unsupported_float_type) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f64,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("PagedSelectiveSSM data inputs must have f32, f16, or bf16 element type."));
 }
 
 TEST(type_prop, paged_selective_ssm_heads_not_divisible_by_groups) {
@@ -302,7 +331,7 @@ TEST(type_prop, paged_selective_ssm_state_size_mismatch) {
                     testing::HasSubstr("The state size of `B`, `C` and `recurrent_state_table` should be the same."));
 }
 
-TEST(type_prop, paged_selective_ssm_block_indices_num_blocks_mismatch) {
+TEST(type_prop, paged_selective_ssm_logical_and_physical_block_counts_are_independent) {
     auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
     auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
     auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
@@ -315,12 +344,28 @@ TEST(type_prop, paged_selective_ssm_block_indices_num_blocks_mismatch) {
     auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
     auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
 
-    OV_EXPECT_THROW(
-        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
-            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
-        NodeValidationFailure,
-        testing::HasSubstr("The number of blocks of `la_block_indices` and `recurrent_state_table` should be the "
-                           "same."));
+    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(
+        OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval});
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
+}
+
+TEST(type_prop, paged_selective_ssm_over_provisioned_state_table) {
+    // The table may carry more physical rows than the logical slots addressing it.
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{12, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{7});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
+
+    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(
+        OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval});
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
 }
 
 TEST(type_prop, paged_selective_ssm_subsequence_and_block_begins_mismatch) {
@@ -340,8 +385,7 @@ TEST(type_prop, paged_selective_ssm_subsequence_and_block_begins_mismatch) {
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr("The number of sequences of `subsequence_begins` and `la_block_indices_begins` should "
-                           "be the same."));
+        testing::HasSubstr("The sizes of `subsequence_begins` and `la_block_indices_begins` should be the same."));
 }
 
 TEST(type_prop, paged_selective_ssm_processed_tokens_and_cache_interval_mismatch) {
@@ -361,8 +405,7 @@ TEST(type_prop, paged_selective_ssm_processed_tokens_and_cache_interval_mismatch
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr(
-            "The number of sequences of `num_processed_tokens` and `cache_interval` should be the same."));
+        testing::HasSubstr("The sizes of `num_processed_tokens` and `cache_interval` should be the same."));
 }
 
 TEST(type_prop, paged_selective_ssm_subsequence_begins_and_processed_tokens_mismatch) {
@@ -382,8 +425,7 @@ TEST(type_prop, paged_selective_ssm_subsequence_begins_and_processed_tokens_mism
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr(
-            "The number of sequences of `subsequence_begins` and `num_processed_tokens` should be the same."));
+        testing::HasSubstr("The size of `subsequence_begins` should be one larger than `num_processed_tokens`."));
 }
 
 TEST(type_prop, paged_selective_ssm_zero_groups) {
@@ -396,7 +438,7 @@ TEST(type_prop, paged_selective_ssm_zero_groups) {
                                                            Shape{6, 0, 16},
                                                            Shape{3, 4, 8, 16}),
                     NodeValidationFailure,
-                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+                    testing::HasSubstr("The number of groups must be greater than zero."));
 }
 
 TEST(type_prop, paged_selective_ssm_dynamic_rank_input_accepted) {
@@ -426,6 +468,33 @@ TEST(type_prop, paged_selective_ssm_dynamic_num_groups_skips_divisibility_check)
     EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{6, 4, 8}));
 }
 
+TEST(type_prop, paged_selective_ssm_asymmetric_num_groups_checks_divisibility) {
+    // The group count is dynamic in `B` but pinned by `C`, so the merged value must drive the check.
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           PartialShape{6, -1, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 3, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, paged_selective_ssm_asymmetric_num_groups_accepted) {
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             PartialShape{6, -1, 16},
+                                             Shape{6, 4, 8},
+                                             Shape{6, 2, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{6, 4, 8}));
+}
+
 TEST(type_prop, paged_selective_ssm_type_mismatch) {
     auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
     auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
@@ -443,7 +512,8 @@ TEST(type_prop, paged_selective_ssm_type_mismatch) {
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr("PagedSelectiveSSM expects A, dt, B, x, and C to have the same element type."));
+        testing::HasSubstr("PagedSelectiveSSM expects inputs A, dt, B, x, C and recurrent_state_table to have the same "
+                           "element type."));
 }
 
 TEST(type_prop, paged_selective_ssm_state_float_type_invalid) {
@@ -463,7 +533,7 @@ TEST(type_prop, paged_selective_ssm_state_float_type_invalid) {
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr("Float inputs must have a floating-point element type."));
+        testing::HasSubstr("recurrent_state_table to have the same element type."));
 }
 
 TEST(type_prop, paged_selective_ssm_index_type_mixed) {
@@ -483,7 +553,7 @@ TEST(type_prop, paged_selective_ssm_index_type_mixed) {
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr("Integer inputs must have i32 or i64 element type."));
+        testing::HasSubstr("expects all metadata inputs to have the same element type."));
 }
 
 }  // namespace ov::test

--- a/src/core/tests/type_prop/paged_selective_ssm.cpp
+++ b/src/core/tests/type_prop/paged_selective_ssm.cpp
@@ -1,0 +1,489 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/paged_selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/openvino.hpp"
+
+namespace ov::test {
+namespace {
+
+std::shared_ptr<op::internal::PagedSelectiveSSM> make_paged_selective_ssm(const element::Type& et,
+                                                                          const element::Type& ind_et,
+                                                                          const PartialShape& A,
+                                                                          const PartialShape& dt,
+                                                                          const PartialShape& B,
+                                                                          const PartialShape& x,
+                                                                          const PartialShape& C,
+                                                                          const PartialShape& state) {
+    auto A_p = std::make_shared<op::v0::Parameter>(et, A);
+    auto dt_p = std::make_shared<op::v0::Parameter>(et, dt);
+    auto B_p = std::make_shared<op::v0::Parameter>(et, B);
+    auto x_p = std::make_shared<op::v0::Parameter>(et, x);
+    auto C_p = std::make_shared<op::v0::Parameter>(et, C);
+    auto state_p = std::make_shared<op::v0::Parameter>(et, state);
+    auto subseq = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+
+    return std::make_shared<op::internal::PagedSelectiveSSM>(OutputVector{A_p,
+                                                                          dt_p,
+                                                                          B_p,
+                                                                          x_p,
+                                                                          C_p,
+                                                                          state_p,
+                                                                          subseq,
+                                                                          block_idx,
+                                                                          block_idx_begins,
+                                                                          processed,
+                                                                          cache_interval});
+}
+
+}  // namespace
+
+TEST(type_prop, paged_selective_ssm_static_f32) {
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             Shape{6, 2, 16},
+                                             Shape{6, 4, 8},
+                                             Shape{6, 2, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
+}
+
+TEST(type_prop, paged_selective_ssm_partial_shape_infer) {
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             Shape{6, 2, 16},
+                                             PartialShape{-1, -1, 8},
+                                             Shape{6, 2, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
+}
+
+TEST(type_prop, paged_selective_ssm_state_type_may_differ) {
+    auto A_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
+    auto dt_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 4});
+    auto B_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 2, 16});
+    auto x_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 4, 8});
+    auto C_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 2, 16});
+    auto state_p = std::make_shared<op::v0::Parameter>(element::bf16, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+
+    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(OutputVector{A_p,
+                                                                                   dt_p,
+                                                                                   B_p,
+                                                                                   x_p,
+                                                                                   C_p,
+                                                                                   state_p,
+                                                                                   subseq,
+                                                                                   block_idx,
+                                                                                   block_idx_begins,
+                                                                                   processed,
+                                                                                   cache_interval});
+    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+}
+
+TEST(type_prop, paged_selective_ssm_bad_index_type) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::f32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("Integer inputs must have i32 or i64 element type."));
+}
+
+TEST(type_prop, paged_selective_ssm_heads_not_divisible_by_groups) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 3, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 3, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, paged_selective_ssm_wrong_input_count) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    EXPECT_THROW(std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+                     OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_A_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4, 1},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_dt_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4, 1},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_B_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_x_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_C_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_state_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_index_rank) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1, -1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_batch_tokens_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{7, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The token dimension of `dt`, `B`, `x` and `C` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_num_heads_mismatch) {
+    OV_EXPECT_THROW(
+        std::ignore = make_paged_selective_ssm(element::f32,
+                                               element::i32,
+                                               Shape{5},
+                                               Shape{6, 4},
+                                               Shape{6, 2, 16},
+                                               Shape{6, 4, 8},
+                                               Shape{6, 2, 16},
+                                               Shape{3, 4, 8, 16}),
+        NodeValidationFailure,
+        testing::HasSubstr("The number of heads of `A`, `dt`, `x` and `recurrent_state_table` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_num_groups_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 3, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of groups of `B` and `C` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_head_dim_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 16},
+                                                           Shape{3, 4, 10, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The head dimension of `x` and `recurrent_state_table` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_state_size_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 32},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The state size of `B`, `C` and `recurrent_state_table` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_block_indices_num_blocks_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{5});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("The number of blocks of `la_block_indices` and `recurrent_state_table` should be the "
+                           "same."));
+}
+
+TEST(type_prop, paged_selective_ssm_subsequence_and_block_begins_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("The number of sequences of `subsequence_begins` and `la_block_indices_begins` should "
+                           "be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_processed_tokens_and_cache_interval_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr(
+            "The number of sequences of `num_processed_tokens` and `cache_interval` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_subsequence_begins_and_processed_tokens_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr(
+            "The number of sequences of `subsequence_begins` and `num_processed_tokens` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_zero_groups) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 0, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 0, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, paged_selective_ssm_dynamic_rank_input_accepted) {
+    // Dynamic rank inputs are accepted since they may be folded to a static rank later.
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             Shape{6, 2, 16},
+                                             PartialShape::dynamic(),
+                                             Shape{6, 2, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_TRUE(op->get_output_partial_shape(0).rank().is_dynamic());
+}
+
+TEST(type_prop, paged_selective_ssm_dynamic_num_groups_skips_divisibility_check) {
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             PartialShape{6, -1, 16},
+                                             Shape{6, 4, 8},
+                                             PartialShape{6, -1, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{6, 4, 8}));
+}
+
+TEST(type_prop, paged_selective_ssm_type_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("PagedSelectiveSSM expects A, dt, B, x, and C to have the same element type."));
+}
+
+TEST(type_prop, paged_selective_ssm_state_float_type_invalid) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::i32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("Float inputs must have a floating-point element type."));
+}
+
+TEST(type_prop, paged_selective_ssm_index_type_mixed) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("Integer inputs must have i32 or i64 element type."));
+}
+
+}  // namespace ov::test

--- a/src/core/tests/type_prop/selective_ssm.cpp
+++ b/src/core/tests/type_prop/selective_ssm.cpp
@@ -133,10 +133,10 @@ TEST(type_prop, selective_ssm_type_mismatch) {
     OV_EXPECT_THROW(
         std::ignore = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state}),
         NodeValidationFailure,
-        testing::HasSubstr("SelectiveSSM expects A, dt, B, x, and C to have the same element type."));
+        testing::HasSubstr("SelectiveSSM expects all inputs to have the same element type."));
 }
 
-TEST(type_prop, selective_ssm_state_type_may_differ) {
+TEST(type_prop, selective_ssm_state_type_must_match) {
     auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
     auto dt = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 4});
     auto B = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 2, 16});
@@ -144,10 +144,37 @@ TEST(type_prop, selective_ssm_state_type_may_differ) {
     auto C = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 2, 16});
     auto recurrent_state = std::make_shared<op::v0::Parameter>(element::bf16, Shape{2, 4, 8, 16});
 
-    const auto op = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state});
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state}),
+        NodeValidationFailure,
+        testing::HasSubstr("SelectiveSSM expects all inputs to have the same element type."));
+}
 
-    EXPECT_EQ(op->get_output_element_type(0), element::f16);
-    EXPECT_EQ(op->get_output_element_type(1), element::bf16);
+TEST(type_prop, selective_ssm_f16_and_bf16_accepted) {
+    for (const auto& et : {element::f16, element::bf16}) {
+        const auto op = make_selective_ssm(et,
+                                           Shape{4},
+                                           Shape{2, 5, 4},
+                                           Shape{2, 5, 2, 16},
+                                           Shape{2, 5, 4, 8},
+                                           Shape{2, 5, 2, 16},
+                                           Shape{2, 4, 8, 16});
+
+        EXPECT_EQ(op->get_output_element_type(0), et);
+        EXPECT_EQ(op->get_output_element_type(1), et);
+    }
+}
+
+TEST(type_prop, selective_ssm_unsupported_float_type) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f64,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("SelectiveSSM inputs must have f32, f16, or bf16 element type."));
 }
 
 TEST(type_prop, selective_ssm_wrong_input_count) {
@@ -240,7 +267,8 @@ TEST(type_prop, selective_ssm_batch_mismatch) {
                                                      Shape{2, 5, 2, 16},
                                                      Shape{2, 4, 8, 16}),
                     NodeValidationFailure,
-                    testing::HasSubstr("The batch dimension of all inputs should be the same."));
+                    testing::HasSubstr("The batch dimension of `dt`, `B`, `x`, `C` and `recurrent_state` should be "
+                                       "the same."));
 }
 
 TEST(type_prop, selective_ssm_seq_len_mismatch) {
@@ -289,7 +317,7 @@ TEST(type_prop, selective_ssm_zero_groups) {
                                                      Shape{2, 5, 0, 16},
                                                      Shape{2, 4, 8, 16}),
                     NodeValidationFailure,
-                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+                    testing::HasSubstr("The number of groups must be greater than zero."));
 }
 
 TEST(type_prop, selective_ssm_dynamic_num_groups_skips_divisibility_check) {
@@ -299,6 +327,32 @@ TEST(type_prop, selective_ssm_dynamic_num_groups_skips_divisibility_check) {
                                        PartialShape{2, 5, -1, 16},
                                        Shape{2, 5, 4, 8},
                                        PartialShape{2, 5, -1, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{2, 5, 4, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{2, 4, 8, 16}));
+}
+
+TEST(type_prop, selective_ssm_asymmetric_num_groups_checks_divisibility) {
+    // The group count is dynamic in `B` but pinned by `C`, so the merged value must drive the check.
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     PartialShape{2, 5, -1, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 3, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, selective_ssm_asymmetric_num_groups_accepted) {
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       PartialShape{2, 5, -1, 16},
+                                       Shape{2, 5, 4, 8},
+                                       Shape{2, 5, 2, 16},
                                        Shape{2, 4, 8, 16});
 
     EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{2, 5, 4, 8}));

--- a/src/core/tests/type_prop/selective_ssm.cpp
+++ b/src/core/tests/type_prop/selective_ssm.cpp
@@ -1,0 +1,308 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/openvino.hpp"
+
+namespace ov::test {
+namespace {
+
+std::shared_ptr<op::internal::SelectiveSSM> make_selective_ssm(const element::Type& et,
+                                                               const PartialShape& A,
+                                                               const PartialShape& dt,
+                                                               const PartialShape& B,
+                                                               const PartialShape& x,
+                                                               const PartialShape& C,
+                                                               const PartialShape& state) {
+    auto A_p = std::make_shared<op::v0::Parameter>(et, A);
+    auto dt_p = std::make_shared<op::v0::Parameter>(et, dt);
+    auto B_p = std::make_shared<op::v0::Parameter>(et, B);
+    auto x_p = std::make_shared<op::v0::Parameter>(et, x);
+    auto C_p = std::make_shared<op::v0::Parameter>(et, C);
+    auto recurrent_state = std::make_shared<op::v0::Parameter>(et, state);
+
+    return std::make_shared<op::internal::SelectiveSSM>(OutputVector{A_p, dt_p, B_p, x_p, C_p, recurrent_state});
+}
+
+}  // namespace
+
+TEST(type_prop, selective_ssm_static_f32) {
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       Shape{2, 5, 2, 16},
+                                       Shape{2, 5, 4, 8},
+                                       Shape{2, 5, 2, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_size(), 2);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_element_type(1), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{2, 5, 4, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(1), PartialShape(Shape{2, 4, 8, 16}));
+}
+
+TEST(type_prop, selective_ssm_partial_shape_infer) {
+    const auto op = make_selective_ssm(element::bf16,
+                                       PartialShape{4},
+                                       PartialShape{{1, 4}, -1, 4},
+                                       PartialShape{{1, 4}, -1, 2, {32, 128}},
+                                       PartialShape{{1, 4}, -1, 4, {2, 8}},
+                                       PartialShape{{1, 4}, -1, 2, {32, 128}},
+                                       PartialShape{{1, 4}, 4, {2, 8}, {32, 128}});
+
+    EXPECT_EQ(op->get_output_element_type(0), element::bf16);
+    EXPECT_EQ(op->get_output_element_type(1), element::bf16);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{{1, 4}, -1, 4, {2, 8}}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{{1, 4}, 4, {2, 8}, {32, 128}}));
+}
+
+TEST(type_prop, selective_ssm_dims_resolved_from_other_inputs) {
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       Shape{2, 5, 2, 16},
+                                       PartialShape{-1, -1, -1, -1},
+                                       Shape{2, 5, 2, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{2, 5, 4, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{2, 4, 8, 16}));
+}
+
+TEST(type_prop, selective_ssm_invalid_A_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4, 1},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_state_size_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 32},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The state size of `B`, `C` and `recurrent_state` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_head_dim_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 4, 10, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The head dimension of `x` and `recurrent_state` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_heads_not_divisible_by_groups) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 3, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 3, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, selective_ssm_type_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 2, 16});
+    auto recurrent_state = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 4, 8, 16});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state}),
+        NodeValidationFailure,
+        testing::HasSubstr("SelectiveSSM expects A, dt, B, x, and C to have the same element type."));
+}
+
+TEST(type_prop, selective_ssm_state_type_may_differ) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 2, 16});
+    auto recurrent_state = std::make_shared<op::v0::Parameter>(element::bf16, Shape{2, 4, 8, 16});
+
+    const auto op = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state});
+
+    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+    EXPECT_EQ(op->get_output_element_type(1), element::bf16);
+}
+
+TEST(type_prop, selective_ssm_wrong_input_count) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 2, 16});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("SelectiveSSM expects 6 inputs, but it has 5"));
+}
+
+TEST(type_prop, selective_ssm_invalid_dt_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4, 1},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_invalid_B_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_invalid_x_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_invalid_C_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_invalid_recurrent_state_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_dynamic_rank_input_accepted) {
+    // Dynamic rank inputs are accepted since they may be folded to a static rank later.
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       Shape{2, 5, 2, 16},
+                                       PartialShape::dynamic(),
+                                       Shape{2, 5, 2, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_TRUE(op->get_output_partial_shape(0).rank().is_dynamic());
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{2, 4, 8, 16}));
+}
+
+TEST(type_prop, selective_ssm_batch_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{3, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The batch dimension of all inputs should be the same."));
+}
+
+TEST(type_prop, selective_ssm_seq_len_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 7, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The sequence length of `dt`, `B`, `x` and `C` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_num_heads_mismatch) {
+    OV_EXPECT_THROW(
+        std::ignore = make_selective_ssm(element::f32,
+                                         Shape{5},
+                                         Shape{2, 5, 4},
+                                         Shape{2, 5, 2, 16},
+                                         Shape{2, 5, 4, 8},
+                                         Shape{2, 5, 2, 16},
+                                         Shape{2, 4, 8, 16}),
+        NodeValidationFailure,
+        testing::HasSubstr("The number of heads of `A`, `dt`, `x` and `recurrent_state` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_num_groups_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 3, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of groups of `B` and `C` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_zero_groups) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 0, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 0, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, selective_ssm_dynamic_num_groups_skips_divisibility_check) {
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       PartialShape{2, 5, -1, 16},
+                                       Shape{2, 5, 4, 8},
+                                       PartialShape{2, 5, -1, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{2, 5, 4, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{2, 4, 8, 16}));
+}
+
+}  // namespace ov::test

--- a/src/core/tests/type_prop/sources.cmake
+++ b/src/core/tests/type_prop/sources.cmake
@@ -137,6 +137,7 @@ set(OV_CORE_TESTS_TYPE_PROP_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/paged_attention.cpp
     ${CMAKE_CURRENT_LIST_DIR}/paged_causal_conv1d.cpp
     ${CMAKE_CURRENT_LIST_DIR}/paged_gated_delta_net.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/paged_selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/parameter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/power.cpp
     ${CMAKE_CURRENT_LIST_DIR}/prelu.cpp
@@ -180,6 +181,7 @@ set(OV_CORE_TESTS_TYPE_PROP_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/search_sorted.cpp
     ${CMAKE_CURRENT_LIST_DIR}/segment_max.cpp
     ${CMAKE_CURRENT_LIST_DIR}/select.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/selu.cpp
     ${CMAKE_CURRENT_LIST_DIR}/shape_of.cpp
     ${CMAKE_CURRENT_LIST_DIR}/shuffle_channels.cpp

--- a/src/core/tests/visitors/op/paged_selective_ssm.cpp
+++ b/src/core/tests/visitors/op/paged_selective_ssm.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/paged_selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include "visitors/visitors.hpp"
+
+namespace ov::test {
+
+TEST(attributes, paged_selective_ssm_default_attrs) {
+    NodeBuilder::opset().insert<op::internal::PagedSelectiveSSM>();
+    const auto A = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{4});
+    const auto dt = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 4});
+    const auto B = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 2, 8});
+    const auto x = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 4, 8});
+    const auto C = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 2, 8});
+    const auto state = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 4, 8, 8});
+    const auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(
+        OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval});
+
+    NodeBuilder builder(op, {A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval});
+    const auto g_op = as_type_ptr<op::internal::PagedSelectiveSSM>(builder.create());
+
+    EXPECT_EQ(builder.get_value_map_size(), 0);
+    EXPECT_NE(g_op, nullptr);
+}
+
+}  // namespace ov::test

--- a/src/core/tests/visitors/op/selective_ssm.cpp
+++ b/src/core/tests/visitors/op/selective_ssm.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include "visitors/visitors.hpp"
+
+namespace ov::test {
+
+TEST(attributes, selective_ssm_default_attrs) {
+    NodeBuilder::opset().insert<op::internal::SelectiveSSM>();
+    const auto A = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{4});
+    const auto dt = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1, 4});
+    const auto B = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1, 2, 8});
+    const auto x = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1, 4, 8});
+    const auto C = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1, 2, 8});
+    const auto state = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 4, 8, 8});
+
+    const auto op = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, state});
+    NodeBuilder builder(op, {A, dt, B, x, C, state});
+    const auto g_op = as_type_ptr<op::internal::SelectiveSSM>(builder.create());
+
+    EXPECT_EQ(builder.get_value_map_size(), 0);
+    EXPECT_NE(g_op, nullptr);
+}
+
+}  // namespace ov::test

--- a/src/core/tests/visitors/sources.cmake
+++ b/src/core/tests/visitors/sources.cmake
@@ -138,6 +138,7 @@ set(OV_CORE_TESTS_VISITORS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/op/pad.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_causal_conv1d.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_gated_delta_net.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/paged_selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/parameter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/power.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/prelu.cpp
@@ -177,6 +178,7 @@ set(OV_CORE_TESTS_VISITORS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/op/scatter_update.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/segment_max.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/select.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/selu.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/shape_of.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/shuffle_channels.cpp

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -155,6 +155,7 @@
 #include "openvino/op/nv12_to_rgb.hpp"
 #include "openvino/op/one_hot.hpp"
 #include "openvino/op/pad.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/prelu.hpp"
 #include "openvino/op/prior_box.hpp"
@@ -192,6 +193,7 @@
 #include "openvino/op/search_sorted.hpp"
 #include "openvino/op/segment_max.hpp"
 #include "openvino/op/select.hpp"
+#include "openvino/op/selective_ssm.hpp"
 #include "openvino/op/selu.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/shuffle_channels.hpp"
@@ -222,6 +224,7 @@
 #include "ov_ops/augru_sequence.hpp"
 #include "ov_ops/glu.hpp"
 #include "pad_shape_inference.hpp"
+#include "paged_selective_ssm_shape_inference.hpp"
 #include "prior_box_clustered_shape_inference.hpp"
 #include "prior_box_shape_inference.hpp"
 #include "proposal_shape_inference.hpp"
@@ -247,6 +250,7 @@
 #include "search_sorted_shape_inference.hpp"
 #include "segment_max_shape_inference.hpp"
 #include "select_shape_inference.hpp"
+#include "selective_ssm_shape_inference.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "shape_inference/shape_inference_status.hpp"
 #include "shape_nodes.hpp"
@@ -754,6 +758,8 @@ const IStaticShapeInferFactory::TRegistry IStaticShapeInferFactory::registry{
     OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::AUGRUSequence, ShapeInferTA, util::bit::mask()),
     OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::RMSNorm, ShapeInferTA, util::bit::mask(1)),
     OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::GLU, ShapeInferTA, util::bit::mask()),
+    OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::SelectiveSSM, ShapeInferTA, util::bit::mask()),
+    OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::PagedSelectiveSSM, ShapeInferTA, util::bit::mask()),
 };
 // clang-format on
 

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/paged_selective_ssm_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/paged_selective_ssm_shape_inference_test.cpp
@@ -1,0 +1,465 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "paged_selective_ssm_shape_inference.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/op/parameter.hpp"
+#include "utils.hpp"
+
+using namespace ov;
+using namespace ov::intel_cpu;
+using ov::op::v0::Parameter;
+using testing::HasSubstr;
+
+namespace {
+
+std::shared_ptr<op::internal::PagedSelectiveSSM> make_paged_selective_ssm() {
+    const auto dynamic = PartialShape::dynamic();
+    auto A = std::make_shared<Parameter>(element::f32, dynamic);
+    auto dt = std::make_shared<Parameter>(element::f32, dynamic);
+    auto B = std::make_shared<Parameter>(element::f32, dynamic);
+    auto x = std::make_shared<Parameter>(element::f32, dynamic);
+    auto C = std::make_shared<Parameter>(element::f32, dynamic);
+    auto state = std::make_shared<Parameter>(element::f32, dynamic);
+    auto subseq = std::make_shared<Parameter>(element::i32, dynamic);
+    auto block_idx = std::make_shared<Parameter>(element::i32, dynamic);
+    auto block_idx_begins = std::make_shared<Parameter>(element::i32, dynamic);
+    auto processed = std::make_shared<Parameter>(element::i32, dynamic);
+    auto cache_interval = std::make_shared<Parameter>(element::i32, dynamic);
+    return std::make_shared<op::internal::PagedSelectiveSSM>(
+        OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval});
+}
+
+}  // namespace
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMBasic) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 1);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({6, 4, 8}));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMInvalidARank) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4, 1},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMInvalidDtRank) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4, 1},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMInvalidBRank) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMInvalidXRank) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMInvalidCRank) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMInvalidStateRank) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMInvalidIndexRank) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2, 2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMTokenDimMismatch) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{7, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The token dimension of `dt`, `B`, `x` and `C` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMNumHeadsMismatch) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{5},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The number of heads of `A`, `dt`, `x` and `recurrent_state_table` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMHeadDimMismatch) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 10, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The head dimension of `x` and `recurrent_state_table` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMNumGroupsMismatch) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 3, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The number of groups of `B` and `C` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMZeroGroups) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 0, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 0, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The number of groups must be greater than zero."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMStateSizeMismatch) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 32},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The state size of `B`, `C` and `recurrent_state_table` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMHeadsNotDivisibleByGroups) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 3, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 3, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMLogicalAndPhysicalBlockCountsAreIndependent) {
+    // The table may carry more logical slots (block_indices) than sequences (block_indices_begins - 1).
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{5},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 1);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({6, 4, 8}));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMOverProvisionedStateTable) {
+    // The table may carry more physical rows than the logical slots addressing it.
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{12, 4, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{7},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 1);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({6, 4, 8}));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMSubsequenceAndBlockBeginsMismatch) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{3},
+                                                    StaticShape{3},
+                                                    StaticShape{2},
+                                                    StaticShape{2},
+                                                    StaticShape{2}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The sizes of `subsequence_begins` and `la_block_indices_begins` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMProcessedTokensAndCacheIntervalMismatch) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{3},
+                                                    StaticShape{3},
+                                                    StaticShape{3},
+                                                    StaticShape{2},
+                                                    StaticShape{3}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The sizes of `num_processed_tokens` and `cache_interval` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMSubsequenceBeginsAndProcessedTokensMismatch) {
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{6, 4, 8},
+                                                    StaticShape{6, 2, 16},
+                                                    StaticShape{3, 4, 8, 16},
+                                                    StaticShape{3},
+                                                    StaticShape{3},
+                                                    StaticShape{3},
+                                                    StaticShape{3},
+                                                    StaticShape{3}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The size of `subsequence_begins` should be one larger than `num_processed_tokens`."));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMMultipleGroups) {
+    // 8 heads split across 4 groups (2 heads per group).
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{8},
+                                                    StaticShape{5, 8},
+                                                    StaticShape{5, 4, 16},
+                                                    StaticShape{5, 8, 8},
+                                                    StaticShape{5, 4, 16},
+                                                    StaticShape{3, 8, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{4},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 1);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({5, 8, 8}));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMMultiQueryStyleSingleGroup) {
+    // All 8 heads share a single group (MQA-style).
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{8},
+                                                    StaticShape{5, 8},
+                                                    StaticShape{5, 1, 16},
+                                                    StaticShape{5, 8, 8},
+                                                    StaticShape{5, 1, 16},
+                                                    StaticShape{3, 8, 8, 16},
+                                                    StaticShape{2},
+                                                    StaticShape{4},
+                                                    StaticShape{2},
+                                                    StaticShape{1},
+                                                    StaticShape{1}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 1);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({5, 8, 8}));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMMultipleSequencesWithDifferentBlockCounts) {
+    // A batch of 3 sequences, each addressing a different number of blocks in the shared state table.
+    const auto op = make_paged_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{9, 4},
+                                                    StaticShape{9, 2, 16},
+                                                    StaticShape{9, 4, 8},
+                                                    StaticShape{9, 2, 16},
+                                                    StaticShape{10, 4, 8, 16},
+                                                    StaticShape{4},
+                                                    StaticShape{9},
+                                                    StaticShape{4},
+                                                    StaticShape{3},
+                                                    StaticShape{3}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 1);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({9, 4, 8}));
+}

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/selective_ssm_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/selective_ssm_shape_inference_test.cpp
@@ -1,0 +1,293 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "selective_ssm_shape_inference.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/op/parameter.hpp"
+#include "utils.hpp"
+
+using namespace ov;
+using namespace ov::intel_cpu;
+using ov::op::v0::Parameter;
+using testing::HasSubstr;
+
+namespace {
+
+std::shared_ptr<op::internal::SelectiveSSM> make_selective_ssm() {
+    const auto dynamic = PartialShape::dynamic();
+    auto A = std::make_shared<Parameter>(element::f32, dynamic);
+    auto dt = std::make_shared<Parameter>(element::f32, dynamic);
+    auto B = std::make_shared<Parameter>(element::f32, dynamic);
+    auto x = std::make_shared<Parameter>(element::f32, dynamic);
+    auto C = std::make_shared<Parameter>(element::f32, dynamic);
+    auto state = std::make_shared<Parameter>(element::f32, dynamic);
+    return std::make_shared<op::internal::SelectiveSSM>(A, dt, B, x, C, state);
+}
+
+}  // namespace
+
+TEST(StaticShapeInferenceTest, SelectiveSSMBasic) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 2);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({6, 5, 4, 8}));
+    EXPECT_EQ(static_output_shapes[1], StaticShape({6, 4, 8, 16}));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMInvalidARank) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4, 1},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMInvalidDtRank) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMInvalidBRank) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMInvalidXRank) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMInvalidCRank) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2},
+                                                    StaticShape{6, 4, 8, 16}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMInvalidRecurrentStateRank) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8}};
+    EXPECT_THROW(shape_inference(op.get(), static_input_shapes), NodeValidationFailure);
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMBatchMismatch) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{7, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The batch dimension of `dt`, `B`, `x`, `C` and `recurrent_state` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMSeqLenMismatch) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 7, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The sequence length of `dt`, `B`, `x` and `C` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMNumHeadsMismatch) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{5},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The number of heads of `A`, `dt`, `x` and `recurrent_state` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMHeadDimMismatch) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 4, 10, 16}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The head dimension of `x` and `recurrent_state` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMNumGroupsMismatch) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 3, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The number of groups of `B` and `C` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMZeroGroups) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 0, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 0, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The number of groups must be greater than zero."));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMStateSizeMismatch) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 2, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 2, 32},
+                                                    StaticShape{6, 4, 8, 16}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The state size of `B`, `C` and `recurrent_state` should be the same."));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMHeadsNotDivisibleByGroups) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{6, 5, 4},
+                                                    StaticShape{6, 5, 3, 16},
+                                                    StaticShape{6, 5, 4, 8},
+                                                    StaticShape{6, 5, 3, 16},
+                                                    StaticShape{6, 4, 8, 16}};
+    OV_EXPECT_THROW(shape_inference(op.get(), static_input_shapes),
+                    NodeValidationFailure,
+                    HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMMultipleGroups) {
+    // 8 heads split across 4 groups (2 heads per group).
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{8},
+                                                    StaticShape{2, 3, 8},
+                                                    StaticShape{2, 3, 4, 16},
+                                                    StaticShape{2, 3, 8, 8},
+                                                    StaticShape{2, 3, 4, 16},
+                                                    StaticShape{2, 8, 8, 16}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 2);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({2, 3, 8, 8}));
+    EXPECT_EQ(static_output_shapes[1], StaticShape({2, 8, 8, 16}));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMMultiQueryStyleSingleGroup) {
+    // All 8 heads share a single group (MQA-style).
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{8},
+                                                    StaticShape{2, 4, 8},
+                                                    StaticShape{2, 4, 1, 16},
+                                                    StaticShape{2, 4, 8, 8},
+                                                    StaticShape{2, 4, 1, 16},
+                                                    StaticShape{2, 8, 8, 16}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 2);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({2, 4, 8, 8}));
+    EXPECT_EQ(static_output_shapes[1], StaticShape({2, 8, 8, 16}));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMSingleHeadSingleGroup) {
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{1},
+                                                    StaticShape{3, 2, 1},
+                                                    StaticShape{3, 2, 1, 8},
+                                                    StaticShape{3, 2, 1, 4},
+                                                    StaticShape{3, 2, 1, 8},
+                                                    StaticShape{3, 1, 4, 8}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 2);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({3, 2, 1, 4}));
+    EXPECT_EQ(static_output_shapes[1], StaticShape({3, 1, 4, 8}));
+}
+
+TEST(StaticShapeInferenceTest, SelectiveSSMDecodeStepSingleToken) {
+    // Single-step decode: sequence length is 1.
+    const auto op = make_selective_ssm();
+
+    std::vector<StaticShape> static_input_shapes = {StaticShape{4},
+                                                    StaticShape{2, 1, 4},
+                                                    StaticShape{2, 1, 2, 16},
+                                                    StaticShape{2, 1, 4, 8},
+                                                    StaticShape{2, 1, 2, 16},
+                                                    StaticShape{2, 4, 8, 16}};
+    const auto static_output_shapes = shape_inference(op.get(), static_input_shapes);
+    ASSERT_EQ(static_output_shapes.size(), 2);
+    EXPECT_EQ(static_output_shapes[0], StaticShape({2, 1, 4, 8}));
+    EXPECT_EQ(static_output_shapes[1], StaticShape({2, 4, 8, 16}));
+}


### PR DESCRIPTION
## Implements ops based on specification from https://github.com/openvinotoolkit/openvino/pull/36372

### Details:
 - *Adds internal core operations SelectiveSSM and PagedSelectiveSSM*
 - *Test coverage*

### Tickets:
 - *CVS-192119*
 - *CVS-192120*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI used to draft implementation based on spec and existing ops. Manually reviewed missing bits in couple of iteration to improve shape infer, documentation and test coverage*
