### PR TITLE
[NPUW] Match Gemma-4 sliding window mask on newer optimum-intel exports

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/sliding_window_mask.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/sliding_window_mask.cpp
@@ -135,6 +135,16 @@ void rebuild_sliding_window_mask(const std::shared_ptr<ov::Node>& attention_mask
     LOG_INFO(std::string(log_prefix) + " sliding window attention mask pattern found and patched.");
 }
 
+// True only for a single-element constant holding zero.
+bool is_zero_scalar_constant(const ov::Output<ov::Node>& output) {
+    auto constant = ov::as_type_ptr<ov::op::v0::Constant>(output.get_node_shared_ptr());
+    if (!constant || ov::shape_size(constant->get_shape()) != 1u) {
+        return false;
+    }
+    const auto values = constant->cast_vector<int64_t>();
+    return !values.empty() && values.front() == 0;
+}
+
 class OldPhi3SlidingMaskMatcher : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("ov::npuw::patterns::OldPhi3SlidingMaskMatcher");
@@ -593,6 +603,15 @@ public:
 
         auto callback = [=](opp::Matcher& m) {
             auto& node_to_output = m.get_pattern_value_map();
+
+            // Only cache_position[0] equals past_kv_len. Any other element of the range is
+            // a different value, and rewriting the mask around it would silently shift the
+            // window, so leave such a subgraph alone.
+            auto matched_select = node_to_output.at(past_kv_len_select).get_node_shared_ptr();
+            if (!is_zero_scalar_constant(matched_select->input_value(1)) ||
+                !is_zero_scalar_constant(matched_select->input_value(2))) {
+                return false;
+            }
 
             // Extract matched nodes from pattern
             auto optional_squeeze = node_to_output.find(past_kv_len_squeeze);

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/sliding_window_mask.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/sliding_window_mask.cpp
@@ -465,6 +465,20 @@ public:
         auto opt_key_range_f32 = opp::optional<ov::op::v0::Convert>({key_range_row->output(0)});
 
         // Q (query) side: Gemma4-specific -- cache_pos = Range(0, seq_len) + past_kv_len
+        //
+        //   Gather (past_kv_len) --------------------------------.
+        //     |                                                  |
+        //     v                                                  |
+        //   Add (past_kv_len + seq_len = full_ctx_len)           |
+        //     |                                                  |
+        //     v                                                  v
+        //   Range (0, full_ctx_len, 1)          Add (Range(0, seq_len, 1), past_kv_len)
+        //     |  K positions                      |  Q positions (cache_position)
+        //   Unsqueeze x3                        Unsqueeze x3
+        //      \                                  /
+        //       `---> Greater / LessEqual -> sliding & causal masks
+        //
+        // Both sides consume the very same shape Gather.
         auto q_range = opp::wrap_type<ov::op::v4::Range>({opp::any_input(), opp::any_input(), opp::any_input()});
         auto cache_position = opp::wrap_type<ov::op::v1::Add>({q_range, past_kv_len_squeeze});
         auto query_range_column = unsqueeze_sequence(cache_position);
@@ -512,6 +526,106 @@ public:
     }
 };
 
+class Gemma4UnifiedSlidingMaskMatcher : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("ov::npuw::patterns::Gemma4UnifiedSlidingMaskMatcher");
+
+    Gemma4UnifiedSlidingMaskMatcher(const std::shared_ptr<ov::Node>& attention_mask_node_ptr,
+                                    const std::shared_ptr<ov::Node>& position_ids_node_ptr) {
+        // Same fix as Gemma4SlidingMaskMatcher, for the sliding window mask emitted by
+        // "Gemma 4 Unified" exports (optimum-intel 3eb79ef3 / huggingface/optimum-intel#1770
+        // and later).
+        //
+        // Those exports no longer feed the shape Gather into the Q-side Add. They build the
+        // whole cache_position range first and take its first element, which is numerically
+        // the same past_kv_len, reached through a different subgraph:
+        //
+        //   Gather (past_kv_len) --------------------------------.
+        //     |                                                  |
+        //     v                                                  v
+        //   Add (past_kv_len + seq_len = full_ctx_len)          Range (past_kv_len, full_ctx_len, 1)
+        //     |                                                  |
+        //     v                                                  v
+        //   Range (0, full_ctx_len, 1)                          Gather (.., 0)  -- cache_position[0]
+        //     |  K positions                                      |             -- == past_kv_len
+        //   Unsqueeze x3                                        Add (Range(0, seq_len, 1), ..)
+        //      \                                                  |  Q positions
+        //       \                                               Unsqueeze x3
+        //        `---> Greater / LessEqual -> sliding & causal masks
+        //
+        // Left unmatched, the mask keeps the form that assumes unpadded KV, and every SWA
+        // layer drops the whole prefill context once the static KV buffer grows past the
+        // sliding window.
+        auto unsqueeze_sequence = [&](std::shared_ptr<ov::Node> node) {
+            auto u1 = opp::wrap_type<ov::op::v0::Unsqueeze>({node, opp::any_input()});
+            auto u2 = opp::wrap_type<ov::op::v0::Unsqueeze>({u1, opp::any_input()});
+            auto u3 = opp::wrap_type<ov::op::v0::Unsqueeze>({u2, opp::any_input()});
+            return u3;
+        };
+
+        // K (key) side: Range(0, past_kv_len + seq_len, 1) -- unchanged from the pattern above
+        auto past_kv_len = opp::wrap_type<ov::op::v8::Gather>({opp::any_input(), opp::any_input(), opp::any_input()});
+        auto past_kv_len_squeeze = opp::optional<ov::op::v0::Squeeze>({past_kv_len});
+        auto zero_const = opp::wrap_type<ov::op::v0::Constant>();
+        auto full_ctx_len = opp::wrap_type<ov::op::v1::Add>({opp::any_input(), past_kv_len_squeeze});
+        auto key_range = opp::wrap_type<ov::op::v4::Range>({zero_const, full_ctx_len, opp::any_input()});
+        auto key_range_row = unsqueeze_sequence(key_range);
+        auto opt_key_range_f32 = opp::optional<ov::op::v0::Convert>({key_range_row->output(0)});
+
+        // Q (query) side: past length taken as the first element of the cache_position range.
+        // The Range still starts from the same past_kv_len, which keeps this pattern anchored
+        // to the subgraph the K side was matched on.
+        auto cache_pos_range =
+            opp::wrap_type<ov::op::v4::Range>({past_kv_len_squeeze, opp::any_input(), opp::any_input()});
+        auto past_kv_len_select =
+            opp::wrap_type<ov::op::v8::Gather>({cache_pos_range, opp::any_input(), opp::any_input()});
+        auto q_range = opp::wrap_type<ov::op::v4::Range>({opp::any_input(), opp::any_input(), opp::any_input()});
+        auto cache_position = opp::wrap_type<ov::op::v1::Add>({q_range, past_kv_len_select});
+        auto query_range_column = unsqueeze_sequence(cache_position);
+
+        // Sliding window & causal masks (positive form: 1 = attend)
+        auto neg_window_size = opp::wrap_type<ov::op::v0::Constant>();
+        auto query_left_bound = opp::wrap_type<ov::op::v1::Add>({query_range_column, neg_window_size});
+        auto sliding_mask = opp::wrap_type<ov::op::v1::Greater>({opt_key_range_f32, query_left_bound});
+        auto sliding_and_true = opp::wrap_type<ov::op::v13::BitwiseAnd>({opp::any_input(), sliding_mask});
+        auto causal_mask = opp::wrap_type<ov::op::v1::LessEqual>({opt_key_range_f32, query_range_column});
+        auto sliding_and_causal_mask = opp::wrap_type<ov::op::v13::BitwiseAnd>({sliding_and_true, causal_mask});
+
+        auto callback = [=](opp::Matcher& m) {
+            auto& node_to_output = m.get_pattern_value_map();
+
+            // Extract matched nodes from pattern
+            auto optional_squeeze = node_to_output.find(past_kv_len_squeeze);
+            auto matched_past_kv_len = optional_squeeze != node_to_output.end()
+                                           ? optional_squeeze->second.get_node_shared_ptr()
+                                           : node_to_output.at(past_kv_len).get_node_shared_ptr();
+            auto matched_full_ctx_len = node_to_output.at(full_ctx_len).get_node_shared_ptr();
+            auto matched_neg_window_size = node_to_output.at(neg_window_size).get_node_shared_ptr();
+            auto matched_sliding_mask = node_to_output.at(sliding_mask).get_node_shared_ptr();
+            auto matched_sliding_and_causal_mask = node_to_output.at(sliding_and_causal_mask).get_node_shared_ptr();
+
+            auto optional_convert = node_to_output.find(opt_key_range_f32);
+            auto matched_key_range_row = optional_convert != node_to_output.end()
+                                             ? optional_convert->second.get_node_shared_ptr()
+                                             : node_to_output.at(key_range_row).get_node_shared_ptr();
+
+            // Call shared transformation helper
+            rebuild_sliding_window_mask(attention_mask_node_ptr,
+                                        position_ids_node_ptr,
+                                        matched_past_kv_len,
+                                        matched_full_ctx_len,
+                                        matched_key_range_row,
+                                        matched_neg_window_size,
+                                        matched_sliding_mask,
+                                        matched_sliding_and_causal_mask,
+                                        "Gemma4 Unified");
+            return true;
+        };
+        register_matcher(std::make_shared<opp::Matcher>(sliding_and_causal_mask, "Gemma4UnifiedSlidingMaskMatcher"),
+                         std::move(callback));
+    }
+};
+
 #ifdef __GNUC__
 #    pragma GCC diagnostic pop
 #endif
@@ -546,6 +660,7 @@ bool SlidingWindowMask::run_on_model(const std::shared_ptr<ov::Model>& model) {
     manager.set_per_pass_validation(true);
     const auto rewriter = manager.register_pass<ov::pass::GraphRewrite>();
     rewriter->add_matcher<Gemma4SlidingMaskMatcher>(attention_mask_node_ptr, position_ids_node_ptr);
+    rewriter->add_matcher<Gemma4UnifiedSlidingMaskMatcher>(attention_mask_node_ptr, position_ids_node_ptr);
     rewriter->add_matcher<Phi3SlidingMaskMatcher>(attention_mask_node_ptr, position_ids_node_ptr);
     rewriter->add_matcher<OldPhi3SlidingMaskMatcher>();
     return manager.run_passes(model);

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_masks.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_masks.cpp
@@ -471,6 +471,69 @@ ov::Output<ov::Node> make_sliding_window_mask_gemma4(const ov::Output<ov::Node>&
     return combine_sliding_and_causal(parts, q_col, neg_window, p);
 }
 
+namespace {
+// Shared body for the two Gemma-4 Unified builders: `select_index` picks which
+// element of the cache_position range feeds the Q-side Add. Only 0 is the real
+// export shape (and the only one equal to past_kv_len).
+ov::Output<ov::Node> make_sliding_window_mask_gemma4_unified_impl(const ov::Output<ov::Node>& seq_source,
+                                                                  const ov::Output<ov::Node>& attention_mask_output,
+                                                                  size_t window_size,
+                                                                  int64_t select_index,
+                                                                  const std::string& p) {
+    auto parts = make_swa_parts(seq_source, attention_mask_output, p);
+
+    // Q side after the transformers 5.5 lowering: the past offset is no longer
+    // added directly. cache_position is built as a range and its first element,
+    // which equals past_kv_len, is what the Add consumes.
+    auto full_ctx_q = std::make_shared<ov::opset11::Add>(parts.past_kv_len, parts.seq_len);
+    full_ctx_q->set_friendly_name(p + "full_ctx_q");
+    auto cache_pos_range =
+        std::make_shared<ov::op::v4::Range>(parts.past_kv_len, full_ctx_q, parts.step, ov::element::i64);
+    cache_pos_range->set_friendly_name(p + "cache_pos_range");
+    auto sel_idx = ov::opset11::Constant::create(ov::element::i64, ov::Shape{}, {select_index});
+    auto sel_axis = ov::opset11::Constant::create(ov::element::i64, ov::Shape{}, {0});
+    auto past_len_select = std::make_shared<ov::opset11::Gather>(cache_pos_range, sel_idx, sel_axis);
+    past_len_select->set_friendly_name(p + "past_len_select");
+
+    auto q_range = std::make_shared<ov::op::v4::Range>(parts.zero, parts.seq_len, parts.step, ov::element::i64);
+    q_range->set_friendly_name(p + "q_range");
+    auto cache_position = std::make_shared<ov::opset11::Add>(q_range, past_len_select);
+    cache_position->set_friendly_name(p + "cache_position");
+    auto q_col = unsq1(unsq1(unsq1(cache_position, 1), 0), 0);
+    q_col->set_friendly_name(p + "q_col");
+
+    auto neg_window = ov::opset11::Constant::create(ov::element::i64,
+                                                    ov::Shape{1, 1, 1, 1},
+                                                    {-static_cast<int64_t>(window_size)});
+    neg_window->set_friendly_name(p + "neg_window");
+
+    return combine_sliding_and_causal(parts, q_col, neg_window, p);
+}
+}  // namespace
+
+ov::Output<ov::Node> make_sliding_window_mask_gemma4_unified(const ov::Output<ov::Node>& seq_source,
+                                                             const ov::Output<ov::Node>& attention_mask_output,
+                                                             ov::element::Type /*unused*/,
+                                                             size_t window_size) {
+    return make_sliding_window_mask_gemma4_unified_impl(seq_source,
+                                                        attention_mask_output,
+                                                        window_size,
+                                                        0,
+                                                        "model.swgu.");
+}
+
+ov::Output<ov::Node> make_sliding_window_mask_gemma4_unified_nonzero_select(
+    const ov::Output<ov::Node>& seq_source,
+    const ov::Output<ov::Node>& attention_mask_output,
+    ov::element::Type /*unused*/,
+    size_t window_size) {
+    return make_sliding_window_mask_gemma4_unified_impl(seq_source,
+                                                        attention_mask_output,
+                                                        window_size,
+                                                        1,
+                                                        "model.swgun.");
+}
+
 ov::Output<ov::Node> make_sliding_window_mask_phi3_legacy(const ov::Output<ov::Node>& seq_source,
                                                           const ov::Output<ov::Node>& attention_mask_output,
                                                           ov::element::Type prec,

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_masks.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/test_engine/models/model_builder_masks.hpp
@@ -116,6 +116,25 @@ ov::Output<ov::Node> make_sliding_window_mask_gemma4(const ov::Output<ov::Node>&
                                                      ov::element::Type /*unused*/,
                                                      size_t window_size);
 
+/// Sliding window + causal mask, Gemma-4 shape as exported after the
+/// transformers 5.5 lowering change (matches NPUW's
+/// Gemma4UnifiedSlidingMaskMatcher). Same as the variant above except the past
+/// offset reaches the Q-side Add indirectly: cache_position is built as
+/// Range(past_kv_len, past_kv_len + seq_len) and its first element is selected,
+/// so the Add sees Gather(Range(..), 0) instead of past_kv_len itself.
+ov::Output<ov::Node> make_sliding_window_mask_gemma4_unified(const ov::Output<ov::Node>& seq_source,
+                                                             const ov::Output<ov::Node>& attention_mask,
+                                                             ov::element::Type /*unused*/,
+                                                             size_t window_size);
+
+/// Same as make_sliding_window_mask_gemma4_unified but selecting
+/// cache_position[1], which is NOT past_kv_len. Used to check the matcher
+/// leaves such a subgraph alone instead of shifting the window.
+ov::Output<ov::Node> make_sliding_window_mask_gemma4_unified_nonzero_select(const ov::Output<ov::Node>& seq_source,
+                                                                            const ov::Output<ov::Node>& attention_mask,
+                                                                            ov::element::Type /*unused*/,
+                                                                            size_t window_size);
+
 /// Sliding window mask, legacy Phi-3 / transformers 4.51 shape (matches NPUW's
 /// OldPhi3SlidingMaskMatcher). INVERTED boolean domain combined via BitwiseOr
 /// (true = masked out): Greater(K, Q.T) | LessEqual(K, Q.T - window), with the

--- a/src/plugins/intel_npu/tests/unit/npuw/pipeline_passes/patch_sliding_mask_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pipeline_passes/patch_sliding_mask_test.cpp
@@ -12,6 +12,8 @@
 #include "openvino/pass/stateful_to_stateless.hpp"
 
 using ov::test::npuw::make_sliding_window_mask_gemma4;
+using ov::test::npuw::make_sliding_window_mask_gemma4_unified;
+using ov::test::npuw::make_sliding_window_mask_gemma4_unified_nonzero_select;
 using ov::test::npuw::make_sliding_window_mask_phi3;
 using ov::test::npuw::make_sliding_window_mask_phi3_legacy;
 using ov::test::npuw::ModelBuilder;
@@ -147,10 +149,12 @@ TEST(LLMMaskTest, TokenTypeIds_Phi3BooleanSlidingMask_Builds) {
     EXPECT_TRUE(has_sdpa_mask_of_type(model, ov::element::f32));
 }
 
-// NPUW's PatchSlidingWindowMask (sliding_window_mask.cpp) registers three
-// matchers: Gemma4SlidingMaskMatcher, Phi3SlidingMaskMatcher (Phi-3, Gemma-2,
-// Gemma-3) and OldPhi3SlidingMaskMatcher (transformers 4.51). Run the real
-// pass over the builder models and check each mask variant gets picked up.
+// NPUW's PatchSlidingWindowMask (sliding_window_mask.cpp) registers four
+// matchers: Gemma4SlidingMaskMatcher, Gemma4UnifiedSlidingMaskMatcher (the
+// same model after the transformers 5.5 lowering change), Phi3SlidingMaskMatcher
+// (Phi-3, Gemma-2, Gemma-3) and OldPhi3SlidingMaskMatcher (transformers 4.51).
+// Run the real pass over the builder models and check each mask variant gets
+// picked up.
 
 TEST(LLMMaskTest, NpuwSlidingPatch_FiresOn_Phi3Pattern) {
     auto model = ov::test::npuw::build_sliding_window_test_model(512, 0, make_sliding_window_mask_phi3);
@@ -162,6 +166,21 @@ TEST(LLMMaskTest, NpuwSlidingPatch_FiresOn_Gemma4Pattern) {
     auto model = ov::test::npuw::build_sliding_window_test_model(512, 0, make_sliding_window_mask_gemma4);
     EXPECT_TRUE(ov::npuw::PatchSlidingWindowMask().run_on_model(model));
     EXPECT_NO_THROW(model->validate_nodes_and_infer_types());
+}
+
+TEST(LLMMaskTest, NpuwSlidingPatch_FiresOn_Gemma4UnifiedPattern) {
+    auto model = ov::test::npuw::build_sliding_window_test_model(512, 0, make_sliding_window_mask_gemma4_unified);
+    EXPECT_TRUE(ov::npuw::PatchSlidingWindowMask().run_on_model(model));
+    EXPECT_NO_THROW(model->validate_nodes_and_infer_types());
+}
+
+// Only cache_position[0] equals past_kv_len. Selecting any other element gives a
+// different value, so the mask must be left as it is rather than rewritten
+// around the range start.
+TEST(LLMMaskTest, NpuwSlidingPatch_IgnoresGemma4UnifiedNonZeroSelect) {
+    auto model =
+        ov::test::npuw::build_sliding_window_test_model(512, 0, make_sliding_window_mask_gemma4_unified_nonzero_select);
+    EXPECT_FALSE(ov::npuw::PatchSlidingWindowMask().run_on_model(model));
 }
 
 TEST(LLMMaskTest, NpuwSlidingPatch_FiresOn_LegacyPhi3Pattern) {


### PR DESCRIPTION
### Details:
`Gemma4SlidingMaskMatcher` (added in #35253) expects the query positions to reach the mask as `Add(Range(0, seq_len), past_kv_len)`, with the same `past_kv_len` node also feeding the key side.

Since the transformers 5.5 rework in optimum-intel (huggingface/optimum-intel#1684) `cache_position` is lowered differently. It is now built as `arange(q_offset, q_offset + q_length)` and transformers takes its first element, so the query side arrives as `Add(Range(0, seq_len), Gather(Range(past_kv_len, full_ctx_len), 0))`. Same value, different subgraph, so the matcher quietly stops matching.

When it does not match, `rebuild_sliding_window_mask()` never runs and the mask keeps the form that assumes unpadded KV. Gemma-4 uses a 512 token sliding window on 30 of its 35 layers, so every SWA layer drops the whole prefill context once the static KV buffer is larger than the window, and the model just repeats a single token. Nothing fails loudly, it compiles and runs at normal speed.

Added a separate matcher for the new lowering rather than loosening the existing one, the same way `OldPhi3SlidingMaskMatcher` and `Phi3SlidingMaskMatcher` were implemented. The old pattern is untouched so older exports behave as before. Both patterns are drawn in the comments.

### Tickets:
 - [EISW-229432](https://jira.devtools.intel.com/browse/EISW-229432)

### AI Assistance:
 - *AI assistance used: yes*
 - Used to help track down the regression and draft the patch.
 - Validated by building locally and running gemma-4-E2B-it int4 through NPUW with CPU as the underlying device at `MAX_PROMPT_LEN=2048`, where the output matches the plain CPU reference. Also validated on NPU hardware (PTL): similarity vs the CPU reference went from 0.04-0.07 to 0.96-1.00 across gemma-4 E2B and E4B, int4 and nf4.

