### PR TITLE
[NPU] Fix interpreter dependency when ENABLE_SYSTEM_LEVEL_ZERO ON

### DIFF
--- a/src/plugins/intel_npu/src/utils/src/vm/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/utils/src/vm/CMakeLists.txt
@@ -34,13 +34,3 @@ target_link_libraries(${TARGET_NAME} PUBLIC
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(${TARGET_NAME} PRIVATE OPENVINO_STATIC_LIBRARY)
 endif()
-
-# Keep an explicit build-order dependency for the bundled Level Zero headers.
-# Although this dependency is currently also propagated through
-# openvino::zero_loader -> LevelZero::Headers, declaring it here protects this
-# target if that link interface changes and prevents parallel compilation
-# before prepare_ze_headers has copied the headers. The target does not exist
-# when system Level Zero is used, because those headers are already available.
-if(TARGET prepare_ze_headers)
-    add_dependencies(${TARGET_NAME} prepare_ze_headers)
-endif()

--- a/src/plugins/intel_npu/src/utils/src/vm/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/utils/src/vm/CMakeLists.txt
@@ -35,9 +35,12 @@ if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(${TARGET_NAME} PRIVATE OPENVINO_STATIC_LIBRARY)
 endif()
 
-# The include directories above use TARGET_PROPERTY expressions instead of
-# target_link_libraries, so CMake creates no build-order edge. Level Zero
-# headers are copied into the build directory by prepare_ze_headers; without
-# this explicit dependency a parallel build may compile ${TARGET_NAME} before
-# the headers are copied, causing a missing-header error
-add_dependencies(${TARGET_NAME} prepare_ze_headers)
+# Keep an explicit build-order dependency for the bundled Level Zero headers.
+# Although this dependency is currently also propagated through
+# openvino::zero_loader -> LevelZero::Headers, declaring it here protects this
+# target if that link interface changes and prevents parallel compilation
+# before prepare_ze_headers has copied the headers. The target does not exist
+# when system Level Zero is used, because those headers are already available.
+if(TARGET prepare_ze_headers)
+    add_dependencies(${TARGET_NAME} prepare_ze_headers)
+endif()


### PR DESCRIPTION
### Details:
 - Remove redundant prepare_ze_headers dependency and to support when ENABLE_SYSTEM_LEVEL_ZERO is ON.


Briefly introduce:
https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/utils/src/vm/CMakeLists.txt#L29 : vm_utils already links to the required Level-Zero header library, making the dependency on prepare_ze_headers redundant.
``` vm_utils 
target_link_libraries(${TARGET_NAME} PUBLIC
    LevelZero::NPUExt     # contain ze_graph_ext.h for npu_vm_runtime.hpp
    openvino::zero_loader # contain level_zero/ze_api.h> for npu_vm_runtime.hpp
)
```

- LevelZero::NPUExt is defined in https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/thirdparty/CMakeLists.txt#L11.
 
- openvino::zero_loader is defined in https://github.com/openvinotoolkit/openvino/blob/master/src/common/zero_loader/CMakeLists.txt#L18.
Target dependency Relationship between openvino::zero_loade's and thirdparty/system level-zero:
   - Target Selection: If ENABLE_SYSTEM_LEVEL_ZERO is ON, the build system first looks for the system package. It aliases LevelZero::LevelZero to either PkgConfig::level_zero (system) or ze_loader (bundled fallback to thirdparty) in https://github.com/openvinotoolkit/openvino/blob/master/thirdparty/dependencies.cmake#L76.
   - Header Propagation: The LevelZero::Headers target (alias of level_zero_headers) wraps the chosen LevelZero::LevelZero to propagate its include directories.  Note: If using the thirdparty level_zero, prepare_ze_headers is added as an optional build dependency.
  
  - Consuming Target: Finally, openvino::zero_loader links against LevelZero::Headers to inherit the header search paths https://github.com/openvinotoolkit/openvino/blob/master/src/common/zero_loader/CMakeLists.txt#L18 define openvino_zero_loader(openvino::zero_loader)


### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
