### PR TITLE
[TRANSFORMATIONS] Fix NCHW/NHWC layout mismatch in ConvertWeightCompressedConv1x1ToMatmul

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_weight_compressed_conv1x1_to_matmul.cpp
@@ -64,7 +64,8 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
     auto weight_reshape_m =
         ov::pass::pattern::wrap_type<ov::op::v1::Reshape>({weight_mult_m, ov::pass::pattern::any_input()});
     auto weight_input_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{weight_mult_m, weight_reshape_m});
-    auto conv1x1_m = ov::pass::pattern::wrap_type<ov::op::v1::Convolution>({a_m, weight_input_m});
+    auto conv1x1_m =
+        ov::pass::pattern::wrap_type<ov::op::v1::Convolution>({a_m, weight_input_m}, ov::pass::pattern::rank_equals(4));
 
     // Optional bias
     auto bias_const_m = wrap_type<ov::op::v0::Constant>(pattern::shape_matches("[1, ?, 1, 1]"));
@@ -259,19 +260,35 @@ ov::pass::ConvertWeightCompressedConv1x1ToMatmul::ConvertWeightCompressedConv1x1
         }
 
         if (reshape_out) {
+            std::shared_ptr<Node> pre_reshape_out = matmul_out;
             if (convert_out) {
                 auto convert_final = convert_out->clone_with_new_inputs({matmul_out});
-                auto reshape_final = reshape_out->clone_with_new_inputs({convert_final, out_order});
-                reshape_final->set_friendly_name(m.get_match_root()->get_friendly_name());
                 ov::copy_runtime_info(convert_out, convert_final);
-                ov::copy_runtime_info(m.get_matched_nodes(), reshape_final);
-                ov::replace_node(m.get_match_root(), reshape_final);
-            } else {
-                auto reshape_final = reshape_out->clone_with_new_inputs({matmul_out, out_order});
-                reshape_final->set_friendly_name(m.get_match_root()->get_friendly_name());
-                ov::copy_runtime_info(m.get_matched_nodes(), reshape_final);
-                ov::replace_node(m.get_match_root(), reshape_final);
+                pre_reshape_out = convert_final;
             }
+
+            // pre_reshape_out is NHWC (channel last, since MatMul(transpose_b=true) produces [N, H, W,
+            // Cout]), but Reshape never reorders elements, and reshape_out was built assuming NCHW
+            // element order (like the original Convolution's output [N, Cout, H, W]). Restore NCHW
+            // order before handing off to reshape_out, unless the spatial size H*W is statically 1 -
+            // in that case NHWC [N, 1, 1, Cout] and NCHW [N, Cout, 1, 1] have identical element order,
+            // so no restoring Transpose is needed.
+            const auto& conv_out_pshape = conv1x1->get_output_partial_shape(0);
+            const auto spatial_size = conv_out_pshape[2] * conv_out_pshape[3];
+            if (!(spatial_size.is_static() && spatial_size.get_length() == 1)) {
+                auto nhwc_to_nchw_order = std::make_shared<ov::op::v0::Constant>(ov::element::i32,
+                                                                                 ov::Shape{4},
+                                                                                 std::vector<int64_t>{0, 3, 1, 2});
+                auto pre_reshape_out_nchw =
+                    std::make_shared<ov::op::v1::Transpose>(pre_reshape_out, nhwc_to_nchw_order);
+                ov::copy_runtime_info(conv1x1, pre_reshape_out_nchw);
+                pre_reshape_out = pre_reshape_out_nchw;
+            }
+
+            auto reshape_final = reshape_out->clone_with_new_inputs({pre_reshape_out, out_order});
+            reshape_final->set_friendly_name(m.get_match_root()->get_friendly_name());
+            ov::copy_runtime_info(m.get_matched_nodes(), reshape_final);
+            ov::replace_node(m.get_match_root(), reshape_final);
         } else {
             if (convert_out) {
                 auto convert_final = convert_out->clone_with_new_inputs({matmul_out});

--- a/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_weight_compressed_conv1x1_to_matmul_test.cpp
@@ -303,4 +303,131 @@ TEST_F(ConvertWeightCompressedConv1x1ToMatmulTest_Blocked, conv3x3) {
     };
     model = CreateConv3x3();
 }
+
+// Regression test for the NCHW/NHWC layout mismatch when the Convolution output is consumed by a
+// Reshape and the spatial size H*W > 1 (see PR #37133). This mirrors the self-attention projections
+// of the machine-translation Transformer model that regressed: a weight-compressed 1x1 Convolution
+// producing NCHW [1, Cout, 1, W] (W > 1) feeding a Reshape to [Cout, W].
+//
+// MatMul(transpose_b=true) produces channel-last output [N, H, W, Cout], while the Convolution it
+// replaces produces channel-second NCHW [N, Cout, H, W]. Reshape never reorders elements, so the
+// matched Reshape (built for the Convolution's NCHW output) must receive NCHW data.
+class ConvertWeightCompressedConv1x1ToMatmulTest_ReshapeConsumerSpatial : public TransformationTestsF {
+public:
+    ConvertWeightCompressedConv1x1ToMatmulTest_ReshapeConsumerSpatial() {
+        manager.register_pass<ov::pass::ConvertWeightCompressedConv1x1ToMatmul>();
+    }
+};
+
+TEST_F(ConvertWeightCompressedConv1x1ToMatmulTest_ReshapeConsumerSpatial, conv1x1_reshape_consumer_spatial_gt_1) {
+    const int Cin = 10;
+    const int Cout = 15;
+    const int W = 5;  // spatial size > 1 - exposes the NHWC/NCHW mismatch
+
+    {
+        // input [1, 1, W, Cin] -> Transpose[0,3,1,2] -> conv input [1, Cin, 1, W]
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 1, W, Cin});
+        auto in_transpose_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
+        auto act_node = std::make_shared<ov::op::v1::Transpose>(input, in_transpose_const);
+
+        auto weights = ov::op::v0::Constant::create(ov::element::i4, ov::Shape{Cout, Cin, 1, 1}, {1});
+        auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, ov::element::f16);
+        auto scale = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{Cout, 1, 1, 1}, {1});
+        auto mul = std::make_shared<ov::op::v1::Multiply>(weights_convert, scale);
+
+        auto conv = std::make_shared<ov::op::v1::Convolution>(act_node,
+                                                              mul,
+                                                              ov::Strides{1, 1},
+                                                              ov::CoordinateDiff{0, 0},
+                                                              ov::CoordinateDiff{0, 0},
+                                                              ov::Strides{1, 1},
+                                                              ov::op::PadType::EXPLICIT);
+        // conv output NCHW [1, Cout, 1, W] -> Reshape to [Cout, W]
+        auto reshape_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{2}, {Cout, W});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(conv, reshape_const, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
+    }
+
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 1, W, Cin});
+
+        // weights squeezed to 2D [Cout, Cin]
+        auto weights = ov::op::v0::Constant::create(ov::element::i4, ov::Shape{Cout, Cin}, {1});
+        auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, ov::element::f16);
+        auto scale = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{Cout, 1}, {1});
+        auto mul = std::make_shared<ov::op::v1::Multiply>(weights_convert, scale);
+
+        // activation is used directly (input transpose is absorbed); MatMul(transpose_b=true)
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input, mul, false, true);  // -> [1, 1, W, Cout] NHWC
+
+        // MatMul output is already NHWC [N, H, W, Cout], so a single Transpose [0, 3, 1, 2] restores NCHW
+        auto nhwc_to_nchw_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
+        auto nchw = std::make_shared<ov::op::v1::Transpose>(matmul, nhwc_to_nchw_const);  // -> [1, Cout, 1, W]
+
+        // matched Reshape to [Cout, W]
+        auto reshape_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{2}, {Cout, W});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(nchw, reshape_const, false);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
+    }
+}
+
+// Companion to conv1x1_reshape_consumer_spatial_gt_1 for the spatial size H*W == 1 case, which
+// mirrors the gpt_oss Transformer self-attention projections: a weight-compressed 1x1 Convolution
+// producing NCHW [1, Cout, 1, 1] whose output is consumed by a Reshape.
+//
+// When H*W == 1 the channel-last MatMul output [N, 1, 1, Cout] and the NCHW order the matched
+// Reshape was built for [N, Cout, 1, 1] have identical element order, so no NCHW-restoring
+// Reshape/Transpose is needed - the MatMul output must feed the matched Reshape directly. This
+// guards against inserting the redundant no-op Reshape/Transpose pair (which is only required when
+// H*W > 1, see conv1x1_reshape_consumer_spatial_gt_1).
+TEST_F(ConvertWeightCompressedConv1x1ToMatmulTest_ReshapeConsumerSpatial, conv1x1_reshape_consumer_spatial_eq_1) {
+    const int Cin = 10;
+    const int Cout = 15;
+
+    {
+        // input [1, 1, 1, Cin] -> Transpose[0,3,1,2] -> conv input [1, Cin, 1, 1]
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 1, 1, Cin});
+        auto in_transpose_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
+        auto act_node = std::make_shared<ov::op::v1::Transpose>(input, in_transpose_const);
+
+        auto weights = ov::op::v0::Constant::create(ov::element::i4, ov::Shape{Cout, Cin, 1, 1}, {1});
+        auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, ov::element::f16);
+        auto scale = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{Cout, 1, 1, 1}, {1});
+        auto mul = std::make_shared<ov::op::v1::Multiply>(weights_convert, scale);
+
+        auto conv = std::make_shared<ov::op::v1::Convolution>(act_node,
+                                                              mul,
+                                                              ov::Strides{1, 1},
+                                                              ov::CoordinateDiff{0, 0},
+                                                              ov::CoordinateDiff{0, 0},
+                                                              ov::Strides{1, 1},
+                                                              ov::op::PadType::EXPLICIT);
+        // conv output NCHW [1, Cout, 1, 1] -> Reshape to [1, Cout]
+        auto reshape_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{2}, {1, Cout});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(conv, reshape_const, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
+    }
+
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 1, 1, Cin});
+
+        // weights squeezed to 2D [Cout, Cin]
+        auto weights = ov::op::v0::Constant::create(ov::element::i4, ov::Shape{Cout, Cin}, {1});
+        auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, ov::element::f16);
+        auto scale = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{Cout, 1}, {1});
+        auto mul = std::make_shared<ov::op::v1::Multiply>(weights_convert, scale);
+
+        // activation is used directly (input transpose is absorbed); MatMul(transpose_b=true)
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input, mul, false, true);  // -> [1, 1, 1, Cout] NHWC
+
+        // H*W == 1: the MatMul output feeds the matched Reshape directly, no Reshape/Transpose pair.
+        auto reshape_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{2}, {1, Cout});
+        auto reshape = std::make_shared<ov::op::v1::Reshape>(matmul, reshape_const, false);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
+    }
+}
 }  // namespace ov::test

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -387,6 +387,7 @@ const std::vector<std::regex>& disabled_test_patterns() {
             std::regex(R"(.*InterpolateLayerCPUTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)"),
             std::regex(R"(.*MatMulLayerCPUTest.*CompareWithRefs.*)"),
             std::regex(R"(.*MatmulWeightsDecompression.*CompareWithRefs.*)"),
+            std::regex(R"(.*Conv1x1WeightCompressedToMatmulTest.*)"),
             std::regex(R"(.*MvnLayerCPUTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)"),
             std::regex(R"(.*NonInputInPlaceTest.*CompareWithRefs.*)"),
             std::regex(R"(.*OVClassCompiledModelGetPropertyTest_EXEC_DEVICES.*CanGetExecutionDeviceInfo.*)"),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -681,6 +681,7 @@ const std::vector<std::regex>& disabled_test_patterns() {
         }
         if (!ov::with_cpu_arm_dotprod() && !ov::with_cpu_arm_i8mm()) {
             patterns.emplace_back(std::regex(R"(.*smoke_GroupedMatMul_Compressed.*)"));
+            patterns.emplace_back(std::regex(R"(.*Conv1x1WeightCompressedToMatmul.*)"));
         }
         // Accuracy issue in case of odd K
         patterns.emplace_back(std::regex(R"(.*smoke_GroupedMatMul_Compressed_CornerCases.*WET=i4.*)"));

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/test_constants.hpp"
+#include "subgraph_tests/conv1x1_weight_compressed_to_matmul.hpp"
+
+namespace {
+using ov::test::Conv1x1ExpectedOpCounts;
+using ov::test::Conv1x1WeightCompressedShapeParams;
+using ov::test::Conv1x1WeightCompressedToMatmulTest;
+using ov::test::InputShape;
+
+const std::vector<ov::element::Type> weights_precisions = {ov::element::i4, ov::element::i8};
+
+const Conv1x1ExpectedOpCounts op_counts_1x1{{"Convolution", 0}, {"FullyConnected", 1}, {"Transpose", 0}, {"Reshape", 1}};
+
+const InputShape transpose_in_1x1{{-1, 1, 1, 128}, {{1, 1, 1, 128}, {3, 1, 1, 128}}};
+// input Transpose, H*W == 1: the output decoration does not change the (fully eliminated) layout ops.
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Conv1x1WeightCompressedToMatmul_TransposeInput,
+    Conv1x1WeightCompressedToMatmulTest,
+    ::testing::Combine(::testing::Values(Conv1x1WeightCompressedShapeParams{transpose_in_1x1, 128}),
+                       ::testing::Values("Transpose"),
+                       ::testing::Values("Transpose", "Reshape"),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::ValuesIn(weights_precisions),
+                       ::testing::Values(op_counts_1x1),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU)),
+    Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
+
+const InputShape reshape_in_1x1{{-1, 128}, {{1, 128}, {3, 128}}};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Conv1x1WeightCompressedToMatmul_ReshapeInput,
+    Conv1x1WeightCompressedToMatmulTest,
+    ::testing::Combine(::testing::Values(Conv1x1WeightCompressedShapeParams{reshape_in_1x1, 128}),
+                       ::testing::Values("Reshape"),
+                       ::testing::Values("Reshape"),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::ValuesIn(weights_precisions),
+                       ::testing::Values(op_counts_1x1),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU)),
+    Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
+
+// H*W > 1: a 1x1 Convolution producing [N, 128, 1, 55] consumed by a Reshape. Transpose after MatMul is needed
+const InputShape transpose_in_1x55{{-1, 1, 55, 128}, {{1, 1, 55, 128}, {3, 1, 55, 128}}};
+const Conv1x1ExpectedOpCounts op_counts_1xW{{"Convolution", 0}, {"FullyConnected", 1}, {"Transpose", 1}, {"Reshape", 1}};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Conv1x1WeightCompressedToMatmul_SpatialGt1,
+    Conv1x1WeightCompressedToMatmulTest,
+    ::testing::Combine(::testing::Values(Conv1x1WeightCompressedShapeParams{transpose_in_1x55, 128}),
+                       ::testing::Values("Transpose"),
+                       ::testing::Values("Reshape"),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::ValuesIn(weights_precisions),
+                       ::testing::Values(op_counts_1xW),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU)),
+    Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
+
+}  // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "common_test_utils/test_constants.hpp"
+#include "openvino/runtime/properties.hpp"
 #include "subgraph_tests/conv1x1_weight_compressed_to_matmul.hpp"
 
 namespace {
@@ -12,6 +13,16 @@ using ov::test::Conv1x1WeightCompressedToMatmulTest;
 using ov::test::InputShape;
 
 const std::vector<ov::element::Type> weights_precisions = {ov::element::i4, ov::element::i8};
+
+// On ARM the compressed-weights path is only numerically correct through KleidiAI, which requires
+// disabling dynamic activation quantization (same convention as smoke_MatMulCompressedWeights_Kleidiai
+// and smoke_GroupedMatMul_Compressed). Platforms without the required ISA are skipped in
+// skip_tests_config.cpp, mirroring how the Kleidiai suite is gated.
+#if defined(OPENVINO_ARCH_ARM64) || defined(OPENVINO_ARCH_ARM)
+const ov::AnyMap config = {ov::hint::dynamic_quantization_group_size(UINT64_MAX)};
+#else
+const ov::AnyMap config = {};
+#endif
 
 const Conv1x1ExpectedOpCounts op_counts_1x1{{"Convolution", 0}, {"FullyConnected", 1}, {"Transpose", 0}, {"Reshape", 1}};
 
@@ -26,6 +37,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1x1),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 
@@ -40,6 +52,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1x1),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 
@@ -56,6 +69,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1xW),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
@@ -1,0 +1,62 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/test_constants.hpp"
+#include "subgraph_tests/conv1x1_weight_compressed_to_matmul.hpp"
+
+namespace {
+using ov::test::Conv1x1ExpectedOpCounts;
+using ov::test::Conv1x1WeightCompressedShapeParams;
+using ov::test::Conv1x1WeightCompressedToMatmulTest;
+using ov::test::InputShape;
+
+const std::vector<ov::element::Type> weights_precisions = {ov::element::i4, ov::element::i8};
+
+const Conv1x1ExpectedOpCounts op_counts_1x1{{"Convolution", 0}, {"FullyConnected", 1}, {"Transpose", 0}, {"Reshape", 1}};
+
+const InputShape transpose_in_1x1{{-1, 1, 1, 128}, {{1, 1, 1, 128}, {3, 1, 1, 128}}};
+// input Transpose, H*W == 1: the output decoration does not change the (fully eliminated) layout ops.
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Conv1x1WeightCompressedToMatmul_TransposeInput,
+    Conv1x1WeightCompressedToMatmulTest,
+    ::testing::Combine(::testing::Values(Conv1x1WeightCompressedShapeParams{transpose_in_1x1, 128}),
+                       ::testing::Values("Transpose"),
+                       ::testing::Values("Transpose", "Reshape"),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::ValuesIn(weights_precisions),
+                       ::testing::Values(op_counts_1x1),
+                       ::testing::Values(ov::test::utils::DEVICE_GPU)),
+    Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
+
+const InputShape reshape_in_1x1{{-1, 128}, {{1, 128}, {3, 128}}};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Conv1x1WeightCompressedToMatmul_ReshapeInput,
+    Conv1x1WeightCompressedToMatmulTest,
+    ::testing::Combine(::testing::Values(Conv1x1WeightCompressedShapeParams{reshape_in_1x1, 128}),
+                       ::testing::Values("Reshape"),
+                       ::testing::Values("Reshape"),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::ValuesIn(weights_precisions),
+                       ::testing::Values(op_counts_1x1),
+                       ::testing::Values(ov::test::utils::DEVICE_GPU)),
+    Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
+
+// H*W > 1: a 1x1 Convolution producing [N, 128, 1, 55] consumed by a Reshape. Transpose after MatMul is needed (Permute type is used in GPU)
+const InputShape transpose_in_1x55{{-1, 1, 55, 128}, {{1, 1, 55, 128}, {3, 1, 55, 128}}};
+const Conv1x1ExpectedOpCounts op_counts_1xW{{"Convolution", 0}, {"FullyConnected", 1}, {"Permute", 1}, {"Reshape", 1}};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Conv1x1WeightCompressedToMatmul_SpatialGt1,
+    Conv1x1WeightCompressedToMatmulTest,
+    ::testing::Combine(::testing::Values(Conv1x1WeightCompressedShapeParams{transpose_in_1x55, 128}),
+                       ::testing::Values("Transpose"),
+                       ::testing::Values("Reshape"),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::ValuesIn(weights_precisions),
+                       ::testing::Values(op_counts_1xW),
+                       ::testing::Values(ov::test::utils::DEVICE_GPU)),
+    Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
+
+}  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
@@ -12,6 +12,7 @@ using ov::test::Conv1x1WeightCompressedToMatmulTest;
 using ov::test::InputShape;
 
 const std::vector<ov::element::Type> weights_precisions = {ov::element::i4, ov::element::i8};
+const ov::AnyMap config = {};
 
 const Conv1x1ExpectedOpCounts op_counts_1x1{{"Convolution", 0}, {"FullyConnected", 1}, {"Transpose", 0}, {"Reshape", 1}};
 
@@ -26,6 +27,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1x1),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_GPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 
@@ -40,6 +42,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1x1),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_GPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 
@@ -56,6 +59,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1xW),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_GPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/conv1x1_weight_compressed_to_matmul.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/conv1x1_weight_compressed_to_matmul.hpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <tuple>
+
+#include "openvino/core/type/element_type.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+
+// Activation Parameter shape (dynamic + static test shapes) plus the Convolution output channels Cout.
+// The input channels and spatial size are derived from data_shape and the input decoration.
+struct Conv1x1WeightCompressedShapeParams {
+    InputShape data_shape;
+    size_t channels_out;
+};
+
+// Expected runtime op-type counts (ov::exec_model_info::LAYER_TYPE) after compilation; only the listed
+// types are asserted. Runtime op names are plugin specific, so the map is supplied per instantiation.
+using Conv1x1ExpectedOpCounts = std::map<std::string, size_t>;
+
+// A decoration is one of "None", "Transpose", "Reshape" ("Reshape" on the input side requires H*W == 1).
+using Conv1x1WeightCompressedToMatmulParams = std::tuple<
+    Conv1x1WeightCompressedShapeParams,  // geometry
+    std::string,                         // input decoration
+    std::string,                         // output decoration
+    ov::element::Type,                   // activation precision
+    ov::element::Type,                   // compressed weights precision
+    Conv1x1ExpectedOpCounts,             // expected runtime op-type counts
+    std::string                          // target device
+>;
+
+class Conv1x1WeightCompressedToMatmulTest
+    : public testing::WithParamInterface<Conv1x1WeightCompressedToMatmulParams>,
+      virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<Conv1x1WeightCompressedToMatmulParams>& obj);
+
+protected:
+    void SetUp() override;
+    void validate() override;
+
+private:
+    Conv1x1ExpectedOpCounts expected_op_counts_;
+};
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/conv1x1_weight_compressed_to_matmul.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/conv1x1_weight_compressed_to_matmul.hpp
@@ -33,6 +33,7 @@ using Conv1x1WeightCompressedToMatmulParams = std::tuple<
     ov::element::Type,                   // activation precision
     ov::element::Type,                   // compressed weights precision
     Conv1x1ExpectedOpCounts,             // expected runtime op-type counts
+    ov::AnyMap,                          // additional plugin configuration
     std::string                          // target device
 >;
 

--- a/src/tests/functional/plugin/shared/include/subgraph_tests/conv1x1_weight_compressed_to_matmul.hpp
+++ b/src/tests/functional/plugin/shared/include/subgraph_tests/conv1x1_weight_compressed_to_matmul.hpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/subgraph/conv1x1_weight_compressed_to_matmul.hpp"
+
+namespace ov {
+namespace test {
+
+TEST_P(Conv1x1WeightCompressedToMatmulTest, Inference) {
+    run();
+}
+
+}  // namespace test
+}  // namespace ov

--- a/src/tests/functional/plugin/shared/src/subgraph/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/conv1x1_weight_compressed_to_matmul.cpp
@@ -34,22 +34,39 @@ void validate_decoration(const std::string& decoration) {
 
 std::string Conv1x1WeightCompressedToMatmulTest::getTestCaseName(
     const testing::TestParamInfo<Conv1x1WeightCompressedToMatmulParams>& obj) {
-    const auto& [shape_params, in_decoration, out_decoration, act_prec, weights_prec, expected_op_counts, device] =
-        obj.param;
+    const auto& [shape_params,
+                 in_decoration,
+                 out_decoration,
+                 act_prec,
+                 weights_prec,
+                 expected_op_counts,
+                 config,
+                 device] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << shape_params.data_shape << "_";
     result << "Cout=" << shape_params.channels_out << "_";
     result << "in=" << in_decoration << "_out=" << out_decoration << "_";
-    result << "actPrec=" << act_prec << "_wPrec=" << weights_prec << "_device=" << device;
+    result << "actPrec=" << act_prec << "_wPrec=" << weights_prec << "_config=(";
+    for (const auto& configEntry : config) {
+        result << configEntry.first << "_";
+    }
+    result << ")_device=" << device;
     return result.str();
 }
 
 void Conv1x1WeightCompressedToMatmulTest::SetUp() {
-    const auto& [shape_params, in_decoration, out_decoration, act_prec, weights_prec, expected_op_counts, device] =
-        GetParam();
+    const auto& [shape_params,
+                 in_decoration,
+                 out_decoration,
+                 act_prec,
+                 weights_prec,
+                 expected_op_counts,
+                 config,
+                 device] = GetParam();
     targetDevice = device;
     expected_op_counts_ = expected_op_counts;
+    configuration.insert(config.begin(), config.end());
     abs_threshold = 0.05f;
     rel_threshold = 0.01f;
     validate_decoration(in_decoration);

--- a/src/tests/functional/plugin/shared/src/subgraph/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/conv1x1_weight_compressed_to_matmul.cpp
@@ -1,0 +1,122 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/conv1x1_weight_compressed_to_matmul.hpp"
+
+#include <sstream>
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/convolution.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/runtime/properties.hpp"
+
+namespace ov {
+namespace test {
+
+namespace {
+const std::string DECOR_NONE = "None";
+const std::string DECOR_TRANSPOSE = "Transpose";
+const std::string DECOR_RESHAPE = "Reshape";
+
+void validate_decoration(const std::string& decoration) {
+    OPENVINO_ASSERT(decoration == DECOR_NONE || decoration == DECOR_TRANSPOSE || decoration == DECOR_RESHAPE,
+                    "Unsupported conv1x1 decoration: ",
+                    decoration);
+}
+}  // namespace
+
+std::string Conv1x1WeightCompressedToMatmulTest::getTestCaseName(
+    const testing::TestParamInfo<Conv1x1WeightCompressedToMatmulParams>& obj) {
+    const auto& [shape_params, in_decoration, out_decoration, act_prec, weights_prec, expected_op_counts, device] =
+        obj.param;
+
+    std::ostringstream result;
+    result << "IS=" << shape_params.data_shape << "_";
+    result << "Cout=" << shape_params.channels_out << "_";
+    result << "in=" << in_decoration << "_out=" << out_decoration << "_";
+    result << "actPrec=" << act_prec << "_wPrec=" << weights_prec << "_device=" << device;
+    return result.str();
+}
+
+void Conv1x1WeightCompressedToMatmulTest::SetUp() {
+    const auto& [shape_params, in_decoration, out_decoration, act_prec, weights_prec, expected_op_counts, device] =
+        GetParam();
+    targetDevice = device;
+    expected_op_counts_ = expected_op_counts;
+    abs_threshold = 0.05f;
+    rel_threshold = 0.01f;
+    validate_decoration(in_decoration);
+    validate_decoration(out_decoration);
+
+    init_input_shapes({shape_params.data_shape});
+    const auto& param_pshape = inputDynamicShapes[0];
+
+    // Cin is the Convolution input channel: last dim for the Transpose input layout, dim 1 otherwise.
+    const auto Cin = (in_decoration == DECOR_TRANSPOSE ? param_pshape[param_pshape.size() - 1] : param_pshape[1]).get_length();
+    OPENVINO_ASSERT(in_decoration != DECOR_RESHAPE || param_pshape.size() == 2,
+                    "Reshape input decoration expects a 2D [N, Cin] activation");
+
+    auto param = std::make_shared<ov::op::v0::Parameter>(act_prec, param_pshape);
+
+    std::shared_ptr<ov::Node> conv_input = param;
+    if (in_decoration == DECOR_TRANSPOSE) {
+        auto order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {0, 3, 1, 2});
+        conv_input = std::make_shared<ov::op::v1::Transpose>(param, order);
+    } else if (in_decoration == DECOR_RESHAPE) {
+        auto pattern = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {0, static_cast<int>(Cin), 1, 1});
+        conv_input = std::make_shared<ov::op::v1::Reshape>(param, pattern, true);
+    }
+
+    const int seed = 1;
+    const int up_to = weights_prec == ov::element::u2 ? 3 : (weights_prec == ov::element::i4 ? 7 : 15);
+    const int start_from = weights_prec == ov::element::u2 ? 0 : 1;
+    auto weights_tensor = ov::test::utils::create_and_fill_tensor(
+        weights_prec,
+        ov::Shape{shape_params.channels_out, static_cast<size_t>(Cin), 1, 1},
+        ov::test::utils::InputGenerateData(start_from, up_to, 1, seed));
+    auto weights = std::make_shared<ov::op::v0::Constant>(weights_tensor);
+    auto weights_convert = std::make_shared<ov::op::v0::Convert>(weights, act_prec);
+    auto scale_tensor = ov::test::utils::create_and_fill_tensor_real_distribution(
+        act_prec, ov::Shape{shape_params.channels_out, 1, 1, 1}, 0.001f, 0.01f, seed);
+    auto scale = std::make_shared<ov::op::v0::Constant>(scale_tensor);
+    auto weights_dequant = std::make_shared<ov::op::v1::Multiply>(weights_convert, scale);
+
+    auto conv = std::make_shared<ov::op::v1::Convolution>(conv_input,
+                                                          weights_dequant,
+                                                          ov::Strides{1, 1},
+                                                          ov::CoordinateDiff{0, 0},
+                                                          ov::CoordinateDiff{0, 0},
+                                                          ov::Strides{1, 1},
+                                                          ov::op::PadType::EXPLICIT);
+
+    std::shared_ptr<ov::Node> out_node = conv;
+    if (out_decoration == DECOR_TRANSPOSE) {
+        auto order = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{4}, {0, 2, 3, 1});
+        out_node = std::make_shared<ov::op::v1::Transpose>(conv, order);
+    } else if (out_decoration == DECOR_RESHAPE) {
+        auto pattern = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{2}, {0, -1});
+        out_node = std::make_shared<ov::op::v1::Reshape>(conv, pattern, true);
+    }
+
+    auto result = std::make_shared<ov::op::v0::Result>(out_node);
+    function = std::make_shared<ov::Model>(ov::ResultVector{result},
+                                           ov::ParameterVector{param},
+                                           "Conv1x1WeightCompressedToMatmul");
+}
+
+void Conv1x1WeightCompressedToMatmulTest::validate() {
+    SubgraphBaseTest::validate();
+    for (const auto& [layer_type, expected_count] : expected_op_counts_) {
+        CheckNumberOfNodesWithType(compiledModel, layer_type, expected_count);
+    }
+}
+
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
Port of PR #37181, adapted to the release branch.

### Details:

- MatMul (transpose_b=true) produces output with the channel dimension last (e.g. [N, H, W, Cout]), while the Convolution it replaces always produces channel dimension second (NCHW: [N, Cout, H, W]).
- When the matched output consumer is a Transpose, this is harmless - the Transpose is dropped and the channel-last MatMul output is reused directly, since it already matches what that Transpose would have produced.
- But when the output consumer is a Reshape, the code fed the channel-last MatMul output straight into it. Reshape never reorders elements, and the matched Reshape was built assuming NCHW element order (like the original Convolution's output) - so this silently scrambled the channel/spatial ordering of the data whenever H*W > 1.
- Restores NCHW order (Transpose [0, 3, 1, 2]) before handing off to the matched Reshape, unless the spatial size H*W is statically known to be 1 (in which case NHWC and NCHW element order are identical). Also bails out gracefully (rather than asserting) if the Convolution's output rank isn't statically known to be 4.
- Updated existing transformation tests, added CPU/GPU plugin tests to cover the affected transformation.

### Tickets:
 - *CVS-191915*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to port the changes and tests to the release branch. The changes were manually verified*
