### PR TITLE
[ONNX FE] Preserve zero_point name in MatMulNBits for weight sharing

### DIFF
--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -226,6 +226,14 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                 converted_zero_points = std::make_shared<v0::Constant>(a.get_element_type(),
                                                                        casted_zp_shape,
                                                                        zero_points_const->get_data_ptr());
+                // Preserve the original zero_point name on the repacked Constant (as done for B) so weight
+                // sharing / weights-as-input can still identify it by name.
+                if (const auto casted_zp_const =
+                        ov::as_type_ptr<v0::Constant>(converted_zero_points.get_node_shared_ptr())) {
+                    casted_zp_const->set_friendly_name(zero_points_const->get_friendly_name());
+                    casted_zp_const->get_output_tensor(0).set_names(
+                        zero_points_const->get_output_tensor(0).get_names());
+                }
             } else if (zero_points.get_element_type() == ov::element::u8) {
                 // for alignment, n_blocks_per_col might not aligned to num_per_byte
                 uint64_t num_per_byte = 8 / bits;
@@ -235,6 +243,11 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                     ov::Shape{static_cast<size_t>(N), static_cast<size_t>(num_elements_aligned), 1};
                 auto casted_zp_org =
                     std::make_shared<v0::Constant>(zp_element_type, casted_zp_shape, zero_points_const->get_data_ptr());
+                // Preserve the original zero_point name on the repacked low-bit Constant (as done for B) so
+                // weight sharing / weights-as-input can identify it by name. This packed Constant keeps the
+                // source uint8 byte count, so the promoted input's tensor matches the external weight at runtime.
+                casted_zp_org->set_friendly_name(zero_points_const->get_friendly_name());
+                casted_zp_org->get_output_tensor(0).set_names(zero_points_const->get_output_tensor(0).get_names());
                 converted_zero_points = std::make_shared<v0::Convert>(casted_zp_org, a.get_element_type());
                 if (n_blocks_per_col != num_elements_aligned) {
                     // if not align

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -28,6 +28,17 @@ namespace frontend {
 namespace onnx {
 namespace com_microsoft {
 namespace opset_1 {
+namespace {
+// MatMulNBits repacks B/scales/zero_point initializers into new low-bit Constants. Preserve the
+// original ONNX initializer's friendly name and tensor names on the repacked Constant so weight
+// sharing / weights-as-input can still identify it as the same external weight.
+void preserve_initializer_name(const std::shared_ptr<v0::Constant>& repacked,
+                               const std::shared_ptr<v0::Constant>& original) {
+    repacked->set_friendly_name(original->get_friendly_name());
+    repacked->get_output_tensor(0).set_names(original->get_output_tensor(0).get_names());
+}
+}  // namespace
+
 ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
     common::default_op_checks(node, 3);
     // Original documentation:
@@ -177,10 +188,9 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
         }
 
         // Preserve the original B initializer name on the repacked weight constant so it can still be
-        // identified by name downstream (e.g. for weight sharing). Only B is named.
+        // identified by name downstream (e.g. for weight sharing).
         if (const auto casted_b_const = ov::as_type_ptr<v0::Constant>(casted_b.get_node_shared_ptr())) {
-            casted_b_const->set_friendly_name(b_const->get_friendly_name());
-            casted_b_const->get_output_tensor(0).set_names(b_const->get_output_tensor(0).get_names());
+            preserve_initializer_name(casted_b_const, b_const);
         }
 
         ov::Output<ov::Node> converted_zero_points;
@@ -230,9 +240,7 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                 // sharing / weights-as-input can still identify it by name.
                 if (const auto casted_zp_const =
                         ov::as_type_ptr<v0::Constant>(converted_zero_points.get_node_shared_ptr())) {
-                    casted_zp_const->set_friendly_name(zero_points_const->get_friendly_name());
-                    casted_zp_const->get_output_tensor(0).set_names(
-                        zero_points_const->get_output_tensor(0).get_names());
+                    preserve_initializer_name(casted_zp_const, zero_points_const);
                 }
             } else if (zero_points.get_element_type() == ov::element::u8) {
                 // for alignment, n_blocks_per_col might not aligned to num_per_byte
@@ -243,6 +251,11 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                     ov::Shape{static_cast<size_t>(N), static_cast<size_t>(num_elements_aligned), 1};
                 auto casted_zp_org =
                     std::make_shared<v0::Constant>(zp_element_type, casted_zp_shape, zero_points_const->get_data_ptr());
+                // Preserve the original zero_point name on the repacked Constant (as done for B) so weight
+                // sharing can promote it. The packed Constant keeps the source uint8 byte count, so the
+                // promoted input's tensor matches the external weight at runtime - true whether or not the
+                // Slice below is inserted, so name it unconditionally.
+                preserve_initializer_name(casted_zp_org, zero_points_const);
                 converted_zero_points = std::make_shared<v0::Convert>(casted_zp_org, a.get_element_type());
                 if (n_blocks_per_col != num_elements_aligned) {
                     // if not align
@@ -254,12 +267,6 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                                                                              static_cast<int32_t>(n_blocks_per_col));
                     converted_zero_points =
                         std::make_shared<v8::Slice>(converted_zero_points, zero, num_elements, one, axis);
-                } else {
-                    // Aligned (no Slice): preserve the original zero_point name on the repacked Constant (as
-                    // done for B) so weight sharing can promote it. The packed Constant keeps the source uint8
-                    // byte count, so the promoted input's tensor matches the external weight at runtime.
-                    casted_zp_org->set_friendly_name(zero_points_const->get_friendly_name());
-                    casted_zp_org->get_output_tensor(0).set_names(zero_points_const->get_output_tensor(0).get_names());
                 }
             } else {
                 FRONT_END_THROW("Unexpected zero point type");

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -243,11 +243,6 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                     ov::Shape{static_cast<size_t>(N), static_cast<size_t>(num_elements_aligned), 1};
                 auto casted_zp_org =
                     std::make_shared<v0::Constant>(zp_element_type, casted_zp_shape, zero_points_const->get_data_ptr());
-                // Preserve the original zero_point name on the repacked low-bit Constant (as done for B) so
-                // weight sharing / weights-as-input can identify it by name. This packed Constant keeps the
-                // source uint8 byte count, so the promoted input's tensor matches the external weight at runtime.
-                casted_zp_org->set_friendly_name(zero_points_const->get_friendly_name());
-                casted_zp_org->get_output_tensor(0).set_names(zero_points_const->get_output_tensor(0).get_names());
                 converted_zero_points = std::make_shared<v0::Convert>(casted_zp_org, a.get_element_type());
                 if (n_blocks_per_col != num_elements_aligned) {
                     // if not align
@@ -259,6 +254,12 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                                                                              static_cast<int32_t>(n_blocks_per_col));
                     converted_zero_points =
                         std::make_shared<v8::Slice>(converted_zero_points, zero, num_elements, one, axis);
+                } else {
+                    // Aligned (no Slice): preserve the original zero_point name on the repacked Constant (as
+                    // done for B) so weight sharing can promote it. The packed Constant keeps the source uint8
+                    // byte count, so the promoted input's tensor matches the external weight at runtime.
+                    casted_zp_org->set_friendly_name(zero_points_const->get_friendly_name());
+                    casted_zp_org->get_output_tensor(0).set_names(zero_points_const->get_output_tensor(0).get_names());
                 }
             } else {
                 FRONT_END_THROW("Unexpected zero point type");

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_3x32_zp_sametype.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_3x32_zp_sametype.prototxt
@@ -1,0 +1,106 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+producer_version: ""
+model_version: 0
+graph {
+  name: "test_matmul_2d"
+  node {
+    input: "a"
+    input: "b_Q4"
+    input: "b_scales"
+    input: "b_zp"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 32
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 3
+      type: INT
+    }
+    attribute {
+      name: "accuracy_level"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  initializer {
+    dims: 3
+    dims: 2
+    dims: 8
+    data_type: 2
+    name: "b_Q4"
+    raw_data: "\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87"
+  }
+  initializer {
+    dims: 6
+    data_type: 1
+    name: "b_zp"
+    raw_data: "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "b_scales"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 7
+}
+opset_import {
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_3x48_zp_unaligned.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_3x48_zp_unaligned.prototxt
@@ -1,0 +1,106 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+producer_version: ""
+model_version: 0
+graph {
+  name: "test_matmul_2d"
+  node {
+    input: "a"
+    input: "b_Q4"
+    input: "b_scales"
+    input: "b_zp"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 48
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 3
+      type: INT
+    }
+    attribute {
+      name: "accuracy_level"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  initializer {
+    dims: 3
+    dims: 3
+    dims: 8
+    data_type: 2
+    name: "b_Q4"
+    raw_data: "\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87"
+  }
+  initializer {
+    dims: 6
+    data_type: 2
+    name: "b_zp"
+    raw_data: "\x23\x45\x56\x23\x45\x56"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 48
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "b_scales"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 9
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 7
+}
+opset_import {
+  version: 1
+}

--- a/src/frontends/onnx/tests/onnx_tensor_names.cpp
+++ b/src/frontends/onnx/tests/onnx_tensor_names.cpp
@@ -184,6 +184,22 @@ OPENVINO_TEST(onnx_tensor_names, matmulnbits_b_name_preserved) {
     EXPECT_EQ(packed_b->get_element_type(), element::u4);
 }
 
+OPENVINO_TEST(onnx_tensor_names, matmulnbits_zp_name_preserved) {
+    // MatMulNBits repacks the zero-point into a low-bit Constant; it must keep the ONNX initializer name
+    // "b_zp" so weight sharing / weights-as-input can identify it (mirrors matmulnbits_b_name_preserved).
+    const auto model = convert_model("com.microsoft/matmulnbits_3x32_zp.onnx");
+
+    const auto ops = model->get_ordered_ops();
+
+    // Repacked zero-point keeps "b_zp" as friendly_name and tensor name.
+    EXPECT_TRUE(matching_node_found_in_graph<op::v0::Constant>(ops, "b_zp", {"b_zp"}));
+
+    // It is the u4 repacked zero-point (bits=4), not the original uint8 initializer.
+    const auto packed_zp = find_by_friendly_name<op::v0::Constant>(ops, "b_zp");
+    ASSERT_NE(packed_zp, nullptr);
+    EXPECT_EQ(packed_zp->get_element_type(), element::u4);
+}
+
 OPENVINO_TEST(onnx_tensor_names, matmulnbits_shared_b_name_collision_resolved) {
     // One B feeding two MatMulNBits creates two same-named Constants; ResolveNameCollisions (in
     // normalize) keeps "b_Q4" on one and suffixes the other - no manual postfix needed.
@@ -192,7 +208,8 @@ OPENVINO_TEST(onnx_tensor_names, matmulnbits_shared_b_name_collision_resolved) {
     const auto ops = model->get_ordered_ops();
 
     // Collect the two named u4 weights directly: counting and uniqueness can't be expressed by the
-    // bool/first-match helpers. Unnamed u4 zero-point constants are excluded by the name check.
+    // bool/first-match helpers. This model has no zero-point input, so the only named u4 constants are
+    // the two repacked B weights (the default zero-point is unnamed).
     std::vector<std::shared_ptr<op::v0::Constant>> packed_weights;
     for (const auto& op : ops) {
         const auto c = ov::as_type_ptr<op::v0::Constant>(op);

--- a/src/frontends/onnx/tests/onnx_tensor_names.cpp
+++ b/src/frontends/onnx/tests/onnx_tensor_names.cpp
@@ -200,6 +200,37 @@ OPENVINO_TEST(onnx_tensor_names, matmulnbits_zp_name_preserved) {
     EXPECT_EQ(packed_zp->get_element_type(), element::u4);
 }
 
+OPENVINO_TEST(onnx_tensor_names, matmulnbits_zp_name_preserved_unaligned) {
+    // Same as matmulnbits_zp_name_preserved, but n_blocks_per_col (3) is not a multiple of num_per_byte
+    // (2 for bits=4), so the packed zero-point takes the Slice path. The repacked Constant must still
+    // keep the ONNX initializer name - this is the bug fixed after e07506d308 moved the name-copy into
+    // the aligned-only else branch.
+    const auto model = convert_model("com.microsoft/matmulnbits_3x48_zp_unaligned.onnx");
+
+    const auto ops = model->get_ordered_ops();
+
+    EXPECT_TRUE(matching_node_found_in_graph<op::v0::Constant>(ops, "b_zp", {"b_zp"}));
+
+    const auto packed_zp = find_by_friendly_name<op::v0::Constant>(ops, "b_zp");
+    ASSERT_NE(packed_zp, nullptr);
+    EXPECT_EQ(packed_zp->get_element_type(), element::u4);
+}
+
+OPENVINO_TEST(onnx_tensor_names, matmulnbits_zp_name_preserved_sametype) {
+    // zero_point has the same element type as A (float), so it takes the "not packed" branch that
+    // builds converted_zero_points directly as a Constant of A's type. Must also keep the ONNX
+    // initializer name.
+    const auto model = convert_model("com.microsoft/matmulnbits_3x32_zp_sametype.onnx");
+
+    const auto ops = model->get_ordered_ops();
+
+    EXPECT_TRUE(matching_node_found_in_graph<op::v0::Constant>(ops, "b_zp", {"b_zp"}));
+
+    const auto packed_zp = find_by_friendly_name<op::v0::Constant>(ops, "b_zp");
+    ASSERT_NE(packed_zp, nullptr);
+    EXPECT_EQ(packed_zp->get_element_type(), element::f32);
+}
+
 OPENVINO_TEST(onnx_tensor_names, matmulnbits_shared_b_name_collision_resolved) {
     // One B feeding two MatMulNBits creates two same-named Constants; ResolveNameCollisions (in
     // normalize) keeps "b_Q4" on one and suffixes the other - no manual postfix needed.


### PR DESCRIPTION
### Details:

The MatMulNBits decomposition repacks the zero_point initializer into a new low-bit Constant (both the same-type and the uint8-packed paths), which dropped the original initializer name. Downstream weight sharing / weights-as-input in the OpenVINO EP identifies shared weights by name, so an externally stored zero_point could never be promoted to an input and was baked into every compiled blob instead.

Restore the original zero_point name (friendly name and tensor names) on the repacked Constant, mirroring the existing handling for the B weight. The repacked packed-uint8 Constant keeps the source byte count, so the promoted input's tensor matches the external weight at runtime. Scales already retain their name because that Constant is reused as-is.


### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-192389

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
