### PR TITLE
[CPU][ARM] New ConvertWeightCompressedConv1x1ToMatmul tests are aligned with existing MatMulCompressedWeights tests

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -387,6 +387,7 @@ const std::vector<std::regex>& disabled_test_patterns() {
             std::regex(R"(.*InterpolateLayerCPUTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)"),
             std::regex(R"(.*MatMulLayerCPUTest.*CompareWithRefs.*)"),
             std::regex(R"(.*MatmulWeightsDecompression.*CompareWithRefs.*)"),
+            std::regex(R"(.*Conv1x1WeightCompressedToMatmulTest.*)"),
             std::regex(R"(.*MvnLayerCPUTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)"),
             std::regex(R"(.*NonInputInPlaceTest.*CompareWithRefs.*)"),
             std::regex(R"(.*OVClassCompiledModelGetPropertyTest_EXEC_DEVICES.*CanGetExecutionDeviceInfo.*)"),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -690,6 +690,7 @@ const std::vector<std::regex>& disabled_test_patterns() {
         }
         if (!ov::with_cpu_arm_dotprod() && !ov::with_cpu_arm_i8mm()) {
             patterns.emplace_back(std::regex(R"(.*smoke_GroupedMatMul_Compressed.*)"));
+            patterns.emplace_back(std::regex(R"(.*Conv1x1WeightCompressedToMatmul.*)"));
         }
         // Accuracy issue in case of odd K
         patterns.emplace_back(std::regex(R"(.*smoke_GroupedMatMul_Compressed_CornerCases.*WET=i4.*)"));

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "common_test_utils/test_constants.hpp"
+#include "openvino/runtime/properties.hpp"
 #include "subgraph_tests/conv1x1_weight_compressed_to_matmul.hpp"
 
 namespace {
@@ -12,6 +13,16 @@ using ov::test::Conv1x1WeightCompressedToMatmulTest;
 using ov::test::InputShape;
 
 const std::vector<ov::element::Type> weights_precisions = {ov::element::i4, ov::element::i8};
+
+// On ARM the compressed-weights path is only numerically correct through KleidiAI, which requires
+// disabling dynamic activation quantization (same convention as smoke_MatMulCompressedWeights_Kleidiai
+// and smoke_GroupedMatMul_Compressed). Platforms without the required ISA are skipped in
+// skip_tests_config.cpp, mirroring how the Kleidiai suite is gated.
+#if defined(OPENVINO_ARCH_ARM64) || defined(OPENVINO_ARCH_ARM)
+const ov::AnyMap config = {ov::hint::dynamic_quantization_group_size(UINT64_MAX)};
+#else
+const ov::AnyMap config = {};
+#endif
 
 const Conv1x1ExpectedOpCounts op_counts_1x1{{"Convolution", 0}, {"FullyConnected", 1}, {"Transpose", 0}, {"Reshape", 1}};
 
@@ -26,6 +37,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1x1),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 
@@ -40,6 +52,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1x1),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 
@@ -56,6 +69,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1xW),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_CPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/conv1x1_weight_compressed_to_matmul.cpp
@@ -12,6 +12,7 @@ using ov::test::Conv1x1WeightCompressedToMatmulTest;
 using ov::test::InputShape;
 
 const std::vector<ov::element::Type> weights_precisions = {ov::element::i4, ov::element::i8};
+const ov::AnyMap config = {};
 
 const Conv1x1ExpectedOpCounts op_counts_1x1{{"Convolution", 0}, {"FullyConnected", 1}, {"Transpose", 0}, {"Reshape", 1}};
 
@@ -26,6 +27,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1x1),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_GPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 
@@ -40,6 +42,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1x1),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_GPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 
@@ -56,6 +59,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(ov::element::f32),
                        ::testing::ValuesIn(weights_precisions),
                        ::testing::Values(op_counts_1xW),
+                       ::testing::Values(config),
                        ::testing::Values(ov::test::utils::DEVICE_GPU)),
     Conv1x1WeightCompressedToMatmulTest::getTestCaseName);
 

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/conv1x1_weight_compressed_to_matmul.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/conv1x1_weight_compressed_to_matmul.hpp
@@ -33,6 +33,7 @@ using Conv1x1WeightCompressedToMatmulParams = std::tuple<
     ov::element::Type,                   // activation precision
     ov::element::Type,                   // compressed weights precision
     Conv1x1ExpectedOpCounts,             // expected runtime op-type counts
+    ov::AnyMap,                          // additional plugin configuration
     std::string                          // target device
 >;
 

--- a/src/tests/functional/plugin/shared/src/subgraph/conv1x1_weight_compressed_to_matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/conv1x1_weight_compressed_to_matmul.cpp
@@ -34,22 +34,39 @@ void validate_decoration(const std::string& decoration) {
 
 std::string Conv1x1WeightCompressedToMatmulTest::getTestCaseName(
     const testing::TestParamInfo<Conv1x1WeightCompressedToMatmulParams>& obj) {
-    const auto& [shape_params, in_decoration, out_decoration, act_prec, weights_prec, expected_op_counts, device] =
-        obj.param;
+    const auto& [shape_params,
+                 in_decoration,
+                 out_decoration,
+                 act_prec,
+                 weights_prec,
+                 expected_op_counts,
+                 config,
+                 device] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << shape_params.data_shape << "_";
     result << "Cout=" << shape_params.channels_out << "_";
     result << "in=" << in_decoration << "_out=" << out_decoration << "_";
-    result << "actPrec=" << act_prec << "_wPrec=" << weights_prec << "_device=" << device;
+    result << "actPrec=" << act_prec << "_wPrec=" << weights_prec << "_config=(";
+    for (const auto& configEntry : config) {
+        result << configEntry.first << "_";
+    }
+    result << ")_device=" << device;
     return result.str();
 }
 
 void Conv1x1WeightCompressedToMatmulTest::SetUp() {
-    const auto& [shape_params, in_decoration, out_decoration, act_prec, weights_prec, expected_op_counts, device] =
-        GetParam();
+    const auto& [shape_params,
+                 in_decoration,
+                 out_decoration,
+                 act_prec,
+                 weights_prec,
+                 expected_op_counts,
+                 config,
+                 device] = GetParam();
     targetDevice = device;
     expected_op_counts_ = expected_op_counts;
+    configuration.insert(config.begin(), config.end());
     abs_threshold = 0.05f;
     rel_threshold = 0.01f;
     validate_decoration(in_decoration);


### PR DESCRIPTION
### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to perform the tests alignment, mentioned in the title*
