### PR TITLE
[GPU] Add f8 & f4 support to reorder_weights_opt kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/f4_utils.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/f4_utils.cl
@@ -177,6 +177,9 @@ float16 __attribute__((overloadable)) _convert_float16(fp4e2m1_t16 val) {
 }
 
 
+fp4e2m1_t __attribute__((overloadable)) _convert_fp4e2m1_t(fp4e2m1_t val) {
+    return val;
+}
 fp4e2m1_t __attribute__((overloadable)) _convert_fp4e2m1_t(half val) {
     fp4e2m1_t res;
     res.data = _intel_convert_f16_to_f4(val);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/f8_utils.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/f8_utils.cl
@@ -360,6 +360,9 @@ float16 __attribute__((overloadable)) _convert_float16(fp8e8m0_t16 val) {
     );
 }
 
+fp8e5m2_t __attribute__((overloadable)) _convert_fp8e5m2_t(fp8e5m2_t val) {
+    return val;
+}
 fp8e5m2_t __attribute__((overloadable)) _convert_fp8e5m2_t(float val) {
     fp8e5m2_t res;
     res.data = _intel_convert_f16_to_bf8((half)val);
@@ -616,6 +619,9 @@ fp8e5m2_t16 __attribute__((overloadable)) _convert_fp8e5m2_t16_sat(half16 val) {
     return res;
 }
 
+fp8e4m3_t __attribute__((overloadable)) _convert_fp8e4m3_t(fp8e4m3_t val) {
+    return val;
+}
 fp8e4m3_t __attribute__((overloadable)) _convert_fp8e4m3_t(float val) {
     fp8e4m3_t res;
     res.data = _intel_convert_f16_to_hf8((half)val);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_opt.cl
@@ -125,7 +125,7 @@ KERNEL(reorder_weights_opt)(const __global INPUT0_TYPE* input, __global OUTPUT_T
         val = (OUTPUT_TYPE)0;
     }
 #else
-    val = valid_lane ? TO_OUTPUT_TYPE(input[input_idx]) : TO_OUTPUT_TYPE(0);
+    val = valid_lane ? TO_OUTPUT_TYPE(input[input_idx]) : OUTPUT_VAL_ZERO;
 #endif
 #else
     OUTPUT_VEC_TYPE val = 0;
@@ -135,7 +135,7 @@ KERNEL(reorder_weights_opt)(const __global INPUT0_TYPE* input, __global OUTPUT_T
             val[b] = TO_OUTPUT_TYPE(input[input_idx]);
         }
 #else
-        val[b] = valid_lane ? TO_OUTPUT_TYPE(input[input_idx]) : TO_OUTPUT_TYPE(0);
+        val[b] = valid_lane ? TO_OUTPUT_TYPE(input[input_idx]) : OUTPUT_VAL_ZERO;
 #endif
         input_idx += PITCH;
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_opt.cl
@@ -2,6 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#define IS_FP8 (F8E5M2_INPUT || F8E4M3_INPUT || F8E8M0_INPUT || F8E5M2_OUTPUT || F8E4M3_OUTPUT || F8E8M0_OUTPUT)
+#define IS_FP4 (F4E2M1_INPUT || F4E2M1_OUTPUT)
+
+#if (IS_FP8 || IS_FP4)
+#include "include/f8_utils.cl"
+#endif
+
+#if IS_FP4
+#include "include/f4_utils.cl"
+#endif
+
 #include "include/batch_headers/common.cl"
 
 INIT_INPUT0_INDEX_FUNC_HERE
@@ -114,7 +125,7 @@ KERNEL(reorder_weights_opt)(const __global INPUT0_TYPE* input, __global OUTPUT_T
         val = (OUTPUT_TYPE)0;
     }
 #else
-    val = valid_lane ? TO_OUTPUT_TYPE(input[input_idx]) : (OUTPUT_TYPE)0;
+    val = valid_lane ? TO_OUTPUT_TYPE(input[input_idx]) : TO_OUTPUT_TYPE(0);
 #endif
 #else
     OUTPUT_VEC_TYPE val = 0;
@@ -124,7 +135,7 @@ KERNEL(reorder_weights_opt)(const __global INPUT0_TYPE* input, __global OUTPUT_T
             val[b] = TO_OUTPUT_TYPE(input[input_idx]);
         }
 #else
-        val[b] = valid_lane ? TO_OUTPUT_TYPE(input[input_idx]) : (OUTPUT_TYPE)0;
+        val[b] = valid_lane ? TO_OUTPUT_TYPE(input[input_idx]) : TO_OUTPUT_TYPE(0);
 #endif
         input_idx += PITCH;
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
@@ -185,6 +185,18 @@ void ParamsKey::EnableInputWeightsType(WeightsType wt) {
         case WeightsType::BF16:
             key.inputWeightsType.val.BF16 = 1;
             break;
+        case WeightsType::F4E2M1:
+            key.inputWeightsType.val.F4E2M1 = 1;
+            break;
+        case WeightsType::F8E4M3:
+            key.inputWeightsType.val.F8E4M3 = 1;
+            break;
+        case WeightsType::F8E5M2:
+            key.inputWeightsType.val.F8E5M2 = 1;
+            break;
+        case WeightsType::F8E8M0:
+            key.inputWeightsType.val.F8E8M0 = 1;
+            break;
         default:
             break;
     }
@@ -217,6 +229,18 @@ void ParamsKey::EnableOutputWeightsType(WeightsType wt) {
             break;
         case WeightsType::BF16:
             key.outputWeightsType.val.BF16 = 1;
+            break;
+        case WeightsType::F4E2M1:
+            key.outputWeightsType.val.F4E2M1 = 1;
+            break;
+        case WeightsType::F8E4M3:
+            key.outputWeightsType.val.F8E4M3 = 1;
+            break;
+        case WeightsType::F8E5M2:
+            key.outputWeightsType.val.F8E5M2 = 1;
+            break;
+        case WeightsType::F8E8M0:
+            key.outputWeightsType.val.F8E8M0 = 1;
             break;
         default:
             break;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_opt.cpp
@@ -14,10 +14,18 @@ ParamsKey ReorderWeightsOpt::GetSupportedKey() const {
     k.EnableInputWeightsType(WeightsType::F16);
     k.EnableInputWeightsType(WeightsType::F32);
     k.EnableInputWeightsType(WeightsType::INT32);
+    k.EnableInputWeightsType(WeightsType::F8E4M3);
+    k.EnableInputWeightsType(WeightsType::F8E5M2);
+    k.EnableInputWeightsType(WeightsType::F4E2M1);
+    k.EnableInputWeightsType(WeightsType::F8E8M0);
     k.EnableOutputWeightsType(WeightsType::INT8);
     k.EnableOutputWeightsType(WeightsType::F16);
     k.EnableOutputWeightsType(WeightsType::F32);
     k.EnableOutputWeightsType(WeightsType::INT32);
+    k.EnableOutputWeightsType(WeightsType::F8E4M3);
+    k.EnableOutputWeightsType(WeightsType::F8E5M2);
+    k.EnableOutputWeightsType(WeightsType::F4E2M1);
+    k.EnableOutputWeightsType(WeightsType::F8E8M0);
     k.EnableInputWeightsLayout(WeightsLayout::oiyx);
     k.EnableInputWeightsLayout(WeightsLayout::ioyx);
     k.EnableInputWeightsLayout(WeightsLayout::oyxi);
@@ -213,6 +221,15 @@ JitConstants ReorderWeightsOpt::GetJitConstants(const reorder_weights_params& pa
             jit.AddConstant(MakeJitConstant("IFM_PADDED_NUM", Align(output.IFM().v, isv_size)));
         }
     }
+
+    jit.AddConstant(MakeJitConstant("F8E5M2_INPUT", params.input.GetDType() == WeightsType::F8E5M2 ? 1 : 0));
+    jit.AddConstant(MakeJitConstant("F8E4M3_INPUT", params.input.GetDType() == WeightsType::F8E4M3 ? 1 : 0));
+    jit.AddConstant(MakeJitConstant("F4E2M1_INPUT", params.input.GetDType() == WeightsType::F4E2M1 ? 1 : 0));
+    jit.AddConstant(MakeJitConstant("F8E8M0_INPUT", params.input.GetDType() == WeightsType::F8E8M0 ? 1 : 0));
+    jit.AddConstant(MakeJitConstant("F8E5M2_OUTPUT", params.output.GetDType() == WeightsType::F8E5M2 ? 1 : 0));
+    jit.AddConstant(MakeJitConstant("F8E4M3_OUTPUT", params.output.GetDType() == WeightsType::F8E4M3 ? 1 : 0));
+    jit.AddConstant(MakeJitConstant("F4E2M1_OUTPUT", params.output.GetDType() == WeightsType::F4E2M1 ? 1 : 0));
+    jit.AddConstant(MakeJitConstant("F8E8M0_OUTPUT", params.output.GetDType() == WeightsType::F8E8M0 ? 1 : 0));
 
     return jit;
 }


### PR DESCRIPTION
### Details:
 - sometimes when running an mxfp8 workload, reorder_weights_opt kernel is chosen depending on config (arch, driver, runtime etc.) which did not happen with the config used during my previous development
### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: no