### PR TITLE
[GPU] Adapt transformation pipeline for u3 weights decompression

### DIFF
--- a/src/core/reference/include/openvino/reference/transpose.hpp
+++ b/src/core/reference/include/openvino/reference/transpose.hpp
@@ -11,6 +11,9 @@
 #include <vector>
 
 #include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_iterator.hpp"
+#include "openvino/reference/utils/coordinate_index.hpp"
+#include "openvino/reference/utils/coordinate_transform.hpp"
 
 namespace ov {
 namespace reference {
@@ -64,11 +67,40 @@ void transpose_4bit(const uint8_t* data,
                     const std::vector<int64_t>& axes_order,
                     const Shape& out_shape);
 
-void transpose_2bit(const uint8_t* data,
-                    uint8_t* out,
-                    const Shape& data_shape,
-                    const std::vector<int64_t>& axes_order,
-                    const Shape& out_shape);
+/**
+ * @brief Reference implementation of Transpose operator for sub-byte packed types (e.g. u2, u3).
+ *
+ * The element iterator handles the bit packing/unpacking, so a single implementation is shared
+ * across the supported bit widths.
+ *
+ * @tparam ET           Packed sub-byte element type.
+ * @param data          Pointer to input data (packed values).
+ * @param out           Pointer to output data (packed values).
+ * @param data_shape    Input data shape.
+ * @param axes_order    Transpose order.
+ * @param out_shape     Output data shape.
+ */
+template <ov::element::Type_t ET>
+void transpose_sub_byte(const uint8_t* data,
+                        uint8_t* out,
+                        const Shape& data_shape,
+                        const std::vector<int64_t>& axes_order,
+                        const Shape& out_shape) {
+    const size_t ndim = data_shape.size();
+    auto in_it = ov::element::iterator<ET>(reinterpret_cast<const int8_t*>(data));
+    auto out_it = ov::element::iterator<ET>(reinterpret_cast<int8_t*>(out));
+
+    ov::Coordinate src_coord(ndim);
+    const ov::CoordinateTransformBasic dst_transform{out_shape};
+    for (const auto& dst_coord : dst_transform) {
+        for (size_t j = 0; j < ndim; ++j)
+            src_coord[axes_order[j]] = dst_coord[j];
+
+        const size_t dst_idx = ov::coordinate_index(dst_coord, out_shape);
+        const size_t src_idx = ov::coordinate_index(src_coord, data_shape);
+        *(out_it + dst_idx) = *(in_it + src_idx);
+    }
+}
 
 }  // namespace reference
 }  // namespace ov

--- a/src/core/reference/src/op/transpose.cpp
+++ b/src/core/reference/src/op/transpose.cpp
@@ -129,26 +129,5 @@ void transpose_4bit(const uint8_t* data,
     }
 }
 
-void transpose_2bit(const uint8_t* data,
-                    uint8_t* out,
-                    const Shape& data_shape,
-                    const std::vector<int64_t>& axes_order,
-                    const Shape& out_shape) {
-    const size_t ndim = data_shape.size();
-    auto in_it = ov::element::iterator<ov::element::u2>(reinterpret_cast<const int8_t*>(data));
-    auto out_it = ov::element::iterator<ov::element::u2>(reinterpret_cast<int8_t*>(out));
-
-    ov::Coordinate src_coord(ndim);
-    const ov::CoordinateTransformBasic dst_transform{out_shape};
-    for (const auto& dst_coord : dst_transform) {
-        for (size_t j = 0; j < ndim; ++j)
-            src_coord[axes_order[j]] = dst_coord[j];
-
-        const size_t dst_idx = ov::coordinate_index(dst_coord, out_shape);
-        const size_t src_idx = ov::coordinate_index(src_coord, data_shape);
-        *(out_it + dst_idx) = *(in_it + src_idx);
-    }
-}
-
 }  // namespace reference
 }  // namespace ov

--- a/src/core/src/op/convert.cpp
+++ b/src/core/src/op/convert.cpp
@@ -251,6 +251,7 @@ bool Convert::has_evaluate() const {
         case element::i64:
         case element::u1:
         case element::u2:
+        case element::u3:
         case element::u4:
         case element::u8:
         case element::u16:

--- a/src/core/src/op/transpose.cpp
+++ b/src/core/src/op/transpose.cpp
@@ -56,11 +56,17 @@ bool Transpose::evaluate(TensorVector& outputs, const TensorVector& inputs) cons
         out.set_shape(out_shape);
 
         if (arg_type == ov::element::u2) {
-            reference::transpose_2bit(static_cast<const uint8_t*>(arg.data()),
-                                      static_cast<uint8_t*>(out.data()),
-                                      arg.get_shape(),
-                                      axes_order,
-                                      out_shape);
+            reference::transpose_sub_byte<ov::element::Type_t::u2>(static_cast<const uint8_t*>(arg.data()),
+                                                                   static_cast<uint8_t*>(out.data()),
+                                                                   arg.get_shape(),
+                                                                   axes_order,
+                                                                   out_shape);
+        } else if (arg_type == ov::element::u3) {
+            reference::transpose_sub_byte<ov::element::Type_t::u3>(static_cast<const uint8_t*>(arg.data()),
+                                                                   static_cast<uint8_t*>(out.data()),
+                                                                   arg.get_shape(),
+                                                                   axes_order,
+                                                                   out_shape);
         } else if (arg_type == ov::element::i4 || arg_type == ov::element::u4) {
             reference::transpose_4bit(static_cast<const uint8_t*>(arg.data()),
                                       static_cast<uint8_t*>(out.data()),

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
@@ -60,7 +60,7 @@ struct FullyConnectedImplementationManager : public ImplementationManager {
                          one_of(out_dt, {data_types::f16, data_types::bf16, data_types::f32, data_types::i32, data_types::i8, data_types::u8});
         bool compressed_case = fc_prim->compressed_weights &&
                                one_of(in0_dt, {data_types::f16, data_types::bf16, data_types::f32, data_types::i8, data_types::u8}) &&
-                               one_of(wei_dt, {data_types::u8, data_types::i8, data_types::u4, data_types::i4}) &&
+                               one_of(wei_dt, {data_types::u8, data_types::i8, data_types::u4, data_types::i4, data_types::u3}) &&
                                one_of(out_dt, {data_types::f16, data_types::bf16, data_types::f32, data_types::u8, data_types::i8});
         const bool fp_compressed_case = fc_prim->compressed_weights && one_of(in0_dt, {data_types::f8e4m3, data_types::f4e2m1, data_types::f8e5m2}) &&
                                         one_of(wei_dt, {data_types::f8e4m3, data_types::f4e2m1, data_types::f8e5m2}) && one_of(out_dt, {data_types::f16, data_types::f32});
@@ -71,7 +71,7 @@ struct FullyConnectedImplementationManager : public ImplementationManager {
             if (fc_prim->decompression_zero_point.is_valid()) {
                 const auto decompression_zp_idx = fc_prim->bias.is_valid() ? 4 : 3;
                 const auto decompression_zp_dt = fc_node.get_input_layout(decompression_zp_idx).data_type;
-                const bool is_wei_compressed = one_of(wei_dt, {ov::element::Type_t::i4, ov::element::Type_t::u4, ov::element::Type_t::u8});
+                const bool is_wei_compressed = one_of(wei_dt, {ov::element::Type_t::i4, ov::element::Type_t::u4, ov::element::Type_t::u3, ov::element::Type_t::u8});
                 const bool is_zp_compressed = one_of(decompression_zp_dt, {ov::element::Type_t::i4, ov::element::Type_t::u4,
                                                     ov::element::Type_t::u8, ov::element::Type_t::i8});
                 if (!is_wei_compressed || !is_zp_compressed) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/compressed_weights_pattern.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/compressed_weights_pattern.hpp
@@ -11,6 +11,7 @@ using namespace ov::pass::pattern;
         auto compressed_constant = [](const ov::Output<ov::Node>& output) {\
             return (output.get_element_type() == ov::element::u8 || output.get_element_type() == ov::element::i8 ||\
                     output.get_element_type() == ov::element::u4 || output.get_element_type() == ov::element::i4 ||\
+                    output.get_element_type() == ov::element::u3 ||\
                     output.get_element_type() == ov::element::u2 ||\
                     output.get_element_type() == ov::element::f8e4m3 || output.get_element_type() == ov::element::f8e5m2 ||\
                     output.get_element_type() == ov::element::f4e2m1);\

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_fc_to_compressed.cpp
@@ -96,7 +96,8 @@ ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnectedToFullyCon
             // Convert ZP to u8
             if (constant->get_element_type() == ov::element::u8)
                 result = constant;
-            else if (constant->get_element_type() == ov::element::u4 || constant->get_element_type() == ov::element::u2)
+            else if (constant->get_element_type() == ov::element::u4 || constant->get_element_type() == ov::element::u3 ||
+                     constant->get_element_type() == ov::element::u2)
                 result = std::make_shared<ov::op::v0::Convert>(node, ov::element::u8);
             // Only unsigned ZP types can be converted to u8.
             else if (weight_u8 && sub_with_convert && !constant->get_element_type().is_signed())

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -533,7 +533,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
     const auto& defaultPrecisions = ov::pass::low_precision::precision_set::get_int8_support();
     const ov::element::TypeVector supported_woq_types =
-        {ov::element::u8, ov::element::i8, ov::element::u4, ov::element::i4, ov::element::u2};
+        {ov::element::u8, ov::element::i8, ov::element::u4, ov::element::i4, ov::element::u3, ov::element::u2};
     bool enableInt8;
     bool unroll_loop = config.get_enable_loop_unrolling();
     const bool disable_gated_mlp_fusion = GPU_DEBUG_VALUE_OR(config.get_disable_gated_mlp_fusion(), true);
@@ -619,8 +619,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
         manager.register_pass<ov::pass::TransposeMatMul>();
 
-        manager.register_pass<ov::pass::MarkDequantization>(std::vector<ov::element::Type>{ov::element::i8, ov::element::u8, ov::element::i4, ov::element::u4, ov::element::u2},
-                                                            !device_info.supports_immad);
+        manager.register_pass<ov::pass::MarkDequantization>(
+            std::vector<ov::element::Type>{ov::element::i8, ov::element::u8, ov::element::i4, ov::element::u4, ov::element::u3, ov::element::u2},
+            !device_info.supports_immad);
         if (config.get_use_onednn() && m_context->get_engine().get_device_info().arch >= cldnn::gpu_arch::xe3p) {
             manager.register_pass<ov::pass::MarkDequantization>(
                 std::vector<ov::element::Type>{ov::element::f8e4m3, ov::element::f8e5m2, ov::element::f4e2m1, ov::element::f8e8m0},

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -259,7 +259,7 @@ TEST_P(MatmulWeightsDecompression, Inference) {
 }
 
 const std::vector<ov::element::Type> activations_precisions = {ov::element::f32, ov::element::f16};
-const std::vector<ov::element::Type> weights_precisions = {ov::element::u8, ov::element::u4, ov::element::i4, ov::element::u2};
+const std::vector<ov::element::Type> weights_precisions = {ov::element::u8, ov::element::u4, ov::element::i4, ov::element::u3, ov::element::u2};
 const std::vector<bool> transpose_weights = {true, false};
 const std::vector<bool> param_weights = {true, false};
 const std::vector<ShapeParams> input_shapes_basic = {

--- a/src/plugins/template/tests/functional/op_reference/convert.cpp
+++ b/src/plugins/template/tests/functional/op_reference/convert.cpp
@@ -1014,6 +1014,29 @@ INSTANTIATE_TEST_SUITE_P(
                       std::vector<ov::float16>{0, 1, 2, 3},
                       std::vector<uint8_t>{0xE4}),
 
+        // destination u3 - minimal essential coverage (8 values fill a full 3-byte packing group)
+        // Test 1: u8 -> u3 (most common quantization path)
+        ConvertParams(ConversionTypes::CONVERT,
+                      ov::PartialShape{8},
+                      ov::element::u8,
+                      ov::element::u3,
+                      std::vector<uint8_t>{0, 1, 2, 3, 4, 5, 6, 7},
+                      std::vector<uint8_t>{0x1B, 0x1B, 0x0F}),
+        // Test 2: i8 -> u3 (signed to unsigned quantization)
+        ConvertParams(ConversionTypes::CONVERT,
+                      ov::PartialShape{8},
+                      ov::element::i8,
+                      ov::element::u3,
+                      std::vector<int8_t>{0, 1, 2, 3, 4, 5, 6, 7},
+                      std::vector<uint8_t>{0x1B, 0x1B, 0x0F}),
+        // Test 3: f16 -> u3 (actual use case: matmul weights compression)
+        ConvertParams(ConversionTypes::CONVERT,
+                      ov::PartialShape{8},
+                      ov::element::f16,
+                      ov::element::u3,
+                      std::vector<ov::float16>{0, 1, 2, 3, 4, 5, 6, 7},
+                      std::vector<uint8_t>{0x1B, 0x1B, 0x0F}),
+
         // destination u8
         ConvertParams(ConversionTypes::CONVERT,
                       ov::PartialShape{8},

--- a/src/plugins/template/tests/functional/op_reference/transpose.cpp
+++ b/src/plugins/template/tests/functional/op_reference/transpose.cpp
@@ -290,6 +290,16 @@ std::vector<TransposeParams> generateTransposeParamsForSubByte() {
                         reference_tests::Tensor(element::u2, {2, 2}, std::vector<uint8_t>{0xD8}),  // {0,2,1,3}
                         "transpose_u2_2d_swap"));
 
+    // u3 transpose test - swap dimensions (8 values fill a full 3-byte packing group)
+    // Input: [2,4] = {0,1,2,3,4,5,6,7} with axes {1,0}
+    // Output: [4,2] = {0,4,1,5,2,6,3,7}
+    params.push_back(
+        TransposeParams(PartialShape::dynamic(),
+                        reference_tests::Tensor(element::u3, {2, 4}, std::vector<uint8_t>{0x1B, 0x1B, 0x0F}),  // {0..7}
+                        reference_tests::Tensor(element::i64, {2}, std::vector<int64_t>{1, 0}),
+                        reference_tests::Tensor(element::u3, {4, 2}, std::vector<uint8_t>{0x05, 0xAF, 0x55}),  // {0,4,1,5,2,6,3,7}
+                        "transpose_u3_2d_swap"));
+
     // u4 transpose test - swap dimensions
     // Input: [2,2] = [[1,2], [3,4]] with axes {1,0}
     // Output: [2,2] = [[1,3], [2,4]] = {1,3,2,4}


### PR DESCRIPTION
### Details:
 - *GPU transformation pipeline is adjusted to keep u3 weights decompression subgraph as is*
 - *fullyconnected_onednn is adjusted to u3 weights in order to trigger OneDNN primitive creation for u3 compression*
 - *`MatmulWeightsDecompression` tests are extended with u3 weights instances. Note: currently, they expectedly fail because u3 weights are not currently supported by OneDNN*
 - *Convert/Transpose reference implementations are extended to support u3*

### Tickets:
 - *CVS-192382*

### AI Assistance:
 - *yes*
 - *AI was used to generate reference implementations for Convert/Transpose and the corresponding tests. The transformation pipeline adjustment was also assisted by AI*
