### PR TITLE
[CPU] Fix issue emitting same CPU operator names across ITT trace

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1606,7 +1606,10 @@ public:
     VERBOSE(node, (config).debugCaps.verbose);                         \
     PERF(node, (config).collectPerfCounters);                          \
     DUMP(node, (config).debugCaps, infer_count);                       \
-    OV_ITT_SCOPED_TASK_BASE(ittScope, (node)->perfCounters().execute); \
+    openvino::itt::ScopedTask<ittScope> ittScopedTask(                 \
+        openvino::itt::handle((node)->getTypeStr() + ": " +            \
+        (node)->getPrimitiveDescriptorType() + ": " +                  \
+        (node)->getOriginalLayers()));                                 \
     DEBUG_LOG(*(node));
 
 inline void Graph::ExecuteNode(const NodePtr& node, SyncInferRequest* request, int numaId) const {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1606,10 +1606,7 @@ public:
     VERBOSE(node, (config).debugCaps.verbose);                         \
     PERF(node, (config).collectPerfCounters);                          \
     DUMP(node, (config).debugCaps, infer_count);                       \
-    openvino::itt::ScopedTask<ittScope> ittScopedTask(                 \
-        openvino::itt::handle((node)->getTypeStr() + ": " +            \
-        (node)->getPrimitiveDescriptorType() + ": " +                  \
-        (node)->getOriginalLayers()));                                 \
+    OV_ITT_SCOPED_TASK_BASE(ittScope, (node)->perfCounters().execute); \
     DEBUG_LOG(*(node));
 
 inline void Graph::ExecuteNode(const NodePtr& node, SyncInferRequest* request, int numaId) const {

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -823,7 +823,7 @@ void Node::updateDynamicParams() {
 }
 
 void Node::execute(const dnnl::stream& strm, int numaId) {
-    OV_ITT_SCOPED_TASK_BASE(itt::domains::ov_op_cpu_details, getName());
+    openvino::itt::ScopedTask<itt::domains::ov_op_cpu_details> ittScopedTask(openvino::itt::handle(getName()));
     if (isDynamicNode()) {
         executeDynamic(strm, numaId);
     } else {

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -823,7 +823,8 @@ void Node::updateDynamicParams() {
 }
 
 void Node::execute(const dnnl::stream& strm, int numaId) {
-    openvino::itt::ScopedTask<itt::domains::ov_op_cpu_details> ittScopedTask(openvino::itt::handle(getName()));
+    OV_ITT_SCOPED_TASK_BASE(itt::domains::ov_op_cpu_details, openvino::itt::handle(getName()));
+
     if (isDynamicNode()) {
         executeDynamic(strm, numaId);
     } else {


### PR DESCRIPTION
### Details:
 - *Repeated node name*: Updated Node::execute()'s usage of ITT to avoid static handle which had unintended side effect of setting the same node name across all nodes, resulting in operator trace events all having the same name.

### AI Assistance:
 - *AI assistance used: no *

