### PR TITLE
[CPU] Add portable SelectiveSSM implementations

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-selective-ssm.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-selective-ssm.rst
@@ -125,7 +125,7 @@ Cases for reading and updating blocks:
   **Required.**
 
 * **6**: ``recurrent_state_table`` - Tensor of type *T* and shape
-  ``[num_blocks, num_heads, head_dim, state_size]``.
+  ``[num_physical_blocks, num_heads, head_dim, state_size]``.
   Paged table of recurrent state snapshots. Each row is one block storing a complete state for
   all heads at a cached token position. This tensor is updated in place during execution.
   The initial state before any tokens are processed is an all-zeros tensor. **Required.**
@@ -135,7 +135,7 @@ Cases for reading and updating blocks:
   ``dt``, ``B``, ``x``, ``C``). The tokens of sequence ``s`` span
   ``[subsequence_begins[s], subsequence_begins[s+1])``. **Required.**
 
-* **8**: ``la_block_indices`` - Tensor of type *T_IND* and shape ``[num_blocks]``.
+* **8**: ``la_block_indices`` - Tensor of type *T_IND* and shape ``[num_logical_blocks]``.
   Physical block row indices into ``recurrent_state_table``, concatenated across all sequences.
   For example, ``[0, 1, 3, 2, 4]`` with five blocks. **Required.**
 
@@ -145,6 +145,9 @@ Cases for reading and updating blocks:
   ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``.
   For example, ``la_block_indices = [0, 1, 3, 2, 4]`` and ``la_block_indices_begins = [0, 3, 5]``
   means sequence 0 uses blocks ``[0, 1, 3]`` and sequence 1 uses blocks ``[2, 4]``. **Required.**
+
+  ``num_logical_blocks`` is the total number of entries in this concatenated indirection array and
+  is independent of ``num_physical_blocks``; entries may refer to the same physical row.
 
 * **10**: ``num_processed_tokens`` - Tensor of type *T_IND* and shape ``[batch_size_in_sequences]``.
   Number of tokens already processed for each sequence. Used together with the cached states

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/selective-ssm.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/selective-ssm.rst
@@ -32,13 +32,13 @@ whole sequence before the recurrence (cheaper than recomputing it per time step)
 
    dtB = dt \cdot B
 
-The per-timestep recurrence then only forms the outer product :math:`dtB_t \otimes x_t`
+The per-timestep recurrence then only forms the outer product :math:`x_t \otimes dtB_t`
 (its full ``[batch_size, seq_len, num_heads, head_dim, state_size]`` form is too large to
 materialize up front):
 
 .. math::
 
-   dBx_t = dtB_t \otimes x_t
+   dBx_t = x_t \otimes dtB_t
 
    state_t = state_{t-1} \cdot dA_t + dBx_t
 

--- a/src/common/transformations/include/sources.cmake
+++ b/src/common/transformations/include/sources.cmake
@@ -85,6 +85,7 @@ set(COMMON_OPTIMIZATIONS_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fq_reshape_fusion.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_clamp_and_fake_quantize.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_gated_delta_net.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_selective_ssm.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_moe_experts.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fused_names_cleanup.hpp
@@ -286,6 +287,7 @@ set(PAGED_ATTENTION_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/eliminate_conv_padding_mask_gating.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/paged_causal_conv1d_fusion.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/paged_gated_delta_net_fusion.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/paged_selective_ssm_fusion.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/position_ids_replacer.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/prev_sequence_length_pattern.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/state_management_pattern.hpp

--- a/src/common/transformations/include/transformations/common_optimizations/fuse_selective_ssm.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/fuse_selective_ssm.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov::pass {
+
+class TRANSFORMATIONS_API RemoveConcatSliceAfterLoopSelectiveSSM : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("RemoveConcatSliceAfterLoopSelectiveSSM");
+    RemoveConcatSliceAfterLoopSelectiveSSM();
+};
+
+class TRANSFORMATIONS_API FuseSelectiveSSMLoop : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("FuseSelectiveSSMLoop");
+    FuseSelectiveSSMLoop();
+};
+
+class TRANSFORMATIONS_API SelectiveSSMFusion : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("SelectiveSSMFusion");
+    SelectiveSSMFusion() = default;
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+};
+
+}  // namespace ov::pass

--- a/src/common/transformations/include/transformations/paged_attention/eliminate_conv_padding_mask_gating.hpp
+++ b/src/common/transformations/include/transformations/paged_attention/eliminate_conv_padding_mask_gating.hpp
@@ -12,16 +12,19 @@ namespace pass {
 
 /**
  * @ingroup ov_transformation_common_api
- * @brief Eliminates the conv padding mask gating subgraph introduced by transformers 5.0+.
+ * @brief Eliminates padding mask gating subgraphs introduced by transformers 5.0+.
  *
  * Transformers 5.0 added `apply_mask_to_padding_states` which multiplies hidden_states
- * by attention_mask before conv layers. First observed in the LFM2 model.
+ * by attention_mask before conv and state-space layers. First observed in LFM2 and
+ * GraniteMoeHybrid models.
  * In PagedAttention mode, sequences are packed contiguously without padding, so this gating is
  * always an identity (mask is all-1s).
  *
- * Matches the pattern:
+ * Matches the patterns:
  * attention_mask -> Slice -> Unsqueeze -> [Convert] -> Multiply -> Add -> Multiply(H, mask_expr)
- * and replaces the final Multiply with its hidden_states input directly.
+ * attention_mask -> Slice -> Unsqueeze -> [Convert] -> Multiply(H, mask)
+ *
+ * Replaces the final Multiply with its hidden_states input directly.
  */
 class TRANSFORMATIONS_API EliminateConvPaddingMaskGating : public ov::pass::MatcherPass {
 public:

--- a/src/common/transformations/include/transformations/paged_attention/paged_selective_ssm_fusion.hpp
+++ b/src/common/transformations/include/transformations/paged_attention/paged_selective_ssm_fusion.hpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <unordered_set>
+
+#include "openvino/pass/matcher_pass.hpp"
+#include "openvino/pass/sdpa_to_paged_attention.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov::pass {
+
+class TRANSFORMATIONS_API PagedSelectiveSSMFusion : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("PagedSelectiveSSMFusion");
+    PagedSelectiveSSMFusion(ov::pass::paged_attention::PaParams& pa_params,
+                            std::unordered_set<std::string>& var_ids_to_remove);
+
+private:
+    size_t m_layer_index = 0;
+};
+
+}  // namespace ov::pass

--- a/src/common/transformations/src/sources.cmake
+++ b/src/common/transformations/src/sources.cmake
@@ -48,6 +48,7 @@ set(COMMON_OPTIMIZATIONS_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fq_reshape_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_clamp_and_fake_quantize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_gated_delta_net.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_moe_experts.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/fused_names_cleanup.cpp
@@ -249,6 +250,7 @@ set(PAGED_ATTENTION_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/eliminate_conv_padding_mask_gating.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/paged_causal_conv1d_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/paged_gated_delta_net_fusion.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/paged_selective_ssm_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/position_ids_replacer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/prev_sequence_length_pattern.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/paged_attention/state_management_pattern.cpp

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_selective_ssm.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_selective_ssm.cpp
@@ -1,0 +1,209 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/fuse_selective_ssm.hpp"
+
+#include <memory>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/exp.hpp"
+#include "openvino/op/loop.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/scatter_update.hpp"
+#include "openvino/op/selective_ssm.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/tile.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/optional.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/symbolic_transformations/symbolic_optimizations.hpp"
+
+namespace pattern = ov::pass::pattern;
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+
+namespace {
+
+bool match_selective_ssm_body(const std::shared_ptr<ov::Node>& node) {
+    auto loop = ov::as_type_ptr<ov::op::v5::Loop>(node);
+    if (!loop || loop->get_input_size() != 8 || loop->get_output_size() != 2) {
+        return false;
+    }
+
+    auto dA_t = pattern::any_input();
+    auto dtB_t = pattern::any_input();
+    auto x_t = pattern::any_input();
+    auto C_t = pattern::any_input();
+    auto last_state = pattern::any_input();
+    auto core_out = pattern::any_input();
+    auto step_index = pattern::any_input();
+
+    auto axis1 = pattern::any_input();
+    auto dtB_sq = pattern::wrap_type<v0::Squeeze>({dtB_t, axis1});
+    auto x_sq = pattern::wrap_type<v0::Squeeze>({x_t, axis1});
+    auto C_sq = pattern::wrap_type<v0::Squeeze>({C_t, axis1});
+    auto dA_sq = pattern::wrap_type<v0::Squeeze>({dA_t, axis1});
+
+    auto dA_4d = pattern::wrap_type<v0::Unsqueeze>({pattern::wrap_type<v0::Unsqueeze>({dA_sq, -1}), -1});
+    auto dBx = pattern::wrap_type<v1::Multiply>(
+        {pattern::wrap_type<v0::Unsqueeze>({dtB_sq, -2}), pattern::wrap_type<v0::Unsqueeze>({x_sq, -1})});
+    auto state_decay = pattern::wrap_type<v1::Multiply>({last_state, dA_4d});
+    auto state_new = pattern::wrap_type<v1::Add>({state_decay, dBx});
+    auto weighted_output = pattern::wrap_type<v1::Multiply>({state_new, pattern::wrap_type<v0::Unsqueeze>({C_sq, -2})});
+    auto output_reduce_sum = pattern::wrap_type<v1::ReduceSum>({weighted_output, -1}, {{"keep_dims", false}});
+    auto output_unsqueeze = pattern::wrap_type<v0::Unsqueeze>({output_reduce_sum, 1});
+    auto output_unsqueeze_conv = pattern::optional<v0::Convert>({output_unsqueeze});
+    auto step_index_unsqueeze = pattern::wrap_type<v0::Unsqueeze>({step_index, 0});
+    auto scatter_update_output =
+        pattern::wrap_type<ov::op::v3::ScatterUpdate>({core_out, step_index_unsqueeze, output_unsqueeze_conv, 1});
+    auto output_result = pattern::wrap_type<v0::Result>({scatter_update_output});
+    auto state_new_conv = pattern::optional<v0::Convert>({state_new});
+    auto state_result = pattern::wrap_type<v0::Result>({state_new_conv});
+
+    auto body = loop->get_function();
+    const auto& body_results = body->get_results();
+    if (body_results.size() < 3) {
+        return false;
+    }
+
+    ov::pass::pattern::Matcher loop_output_matcher(output_result);
+    if (!loop_output_matcher.match(body_results[2]->output(0))) {
+        return false;
+    }
+    ov::pass::pattern::Matcher loop_state_matcher(state_result);
+    return loop_state_matcher.match(body_results[1]->output(0));
+}
+
+}  // namespace
+
+namespace ov::pass {
+
+RemoveConcatSliceAfterLoopSelectiveSSM::RemoveConcatSliceAfterLoopSelectiveSSM() {
+    auto x = pattern::any_input(pattern::shape_matches("[?, ?, head_num, head_dim]"));
+    auto init_state = pattern::any_input(pattern::rank_equals(4));
+
+    auto loop_inputs = ov::OutputVector{pattern::any_input(),
+                                        pattern::any_input(),
+                                        pattern::any_input(),
+                                        pattern::any_input(),
+                                        x,
+                                        pattern::any_input(),
+                                        init_state,
+                                        pattern::any_input()};
+
+    auto loop_output0 = pattern::wrap_type<ov::op::v5::Loop>(loop_inputs, pattern::output_index_matches(0));
+    auto loop_output1 = pattern::wrap_type<ov::op::v5::Loop>(loop_inputs, pattern::output_index_matches(1));
+
+    auto reshape_output = pattern::wrap_type<v1::Reshape>({loop_output0, {-1}});
+    auto reshape_state = pattern::wrap_type<v1::Reshape>({loop_output1, {-1}});
+    auto concat_loop = pattern::wrap_type<v0::Concat>({reshape_output, reshape_state}, {{"axis", 0}});
+    auto out_numel = pattern::any_input(pattern::has_static_shape());
+    auto slice_output = pattern::wrap_type<ov::op::v8::Slice>({concat_loop, {0}, out_numel, {1}, {0}});
+    auto restored_output = pattern::wrap_type<v1::Reshape>({slice_output, pattern::any_input()},
+                                                           pattern::shape_matches("[?, ?, head_num, head_dim]"));
+    auto slice_state = pattern::wrap_type<ov::op::v8::Slice>({concat_loop, out_numel, pattern::any_input(), {1}, {0}});
+    auto restored_state =
+        pattern::wrap_type<v1::Reshape>({slice_state, pattern::any_input()},
+                                        pattern::shape_matches("[?, head_num, head_dim, state_size]"));
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        bool changed = false;
+        auto loop_node = pattern_map.at(loop_output0).get_node_shared_ptr();
+        if (pattern_map.count(restored_output)) {
+            auto restored_output_out = pattern_map.at(restored_output);
+            if (!ov::replace_output_update_name(restored_output_out, loop_node->output(0))) {
+                restored_output_out.replace(loop_node->output(0));
+            }
+            changed = true;
+        }
+        if (pattern_map.count(restored_state)) {
+            auto restored_state_out = pattern_map.at(restored_state);
+            if (!ov::replace_output_update_name(restored_state_out, loop_node->output(1))) {
+                restored_state_out.replace(loop_node->output(1));
+            }
+            changed = true;
+        }
+        return changed;
+    };
+
+    auto matcher = std::make_shared<ov::pass::pattern::Matcher>(restored_output | restored_state,
+                                                                "RemoveConcatSliceAfterLoopSelectiveSSM");
+    register_matcher(matcher, callback);
+}
+
+FuseSelectiveSSMLoop::FuseSelectiveSSMLoop() {
+    auto A = pattern::any_input(pattern::shape_matches("[head_num]"));
+    auto dt = pattern::any_input(pattern::shape_matches("[?, ?, head_num]"));
+    auto B = pattern::any_input(pattern::shape_matches("[?, ?, group_num, state_size]"));
+    auto x = pattern::any_input(pattern::shape_matches("[?, ?, head_num, head_dim]"));
+    auto C = pattern::any_input(pattern::shape_matches("[?, ?, group_num, state_size]"));
+    auto init_state = pattern::any_input(pattern::shape_matches("[?, head_num, head_dim, state_size]"));
+
+    auto B_expanded = pattern::wrap_type<v1::Reshape>(
+        {pattern::wrap_type<v0::Tile>({pattern::wrap_type<v0::Unsqueeze>({B, 3}), pattern::any_input()}),
+         pattern::any_input()});
+    auto C_expanded = pattern::wrap_type<v1::Reshape>(
+        {pattern::wrap_type<v0::Tile>({pattern::wrap_type<v0::Unsqueeze>({C, 3}), pattern::any_input()}),
+         pattern::any_input()});
+    auto dA = pattern::wrap_type<v0::Exp>({pattern::wrap_type<v1::Multiply>({A, dt})});
+    auto dtB = pattern::wrap_type<v1::Multiply>({pattern::wrap_type<v0::Unsqueeze>({dt, -1}), B_expanded});
+
+    auto loop_output = pattern::wrap_type<ov::op::v5::Loop>(ov::OutputVector{pattern::any_input(),
+                                                                             pattern::any_input(),
+                                                                             dA,
+                                                                             dtB,
+                                                                             x,
+                                                                             C_expanded,
+                                                                             init_state,
+                                                                             pattern::any_input()},
+                                                            [](const std::shared_ptr<ov::Node>& node) {
+                                                                return match_selective_ssm_body(node);
+                                                            });
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto loop_node = pattern_map.at(loop_output).get_node_shared_ptr();
+
+        auto selective_ssm =
+            std::make_shared<ov::op::internal::SelectiveSSM>(ov::OutputVector{pattern_map.at(A),
+                                                                              pattern_map.at(dt),
+                                                                              pattern_map.at(B),
+                                                                              pattern_map.at(x),
+                                                                              pattern_map.at(C),
+                                                                              pattern_map.at(init_state)});
+        selective_ssm->set_friendly_name(loop_node->get_friendly_name());
+        ov::copy_runtime_info(loop_node, selective_ssm);
+        ov::replace_node(loop_node, selective_ssm);
+        return true;
+    };
+
+    auto matcher = std::make_shared<ov::pass::pattern::Matcher>(loop_output, "FuseSelectiveSSMLoop");
+    register_matcher(matcher, callback);
+}
+
+bool SelectiveSSMFusion::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    RUN_ON_MODEL_SCOPE(SelectiveSSMFusion);
+    ov::pass::SymbolicOptimizations symbolic_optimizations(false, get_pass_config());
+    auto symbolic_ctx_manager = symbolic_optimizations.get_manager();
+    symbolic_ctx_manager->register_pass<ov::pass::RemoveConcatSliceAfterLoopSelectiveSSM>();
+    symbolic_ctx_manager->register_pass<ov::pass::FuseSelectiveSSMLoop>();
+    return symbolic_optimizations.run_on_model(model);
+}
+
+}  // namespace ov::pass

--- a/src/common/transformations/src/transformations/paged_attention/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/convert_pagedattn_inputs.cpp
@@ -14,6 +14,7 @@
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/op/paged_causal_conv1d.hpp"
 #include "openvino/op/paged_gated_delta_net.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/util/log.hpp"
 #include "transformations/rt_info/keep_const_precision.hpp"
@@ -35,7 +36,8 @@ ConvertPagedAttnInputs::ConvertPagedAttnInputs(const KVCacheConfig& config,
 
     auto result = pattern::wrap_type<ov::op::PagedAttentionExtension>() |
                   pattern::wrap_type<ov::op::internal::PagedCausalConv1D>() |
-                  pattern::wrap_type<ov::op::internal::PagedGatedDeltaNet>();
+                  pattern::wrap_type<ov::op::internal::PagedGatedDeltaNet>() |
+                  pattern::wrap_type<ov::op::internal::PagedSelectiveSSM>();
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto root = m.get_match_root();
         bool status = false;
@@ -167,6 +169,22 @@ ConvertPagedAttnInputs::ConvertPagedAttnInputs(const KVCacheConfig& config,
             gated_delta_state_table->set_element_type(gated_delta_cache_precision);
             enable_keep_const_precision(gated_delta_state_table);
             gated_delta_state_table->validate_and_infer_types();
+            return true;
+        }
+
+        if (const auto paged_ssm = ov::as_type_ptr<ov::op::internal::PagedSelectiveSSM>(root)) {
+            auto selective_ssm_state_table = ov::as_type_ptr<v0::Parameter>(paged_ssm->get_input_node_shared_ptr(5));
+            if (!selective_ssm_state_table) {
+                return false;
+            }
+
+            // Unlike KV cache, the SelectiveSSM state table cannot have an independent precision.
+            const auto selective_ssm_cache_precision = paged_ssm->get_input_element_type(0);
+
+            selective_ssm_state_table->set_element_type(selective_ssm_cache_precision);
+            enable_keep_const_precision(selective_ssm_state_table);
+            selective_ssm_state_table->validate_and_infer_types();
+            paged_ssm->validate_and_infer_types();
             return true;
         }
 

--- a/src/common/transformations/src/transformations/paged_attention/eliminate_conv_padding_mask_gating.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/eliminate_conv_padding_mask_gating.cpp
@@ -11,41 +11,84 @@
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/slice.hpp"
 #include "openvino/op/unsqueeze.hpp"
-#include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 
-using ov::pass::pattern::any_input;
 using ov::pass::pattern::wrap_type;
 
 namespace v0 = ov::op::v0;
 namespace v1 = ov::op::v1;
 namespace v8 = ov::op::v8;
 
+namespace {
+
+bool has_static_rank(const ov::Output<ov::Node>& output, const int64_t expected_rank) {
+    const auto& rank = output.get_partial_shape().rank();
+    return rank.is_static() && rank.get_length() == expected_rank;
+}
+
+bool is_attention_mask_slice(ov::Output<ov::Node> output) {
+    auto node = output.get_node_shared_ptr();
+    if (ov::is_type<v0::Convert>(node)) {
+        node = node->input_value(0).get_node_shared_ptr();
+    }
+    if (ov::is_type<v0::Unsqueeze>(node)) {
+        node = node->input_value(0).get_node_shared_ptr();
+    }
+
+    const auto slice = ov::as_type_ptr<v8::Slice>(node);
+    if (!slice) {
+        return false;
+    }
+    const auto parameter = ov::as_type_ptr<v0::Parameter>(slice->get_input_node_shared_ptr(0));
+    return parameter && parameter->output(0).get_names().count("attention_mask");
+}
+
+bool is_attention_mask_expression(const ov::Output<ov::Node>& output) {
+    if (is_attention_mask_slice(output)) {
+        return true;
+    }
+
+    const auto add = ov::as_type_ptr<v1::Add>(output.get_node_shared_ptr());
+    if (!add) {
+        return false;
+    }
+    for (const auto& add_input : add->input_values()) {
+        const auto multiply = ov::as_type_ptr<v1::Multiply>(add_input.get_node_shared_ptr());
+        if (!multiply) {
+            continue;
+        }
+        for (const auto& multiply_input : multiply->input_values()) {
+            if (is_attention_mask_slice(multiply_input)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
 namespace ov::pass {
 
 EliminateConvPaddingMaskGating::EliminateConvPaddingMaskGating() {
     MATCHER_SCOPE(EliminateConvPaddingMaskGating);
 
-    // Pattern: attention_mask -> Slice -> Unsqueeze -> [Convert] -> Multiply -> Add -> Multiply(H, mask_expr)
-    auto attn_mask = wrap_type<v0::Parameter>([](const ov::Output<ov::Node>& output) {
-        return output.get_names().count("attention_mask");
-    });
-    auto slice = wrap_type<v8::Slice>({attn_mask, any_input(), any_input(), any_input(), any_input()});
-    auto unsqueeze = pattern::optional<v0::Unsqueeze>({slice, any_input()});
-    auto convert = pattern::optional<v0::Convert>({unsqueeze});
-    auto mul_mask = wrap_type<v1::Multiply>({convert, any_input()});
-    auto add = wrap_type<v1::Add>({mul_mask, any_input()});
-    auto hidden_states = any_input();
-    auto mul_gate = wrap_type<v1::Multiply>({hidden_states, add});
-
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
-        const auto& pm = m.get_pattern_value_map();
-        pm.at(mul_gate).get_node_shared_ptr()->output(0).replace(pm.at(hidden_states));
-        return true;
+    auto multiply_pattern = wrap_type<v1::Multiply>();
+    ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& matcher) {
+        const auto multiply = ov::as_type_ptr<v1::Multiply>(matcher.get_match_root());
+        for (size_t hidden_index = 0; hidden_index < 2; ++hidden_index) {
+            const auto hidden_states = multiply->input_value(hidden_index);
+            const auto mask_expression = multiply->input_value(1 - hidden_index);
+            if (has_static_rank(hidden_states, 3) && is_attention_mask_expression(mask_expression)) {
+                multiply->output(0).replace(hidden_states);
+                return true;
+            }
+        }
+        return false;
     };
 
-    auto m = std::make_shared<ov::pass::pattern::Matcher>(mul_gate, matcher_name);
-    this->register_matcher(m, callback);
+    auto matcher = std::make_shared<ov::pass::pattern::Matcher>(multiply_pattern, matcher_name);
+    this->register_matcher(matcher, callback);
 }
 
 }  // namespace ov::pass

--- a/src/common/transformations/src/transformations/paged_attention/paged_selective_ssm_fusion.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/paged_selective_ssm_fusion.cpp
@@ -1,0 +1,149 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/paged_attention/paged_selective_ssm_fusion.hpp"
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/selective_ssm.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/util/read_value_base.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/optional.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/rt_info/keep_const_precision.hpp"
+
+using ov::pass::pattern::any_input;
+using ov::pass::pattern::wrap_type;
+
+namespace v0 = ov::op::v0;
+
+namespace {
+
+constexpr const char* SELECTIVE_SSM_STATE_TABLE_PREFIX = "selective_ssm_state_table.";
+
+std::string make_selective_ssm_state_table_name(const size_t layer_index) {
+    return std::string(SELECTIVE_SSM_STATE_TABLE_PREFIX) + std::to_string(layer_index);
+}
+
+ov::PartialShape make_selective_ssm_state_table_shape(const ov::PartialShape& state_shape) {
+    if (state_shape.rank().is_static() && state_shape.rank().get_length() == 4) {
+        return ov::PartialShape{ov::Dimension::dynamic(), state_shape[1], state_shape[2], state_shape[3]};
+    }
+    return ov::PartialShape::dynamic(4);
+}
+
+ov::Output<ov::Node> flatten_batch_length(const ov::Output<ov::Node>& input,
+                                          const std::vector<int64_t>& tail_dim_indices) {
+    const auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(input, ov::element::i64);
+    const auto idx_const = v0::Constant::create(ov::element::i64, ov::Shape{tail_dim_indices.size()}, tail_dim_indices);
+    const auto axis_0 = v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+    const auto tail_dims = std::make_shared<ov::op::v8::Gather>(shape_of, idx_const, axis_0);
+    const auto flat_dim = v0::Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+    const auto flat_shape = std::make_shared<v0::Concat>(ov::OutputVector{flat_dim, tail_dims}, 0);
+    const auto reshaped = std::make_shared<ov::op::v1::Reshape>(input, flat_shape, false);
+    ov::copy_runtime_info(input.get_node_shared_ptr(), {shape_of, tail_dims, flat_shape, reshaped});
+    return reshaped;
+}
+
+}  // namespace
+
+namespace ov::pass {
+
+PagedSelectiveSSMFusion::PagedSelectiveSSMFusion(ov::pass::paged_attention::PaParams& pa_params,
+                                                 std::unordered_set<std::string>& var_ids_to_remove) {
+    auto A = any_input();
+    auto dt = any_input();
+    auto B = any_input();
+    auto x = any_input();
+    auto C = any_input();
+    auto cache_param = any_input();
+    auto read_value = wrap_type<ov::op::util::ReadValueBase>({cache_param});
+    auto gathered_state = ov::pass::pattern::optional<ov::op::v8::Gather>({read_value, any_input(), any_input()});
+    auto ssm = wrap_type<ov::op::internal::SelectiveSSM>({A, dt, B, x, C, gathered_state});
+
+    ov::matcher_pass_callback callback =
+        [OV_CAPTURE_CPY_AND_THIS, &pa_params, &var_ids_to_remove](ov::pass::pattern::Matcher& m) {
+            if (transformation_callback(m.get_match_root())) {
+                return false;
+            }
+            const auto& pm = m.get_pattern_value_map();
+            const auto ssm_node = ov::as_type_ptr<ov::op::internal::SelectiveSSM>(pm.at(ssm).get_node_shared_ptr());
+            if (!ssm_node || ssm_node->get_output_size() != 2) {
+                return false;
+            }
+
+            pa_params.add("subsequence_begins", ov::element::i32, ov::PartialShape{-1});
+            pa_params.add("la.block_indices", ov::element::i32, ov::PartialShape{-1});
+            pa_params.add("la.block_indices_begins", ov::element::i32, ov::PartialShape{-1});
+            pa_params.add("la.past_lens", ov::element::i32, ov::PartialShape{-1});
+            pa_params.add("la.cache_interval", ov::element::i32, ov::PartialShape{-1});
+
+            const auto state_consumers = ssm_node->output(1).get_target_inputs();
+            const auto& state_out = pm.at(read_value);
+            const auto state_table_param =
+                pa_params.add(make_selective_ssm_state_table_name(m_layer_index++),
+                              ov::element::dynamic,
+                              make_selective_ssm_state_table_shape(state_out.get_partial_shape()));
+            enable_keep_const_precision(state_table_param);
+
+            const auto rv = ov::as_type_ptr<ov::op::util::ReadValueBase>(pm.at(read_value).get_node_shared_ptr());
+            OPENVINO_ASSERT(rv, "Matched cache node is expected to be ReadValue");
+            var_ids_to_remove.insert(rv->get_variable_id());
+
+            const auto dt_flat = flatten_batch_length(pm.at(dt), {2});
+            const auto B_flat = flatten_batch_length(pm.at(B), {2, 3});
+            const auto x_flat = flatten_batch_length(pm.at(x), {2, 3});
+            const auto C_flat = flatten_batch_length(pm.at(C), {2, 3});
+
+            const auto paged_ssm =
+                std::make_shared<ov::op::internal::PagedSelectiveSSM>(pm.at(A),
+                                                                      dt_flat,
+                                                                      B_flat,
+                                                                      x_flat,
+                                                                      C_flat,
+                                                                      state_table_param->output(0),
+                                                                      pa_params["subsequence_begins"],
+                                                                      pa_params["la.block_indices"],
+                                                                      pa_params["la.block_indices_begins"],
+                                                                      pa_params["la.past_lens"],
+                                                                      pa_params["la.cache_interval"]);
+            paged_ssm->set_friendly_name(ssm_node->get_friendly_name() + "/PagedSelectiveSSM");
+
+            const auto x_shape = std::make_shared<ov::op::v3::ShapeOf>(pm.at(x), ov::element::i64);
+            const auto out_shape = std::make_shared<ov::op::v1::Reshape>(paged_ssm, x_shape, false);
+            out_shape->set_friendly_name(ssm_node->get_friendly_name());
+            ov::copy_runtime_info(ssm_node, {paged_ssm, x_shape, out_shape});
+
+            for (const auto& state_consumer : state_consumers) {
+                state_consumer.replace_source_output(ssm_node->input_value(5));
+            }
+
+            if (!ov::replace_output_update_name(ssm_node->output(0), out_shape->output(0))) {
+                ssm_node->output(0).replace(out_shape->output(0));
+            }
+
+            register_new_node(out_shape);
+            register_new_node(paged_ssm);
+            return true;
+        };
+
+    const auto matcher = std::make_shared<ov::pass::pattern::Matcher>(ssm, "PagedSelectiveSSMFusion");
+    register_matcher(matcher, callback);
+}
+
+}  // namespace ov::pass

--- a/src/common/transformations/tests/common_optimizations/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_pagedattn_inputs.cpp
@@ -11,6 +11,7 @@
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/op/paged_causal_conv1d.hpp"
 #include "openvino/op/paged_gated_delta_net.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/runtime/properties.hpp"
@@ -531,6 +532,73 @@ TEST_F(ConvertPagedAttnInputsStateTableTest, ConvertPagedGatedDeltaNetPrecision)
     // Verify no Convert node between Parameter and PagedGatedDeltaNet
     EXPECT_TRUE(ov::is_type<v0::Parameter>(paged_gdn->get_input_node_shared_ptr(3)));
     EXPECT_EQ(gated_delta_state_table->get_element_type(), ov::element::f16);
+}
+
+TEST_F(ConvertPagedAttnInputsStateTableTest, ConvertPagedSelectiveSSMPrecision) {
+    auto A = std::make_shared<v0::Parameter>(element::f32, PartialShape{2});
+    auto dt = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2});
+    auto B = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 1, 8});
+    auto x = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 64});
+    auto C = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 1, 8});
+    auto state_table = std::make_shared<v0::Parameter>(element::dynamic, PartialShape{-1, 2, 64, 8});
+    state_table->set_friendly_name("selective_ssm_state_table.0");
+    enable_keep_const_precision(state_table);
+    auto subsequence_begins = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_indices = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_indices_begins = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto num_processed_tokens = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+
+    auto paged_ssm = std::make_shared<op::internal::PagedSelectiveSSM>(A,
+                                                                       dt,
+                                                                       B,
+                                                                       x,
+                                                                       C,
+                                                                       state_table,
+                                                                       subsequence_begins,
+                                                                       block_indices,
+                                                                       block_indices_begins,
+                                                                       num_processed_tokens,
+                                                                       cache_interval);
+    auto local_model = std::make_shared<Model>(OutputVector{paged_ssm},
+                                               ParameterVector{A,
+                                                               dt,
+                                                               B,
+                                                               x,
+                                                               C,
+                                                               state_table,
+                                                               subsequence_begins,
+                                                               block_indices,
+                                                               block_indices_begins,
+                                                               num_processed_tokens,
+                                                               cache_interval});
+
+    for (auto& node : local_model->get_ops()) {
+        ov::disable_keep_const_precision(node);
+    }
+
+    ov::pass::ConvertPagedAttnInputs::KVCacheConfig cache_config;
+    // Deliberately differs from the data inputs after ConvertPrecision.
+    cache_config.inferencePrecision = ov::element::f32;
+
+    ov::pass::Manager local_manager;
+    precisions_map fp_convert_precision_map = {{ov::element::f64, ov::element::f32},
+                                               {ov::element::f32, ov::element::f16}};
+    type_to_fuse_map empty_fuse_map = {};
+    local_manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
+                                                            empty_fuse_map,
+                                                            /*keep_precision_sensitive_in_fp32*/ true,
+                                                            /*convert_input_output_precision*/ false,
+                                                            /*store_original_precision_as_rt_attribute*/ true);
+
+    auto update_paged_attention_shape_func =
+        [](const ov::element::Type&, const bool, const size_t, int64_t&, int64_t&) {};
+    local_manager.register_pass<ov::pass::ConvertPagedAttnInputs>(cache_config, update_paged_attention_shape_func);
+    local_manager.run_passes(local_model);
+
+    EXPECT_TRUE(ov::is_type<v0::Parameter>(paged_ssm->get_input_node_shared_ptr(5)));
+    EXPECT_EQ(state_table->get_element_type(), ov::element::f16);
+    EXPECT_EQ(paged_ssm->get_output_element_type(0), ov::element::f16);
 }
 
 }  // namespace

--- a/src/common/transformations/tests/common_optimizations/fuse_selective_ssm.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_selective_ssm.cpp
@@ -1,0 +1,205 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/common_optimizations/fuse_selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include <climits>
+#include <memory>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/exp.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/loop.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_prod.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/scatter_update.hpp"
+#include "openvino/op/selective_ssm.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/tile.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/pass/manager.hpp"
+
+namespace ov::test {
+namespace {
+
+std::shared_ptr<ov::Model> build_looped_selective_ssm(int32_t num_heads,
+                                                      int32_t num_groups,
+                                                      int32_t head_dim,
+                                                      int32_t state_size,
+                                                      ov::element::Type dtype = ov::element::f32,
+                                                      bool with_post_loop = false,
+                                                      bool break_body = false) {
+    using namespace ov::op;
+
+    const int32_t heads_per_group = num_heads / num_groups;
+    auto A = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{num_heads});
+    auto dt = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, -1, num_heads});
+    auto B = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, -1, num_groups, state_size});
+    auto x = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, -1, num_heads, head_dim});
+    auto C = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, -1, num_groups, state_size});
+    auto h0 = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, num_heads, head_dim, state_size});
+
+    auto expand_groups = [&](const std::shared_ptr<v0::Parameter>& src) {
+        auto unsq_axis = v0::Constant::create(ov::element::i32, {}, {3});
+        auto src_5d = std::make_shared<v0::Unsqueeze>(src, unsq_axis);
+        auto tile_shape = v0::Constant::create(ov::element::i64, {5}, {1, 1, 1, heads_per_group, 1});
+        auto tiled = std::make_shared<v0::Tile>(src_5d, tile_shape);
+        auto target = v0::Constant::create(ov::element::i64, {4}, {0, 0, num_heads, state_size});
+        return std::make_shared<v1::Reshape>(tiled, target, true);
+    };
+    auto B_expanded = expand_groups(B);
+    auto C_expanded = expand_groups(C);
+    auto dA = std::make_shared<v0::Exp>(std::make_shared<v1::Multiply>(A, dt));
+    auto dtB = std::make_shared<v1::Multiply>(
+        std::make_shared<v0::Unsqueeze>(dt, v0::Constant::create(ov::element::i32, {1}, {-1})),
+        B_expanded);
+
+    auto shape_of_x = std::make_shared<v3::ShapeOf>(x);
+    auto core_init = std::make_shared<v3::Broadcast>(v0::Constant::create(dtype, {}, {0.0f}), shape_of_x);
+    auto trip_count_i64 = std::make_shared<v8::Gather>(shape_of_x,
+                                                       v0::Constant::create(ov::element::i64, {1}, {1}),
+                                                       v0::Constant::create(ov::element::i64, {}, {0}));
+    auto trip_count = std::make_shared<v0::Convert>(trip_count_i64, ov::element::i32);
+
+    auto timestep = std::make_shared<v0::Parameter>(ov::element::i32, ov::Shape{});
+    auto dA_t = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, 1, num_heads});
+    auto dtB_t = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, 1, num_heads, state_size});
+    auto x_t = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, 1, num_heads, head_dim});
+    auto C_t = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, 1, num_heads, state_size});
+    auto last_state = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, num_heads, head_dim, state_size});
+    auto core_out = std::make_shared<v0::Parameter>(dtype, ov::PartialShape{-1, -1, num_heads, head_dim});
+
+    auto axis1 = v0::Constant::create(ov::element::i32, {}, {1});
+    auto minus1 = v0::Constant::create(ov::element::i32, {1}, {-1});
+    auto minus2 = v0::Constant::create(ov::element::i32, {1}, {-2});
+    auto dA_sq = std::make_shared<v0::Squeeze>(dA_t, axis1);
+    auto dtB_sq = std::make_shared<v0::Squeeze>(dtB_t, axis1);
+    auto x_sq = std::make_shared<v0::Squeeze>(x_t, axis1);
+    auto C_sq = std::make_shared<v0::Squeeze>(C_t, axis1);
+    auto dA_4d = std::make_shared<v0::Unsqueeze>(std::make_shared<v0::Unsqueeze>(dA_sq, minus1), minus1);
+    auto dBx = std::make_shared<v1::Multiply>(std::make_shared<v0::Unsqueeze>(dtB_sq, minus2),
+                                              std::make_shared<v0::Unsqueeze>(x_sq, minus1));
+    auto state_decay = std::make_shared<v1::Multiply>(last_state, dA_4d);
+    std::shared_ptr<ov::Node> state_new =
+        break_body ? std::static_pointer_cast<ov::Node>(std::make_shared<v1::Subtract>(state_decay, dBx))
+                   : std::static_pointer_cast<ov::Node>(std::make_shared<v1::Add>(state_decay, dBx));
+    auto y = std::make_shared<v1::Multiply>(state_new, std::make_shared<v0::Unsqueeze>(C_sq, minus2));
+    auto y_sum = std::make_shared<v1::ReduceSum>(y, minus1, false);
+    auto y_unsq = std::make_shared<v0::Unsqueeze>(y_sum, axis1);
+    auto timestep_unsq = std::make_shared<v0::Unsqueeze>(timestep, v0::Constant::create(ov::element::i32, {1}, {0}));
+    auto core_out_new = std::make_shared<v3::ScatterUpdate>(core_out, timestep_unsq, y_unsq, axis1);
+
+    auto body_cond = v0::Constant::create(ov::element::boolean, {1}, {true});
+    auto body = std::make_shared<ov::Model>(ov::OutputVector{body_cond, state_new, core_out_new},
+                                            ov::ParameterVector{timestep, dA_t, dtB_t, x_t, C_t, last_state, core_out},
+                                            "selective_ssm_body");
+
+    auto loop = std::make_shared<v5::Loop>(trip_count, v0::Constant::create(ov::element::boolean, {1}, {true}));
+    loop->set_function(body);
+    loop->set_sliced_input(dA_t, dA, 0, 1, 1, -1, 1);
+    loop->set_sliced_input(dtB_t, dtB, 0, 1, 1, -1, 1);
+    loop->set_sliced_input(x_t, x, 0, 1, 1, -1, 1);
+    loop->set_sliced_input(C_t, C_expanded, 0, 1, 1, -1, 1);
+    loop->set_merged_input(last_state, h0, state_new);
+    loop->set_merged_input(core_out, core_init, core_out_new);
+    loop->set_special_body_ports({0, 0});
+
+    auto output = loop->get_iter_value(core_out_new, -1);
+    auto state_out = loop->get_iter_value(state_new, -1);
+    ov::Output<ov::Node> final_output = output;
+    ov::Output<ov::Node> final_state = state_out;
+    if (with_post_loop) {
+        auto reshape_m1 = v0::Constant::create(ov::element::i64, {1}, {-1});
+        auto flat_out = std::make_shared<v1::Reshape>(output, reshape_m1, false);
+        auto flat_state = std::make_shared<v1::Reshape>(state_out, reshape_m1, false);
+        auto packed = std::make_shared<v0::Concat>(ov::OutputVector{flat_out, flat_state}, 0);
+        auto out_shape = std::make_shared<v3::ShapeOf>(core_init);
+        auto state_shape = std::make_shared<v3::ShapeOf>(h0);
+        auto out_numel =
+            std::make_shared<v1::ReduceProd>(out_shape, v0::Constant::create(ov::element::i64, {1}, {0}), true);
+        auto s_start = v0::Constant::create(ov::element::i64, {1}, {0});
+        auto s_step = v0::Constant::create(ov::element::i64, {1}, {1});
+        auto s_axis = v0::Constant::create(ov::element::i64, {1}, {0});
+        auto s_end_inf = v0::Constant::create(ov::element::i64, {1}, {LLONG_MAX});
+        auto out_slice = std::make_shared<v8::Slice>(packed, s_start, out_numel, s_step, s_axis);
+        auto state_slice = std::make_shared<v8::Slice>(packed, out_numel, s_end_inf, s_step, s_axis);
+        final_output = std::make_shared<v1::Reshape>(out_slice, out_shape, false);
+        final_state = std::make_shared<v1::Reshape>(state_slice, state_shape, false);
+    }
+
+    return std::make_shared<ov::Model>(ov::OutputVector{final_output, final_state},
+                                       ov::ParameterVector{A, dt, B, x, C, h0});
+}
+
+size_t count_ops_of_type(const std::shared_ptr<ov::Model>& model, const std::string& type_name) {
+    size_t count = 0;
+    for (const auto& node : model->get_ops()) {
+        if (node->get_type_name() == type_name) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+}  // namespace
+
+TEST(TransformationTests, SelectiveSSMFusion_FuseLoop) {
+    auto model = build_looped_selective_ssm(4, 2, 8, 16);
+    ov::pass::Manager manager;
+    manager.register_pass<ov::pass::SelectiveSSMFusion>();
+    manager.run_passes(model);
+    EXPECT_EQ(count_ops_of_type(model, "Loop"), 0u);
+    EXPECT_EQ(count_ops_of_type(model, "SelectiveSSM"), 1u);
+}
+
+TEST(TransformationTests, SelectiveSSMFusion_FuseLoopLowPrecision) {
+    for (const auto dtype : {ov::element::f16, ov::element::bf16}) {
+        SCOPED_TRACE(dtype.get_type_name());
+        auto model = build_looped_selective_ssm(8, 2, 16, 32, dtype);
+        ov::pass::Manager manager;
+        manager.register_pass<ov::pass::SelectiveSSMFusion>();
+        manager.run_passes(model);
+
+        EXPECT_EQ(count_ops_of_type(model, "Loop"), 0u);
+        EXPECT_EQ(count_ops_of_type(model, "SelectiveSSM"), 1u);
+        for (const auto& node : model->get_ops()) {
+            if (const auto ssm = ov::as_type_ptr<ov::op::internal::SelectiveSSM>(node)) {
+                EXPECT_EQ(ssm->get_output_element_type(0), dtype);
+                EXPECT_EQ(ssm->get_output_element_type(1), dtype);
+            }
+        }
+    }
+}
+
+TEST(TransformationTests, SelectiveSSMFusion_FuseLoopWithPostLoopReshape) {
+    auto model = build_looped_selective_ssm(4, 2, 8, 16, ov::element::f32, true);
+    ov::pass::Manager manager;
+    manager.register_pass<ov::pass::SelectiveSSMFusion>();
+    manager.run_passes(model);
+    EXPECT_EQ(count_ops_of_type(model, "Loop"), 0u);
+    EXPECT_EQ(count_ops_of_type(model, "SelectiveSSM"), 1u);
+}
+
+TEST(TransformationTests, SelectiveSSMFusion_DoesNotFuseOnBrokenBody) {
+    auto model = build_looped_selective_ssm(4, 2, 8, 16, ov::element::f32, false, true);
+    ov::pass::Manager manager;
+    manager.register_pass<ov::pass::SelectiveSSMFusion>();
+    manager.run_passes(model);
+    EXPECT_EQ(count_ops_of_type(model, "SelectiveSSM"), 0u);
+    EXPECT_EQ(count_ops_of_type(model, "Loop"), 1u);
+}
+
+}  // namespace ov::test

--- a/src/common/transformations/tests/common_optimizations/paged_selective_ssm_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/paged_selective_ssm_fusion.cpp
@@ -1,0 +1,160 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/paged_attention/paged_selective_ssm_fusion.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_set>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/read_value.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/selective_ssm.hpp"
+#include "openvino/pass/manager.hpp"
+#include "openvino/pass/sdpa_to_paged_attention.hpp"
+
+namespace {
+
+using namespace ov;
+namespace v0 = ov::op::v0;
+namespace v3 = ov::op::v3;
+namespace internal = ov::op::internal;
+
+std::shared_ptr<v0::Parameter> make_f32_param(const std::string& name, const Shape& shape) {
+    auto p = std::make_shared<v0::Parameter>(element::f32, shape);
+    p->set_friendly_name(name);
+    p->get_output_tensor(0).set_names({name});
+    return p;
+}
+
+std::shared_ptr<ov::Model> build_fusable_model() {
+    auto A = make_f32_param("A", Shape{4});
+    auto dt = make_f32_param("dt", Shape{2, 3, 4});
+    auto B = make_f32_param("B", Shape{2, 3, 2, 8});
+    auto x = make_f32_param("x", Shape{2, 3, 4, 6});
+    auto C = make_f32_param("C", Shape{2, 3, 2, 8});
+    auto recurrent_state = make_f32_param("past_recurrent_state", Shape{2, 4, 6, 8});
+    recurrent_state->get_output_tensor(0).set_names({"cache_params.past.recurrent_state.0"});
+    auto read_value = std::make_shared<v3::ReadValue>(recurrent_state->output(0), "cache_param_0");
+    auto ssm = std::make_shared<internal::SelectiveSSM>(A, dt, B, x, C, read_value);
+    auto out = std::make_shared<v0::Result>(ssm->output(0));
+    auto present_state = std::make_shared<v0::Result>(ssm->output(1));
+    present_state->get_output_tensor(0).set_names({"cache_params.present.recurrent_state.0"});
+    return std::make_shared<ov::Model>(ResultVector{out, present_state},
+                                       ParameterVector{A, dt, B, x, C, recurrent_state});
+}
+
+std::shared_ptr<internal::SelectiveSSM> find_selective_ssm(const std::shared_ptr<ov::Model>& model) {
+    for (const auto& node : model->get_ops()) {
+        if (const auto ssm = ov::as_type_ptr<internal::SelectiveSSM>(node)) {
+            return ssm;
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<internal::PagedSelectiveSSM> find_paged_selective_ssm(const std::shared_ptr<ov::Model>& model) {
+    for (const auto& node : model->get_ops()) {
+        if (const auto paged_ssm = ov::as_type_ptr<internal::PagedSelectiveSSM>(node)) {
+            return paged_ssm;
+        }
+    }
+    return nullptr;
+}
+
+void run_paged_fusion(const std::shared_ptr<ov::Model>& model, std::unordered_set<std::string>& ids) {
+    ov::pass::paged_attention::PaParams pa_params(model->get_parameters());
+    ov::pass::Manager manager;
+    manager.set_per_pass_validation(false);
+    manager.register_pass<ov::pass::PagedSelectiveSSMFusion>(pa_params, ids);
+    manager.run_passes(model);
+    model->add_parameters(pa_params.items());
+    model->validate_nodes_and_infer_types();
+}
+
+}  // namespace
+
+TEST(TransformationTests, PagedSelectiveSSMFusion_Positive) {
+    auto model = build_fusable_model();
+    std::unordered_set<std::string> ids;
+    run_paged_fusion(model, ids);
+
+    const auto paged_ssm = find_paged_selective_ssm(model);
+    ASSERT_NE(paged_ssm, nullptr);
+    EXPECT_EQ(find_selective_ssm(model), nullptr);
+    EXPECT_EQ(ids.count("cache_param_0"), 1u);
+
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(0), PartialShape({4}));
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(1), PartialShape({6, 4}));
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(2), PartialShape({6, 2, 8}));
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(3), PartialShape({6, 4, 6}));
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(4), PartialShape({6, 2, 8}));
+    EXPECT_EQ(paged_ssm->get_output_partial_shape(0), PartialShape({6, 4, 6}));
+
+    const auto state_table = ov::as_type_ptr<v0::Parameter>(paged_ssm->get_input_node_shared_ptr(5));
+    ASSERT_NE(state_table, nullptr);
+    EXPECT_EQ(state_table->get_friendly_name(), "selective_ssm_state_table.0");
+    EXPECT_EQ(state_table->get_element_type(), element::dynamic);
+    EXPECT_EQ(state_table->get_partial_shape(), PartialShape({Dimension::dynamic(), 4, 6, 8}));
+
+    const std::vector<std::string> expected_paged_inputs = {"subsequence_begins",
+                                                            "la.block_indices",
+                                                            "la.block_indices_begins",
+                                                            "la.past_lens",
+                                                            "la.cache_interval"};
+    for (size_t i = 0; i < expected_paged_inputs.size(); ++i) {
+        const auto parameter = ov::as_type_ptr<v0::Parameter>(paged_ssm->get_input_node_shared_ptr(i + 6));
+        ASSERT_NE(parameter, nullptr);
+        EXPECT_EQ(parameter->get_friendly_name(), expected_paged_inputs[i]);
+        EXPECT_EQ(parameter->get_element_type(), element::i32);
+        EXPECT_EQ(parameter->get_partial_shape(), PartialShape({Dimension::dynamic()}));
+    }
+
+    ASSERT_EQ(model->get_results().size(), 2u);
+    EXPECT_TRUE(ov::is_type<v3::ReadValue>(model->get_results()[1]->get_input_node_shared_ptr(0)));
+    EXPECT_EQ(model->get_results()[0]->get_input_partial_shape(0), PartialShape({2, 3, 4, 6}));
+}
+
+TEST(TransformationTests, PagedSelectiveSSMFusion_GatheredState) {
+    auto model = build_fusable_model();
+    const auto ssm = find_selective_ssm(model);
+    ASSERT_NE(ssm, nullptr);
+    const auto read_value = ssm->get_input_node_shared_ptr(5);
+    auto beam_idx = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    beam_idx->set_friendly_name("beam_idx");
+    const auto axis = v0::Constant::create(element::i64, Shape{}, {0});
+    const auto gathered_state = std::make_shared<ov::op::v8::Gather>(read_value, beam_idx, axis);
+    ssm->input(5).replace_source_output(gathered_state);
+    model->add_parameters({beam_idx});
+    model->validate_nodes_and_infer_types();
+
+    std::unordered_set<std::string> ids;
+    run_paged_fusion(model, ids);
+
+    EXPECT_NE(find_paged_selective_ssm(model), nullptr);
+    EXPECT_EQ(ids.count("cache_param_0"), 1u);
+    ASSERT_EQ(model->get_results().size(), 2u);
+    EXPECT_TRUE(ov::is_type<ov::op::v8::Gather>(model->get_results()[1]->get_input_node_shared_ptr(0)));
+}
+
+TEST(TransformationTests, PagedSelectiveSSMFusion_DoesNotFuseWithoutReadValue) {
+    auto model = build_fusable_model();
+    const auto ssm = find_selective_ssm(model);
+    ASSERT_NE(ssm, nullptr);
+    ssm->input(5).replace_source_output(model->get_parameters().back());
+    model->validate_nodes_and_infer_types();
+
+    std::unordered_set<std::string> ids;
+    run_paged_fusion(model, ids);
+
+    EXPECT_EQ(find_paged_selective_ssm(model), nullptr);
+    EXPECT_NE(find_selective_ssm(model), nullptr);
+    EXPECT_TRUE(ids.empty());
+}

--- a/src/common/transformations/tests/common_optimizations/paged_selective_ssm_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/paged_selective_ssm_fusion.cpp
@@ -27,20 +27,26 @@ namespace v0 = ov::op::v0;
 namespace v3 = ov::op::v3;
 namespace internal = ov::op::internal;
 
-std::shared_ptr<v0::Parameter> make_f32_param(const std::string& name, const Shape& shape) {
+std::shared_ptr<v0::Parameter> make_f32_param(const std::string& name, const PartialShape& shape) {
     auto p = std::make_shared<v0::Parameter>(element::f32, shape);
     p->set_friendly_name(name);
     p->get_output_tensor(0).set_names({name});
     return p;
 }
 
-std::shared_ptr<ov::Model> build_fusable_model() {
-    auto A = make_f32_param("A", Shape{4});
-    auto dt = make_f32_param("dt", Shape{2, 3, 4});
-    auto B = make_f32_param("B", Shape{2, 3, 2, 8});
-    auto x = make_f32_param("x", Shape{2, 3, 4, 6});
-    auto C = make_f32_param("C", Shape{2, 3, 2, 8});
-    auto recurrent_state = make_f32_param("past_recurrent_state", Shape{2, 4, 6, 8});
+std::shared_ptr<ov::Model> build_fusable_model(bool dynamic_shapes = false) {
+    const PartialShape dt_shape = dynamic_shapes ? PartialShape{-1, -1, 4} : PartialShape{2, 3, 4};
+    const PartialShape projection_shape =
+        dynamic_shapes ? PartialShape{-1, -1, 2, 8} : PartialShape{2, 3, 2, 8};
+    const PartialShape x_shape = dynamic_shapes ? PartialShape{-1, -1, 4, 6} : PartialShape{2, 3, 4, 6};
+    const PartialShape state_shape = dynamic_shapes ? PartialShape{-1, 4, 6, 8} : PartialShape{2, 4, 6, 8};
+
+    auto A = make_f32_param("A", PartialShape{4});
+    auto dt = make_f32_param("dt", dt_shape);
+    auto B = make_f32_param("B", projection_shape);
+    auto x = make_f32_param("x", x_shape);
+    auto C = make_f32_param("C", projection_shape);
+    auto recurrent_state = make_f32_param("past_recurrent_state", state_shape);
     recurrent_state->get_output_tensor(0).set_names({"cache_params.past.recurrent_state.0"});
     auto read_value = std::make_shared<v3::ReadValue>(recurrent_state->output(0), "cache_param_0");
     auto ssm = std::make_shared<internal::SelectiveSSM>(A, dt, B, x, C, read_value);
@@ -120,6 +126,28 @@ TEST(TransformationTests, PagedSelectiveSSMFusion_Positive) {
     ASSERT_EQ(model->get_results().size(), 2u);
     EXPECT_TRUE(ov::is_type<v3::ReadValue>(model->get_results()[1]->get_input_node_shared_ptr(0)));
     EXPECT_EQ(model->get_results()[0]->get_input_partial_shape(0), PartialShape({2, 3, 4, 6}));
+}
+
+TEST(TransformationTests, PagedSelectiveSSMFusion_DynamicBatchAndSequence) {
+    auto model = build_fusable_model(true);
+    std::unordered_set<std::string> ids;
+    run_paged_fusion(model, ids);
+
+    const auto paged_ssm = find_paged_selective_ssm(model);
+    ASSERT_NE(paged_ssm, nullptr);
+    EXPECT_EQ(find_selective_ssm(model), nullptr);
+    EXPECT_EQ(ids.count("cache_param_0"), 1u);
+
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(1), PartialShape({-1, 4}));
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(2), PartialShape({-1, 2, 8}));
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(3), PartialShape({-1, 4, 6}));
+    EXPECT_EQ(paged_ssm->get_input_partial_shape(4), PartialShape({-1, 2, 8}));
+    EXPECT_EQ(paged_ssm->get_output_partial_shape(0), PartialShape({-1, 4, 6}));
+
+    const auto state_table = ov::as_type_ptr<v0::Parameter>(paged_ssm->get_input_node_shared_ptr(5));
+    ASSERT_NE(state_table, nullptr);
+    EXPECT_EQ(state_table->get_partial_shape(), PartialShape({-1, 4, 6, 8}));
+    EXPECT_EQ(model->get_results()[0]->get_input_partial_shape(0), PartialShape({-1, -1, 4, 6}));
 }
 
 TEST(TransformationTests, PagedSelectiveSSMFusion_GatheredState) {

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -6852,6 +6852,39 @@ TEST_F(SDPAToPATest, SDPAToPA_LFM2_EliminateConvPaddingMaskGating) {
     }
 }
 
+TEST_F(SDPAToPATest, SDPAToPA_GraniteMoeHybrid_EliminateDirectPaddingMaskGating) {
+    {
+        auto attention_mask = make_param(PartialShape{DYN, DYN}, element::i64, "attention_mask");
+        auto hidden_states = make_param(PartialShape{DYN, DYN, 64}, element::f32, "hidden_states");
+        auto slice = makeOP<v8::Slice>({attention_mask, {0}, {1}, {1}, {1}});
+        auto unsqueeze = makeOP<v0::Unsqueeze>({slice, 2});
+        auto convert = makeOP<v0::Convert>({unsqueeze}, {{"destination_type", "f32"}});
+        auto multiply = makeOP<v1::Multiply>({hidden_states, convert}, {{"auto_broadcast", "numpy"}});
+        auto weights = make_param(PartialShape{64, 64}, element::f32, "weights");
+        auto matmul = makeOP<v0::MatMul>({multiply, weights}, {{"transpose_a", false}, {"transpose_b", false}});
+        auto result = makeOP<v0::Result>({matmul});
+
+        auto params = nodes_to_params({attention_mask, hidden_states, weights});
+        model = std::make_shared<ov::Model>(OutputVector{result}, ParameterVector{params});
+
+        ov::pass::Manager pass_manager;
+        pass_manager.set_per_pass_validation(false);
+        pass_manager.register_pass<ov::pass::EliminateConvPaddingMaskGating>();
+        pass_manager.run_passes(model);
+
+        model->remove_parameter(params[0]);
+    }
+    {
+        auto hidden_states = make_param(PartialShape{DYN, DYN, 64}, element::f32, "hidden_states");
+        auto weights = make_param(PartialShape{64, 64}, element::f32, "weights");
+        auto matmul = makeOP<v0::MatMul>({hidden_states, weights}, {{"transpose_a", false}, {"transpose_b", false}});
+        auto result = makeOP<v0::Result>({matmul});
+
+        auto params = nodes_to_params({hidden_states, weights});
+        model_ref = std::make_shared<ov::Model>(OutputVector{result}, ParameterVector{params});
+    }
+}
+
 // Minimal single-layer stateful SDPA model. With fq_on_k / fq_on_v, a 5-input v0::FakeQuantize is
 // inserted after the KV-cache Concat (the a8w8 / SmoothQuant location) - feeding SDPA directly
 // (non-GQA) or the repeat_kv Unsqueeze-Broadcast-Reshape expansion (gqa == true). With per_channel,

--- a/src/common/transformations/tests/sources.cmake
+++ b/src/common/transformations/tests/sources.cmake
@@ -65,6 +65,7 @@ set(COMMON_OPTIMIZATIONS_TESTS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/fq_reshape_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/fuse_clamp_and_fake_quantize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/fuse_gated_delta_net.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/fuse_selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/fuse_moe_test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/fuse_rotary_positional_embeddings.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/fused_names_cleanup.cpp
@@ -102,6 +103,7 @@ set(COMMON_OPTIMIZATIONS_TESTS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/pad_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/paged_causal_conv1d_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/paged_gated_delta_net_fusion.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/paged_selective_ssm_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/preprocessing_fusion_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/pull_through_reduce_test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/push_constant_to_subgraphs.cpp

--- a/src/core/dev_api/dev_headers.cmake
+++ b/src/core/dev_api/dev_headers.cmake
@@ -28,7 +28,9 @@ set(DEV_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/paged_attention.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/paged_causal_conv1d.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/paged_gated_delta_net.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/openvino/op/paged_selective_ssm.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/rms_norm.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/openvino/op/selective_ssm.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/util/node_util.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/util/slice_plan.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/opsets/opset10_decl.hpp

--- a/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov::op::internal {
+/// \note PagedSelectiveSSM op class is under development and subject to change
+///
+/// \brief Operator performing paged SelectiveSSM computation for continuous batching.
+///
+/// Paged variant of the SelectiveSSM (Mamba2 selective state-space, arXiv:2405.21060) recurrence. Processes
+/// tokens from multiple sequences packed into a single batch and manages the recurrent SSM state (a per-head
+/// ``[head_dim, state_size]`` matrix) using a paged block table, enabling non-contiguous memory allocation
+/// across sequences. Per token: ``dA = exp(A * dt)``, ``dtB = dt * B``, ``dBx = dtB (x) x``,
+/// ``state = state * dA + dBx``, ``output = sum(state * C)``.
+///
+/// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
+/// ``g = h / heads_per_group``, where ``heads_per_group = num_heads / num_groups``.
+///
+/// ``recurrent_state_table`` is updated in place. For sequence ``s``, the state is cached every
+/// ``cache_interval[s]`` tokens into the blocks addressed by
+/// ``la_block_indices[la_block_indices_begins[s] : la_block_indices_begins[s+1]]``;
+/// ``cache_interval[s] <= 0`` disables caching for that sequence. ``num_processed_tokens[s]`` gives the
+/// count of previously processed tokens, used to resume from the correct cached state and block offset.
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API PagedSelectiveSSM : public ov::op::Op {
+public:
+    OPENVINO_OP("PagedSelectiveSSM");
+
+    PagedSelectiveSSM() = default;
+    /// \brief Constructs a PagedSelectiveSSM operation.
+    ///
+    /// \param A (Negative) log-decay rates per head [num_heads].
+    /// \param dt Per-token, per-head time steps used for discretization [batch_size_in_tokens, num_heads].
+    /// \param B Grouped input projection [batch_size_in_tokens, num_groups, state_size].
+    /// \param x Input hidden states [batch_size_in_tokens, num_heads, head_dim].
+    /// \param C Grouped output projection [batch_size_in_tokens, num_groups, state_size].
+    /// \param recurrent_state_table Paged table of recurrent state snapshots, updated in place
+    ///        [num_blocks, num_heads, head_dim, state_size]; an all-zeros tensor before any tokens are cached.
+    /// \param subsequence_begins Start indices of each sequence's tokens in the flattened token batch
+    ///        [batch_size_in_sequences + 1], element type i32 or i64.
+    /// \param la_block_indices Physical block row indices into recurrent_state_table, concatenated across
+    ///        all sequences [num_blocks], element type i32 or i64.
+    /// \param la_block_indices_begins Splits la_block_indices among sequences
+    ///        [batch_size_in_sequences + 1], element type i32 or i64.
+    /// \param num_processed_tokens Number of tokens already processed for each sequence
+    ///        [batch_size_in_sequences], element type i32 or i64.
+    /// \param cache_interval Interval (in tokens) at which the recurrent state is cached for each sequence;
+    ///        a value <= 0 disables caching [batch_size_in_sequences], element type i32 or i64.
+    PagedSelectiveSSM(const Output<Node>& A,
+                      const Output<Node>& dt,
+                      const Output<Node>& B,
+                      const Output<Node>& x,
+                      const Output<Node>& C,
+                      const Output<Node>& recurrent_state_table,
+                      const Output<Node>& subsequence_begins,
+                      const Output<Node>& la_block_indices,
+                      const Output<Node>& la_block_indices_begins,
+                      const Output<Node>& num_processed_tokens,
+                      const Output<Node>& cache_interval);
+
+    /// \brief Constructs a PagedSelectiveSSM operation from input vector.
+    ///
+    /// \param args Input tensor vector (11 inputs in order listed above).
+    explicit PagedSelectiveSSM(const ov::OutputVector& args);
+
+    void validate_and_infer_types() override;
+    bool visit_attributes(AttributeVisitor& visitor) override;
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
+};
+
+}  // namespace ov::op::internal

--- a/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/paged_selective_ssm.hpp
@@ -13,7 +13,7 @@ namespace ov::op::internal {
 /// Paged variant of the SelectiveSSM (Mamba2 selective state-space, arXiv:2405.21060) recurrence. Processes
 /// tokens from multiple sequences packed into a single batch and manages the recurrent SSM state (a per-head
 /// ``[head_dim, state_size]`` matrix) using a paged block table, enabling non-contiguous memory allocation
-/// across sequences. Per token: ``dA = exp(A * dt)``, ``dtB = dt * B``, ``dBx = dtB (x) x``,
+/// across sequences. Per token: ``dA = exp(A * dt)``, ``dtB = dt * B``, ``dBx = x (x) dtB``,
 /// ``state = state * dA + dBx``, ``output = sum(state * C)``.
 ///
 /// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
@@ -38,11 +38,11 @@ public:
     /// \param x Input hidden states [batch_size_in_tokens, num_heads, head_dim].
     /// \param C Grouped output projection [batch_size_in_tokens, num_groups, state_size].
     /// \param recurrent_state_table Paged table of recurrent state snapshots, updated in place
-    ///        [num_blocks, num_heads, head_dim, state_size]; an all-zeros tensor before any tokens are cached.
+    ///        [num_physical_blocks, num_heads, head_dim, state_size]; an all-zeros tensor before any tokens are cached.
     /// \param subsequence_begins Start indices of each sequence's tokens in the flattened token batch
     ///        [batch_size_in_sequences + 1], element type i32 or i64.
     /// \param la_block_indices Physical block row indices into recurrent_state_table, concatenated across
-    ///        all sequences [num_blocks], element type i32 or i64.
+    ///        all sequences [num_logical_blocks], element type i32 or i64.
     /// \param la_block_indices_begins Splits la_block_indices among sequences
     ///        [batch_size_in_sequences + 1], element type i32 or i64.
     /// \param num_processed_tokens Number of tokens already processed for each sequence

--- a/src/core/dev_api/openvino/op/selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/selective_ssm.hpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov::op::internal {
+/// \note SelectiveSSM op class is under development and subject to change
+///
+/// \brief Operator performing the Mamba2 selective state-space recurrence (arXiv:2405.21060).
+///
+/// Discretizes ``A`` (log-decay rates) and ``B`` (input projection) with ``dt`` (time steps) ahead of the
+/// recurrence: ``dA = exp(A * dt)``, ``dtB = dt * B``. Then, for each token ``t``:
+/// ``dBx_t = dtB_t (x) x_t``, ``state_t = state_{t-1} * dA_t + dBx_t``, ``y_t = sum(state_t * C_t)``.
+///
+/// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
+/// ``g = h / heads_per_group``, where ``heads_per_group = num_heads / num_groups``.
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API SelectiveSSM : public ov::op::Op {
+public:
+    OPENVINO_OP("SelectiveSSM");
+
+    SelectiveSSM() = default;
+    /// \brief Constructs a SelectiveSSM operation.
+    ///
+    /// \param A (Negative) log-decay rates per head [num_heads].
+    /// \param dt Per-token, per-head time steps used for discretization [batch_size, seq_len, num_heads].
+    /// \param B Grouped input projection [batch_size, seq_len, num_groups, state_size].
+    /// \param x Input hidden states [batch_size, seq_len, num_heads, head_dim].
+    /// \param C Grouped output projection [batch_size, seq_len, num_groups, state_size].
+    /// \param recurrent_state Initial SSM hidden state [batch_size, num_heads, head_dim, state_size];
+    ///        an all-zeros tensor for a fresh sequence.
+    SelectiveSSM(const Output<Node>& A,
+                 const Output<Node>& dt,
+                 const Output<Node>& B,
+                 const Output<Node>& x,
+                 const Output<Node>& C,
+                 const Output<Node>& recurrent_state);
+
+    /// \brief Constructs a SelectiveSSM operation from input vector.
+    ///
+    /// \param args Input tensor vector in order: A, dt, B, x, C, recurrent_state.
+    explicit SelectiveSSM(const ov::OutputVector& args);
+
+    void validate_and_infer_types() override;
+    bool visit_attributes(AttributeVisitor& visitor) override;
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
+};
+
+}  // namespace ov::op::internal

--- a/src/core/dev_api/openvino/op/selective_ssm.hpp
+++ b/src/core/dev_api/openvino/op/selective_ssm.hpp
@@ -12,7 +12,7 @@ namespace ov::op::internal {
 ///
 /// Discretizes ``A`` (log-decay rates) and ``B`` (input projection) with ``dt`` (time steps) ahead of the
 /// recurrence: ``dA = exp(A * dt)``, ``dtB = dt * B``. Then, for each token ``t``:
-/// ``dBx_t = dtB_t (x) x_t``, ``state_t = state_{t-1} * dA_t + dBx_t``, ``y_t = sum(state_t * C_t)``.
+/// ``dBx_t = x_t (x) dtB_t``, ``state_t = state_{t-1} * dA_t + dBx_t``, ``y_t = sum(state_t * C_t)``.
 ///
 /// ``B`` and ``C`` are grouped and shared across heads: each head ``h`` reads group
 /// ``g = h / heads_per_group``, where ``heads_per_group = num_heads / num_groups``.

--- a/src/core/shape_inference/CMakeLists.txt
+++ b/src/core/shape_inference/CMakeLists.txt
@@ -100,6 +100,7 @@ target_sources(${TARGET_NAME}
     ${SHAPE_INFER_INCLUDE_DIR}/paged_attention_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/paged_causal_conv1d_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/paged_gated_delta_net_shape_inference.hpp
+    ${SHAPE_INFER_INCLUDE_DIR}/paged_selective_ssm_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/pooling_shape_inference_util.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/prior_box_clustered_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/prior_box_shape_inference.hpp
@@ -130,6 +131,7 @@ target_sources(${TARGET_NAME}
     ${SHAPE_INFER_INCLUDE_DIR}/search_sorted_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/segment_max_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/select_shape_inference.hpp
+    ${SHAPE_INFER_INCLUDE_DIR}/selective_ssm_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/sequence_generator.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/shape_infer_type_utils.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/shape_nodes.hpp

--- a/src/core/shape_inference/include/paged_selective_ssm_shape_inference.hpp
+++ b/src/core/shape_inference/include/paged_selective_ssm_shape_inference.hpp
@@ -9,6 +9,16 @@
 
 namespace ov::op::internal {
 
+template <typename TDim>
+bool merge_paged_selective_ssm_dim(TDim& destination, bool& initialized, const TDim& source) {
+    if (!initialized) {
+        destination = source;
+        initialized = true;
+        return true;
+    }
+    return TDim::merge(destination, destination, source);
+}
+
 template <class T, class TRShape = result_shape_t<T>>
 std::vector<TRShape> shape_infer(const PagedSelectiveSSM* op, const std::vector<T>& input_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 11);
@@ -19,136 +29,132 @@ std::vector<TRShape> shape_infer(const PagedSelectiveSSM* op, const std::vector<
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[3].rank().compatible(3));
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[4].rank().compatible(3));
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[5].rank().compatible(4));
-    for (size_t i = 6; i < 11; ++i) {
-        NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[i].rank().compatible(1));
+    for (size_t input = 6; input < 11; ++input) {
+        NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[input].rank().compatible(1));
     }
 
-    const auto& A_ps = input_shapes[0];
-    const auto& dt_ps = input_shapes[1];
-    const auto& B_ps = input_shapes[2];
-    const auto& x_ps = input_shapes[3];
-    const auto& C_ps = input_shapes[4];
-    const auto& state_ps = input_shapes[5];
-    const auto& subsequence_begins_ps = input_shapes[6];
-    const auto& la_block_indices_ps = input_shapes[7];
-    const auto& la_block_indices_begins_ps = input_shapes[8];
-    const auto& num_processed_tokens_ps = input_shapes[9];
-    const auto& cache_interval_ps = input_shapes[10];
+    const auto& A_shape = input_shapes[0];
+    const auto& dt_shape = input_shapes[1];
+    const auto& B_shape = input_shapes[2];
+    const auto& x_shape = input_shapes[3];
+    const auto& C_shape = input_shapes[4];
+    const auto& state_shape = input_shapes[5];
+    const auto& subsequence_shape = input_shapes[6];
+    const auto& block_indices_begins_shape = input_shapes[8];
+    const auto& processed_shape = input_shapes[9];
+    const auto& interval_shape = input_shapes[10];
+    using DimType = typename T::value_type;
 
-    const auto A_rank_is_static = A_ps.rank().is_static();
-    const auto dt_rank_is_static = dt_ps.rank().is_static();
-    const auto B_rank_is_static = B_ps.rank().is_static();
-    const auto x_rank_is_static = x_ps.rank().is_static();
-    const auto C_rank_is_static = C_ps.rank().is_static();
-    const auto state_rank_is_static = state_ps.rank().is_static();
-    const auto subsequence_begins_rank_is_static = subsequence_begins_ps.rank().is_static();
-    const auto la_block_indices_rank_is_static = la_block_indices_ps.rank().is_static();
-    const auto la_block_indices_begins_rank_is_static = la_block_indices_begins_ps.rank().is_static();
-    const auto num_processed_tokens_rank_is_static = num_processed_tokens_ps.rank().is_static();
-    const auto cache_interval_rank_is_static = cache_interval_ps.rank().is_static();
+    DimType token_dim{};
+    DimType heads_dim{};
+    DimType head_dim{};
+    DimType groups_dim{};
+    DimType state_size_dim{};
 
-    Dimension token_dim, num_heads_dim, head_dim_dim, state_size_dim;
-
+    bool token_initialized = false;
     bool token_ok = true;
-    if (x_rank_is_static)
-        token_ok &= Dimension::merge(token_dim, token_dim, x_ps[0]);
-    if (dt_rank_is_static)
-        token_ok &= Dimension::merge(token_dim, token_dim, dt_ps[0]);
-    if (B_rank_is_static)
-        token_ok &= Dimension::merge(token_dim, token_dim, B_ps[0]);
-    if (C_rank_is_static)
-        token_ok &= Dimension::merge(token_dim, token_dim, C_ps[0]);
+    if (x_shape.rank().is_static())
+        token_ok &= merge_paged_selective_ssm_dim(token_dim, token_initialized, x_shape[0]);
+    if (dt_shape.rank().is_static())
+        token_ok &= merge_paged_selective_ssm_dim(token_dim, token_initialized, dt_shape[0]);
+    if (B_shape.rank().is_static())
+        token_ok &= merge_paged_selective_ssm_dim(token_dim, token_initialized, B_shape[0]);
+    if (C_shape.rank().is_static())
+        token_ok &= merge_paged_selective_ssm_dim(token_dim, token_initialized, C_shape[0]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            token_ok,
                            "The token dimension of `dt`, `B`, `x` and `C` should be the same.");
 
-    bool num_heads_ok = true;
-    if (x_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, x_ps[1]);
-    if (A_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, A_ps[0]);
-    if (dt_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, dt_ps[1]);
-    if (state_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, state_ps[1]);
+    bool heads_initialized = false;
+    bool heads_ok = true;
+    if (x_shape.rank().is_static())
+        heads_ok &= merge_paged_selective_ssm_dim(heads_dim, heads_initialized, x_shape[1]);
+    if (A_shape.rank().is_static())
+        heads_ok &= merge_paged_selective_ssm_dim(heads_dim, heads_initialized, A_shape[0]);
+    if (dt_shape.rank().is_static())
+        heads_ok &= merge_paged_selective_ssm_dim(heads_dim, heads_initialized, dt_shape[1]);
+    if (state_shape.rank().is_static())
+        heads_ok &= merge_paged_selective_ssm_dim(heads_dim, heads_initialized, state_shape[1]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
-                           num_heads_ok,
+                           heads_ok,
                            "The number of heads of `A`, `dt`, `x` and `recurrent_state_table` should be the same.");
 
-    if (B_rank_is_static && C_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               C_ps[1].compatible(B_ps[1]),
-                               "The number of groups of `B` and `C` should be the same.");
-    }
-
+    bool head_dim_initialized = false;
     bool head_dim_ok = true;
-    if (x_rank_is_static)
-        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, x_ps[2]);
-    if (state_rank_is_static)
-        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, state_ps[2]);
+    if (x_shape.rank().is_static())
+        head_dim_ok &= merge_paged_selective_ssm_dim(head_dim, head_dim_initialized, x_shape[2]);
+    if (state_shape.rank().is_static())
+        head_dim_ok &= merge_paged_selective_ssm_dim(head_dim, head_dim_initialized, state_shape[2]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            head_dim_ok,
                            "The head dimension of `x` and `recurrent_state_table` should be the same.");
 
+    bool groups_initialized = false;
+    bool groups_ok = true;
+    if (B_shape.rank().is_static())
+        groups_ok &= merge_paged_selective_ssm_dim(groups_dim, groups_initialized, B_shape[1]);
+    if (C_shape.rank().is_static())
+        groups_ok &= merge_paged_selective_ssm_dim(groups_dim, groups_initialized, C_shape[1]);
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, groups_ok, "The number of groups of `B` and `C` should be the same.");
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           groups_dim.is_dynamic() || groups_dim.get_length() > 0,
+                           "The number of groups must be greater than zero.");
+
+    bool state_size_initialized = false;
     bool state_size_ok = true;
-    if (state_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, state_ps[3]);
-    if (B_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, B_ps[2]);
-    if (C_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, C_ps[2]);
+    if (state_shape.rank().is_static())
+        state_size_ok &= merge_paged_selective_ssm_dim(state_size_dim, state_size_initialized, state_shape[3]);
+    if (B_shape.rank().is_static())
+        state_size_ok &= merge_paged_selective_ssm_dim(state_size_dim, state_size_initialized, B_shape[2]);
+    if (C_shape.rank().is_static())
+        state_size_ok &= merge_paged_selective_ssm_dim(state_size_dim, state_size_initialized, C_shape[2]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            state_size_ok,
                            "The state size of `B`, `C` and `recurrent_state_table` should be the same.");
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           state_size_dim.is_dynamic() || state_size_dim.get_length() > 0,
+                           "The state size must be greater than zero.");
 
-    if (num_heads_dim.is_static() && B_rank_is_static) {
-        const auto& num_groups = B_ps[1];
-        if (num_groups.is_static()) {
-            NODE_SHAPE_INFER_CHECK(
-                op,
-                input_shapes,
-                num_groups.get_length() != 0 && num_heads_dim.get_length() % num_groups.get_length() == 0,
-                "The number of heads should be divisible by the number of groups.");
-        }
-    }
-
-    if (la_block_indices_rank_is_static && state_rank_is_static) {
+    if (heads_dim.is_static() && groups_dim.is_static()) {
         NODE_SHAPE_INFER_CHECK(op,
                                input_shapes,
-                               la_block_indices_ps[0].compatible(state_ps[0]),
-                               "The number of blocks of `la_block_indices` and `recurrent_state_table` should "
-                               "be the same.");
-    }
-    if (subsequence_begins_rank_is_static && la_block_indices_begins_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               subsequence_begins_ps[0].compatible(la_block_indices_begins_ps[0]),
-                               "The number of sequences of `subsequence_begins` and `la_block_indices_begins` "
-                               "should be the same.");
-    }
-    if (num_processed_tokens_rank_is_static && cache_interval_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               num_processed_tokens_ps[0].compatible(cache_interval_ps[0]),
-                               "The number of sequences of `num_processed_tokens` and `cache_interval` should "
-                               "be the same.");
-    }
-    if (subsequence_begins_rank_is_static && num_processed_tokens_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               (subsequence_begins_ps[0] - Dimension(1)).compatible(num_processed_tokens_ps[0]),
-                               "The number of sequences of `subsequence_begins` and `num_processed_tokens` "
-                               "should be the same.");
+                               groups_dim.get_length() != 0 && heads_dim.get_length() % groups_dim.get_length() == 0,
+                               "The number of heads should be divisible by the number of groups.");
     }
 
-    auto output_shapes = std::vector<TRShape>{x_ps};
-    if (x_rank_is_static) {
-        output_shapes[0] = TRShape{token_dim, num_heads_dim, head_dim_dim};
+    if (subsequence_shape.rank().is_static() && block_indices_begins_shape.rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               subsequence_shape[0].compatible(block_indices_begins_shape[0]),
+                               "The sizes of `subsequence_begins` and `la_block_indices_begins` should be the same.");
+    }
+    if (processed_shape.rank().is_static() && interval_shape.rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               processed_shape[0].compatible(interval_shape[0]),
+                               "The sizes of `num_processed_tokens` and `cache_interval` should be the same.");
+    }
+    if (subsequence_shape.rank().is_static() && processed_shape.rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               subsequence_shape[0].is_dynamic() || subsequence_shape[0].get_length() >= 1,
+                               "The size of `subsequence_begins` must be at least one.");
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               (subsequence_shape[0] - DimType(1)).compatible(processed_shape[0]),
+                               "The size of `subsequence_begins` should be one larger than "
+                               "`num_processed_tokens`.");
+    }
+
+    auto output_shapes = std::vector<TRShape>{x_shape};
+    if (x_shape.rank().is_static()) {
+        output_shapes[0] = TRShape{token_dim, heads_dim, head_dim};
     }
     return output_shapes;
 }

--- a/src/core/shape_inference/include/paged_selective_ssm_shape_inference.hpp
+++ b/src/core/shape_inference/include/paged_selective_ssm_shape_inference.hpp
@@ -1,0 +1,156 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/paged_selective_ssm.hpp"
+#include "utils.hpp"
+
+namespace ov::op::internal {
+
+template <class T, class TRShape = result_shape_t<T>>
+std::vector<TRShape> shape_infer(const PagedSelectiveSSM* op, const std::vector<T>& input_shapes) {
+    NODE_VALIDATION_CHECK(op, input_shapes.size() == 11);
+
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[0].rank().compatible(1));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[1].rank().compatible(2));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[2].rank().compatible(3));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[3].rank().compatible(3));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[4].rank().compatible(3));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[5].rank().compatible(4));
+    for (size_t i = 6; i < 11; ++i) {
+        NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[i].rank().compatible(1));
+    }
+
+    const auto& A_ps = input_shapes[0];
+    const auto& dt_ps = input_shapes[1];
+    const auto& B_ps = input_shapes[2];
+    const auto& x_ps = input_shapes[3];
+    const auto& C_ps = input_shapes[4];
+    const auto& state_ps = input_shapes[5];
+    const auto& subsequence_begins_ps = input_shapes[6];
+    const auto& la_block_indices_ps = input_shapes[7];
+    const auto& la_block_indices_begins_ps = input_shapes[8];
+    const auto& num_processed_tokens_ps = input_shapes[9];
+    const auto& cache_interval_ps = input_shapes[10];
+
+    const auto A_rank_is_static = A_ps.rank().is_static();
+    const auto dt_rank_is_static = dt_ps.rank().is_static();
+    const auto B_rank_is_static = B_ps.rank().is_static();
+    const auto x_rank_is_static = x_ps.rank().is_static();
+    const auto C_rank_is_static = C_ps.rank().is_static();
+    const auto state_rank_is_static = state_ps.rank().is_static();
+    const auto subsequence_begins_rank_is_static = subsequence_begins_ps.rank().is_static();
+    const auto la_block_indices_rank_is_static = la_block_indices_ps.rank().is_static();
+    const auto la_block_indices_begins_rank_is_static = la_block_indices_begins_ps.rank().is_static();
+    const auto num_processed_tokens_rank_is_static = num_processed_tokens_ps.rank().is_static();
+    const auto cache_interval_rank_is_static = cache_interval_ps.rank().is_static();
+
+    Dimension token_dim, num_heads_dim, head_dim_dim, state_size_dim;
+
+    bool token_ok = true;
+    if (x_rank_is_static)
+        token_ok &= Dimension::merge(token_dim, token_dim, x_ps[0]);
+    if (dt_rank_is_static)
+        token_ok &= Dimension::merge(token_dim, token_dim, dt_ps[0]);
+    if (B_rank_is_static)
+        token_ok &= Dimension::merge(token_dim, token_dim, B_ps[0]);
+    if (C_rank_is_static)
+        token_ok &= Dimension::merge(token_dim, token_dim, C_ps[0]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           token_ok,
+                           "The token dimension of `dt`, `B`, `x` and `C` should be the same.");
+
+    bool num_heads_ok = true;
+    if (x_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, x_ps[1]);
+    if (A_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, A_ps[0]);
+    if (dt_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, dt_ps[1]);
+    if (state_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, state_ps[1]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           num_heads_ok,
+                           "The number of heads of `A`, `dt`, `x` and `recurrent_state_table` should be the same.");
+
+    if (B_rank_is_static && C_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               C_ps[1].compatible(B_ps[1]),
+                               "The number of groups of `B` and `C` should be the same.");
+    }
+
+    bool head_dim_ok = true;
+    if (x_rank_is_static)
+        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, x_ps[2]);
+    if (state_rank_is_static)
+        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, state_ps[2]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           head_dim_ok,
+                           "The head dimension of `x` and `recurrent_state_table` should be the same.");
+
+    bool state_size_ok = true;
+    if (state_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, state_ps[3]);
+    if (B_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, B_ps[2]);
+    if (C_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, C_ps[2]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           state_size_ok,
+                           "The state size of `B`, `C` and `recurrent_state_table` should be the same.");
+
+    if (num_heads_dim.is_static() && B_rank_is_static) {
+        const auto& num_groups = B_ps[1];
+        if (num_groups.is_static()) {
+            NODE_SHAPE_INFER_CHECK(
+                op,
+                input_shapes,
+                num_groups.get_length() != 0 && num_heads_dim.get_length() % num_groups.get_length() == 0,
+                "The number of heads should be divisible by the number of groups.");
+        }
+    }
+
+    if (la_block_indices_rank_is_static && state_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               la_block_indices_ps[0].compatible(state_ps[0]),
+                               "The number of blocks of `la_block_indices` and `recurrent_state_table` should "
+                               "be the same.");
+    }
+    if (subsequence_begins_rank_is_static && la_block_indices_begins_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               subsequence_begins_ps[0].compatible(la_block_indices_begins_ps[0]),
+                               "The number of sequences of `subsequence_begins` and `la_block_indices_begins` "
+                               "should be the same.");
+    }
+    if (num_processed_tokens_rank_is_static && cache_interval_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               num_processed_tokens_ps[0].compatible(cache_interval_ps[0]),
+                               "The number of sequences of `num_processed_tokens` and `cache_interval` should "
+                               "be the same.");
+    }
+    if (subsequence_begins_rank_is_static && num_processed_tokens_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               (subsequence_begins_ps[0] - Dimension(1)).compatible(num_processed_tokens_ps[0]),
+                               "The number of sequences of `subsequence_begins` and `num_processed_tokens` "
+                               "should be the same.");
+    }
+
+    auto output_shapes = std::vector<TRShape>{x_ps};
+    if (x_rank_is_static) {
+        output_shapes[0] = TRShape{token_dim, num_heads_dim, head_dim_dim};
+    }
+    return output_shapes;
+}
+
+}  // namespace ov::op::internal

--- a/src/core/shape_inference/include/selective_ssm_shape_inference.hpp
+++ b/src/core/shape_inference/include/selective_ssm_shape_inference.hpp
@@ -1,0 +1,130 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/selective_ssm.hpp"
+#include "utils.hpp"
+
+namespace ov::op::internal {
+
+template <class T, class TRShape = result_shape_t<T>>
+std::vector<TRShape> shape_infer(const SelectiveSSM* op, const std::vector<T>& input_shapes) {
+    NODE_VALIDATION_CHECK(op, input_shapes.size() == 6);
+
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[0].rank().compatible(1));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[1].rank().compatible(3));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[2].rank().compatible(4));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[3].rank().compatible(4));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[4].rank().compatible(4));
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[5].rank().compatible(4));
+
+    const auto& A_ps = input_shapes[0];
+    const auto& dt_ps = input_shapes[1];
+    const auto& B_ps = input_shapes[2];
+    const auto& x_ps = input_shapes[3];
+    const auto& C_ps = input_shapes[4];
+    const auto& state_ps = input_shapes[5];
+
+    const auto A_rank_is_static = A_ps.rank().is_static();
+    const auto dt_rank_is_static = dt_ps.rank().is_static();
+    const auto B_rank_is_static = B_ps.rank().is_static();
+    const auto x_rank_is_static = x_ps.rank().is_static();
+    const auto C_rank_is_static = C_ps.rank().is_static();
+    const auto state_rank_is_static = state_ps.rank().is_static();
+
+    Dimension batch_dim, seq_len_dim, num_heads_dim, head_dim_dim, state_size_dim;
+
+    bool batch_ok = true;
+    if (x_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, x_ps[0]);
+    if (dt_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, dt_ps[0]);
+    if (B_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, B_ps[0]);
+    if (C_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, C_ps[0]);
+    if (state_rank_is_static)
+        batch_ok &= Dimension::merge(batch_dim, batch_dim, state_ps[0]);
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, batch_ok, "The batch dimension of all inputs should be the same.");
+
+    bool seq_len_ok = true;
+    if (x_rank_is_static)
+        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, x_ps[1]);
+    if (dt_rank_is_static)
+        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, dt_ps[1]);
+    if (B_rank_is_static)
+        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, B_ps[1]);
+    if (C_rank_is_static)
+        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, C_ps[1]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           seq_len_ok,
+                           "The sequence length of `dt`, `B`, `x` and `C` should be the same.");
+
+    bool num_heads_ok = true;
+    if (x_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, x_ps[2]);
+    if (A_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, A_ps[0]);
+    if (dt_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, dt_ps[2]);
+    if (state_rank_is_static)
+        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, state_ps[1]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           num_heads_ok,
+                           "The number of heads of `A`, `dt`, `x` and `recurrent_state` should be the same.");
+
+    bool head_dim_ok = true;
+    if (x_rank_is_static)
+        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, x_ps[3]);
+    if (state_rank_is_static)
+        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, state_ps[2]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           head_dim_ok,
+                           "The head dimension of `x` and `recurrent_state` should be the same.");
+
+    if (B_rank_is_static && C_rank_is_static) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               C_ps[2].compatible(B_ps[2]),
+                               "The number of groups of `B` and `C` should be the same.");
+    }
+
+    bool state_size_ok = true;
+    if (state_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, state_ps[3]);
+    if (B_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, B_ps[3]);
+    if (C_rank_is_static)
+        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, C_ps[3]);
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           state_size_ok,
+                           "The state size of `B`, `C` and `recurrent_state` should be the same.");
+
+    if (num_heads_dim.is_static() && B_rank_is_static) {
+        const auto& num_groups = B_ps[2];
+        if (num_groups.is_static()) {
+            NODE_SHAPE_INFER_CHECK(
+                op,
+                input_shapes,
+                num_groups.get_length() != 0 && num_heads_dim.get_length() % num_groups.get_length() == 0,
+                "The number of heads should be divisible by the number of groups.");
+        }
+    }
+
+    auto output_shapes = std::vector<TRShape>{x_ps, state_ps};
+    if (x_rank_is_static) {
+        output_shapes[0] = TRShape{batch_dim, seq_len_dim, num_heads_dim, head_dim_dim};
+    }
+    if (state_rank_is_static) {
+        output_shapes[1] = TRShape{batch_dim, num_heads_dim, head_dim_dim, state_size_dim};
+    }
+    return output_shapes;
+}
+
+}  // namespace ov::op::internal

--- a/src/core/shape_inference/include/selective_ssm_shape_inference.hpp
+++ b/src/core/shape_inference/include/selective_ssm_shape_inference.hpp
@@ -9,6 +9,16 @@
 
 namespace ov::op::internal {
 
+template <typename TDim>
+bool merge_selective_ssm_dim(TDim& destination, bool& initialized, const TDim& source) {
+    if (!initialized) {
+        destination = source;
+        initialized = true;
+        return true;
+    }
+    return TDim::merge(destination, destination, source);
+}
+
 template <class T, class TRShape = result_shape_t<T>>
 std::vector<TRShape> shape_infer(const SelectiveSSM* op, const std::vector<T>& input_shapes) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 6);
@@ -20,109 +30,118 @@ std::vector<TRShape> shape_infer(const SelectiveSSM* op, const std::vector<T>& i
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[4].rank().compatible(4));
     NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[5].rank().compatible(4));
 
-    const auto& A_ps = input_shapes[0];
-    const auto& dt_ps = input_shapes[1];
-    const auto& B_ps = input_shapes[2];
-    const auto& x_ps = input_shapes[3];
-    const auto& C_ps = input_shapes[4];
-    const auto& state_ps = input_shapes[5];
+    const auto& A_shape = input_shapes[0];
+    const auto& dt_shape = input_shapes[1];
+    const auto& B_shape = input_shapes[2];
+    const auto& x_shape = input_shapes[3];
+    const auto& C_shape = input_shapes[4];
+    const auto& state_shape = input_shapes[5];
+    using DimType = typename T::value_type;
 
-    const auto A_rank_is_static = A_ps.rank().is_static();
-    const auto dt_rank_is_static = dt_ps.rank().is_static();
-    const auto B_rank_is_static = B_ps.rank().is_static();
-    const auto x_rank_is_static = x_ps.rank().is_static();
-    const auto C_rank_is_static = C_ps.rank().is_static();
-    const auto state_rank_is_static = state_ps.rank().is_static();
+    DimType batch_dim{};
+    DimType sequence_dim{};
+    DimType heads_dim{};
+    DimType head_dim{};
+    DimType groups_dim{};
+    DimType state_size_dim{};
 
-    Dimension batch_dim, seq_len_dim, num_heads_dim, head_dim_dim, state_size_dim;
-
+    bool batch_initialized = false;
     bool batch_ok = true;
-    if (x_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, x_ps[0]);
-    if (dt_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, dt_ps[0]);
-    if (B_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, B_ps[0]);
-    if (C_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, C_ps[0]);
-    if (state_rank_is_static)
-        batch_ok &= Dimension::merge(batch_dim, batch_dim, state_ps[0]);
+    if (x_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, x_shape[0]);
+    if (dt_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, dt_shape[0]);
+    if (B_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, B_shape[0]);
+    if (C_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, C_shape[0]);
+    if (state_shape.rank().is_static())
+        batch_ok &= merge_selective_ssm_dim(batch_dim, batch_initialized, state_shape[0]);
     NODE_SHAPE_INFER_CHECK(op, input_shapes, batch_ok, "The batch dimension of all inputs should be the same.");
 
-    bool seq_len_ok = true;
-    if (x_rank_is_static)
-        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, x_ps[1]);
-    if (dt_rank_is_static)
-        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, dt_ps[1]);
-    if (B_rank_is_static)
-        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, B_ps[1]);
-    if (C_rank_is_static)
-        seq_len_ok &= Dimension::merge(seq_len_dim, seq_len_dim, C_ps[1]);
+    bool sequence_initialized = false;
+    bool sequence_ok = true;
+    if (x_shape.rank().is_static())
+        sequence_ok &= merge_selective_ssm_dim(sequence_dim, sequence_initialized, x_shape[1]);
+    if (dt_shape.rank().is_static())
+        sequence_ok &= merge_selective_ssm_dim(sequence_dim, sequence_initialized, dt_shape[1]);
+    if (B_shape.rank().is_static())
+        sequence_ok &= merge_selective_ssm_dim(sequence_dim, sequence_initialized, B_shape[1]);
+    if (C_shape.rank().is_static())
+        sequence_ok &= merge_selective_ssm_dim(sequence_dim, sequence_initialized, C_shape[1]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
-                           seq_len_ok,
+                           sequence_ok,
                            "The sequence length of `dt`, `B`, `x` and `C` should be the same.");
 
-    bool num_heads_ok = true;
-    if (x_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, x_ps[2]);
-    if (A_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, A_ps[0]);
-    if (dt_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, dt_ps[2]);
-    if (state_rank_is_static)
-        num_heads_ok &= Dimension::merge(num_heads_dim, num_heads_dim, state_ps[1]);
+    bool heads_initialized = false;
+    bool heads_ok = true;
+    if (x_shape.rank().is_static())
+        heads_ok &= merge_selective_ssm_dim(heads_dim, heads_initialized, x_shape[2]);
+    if (A_shape.rank().is_static())
+        heads_ok &= merge_selective_ssm_dim(heads_dim, heads_initialized, A_shape[0]);
+    if (dt_shape.rank().is_static())
+        heads_ok &= merge_selective_ssm_dim(heads_dim, heads_initialized, dt_shape[2]);
+    if (state_shape.rank().is_static())
+        heads_ok &= merge_selective_ssm_dim(heads_dim, heads_initialized, state_shape[1]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
-                           num_heads_ok,
+                           heads_ok,
                            "The number of heads of `A`, `dt`, `x` and `recurrent_state` should be the same.");
 
+    bool head_dim_initialized = false;
     bool head_dim_ok = true;
-    if (x_rank_is_static)
-        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, x_ps[3]);
-    if (state_rank_is_static)
-        head_dim_ok &= Dimension::merge(head_dim_dim, head_dim_dim, state_ps[2]);
+    if (x_shape.rank().is_static())
+        head_dim_ok &= merge_selective_ssm_dim(head_dim, head_dim_initialized, x_shape[3]);
+    if (state_shape.rank().is_static())
+        head_dim_ok &= merge_selective_ssm_dim(head_dim, head_dim_initialized, state_shape[2]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            head_dim_ok,
                            "The head dimension of `x` and `recurrent_state` should be the same.");
 
-    if (B_rank_is_static && C_rank_is_static) {
-        NODE_SHAPE_INFER_CHECK(op,
-                               input_shapes,
-                               C_ps[2].compatible(B_ps[2]),
-                               "The number of groups of `B` and `C` should be the same.");
-    }
+    bool groups_initialized = false;
+    bool groups_ok = true;
+    if (B_shape.rank().is_static())
+        groups_ok &= merge_selective_ssm_dim(groups_dim, groups_initialized, B_shape[2]);
+    if (C_shape.rank().is_static())
+        groups_ok &= merge_selective_ssm_dim(groups_dim, groups_initialized, C_shape[2]);
+    NODE_SHAPE_INFER_CHECK(op, input_shapes, groups_ok, "The number of groups of `B` and `C` should be the same.");
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           groups_dim.is_dynamic() || groups_dim.get_length() > 0,
+                           "The number of groups must be greater than zero.");
 
+    bool state_size_initialized = false;
     bool state_size_ok = true;
-    if (state_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, state_ps[3]);
-    if (B_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, B_ps[3]);
-    if (C_rank_is_static)
-        state_size_ok &= Dimension::merge(state_size_dim, state_size_dim, C_ps[3]);
+    if (state_shape.rank().is_static())
+        state_size_ok &= merge_selective_ssm_dim(state_size_dim, state_size_initialized, state_shape[3]);
+    if (B_shape.rank().is_static())
+        state_size_ok &= merge_selective_ssm_dim(state_size_dim, state_size_initialized, B_shape[3]);
+    if (C_shape.rank().is_static())
+        state_size_ok &= merge_selective_ssm_dim(state_size_dim, state_size_initialized, C_shape[3]);
     NODE_SHAPE_INFER_CHECK(op,
                            input_shapes,
                            state_size_ok,
                            "The state size of `B`, `C` and `recurrent_state` should be the same.");
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           state_size_dim.is_dynamic() || state_size_dim.get_length() > 0,
+                           "The state size must be greater than zero.");
 
-    if (num_heads_dim.is_static() && B_rank_is_static) {
-        const auto& num_groups = B_ps[2];
-        if (num_groups.is_static()) {
-            NODE_SHAPE_INFER_CHECK(
-                op,
-                input_shapes,
-                num_groups.get_length() != 0 && num_heads_dim.get_length() % num_groups.get_length() == 0,
-                "The number of heads should be divisible by the number of groups.");
-        }
+    if (heads_dim.is_static() && groups_dim.is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               groups_dim.get_length() != 0 && heads_dim.get_length() % groups_dim.get_length() == 0,
+                               "The number of heads should be divisible by the number of groups.");
     }
 
-    auto output_shapes = std::vector<TRShape>{x_ps, state_ps};
-    if (x_rank_is_static) {
-        output_shapes[0] = TRShape{batch_dim, seq_len_dim, num_heads_dim, head_dim_dim};
+    auto output_shapes = std::vector<TRShape>{x_shape, state_shape};
+    if (x_shape.rank().is_static()) {
+        output_shapes[0] = TRShape{batch_dim, sequence_dim, heads_dim, head_dim};
     }
-    if (state_rank_is_static) {
-        output_shapes[1] = TRShape{batch_dim, num_heads_dim, head_dim_dim, state_size_dim};
+    if (state_shape.rank().is_static()) {
+        output_shapes[1] = TRShape{batch_dim, heads_dim, head_dim, state_size_dim};
     }
     return output_shapes;
 }

--- a/src/core/src/op/paged_selective_ssm.cpp
+++ b/src/core/src/op/paged_selective_ssm.cpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/paged_selective_ssm.hpp"
+
+#include "itt.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/op.hpp"
+#include "paged_selective_ssm_shape_inference.hpp"
+
+namespace ov::op::internal {
+
+PagedSelectiveSSM::PagedSelectiveSSM(const Output<Node>& A,
+                                     const Output<Node>& dt,
+                                     const Output<Node>& B,
+                                     const Output<Node>& x,
+                                     const Output<Node>& C,
+                                     const Output<Node>& recurrent_state_table,
+                                     const Output<Node>& subsequence_begins,
+                                     const Output<Node>& la_block_indices,
+                                     const Output<Node>& la_block_indices_begins,
+                                     const Output<Node>& num_processed_tokens,
+                                     const Output<Node>& cache_interval)
+    : Op({A,
+          dt,
+          B,
+          x,
+          C,
+          recurrent_state_table,
+          subsequence_begins,
+          la_block_indices,
+          la_block_indices_begins,
+          num_processed_tokens,
+          cache_interval}) {
+    constructor_validate_and_infer_types();
+}
+
+PagedSelectiveSSM::PagedSelectiveSSM(const ov::OutputVector& args) : ov::op::Op(args) {
+    constructor_validate_and_infer_types();
+}
+
+void PagedSelectiveSSM::validate_and_infer_types() {
+    OV_OP_SCOPE(PagedSelectiveSSM_validate_and_infer_types);
+    NODE_VALIDATION_CHECK(this, get_input_size() == 11);
+
+    ov::element::Type common_float_type = get_input_element_type(0);
+    const bool float_types_merge =
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(4));
+    NODE_VALIDATION_CHECK(this,
+                          float_types_merge,
+                          "PagedSelectiveSSM expects A, dt, B, x, and C to have the same element type.");
+    NODE_VALIDATION_CHECK(this,
+                          common_float_type.is_dynamic() || common_float_type.is_real(),
+                          "Float inputs must have a floating-point element type.");
+
+    // recurrent_state_table (5) is an in-place state cache and is allowed to use an independent float
+    // element type so plugins can maintain lower-precision state without breaking in-place semantics.
+    const auto& state_et = get_input_element_type(5);
+    NODE_VALIDATION_CHECK(this,
+                          state_et.is_dynamic() || state_et.is_real(),
+                          "Float inputs must have a floating-point element type.");
+    for (size_t i = 6; i < 11; ++i) {
+        const auto& et = get_input_element_type(i);
+        NODE_VALIDATION_CHECK(this,
+                              et.is_dynamic() || et == ov::element::i32 || et == ov::element::i64,
+                              "Integer inputs must have i32 or i64 element type.");
+    }
+
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
+    set_output_type(0, common_float_type, output_shapes[0]);
+}
+
+bool PagedSelectiveSSM::visit_attributes(AttributeVisitor&) {
+    OV_OP_SCOPE(PagedSelectiveSSM_visit_attributes);
+    return true;
+}
+
+std::shared_ptr<ov::Node> PagedSelectiveSSM::clone_with_new_inputs(const ov::OutputVector& new_args) const {
+    OV_OP_SCOPE(PagedSelectiveSSM_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    return std::make_shared<PagedSelectiveSSM>(new_args);
+}
+
+}  // namespace ov::op::internal

--- a/src/core/src/op/paged_selective_ssm.cpp
+++ b/src/core/src/op/paged_selective_ssm.cpp
@@ -42,33 +42,35 @@ PagedSelectiveSSM::PagedSelectiveSSM(const ov::OutputVector& args) : ov::op::Op(
 
 void PagedSelectiveSSM::validate_and_infer_types() {
     OV_OP_SCOPE(PagedSelectiveSSM_validate_and_infer_types);
-    NODE_VALIDATION_CHECK(this, get_input_size() == 11);
+    NODE_VALIDATION_CHECK(this, get_input_size() == 11, "PagedSelectiveSSM expects 11 inputs, got ", get_input_size());
 
     ov::element::Type common_float_type = get_input_element_type(0);
-    const bool float_types_merge =
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(4));
+    bool float_types_merge = true;
+    for (size_t input = 1; input < 6; ++input) {
+        float_types_merge &=
+            ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(input));
+    }
     NODE_VALIDATION_CHECK(this,
                           float_types_merge,
-                          "PagedSelectiveSSM expects A, dt, B, x, and C to have the same element type.");
+                          "PagedSelectiveSSM expects inputs A, dt, B, x, C and recurrent_state_table to have the "
+                          "same element type.");
     NODE_VALIDATION_CHECK(this,
                           common_float_type.is_dynamic() || common_float_type.is_real(),
-                          "Float inputs must have a floating-point element type.");
+                          "PagedSelectiveSSM data inputs must have a floating-point element type.");
 
-    // recurrent_state_table (5) is an in-place state cache and is allowed to use an independent float
-    // element type so plugins can maintain lower-precision state without breaking in-place semantics.
-    const auto& state_et = get_input_element_type(5);
-    NODE_VALIDATION_CHECK(this,
-                          state_et.is_dynamic() || state_et.is_real(),
-                          "Float inputs must have a floating-point element type.");
-    for (size_t i = 6; i < 11; ++i) {
-        const auto& et = get_input_element_type(i);
-        NODE_VALIDATION_CHECK(this,
-                              et.is_dynamic() || et == ov::element::i32 || et == ov::element::i64,
-                              "Integer inputs must have i32 or i64 element type.");
+    ov::element::Type common_index_type = get_input_element_type(6);
+    bool index_types_merge = true;
+    for (size_t input = 7; input < 11; ++input) {
+        index_types_merge &=
+            ov::element::Type::merge(common_index_type, common_index_type, get_input_element_type(input));
     }
+    NODE_VALIDATION_CHECK(this,
+                          index_types_merge,
+                          "PagedSelectiveSSM expects all metadata inputs to have the same element type.");
+    NODE_VALIDATION_CHECK(this,
+                          common_index_type.is_dynamic() || common_index_type == ov::element::i32 ||
+                              common_index_type == ov::element::i64,
+                          "PagedSelectiveSSM metadata inputs must have i32 or i64 element type.");
 
     const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
     set_output_type(0, common_float_type, output_shapes[0]);

--- a/src/core/src/op/selective_ssm.cpp
+++ b/src/core/src/op/selective_ssm.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/selective_ssm.hpp"
+
+#include "itt.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/op.hpp"
+#include "selective_ssm_shape_inference.hpp"
+
+namespace ov::op::internal {
+
+SelectiveSSM::SelectiveSSM(const Output<Node>& A,
+                           const Output<Node>& dt,
+                           const Output<Node>& B,
+                           const Output<Node>& x,
+                           const Output<Node>& C,
+                           const Output<Node>& recurrent_state)
+    : Op({A, dt, B, x, C, recurrent_state}) {
+    constructor_validate_and_infer_types();
+}
+
+SelectiveSSM::SelectiveSSM(const ov::OutputVector& args) : ov::op::Op(args) {
+    constructor_validate_and_infer_types();
+}
+
+void SelectiveSSM::validate_and_infer_types() {
+    OV_OP_SCOPE(SelectiveSSM_validate_and_infer_types);
+    NODE_VALIDATION_CHECK(this, get_input_size() == 6, "SelectiveSSM expects 6 inputs, but it has ", get_input_size());
+
+    ov::element::Type common_float_type = get_input_element_type(0);
+    const bool float_types_merge =
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3)) &&
+        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(4));
+    NODE_VALIDATION_CHECK(this,
+                          float_types_merge,
+                          "SelectiveSSM expects A, dt, B, x, and C to have the same element type.");
+    NODE_VALIDATION_CHECK(this,
+                          common_float_type.is_dynamic() || common_float_type.is_real(),
+                          "Float inputs must have a floating-point element type.");
+
+    // recurrent_state (5) is an in-place state cache and is allowed to use an independent float
+    // element type so plugins can maintain lower-precision state without breaking in-place semantics.
+    const auto& state_et = get_input_element_type(5);
+    NODE_VALIDATION_CHECK(this,
+                          state_et.is_dynamic() || state_et.is_real(),
+                          "Float inputs must have a floating-point element type.");
+
+    const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
+    set_output_type(0, common_float_type, output_shapes[0]);
+    set_output_type(1, state_et, output_shapes[1]);
+}
+
+bool SelectiveSSM::visit_attributes(AttributeVisitor&) {
+    OV_OP_SCOPE(SelectiveSSM_visit_attributes);
+    return true;
+}
+
+std::shared_ptr<ov::Node> SelectiveSSM::clone_with_new_inputs(const ov::OutputVector& new_args) const {
+    check_new_args_count(this, new_args);
+    return std::make_shared<SelectiveSSM>(new_args);
+}
+
+}  // namespace ov::op::internal

--- a/src/core/src/op/selective_ssm.cpp
+++ b/src/core/src/op/selective_ssm.cpp
@@ -30,28 +30,19 @@ void SelectiveSSM::validate_and_infer_types() {
     NODE_VALIDATION_CHECK(this, get_input_size() == 6, "SelectiveSSM expects 6 inputs, but it has ", get_input_size());
 
     ov::element::Type common_float_type = get_input_element_type(0);
-    const bool float_types_merge =
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(1)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(2)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(3)) &&
-        ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(4));
-    NODE_VALIDATION_CHECK(this,
-                          float_types_merge,
-                          "SelectiveSSM expects A, dt, B, x, and C to have the same element type.");
+    bool float_types_merge = true;
+    for (size_t input = 1; input < 6; ++input) {
+        float_types_merge &=
+            ov::element::Type::merge(common_float_type, common_float_type, get_input_element_type(input));
+    }
+    NODE_VALIDATION_CHECK(this, float_types_merge, "SelectiveSSM expects all inputs to have the same element type.");
     NODE_VALIDATION_CHECK(this,
                           common_float_type.is_dynamic() || common_float_type.is_real(),
-                          "Float inputs must have a floating-point element type.");
-
-    // recurrent_state (5) is an in-place state cache and is allowed to use an independent float
-    // element type so plugins can maintain lower-precision state without breaking in-place semantics.
-    const auto& state_et = get_input_element_type(5);
-    NODE_VALIDATION_CHECK(this,
-                          state_et.is_dynamic() || state_et.is_real(),
-                          "Float inputs must have a floating-point element type.");
+                          "SelectiveSSM inputs must have a floating-point element type.");
 
     const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
     set_output_type(0, common_float_type, output_shapes[0]);
-    set_output_type(1, state_et, output_shapes[1]);
+    set_output_type(1, common_float_type, output_shapes[1]);
 }
 
 bool SelectiveSSM::visit_attributes(AttributeVisitor&) {

--- a/src/core/src/pass/sdpa_to_paged_attention.cpp
+++ b/src/core/src/pass/sdpa_to_paged_attention.cpp
@@ -15,12 +15,14 @@
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/common_optimizations/fuse_gated_delta_net.hpp"
+#include "transformations/common_optimizations/fuse_selective_ssm.hpp"
 #include "transformations/common_optimizations/sdpa_fusion.hpp"
 #include "transformations/op_conversions/convert_slice_to_strided_slice.hpp"
 #include "transformations/paged_attention/attention_mask_shape_replacer.hpp"
 #include "transformations/paged_attention/eliminate_conv_padding_mask_gating.hpp"
 #include "transformations/paged_attention/paged_causal_conv1d_fusion.hpp"
 #include "transformations/paged_attention/paged_gated_delta_net_fusion.hpp"
+#include "transformations/paged_attention/paged_selective_ssm_fusion.hpp"
 #include "transformations/paged_attention/position_ids_replacer.hpp"
 #include "transformations/paged_attention/prev_sequence_length_pattern.hpp"
 #include "transformations/paged_attention/state_management_pattern.hpp"
@@ -148,11 +150,13 @@ bool ov::pass::SDPAToPagedAttention::run_on_model(const std::shared_ptr<ov::Mode
     manager.register_pass<ov::pass::GatedDeltaNetFusion>();  // This pass is required to ensure that all GatedDeltaNet
                                                              // nodes are in the expected form before running
                                                              // PagedGatedDeltaNetFusion.
+    manager.register_pass<ov::pass::SelectiveSSMFusion>();
     manager.register_pass<StateManagementPattern>(m_params, m_results, m_options, var_ids_to_remove);
     manager.register_pass<EliminateConvPaddingMaskGating>();
     manager.register_pass<AttentionMaskShapeReplacer>(input_ids_node);
     manager.register_pass<PagedCausalConv1DFusion>(m_params, var_ids_to_remove);
     manager.register_pass<PagedGatedDeltaNetFusion>(m_params, var_ids_to_remove);
+    manager.register_pass<PagedSelectiveSSMFusion>(m_params, var_ids_to_remove);
     manager.register_pass<PrevSequenceLengthPattern>(processed_input_ids, max_context_len, position_ids);
     manager.register_pass<TotalSequenceLengthPattern>(max_context_len);
     manager.register_pass<TotalSequenceLengthPatternQwen>(max_context_len);

--- a/src/core/src/sources.cmake
+++ b/src/core/src/sources.cmake
@@ -187,6 +187,7 @@ set(LIBRARY_SRC
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_attention.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_causal_conv1d.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_gated_delta_net.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/paged_selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/parameter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/power.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/prelu.cpp
@@ -229,6 +230,7 @@ set(LIBRARY_SRC
     ${CMAKE_CURRENT_LIST_DIR}/op/search_sorted.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/segment_max.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/select.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/selu.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/shape_of.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/shuffle_channels.cpp

--- a/src/core/tests/type_prop/paged_selective_ssm.cpp
+++ b/src/core/tests/type_prop/paged_selective_ssm.cpp
@@ -1,0 +1,489 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/paged_selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/openvino.hpp"
+
+namespace ov::test {
+namespace {
+
+std::shared_ptr<op::internal::PagedSelectiveSSM> make_paged_selective_ssm(const element::Type& et,
+                                                                          const element::Type& ind_et,
+                                                                          const PartialShape& A,
+                                                                          const PartialShape& dt,
+                                                                          const PartialShape& B,
+                                                                          const PartialShape& x,
+                                                                          const PartialShape& C,
+                                                                          const PartialShape& state) {
+    auto A_p = std::make_shared<op::v0::Parameter>(et, A);
+    auto dt_p = std::make_shared<op::v0::Parameter>(et, dt);
+    auto B_p = std::make_shared<op::v0::Parameter>(et, B);
+    auto x_p = std::make_shared<op::v0::Parameter>(et, x);
+    auto C_p = std::make_shared<op::v0::Parameter>(et, C);
+    auto state_p = std::make_shared<op::v0::Parameter>(et, state);
+    auto subseq = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(ind_et, PartialShape{-1});
+
+    return std::make_shared<op::internal::PagedSelectiveSSM>(OutputVector{A_p,
+                                                                          dt_p,
+                                                                          B_p,
+                                                                          x_p,
+                                                                          C_p,
+                                                                          state_p,
+                                                                          subseq,
+                                                                          block_idx,
+                                                                          block_idx_begins,
+                                                                          processed,
+                                                                          cache_interval});
+}
+
+}  // namespace
+
+TEST(type_prop, paged_selective_ssm_static_f32) {
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             Shape{6, 2, 16},
+                                             Shape{6, 4, 8},
+                                             Shape{6, 2, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
+}
+
+TEST(type_prop, paged_selective_ssm_partial_shape_infer) {
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             Shape{6, 2, 16},
+                                             PartialShape{-1, -1, 8},
+                                             Shape{6, 2, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
+}
+
+TEST(type_prop, paged_selective_ssm_state_type_may_differ) {
+    auto A_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
+    auto dt_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 4});
+    auto B_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 2, 16});
+    auto x_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 4, 8});
+    auto C_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 2, 16});
+    auto state_p = std::make_shared<op::v0::Parameter>(element::bf16, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
+
+    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(OutputVector{A_p,
+                                                                                   dt_p,
+                                                                                   B_p,
+                                                                                   x_p,
+                                                                                   C_p,
+                                                                                   state_p,
+                                                                                   subseq,
+                                                                                   block_idx,
+                                                                                   block_idx_begins,
+                                                                                   processed,
+                                                                                   cache_interval});
+    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+}
+
+TEST(type_prop, paged_selective_ssm_bad_index_type) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::f32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("Integer inputs must have i32 or i64 element type."));
+}
+
+TEST(type_prop, paged_selective_ssm_heads_not_divisible_by_groups) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 3, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 3, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, paged_selective_ssm_wrong_input_count) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    EXPECT_THROW(std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+                     OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_A_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4, 1},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_dt_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4, 1},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_B_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_x_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_C_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2},
+                                                        Shape{3, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_state_rank) {
+    EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                        element::i32,
+                                                        Shape{4},
+                                                        Shape{6, 4},
+                                                        Shape{6, 2, 16},
+                                                        Shape{6, 4, 8},
+                                                        Shape{6, 2, 16},
+                                                        Shape{3, 4, 8}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_invalid_index_rank) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1, -1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure);
+}
+
+TEST(type_prop, paged_selective_ssm_batch_tokens_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{7, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The token dimension of `dt`, `B`, `x` and `C` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_num_heads_mismatch) {
+    OV_EXPECT_THROW(
+        std::ignore = make_paged_selective_ssm(element::f32,
+                                               element::i32,
+                                               Shape{5},
+                                               Shape{6, 4},
+                                               Shape{6, 2, 16},
+                                               Shape{6, 4, 8},
+                                               Shape{6, 2, 16},
+                                               Shape{3, 4, 8, 16}),
+        NodeValidationFailure,
+        testing::HasSubstr("The number of heads of `A`, `dt`, `x` and `recurrent_state_table` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_num_groups_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 3, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of groups of `B` and `C` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_head_dim_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 16},
+                                                           Shape{3, 4, 10, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The head dimension of `x` and `recurrent_state_table` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_state_size_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 2, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 2, 32},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The state size of `B`, `C` and `recurrent_state_table` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_block_indices_num_blocks_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{5});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("The number of blocks of `la_block_indices` and `recurrent_state_table` should be the "
+                           "same."));
+}
+
+TEST(type_prop, paged_selective_ssm_subsequence_and_block_begins_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("The number of sequences of `subsequence_begins` and `la_block_indices_begins` should "
+                           "be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_processed_tokens_and_cache_interval_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{2});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr(
+            "The number of sequences of `num_processed_tokens` and `cache_interval` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_subsequence_begins_and_processed_tokens_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr(
+            "The number of sequences of `subsequence_begins` and `num_processed_tokens` should be the same."));
+}
+
+TEST(type_prop, paged_selective_ssm_zero_groups) {
+    OV_EXPECT_THROW(std::ignore = make_paged_selective_ssm(element::f32,
+                                                           element::i32,
+                                                           Shape{4},
+                                                           Shape{6, 4},
+                                                           Shape{6, 0, 16},
+                                                           Shape{6, 4, 8},
+                                                           Shape{6, 0, 16},
+                                                           Shape{3, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, paged_selective_ssm_dynamic_rank_input_accepted) {
+    // Dynamic rank inputs are accepted since they may be folded to a static rank later.
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             Shape{6, 2, 16},
+                                             PartialShape::dynamic(),
+                                             Shape{6, 2, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_TRUE(op->get_output_partial_shape(0).rank().is_dynamic());
+}
+
+TEST(type_prop, paged_selective_ssm_dynamic_num_groups_skips_divisibility_check) {
+    const auto op = make_paged_selective_ssm(element::f32,
+                                             element::i32,
+                                             Shape{4},
+                                             Shape{6, 4},
+                                             PartialShape{6, -1, 16},
+                                             Shape{6, 4, 8},
+                                             PartialShape{6, -1, 16},
+                                             Shape{3, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{6, 4, 8}));
+}
+
+TEST(type_prop, paged_selective_ssm_type_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("PagedSelectiveSSM expects A, dt, B, x, and C to have the same element type."));
+}
+
+TEST(type_prop, paged_selective_ssm_state_float_type_invalid) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::i32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("Float inputs must have a floating-point element type."));
+}
+
+TEST(type_prop, paged_selective_ssm_index_type_mixed) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, Shape{3, 4, 8, 16});
+    auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
+            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
+        NodeValidationFailure,
+        testing::HasSubstr("Integer inputs must have i32 or i64 element type."));
+}
+
+}  // namespace ov::test

--- a/src/core/tests/type_prop/paged_selective_ssm.cpp
+++ b/src/core/tests/type_prop/paged_selective_ssm.cpp
@@ -75,7 +75,7 @@ TEST(type_prop, paged_selective_ssm_partial_shape_infer) {
     EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
 }
 
-TEST(type_prop, paged_selective_ssm_state_type_may_differ) {
+TEST(type_prop, paged_selective_ssm_state_type_must_match) {
     auto A_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
     auto dt_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 4});
     auto B_p = std::make_shared<op::v0::Parameter>(element::f16, Shape{6, 2, 16});
@@ -88,18 +88,19 @@ TEST(type_prop, paged_selective_ssm_state_type_may_differ) {
     auto processed = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
     auto cache_interval = std::make_shared<op::v0::Parameter>(element::i64, PartialShape{-1});
 
-    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(OutputVector{A_p,
-                                                                                   dt_p,
-                                                                                   B_p,
-                                                                                   x_p,
-                                                                                   C_p,
-                                                                                   state_p,
-                                                                                   subseq,
-                                                                                   block_idx,
-                                                                                   block_idx_begins,
-                                                                                   processed,
-                                                                                   cache_interval});
-    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(OutputVector{A_p,
+                                                                                                 dt_p,
+                                                                                                 B_p,
+                                                                                                 x_p,
+                                                                                                 C_p,
+                                                                                                 state_p,
+                                                                                                 subseq,
+                                                                                                 block_idx,
+                                                                                                 block_idx_begins,
+                                                                                                 processed,
+                                                                                                 cache_interval}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("recurrent_state_table to have the same element type."));
 }
 
 TEST(type_prop, paged_selective_ssm_bad_index_type) {
@@ -112,7 +113,7 @@ TEST(type_prop, paged_selective_ssm_bad_index_type) {
                                                            Shape{6, 2, 16},
                                                            Shape{3, 4, 8, 16}),
                     NodeValidationFailure,
-                    testing::HasSubstr("Integer inputs must have i32 or i64 element type."));
+                    testing::HasSubstr("metadata inputs must have i32 or i64 element type."));
 }
 
 TEST(type_prop, paged_selective_ssm_heads_not_divisible_by_groups) {
@@ -302,7 +303,7 @@ TEST(type_prop, paged_selective_ssm_state_size_mismatch) {
                     testing::HasSubstr("The state size of `B`, `C` and `recurrent_state_table` should be the same."));
 }
 
-TEST(type_prop, paged_selective_ssm_block_indices_num_blocks_mismatch) {
+TEST(type_prop, paged_selective_ssm_logical_and_physical_block_counts_are_independent) {
     auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
     auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 4});
     auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{6, 2, 16});
@@ -315,12 +316,9 @@ TEST(type_prop, paged_selective_ssm_block_indices_num_blocks_mismatch) {
     auto processed = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
     auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, Shape{1});
 
-    OV_EXPECT_THROW(
-        std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
-            OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
-        NodeValidationFailure,
-        testing::HasSubstr("The number of blocks of `la_block_indices` and `recurrent_state_table` should be the "
-                           "same."));
+    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(
+        OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval});
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{6, 4, 8}));
 }
 
 TEST(type_prop, paged_selective_ssm_subsequence_and_block_begins_mismatch) {
@@ -340,8 +338,7 @@ TEST(type_prop, paged_selective_ssm_subsequence_and_block_begins_mismatch) {
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr("The number of sequences of `subsequence_begins` and `la_block_indices_begins` should "
-                           "be the same."));
+        testing::HasSubstr("The sizes of `subsequence_begins` and `la_block_indices_begins` should be the same."));
 }
 
 TEST(type_prop, paged_selective_ssm_processed_tokens_and_cache_interval_mismatch) {
@@ -361,8 +358,7 @@ TEST(type_prop, paged_selective_ssm_processed_tokens_and_cache_interval_mismatch
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr(
-            "The number of sequences of `num_processed_tokens` and `cache_interval` should be the same."));
+        testing::HasSubstr("The sizes of `num_processed_tokens` and `cache_interval` should be the same."));
 }
 
 TEST(type_prop, paged_selective_ssm_subsequence_begins_and_processed_tokens_mismatch) {
@@ -382,8 +378,7 @@ TEST(type_prop, paged_selective_ssm_subsequence_begins_and_processed_tokens_mism
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr(
-            "The number of sequences of `subsequence_begins` and `num_processed_tokens` should be the same."));
+        testing::HasSubstr("The size of `subsequence_begins` should be one larger than `num_processed_tokens`."));
 }
 
 TEST(type_prop, paged_selective_ssm_zero_groups) {
@@ -396,7 +391,7 @@ TEST(type_prop, paged_selective_ssm_zero_groups) {
                                                            Shape{6, 0, 16},
                                                            Shape{3, 4, 8, 16}),
                     NodeValidationFailure,
-                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+                    testing::HasSubstr("The number of groups must be greater than zero."));
 }
 
 TEST(type_prop, paged_selective_ssm_dynamic_rank_input_accepted) {
@@ -443,7 +438,8 @@ TEST(type_prop, paged_selective_ssm_type_mismatch) {
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr("PagedSelectiveSSM expects A, dt, B, x, and C to have the same element type."));
+        testing::HasSubstr("PagedSelectiveSSM expects inputs A, dt, B, x, C and recurrent_state_table to have the same "
+                           "element type."));
 }
 
 TEST(type_prop, paged_selective_ssm_state_float_type_invalid) {
@@ -463,7 +459,7 @@ TEST(type_prop, paged_selective_ssm_state_float_type_invalid) {
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr("Float inputs must have a floating-point element type."));
+        testing::HasSubstr("recurrent_state_table to have the same element type."));
 }
 
 TEST(type_prop, paged_selective_ssm_index_type_mixed) {
@@ -483,7 +479,7 @@ TEST(type_prop, paged_selective_ssm_index_type_mixed) {
         std::ignore = std::make_shared<op::internal::PagedSelectiveSSM>(
             OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval}),
         NodeValidationFailure,
-        testing::HasSubstr("Integer inputs must have i32 or i64 element type."));
+        testing::HasSubstr("expects all metadata inputs to have the same element type."));
 }
 
 }  // namespace ov::test

--- a/src/core/tests/type_prop/selective_ssm.cpp
+++ b/src/core/tests/type_prop/selective_ssm.cpp
@@ -1,0 +1,308 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/openvino.hpp"
+
+namespace ov::test {
+namespace {
+
+std::shared_ptr<op::internal::SelectiveSSM> make_selective_ssm(const element::Type& et,
+                                                               const PartialShape& A,
+                                                               const PartialShape& dt,
+                                                               const PartialShape& B,
+                                                               const PartialShape& x,
+                                                               const PartialShape& C,
+                                                               const PartialShape& state) {
+    auto A_p = std::make_shared<op::v0::Parameter>(et, A);
+    auto dt_p = std::make_shared<op::v0::Parameter>(et, dt);
+    auto B_p = std::make_shared<op::v0::Parameter>(et, B);
+    auto x_p = std::make_shared<op::v0::Parameter>(et, x);
+    auto C_p = std::make_shared<op::v0::Parameter>(et, C);
+    auto recurrent_state = std::make_shared<op::v0::Parameter>(et, state);
+
+    return std::make_shared<op::internal::SelectiveSSM>(OutputVector{A_p, dt_p, B_p, x_p, C_p, recurrent_state});
+}
+
+}  // namespace
+
+TEST(type_prop, selective_ssm_static_f32) {
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       Shape{2, 5, 2, 16},
+                                       Shape{2, 5, 4, 8},
+                                       Shape{2, 5, 2, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_size(), 2);
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_element_type(1), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape(Shape{2, 5, 4, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(1), PartialShape(Shape{2, 4, 8, 16}));
+}
+
+TEST(type_prop, selective_ssm_partial_shape_infer) {
+    const auto op = make_selective_ssm(element::bf16,
+                                       PartialShape{4},
+                                       PartialShape{{1, 4}, -1, 4},
+                                       PartialShape{{1, 4}, -1, 2, {32, 128}},
+                                       PartialShape{{1, 4}, -1, 4, {2, 8}},
+                                       PartialShape{{1, 4}, -1, 2, {32, 128}},
+                                       PartialShape{{1, 4}, 4, {2, 8}, {32, 128}});
+
+    EXPECT_EQ(op->get_output_element_type(0), element::bf16);
+    EXPECT_EQ(op->get_output_element_type(1), element::bf16);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{{1, 4}, -1, 4, {2, 8}}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{{1, 4}, 4, {2, 8}, {32, 128}}));
+}
+
+TEST(type_prop, selective_ssm_dims_resolved_from_other_inputs) {
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       Shape{2, 5, 2, 16},
+                                       PartialShape{-1, -1, -1, -1},
+                                       Shape{2, 5, 2, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{2, 5, 4, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{2, 4, 8, 16}));
+}
+
+TEST(type_prop, selective_ssm_invalid_A_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4, 1},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_state_size_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 32},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The state size of `B`, `C` and `recurrent_state` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_head_dim_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 4, 10, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The head dimension of `x` and `recurrent_state` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_heads_not_divisible_by_groups) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 3, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 3, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, selective_ssm_type_mismatch) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 2, 16});
+    auto recurrent_state = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 4, 8, 16});
+
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state}),
+        NodeValidationFailure,
+        testing::HasSubstr("SelectiveSSM expects A, dt, B, x, and C to have the same element type."));
+}
+
+TEST(type_prop, selective_ssm_state_type_may_differ) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 2, 16});
+    auto recurrent_state = std::make_shared<op::v0::Parameter>(element::bf16, Shape{2, 4, 8, 16});
+
+    const auto op = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state});
+
+    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+    EXPECT_EQ(op->get_output_element_type(1), element::bf16);
+}
+
+TEST(type_prop, selective_ssm_wrong_input_count) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, Shape{4});
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 4});
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 2, 16});
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 4, 8});
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, Shape{2, 5, 2, 16});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("SelectiveSSM expects 6 inputs, but it has 5"));
+}
+
+TEST(type_prop, selective_ssm_invalid_dt_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4, 1},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_invalid_B_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_invalid_x_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_invalid_C_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2},
+                                                  Shape{2, 4, 8, 16}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_invalid_recurrent_state_rank) {
+    EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                  Shape{4},
+                                                  Shape{2, 5, 4},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 5, 4, 8},
+                                                  Shape{2, 5, 2, 16},
+                                                  Shape{2, 4, 8}),
+                 NodeValidationFailure);
+}
+
+TEST(type_prop, selective_ssm_dynamic_rank_input_accepted) {
+    // Dynamic rank inputs are accepted since they may be folded to a static rank later.
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       Shape{2, 5, 2, 16},
+                                       PartialShape::dynamic(),
+                                       Shape{2, 5, 2, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_TRUE(op->get_output_partial_shape(0).rank().is_dynamic());
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{2, 4, 8, 16}));
+}
+
+TEST(type_prop, selective_ssm_batch_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{3, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The batch dimension of all inputs should be the same."));
+}
+
+TEST(type_prop, selective_ssm_seq_len_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 7, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The sequence length of `dt`, `B`, `x` and `C` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_num_heads_mismatch) {
+    OV_EXPECT_THROW(
+        std::ignore = make_selective_ssm(element::f32,
+                                         Shape{5},
+                                         Shape{2, 5, 4},
+                                         Shape{2, 5, 2, 16},
+                                         Shape{2, 5, 4, 8},
+                                         Shape{2, 5, 2, 16},
+                                         Shape{2, 4, 8, 16}),
+        NodeValidationFailure,
+        testing::HasSubstr("The number of heads of `A`, `dt`, `x` and `recurrent_state` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_num_groups_mismatch) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 2, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 3, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of groups of `B` and `C` should be the same."));
+}
+
+TEST(type_prop, selective_ssm_zero_groups) {
+    OV_EXPECT_THROW(std::ignore = make_selective_ssm(element::f32,
+                                                     Shape{4},
+                                                     Shape{2, 5, 4},
+                                                     Shape{2, 5, 0, 16},
+                                                     Shape{2, 5, 4, 8},
+                                                     Shape{2, 5, 0, 16},
+                                                     Shape{2, 4, 8, 16}),
+                    NodeValidationFailure,
+                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+}
+
+TEST(type_prop, selective_ssm_dynamic_num_groups_skips_divisibility_check) {
+    const auto op = make_selective_ssm(element::f32,
+                                       Shape{4},
+                                       Shape{2, 5, 4},
+                                       PartialShape{2, 5, -1, 16},
+                                       Shape{2, 5, 4, 8},
+                                       PartialShape{2, 5, -1, 16},
+                                       Shape{2, 4, 8, 16});
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{2, 5, 4, 8}));
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{2, 4, 8, 16}));
+}
+
+}  // namespace ov::test

--- a/src/core/tests/type_prop/selective_ssm.cpp
+++ b/src/core/tests/type_prop/selective_ssm.cpp
@@ -133,10 +133,10 @@ TEST(type_prop, selective_ssm_type_mismatch) {
     OV_EXPECT_THROW(
         std::ignore = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state}),
         NodeValidationFailure,
-        testing::HasSubstr("SelectiveSSM expects A, dt, B, x, and C to have the same element type."));
+        testing::HasSubstr("SelectiveSSM expects all inputs to have the same element type."));
 }
 
-TEST(type_prop, selective_ssm_state_type_may_differ) {
+TEST(type_prop, selective_ssm_state_type_must_match) {
     auto A = std::make_shared<op::v0::Parameter>(element::f16, Shape{4});
     auto dt = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 4});
     auto B = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 2, 16});
@@ -144,10 +144,10 @@ TEST(type_prop, selective_ssm_state_type_may_differ) {
     auto C = std::make_shared<op::v0::Parameter>(element::f16, Shape{2, 5, 2, 16});
     auto recurrent_state = std::make_shared<op::v0::Parameter>(element::bf16, Shape{2, 4, 8, 16});
 
-    const auto op = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state});
-
-    EXPECT_EQ(op->get_output_element_type(0), element::f16);
-    EXPECT_EQ(op->get_output_element_type(1), element::bf16);
+    OV_EXPECT_THROW(
+        std::ignore = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, recurrent_state}),
+        NodeValidationFailure,
+        testing::HasSubstr("SelectiveSSM expects all inputs to have the same element type."));
 }
 
 TEST(type_prop, selective_ssm_wrong_input_count) {
@@ -289,7 +289,7 @@ TEST(type_prop, selective_ssm_zero_groups) {
                                                      Shape{2, 5, 0, 16},
                                                      Shape{2, 4, 8, 16}),
                     NodeValidationFailure,
-                    testing::HasSubstr("The number of heads should be divisible by the number of groups."));
+                    testing::HasSubstr("The number of groups must be greater than zero."));
 }
 
 TEST(type_prop, selective_ssm_dynamic_num_groups_skips_divisibility_check) {

--- a/src/core/tests/type_prop/sources.cmake
+++ b/src/core/tests/type_prop/sources.cmake
@@ -137,6 +137,7 @@ set(OV_CORE_TESTS_TYPE_PROP_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/paged_attention.cpp
     ${CMAKE_CURRENT_LIST_DIR}/paged_causal_conv1d.cpp
     ${CMAKE_CURRENT_LIST_DIR}/paged_gated_delta_net.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/paged_selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/parameter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/power.cpp
     ${CMAKE_CURRENT_LIST_DIR}/prelu.cpp
@@ -180,6 +181,7 @@ set(OV_CORE_TESTS_TYPE_PROP_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/search_sorted.cpp
     ${CMAKE_CURRENT_LIST_DIR}/segment_max.cpp
     ${CMAKE_CURRENT_LIST_DIR}/select.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/selu.cpp
     ${CMAKE_CURRENT_LIST_DIR}/shape_of.cpp
     ${CMAKE_CURRENT_LIST_DIR}/shuffle_channels.cpp

--- a/src/core/tests/visitors/op/paged_selective_ssm.cpp
+++ b/src/core/tests/visitors/op/paged_selective_ssm.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/paged_selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include "visitors/visitors.hpp"
+
+namespace ov::test {
+
+TEST(attributes, paged_selective_ssm_default_attrs) {
+    NodeBuilder::opset().insert<op::internal::PagedSelectiveSSM>();
+    const auto A = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{4});
+    const auto dt = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 4});
+    const auto B = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 2, 8});
+    const auto x = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 4, 8});
+    const auto C = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 2, 8});
+    const auto state = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 4, 8, 8});
+    const auto subseq = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto block_idx = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto block_idx_begins = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto processed = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+    const auto cache_interval = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{-1});
+
+    const auto op = std::make_shared<op::internal::PagedSelectiveSSM>(
+        OutputVector{A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval});
+
+    NodeBuilder builder(op, {A, dt, B, x, C, state, subseq, block_idx, block_idx_begins, processed, cache_interval});
+    const auto g_op = as_type_ptr<op::internal::PagedSelectiveSSM>(builder.create());
+
+    EXPECT_EQ(builder.get_value_map_size(), 0);
+    EXPECT_NE(g_op, nullptr);
+}
+
+}  // namespace ov::test

--- a/src/core/tests/visitors/op/selective_ssm.cpp
+++ b/src/core/tests/visitors/op/selective_ssm.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/selective_ssm.hpp"
+
+#include <gtest/gtest.h>
+
+#include "visitors/visitors.hpp"
+
+namespace ov::test {
+
+TEST(attributes, selective_ssm_default_attrs) {
+    NodeBuilder::opset().insert<op::internal::SelectiveSSM>();
+    const auto A = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{4});
+    const auto dt = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1, 4});
+    const auto B = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1, 2, 8});
+    const auto x = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1, 4, 8});
+    const auto C = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, -1, 2, 8});
+    const auto state = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{-1, 4, 8, 8});
+
+    const auto op = std::make_shared<op::internal::SelectiveSSM>(OutputVector{A, dt, B, x, C, state});
+    NodeBuilder builder(op, {A, dt, B, x, C, state});
+    const auto g_op = as_type_ptr<op::internal::SelectiveSSM>(builder.create());
+
+    EXPECT_EQ(builder.get_value_map_size(), 0);
+    EXPECT_NE(g_op, nullptr);
+}
+
+}  // namespace ov::test

--- a/src/core/tests/visitors/sources.cmake
+++ b/src/core/tests/visitors/sources.cmake
@@ -138,6 +138,7 @@ set(OV_CORE_TESTS_VISITORS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/op/pad.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_causal_conv1d.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/paged_gated_delta_net.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/paged_selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/parameter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/power.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/prelu.cpp
@@ -177,6 +178,7 @@ set(OV_CORE_TESTS_VISITORS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/op/scatter_update.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/segment_max.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/select.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/selective_ssm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/selu.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/shape_of.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/shuffle_channels.cpp

--- a/src/plugins/intel_cpu/src/cpu_types.cpp
+++ b/src/plugins/intel_cpu/src/cpu_types.cpp
@@ -267,6 +267,8 @@ static const TypeToNameMap& get_type_to_name_tbl() {
         {"GatherMatmulCompressed", Type::GatherMatmul},
         {"GatedDeltaNet", Type::GatedDeltaNet},
         {"PagedGatedDeltaNet", Type::PagedGatedDeltaNet},
+        {"SelectiveSSM", Type::SelectiveSSM},
+        {"PagedSelectiveSSM", Type::PagedSelectiveSSM},
         {"PagedCausalConv1D", Type::PagedCausalConv1D}};
     return type_to_name_tbl;
 }
@@ -406,6 +408,8 @@ std::string NameFromType(const Type type) {
         CASE(GatherMatmul);
         CASE(GatedDeltaNet);
         CASE(PagedGatedDeltaNet);
+        CASE(SelectiveSSM);
+        CASE(PagedSelectiveSSM);
         CASE(PagedCausalConv1D);
         CASE(Unknown);
     }

--- a/src/plugins/intel_cpu/src/cpu_types.h
+++ b/src/plugins/intel_cpu/src/cpu_types.h
@@ -142,6 +142,8 @@ enum class Type : uint8_t {
     GatherMatmul,
     GatedDeltaNet,
     PagedGatedDeltaNet,
+    SelectiveSSM,
+    PagedSelectiveSSM,
     PagedCausalConv1D
 };
 

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -46,6 +46,7 @@
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/op/paged_causal_conv1d.hpp"
 #include "openvino/op/paged_gated_delta_net.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
 #include "openvino/op/prelu.hpp"
 #include "openvino/op/prior_box.hpp"
 #include "openvino/op/prior_box_clustered.hpp"
@@ -58,6 +59,7 @@
 #include "openvino/op/relu.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/select.hpp"
+#include "openvino/op/selective_ssm.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/shuffle_channels.hpp"
 #include "openvino/op/squeeze.hpp"
@@ -210,6 +212,8 @@ OPENVINO_CREATE_EXTENSIONS(std::vector<ov::Extension::Ptr>({
     std::make_shared<ov::OpExtension<ov::op::PagedAttentionExtension>>(),
     std::make_shared<ov::OpExtension<ov::op::internal::GatedDeltaNet>>(),
     std::make_shared<ov::OpExtension<ov::op::internal::PagedGatedDeltaNet>>(),
+    std::make_shared<ov::OpExtension<ov::op::internal::SelectiveSSM>>(),
+    std::make_shared<ov::OpExtension<ov::op::internal::PagedSelectiveSSM>>(),
     std::make_shared<ov::OpExtension<ov::op::internal::PagedCausalConv1D>>(),
     // clang-format off
     OP_EXTENSION_X64(std::make_shared<ov::OpExtension<ov::intel_cpu::InteractionNode>>())

--- a/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.cpp
@@ -1,0 +1,161 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "paged_selective_ssm_executor.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "memory_desc/cpu_blocked_memory_desc.h"
+#include "nodes/executors/memory_arguments.hpp"
+#include "nodes/kernels/selective_ssm.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov::intel_cpu {
+namespace {
+
+bool is_supported_data_precision(const ov::element::Type& precision) {
+    return precision == ov::element::f32 || precision == ov::element::f16 || precision == ov::element::bf16;
+}
+
+bool is_supported_index_precision(const ov::element::Type& precision) {
+    return precision == ov::element::i32 || precision == ov::element::i64;
+}
+
+}  // namespace
+
+bool PagedSelectiveSSMExecutor::supports(const PagedSelectiveSSMConfig& config) {
+    const auto data_precision = config.descs.at(ARG_PAGED_SSM_A)->getPrecision();
+    if (!is_supported_data_precision(data_precision)) {
+        return false;
+    }
+    for (const auto arg : {ARG_PAGED_SSM_DT,
+                           ARG_PAGED_SSM_B,
+                           ARG_PAGED_SSM_X,
+                           ARG_PAGED_SSM_C,
+                           ARG_PAGED_SSM_STATE,
+                           ARG_PAGED_SSM_OUT}) {
+        if (config.descs.at(arg)->getPrecision() != data_precision) {
+            return false;
+        }
+    }
+
+    const auto index_precision = config.descs.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getPrecision();
+    if (!is_supported_index_precision(index_precision)) {
+        return false;
+    }
+    for (const auto arg : {ARG_PAGED_SSM_BLOCK_INDICES,
+                           ARG_PAGED_SSM_BLOCK_INDICES_BEGINS,
+                           ARG_PAGED_SSM_NUM_PROCESSED_TOKENS,
+                           ARG_PAGED_SSM_CACHE_INTERVAL}) {
+        if (config.descs.at(arg)->getPrecision() != index_precision) {
+            return false;
+        }
+    }
+    return true;
+}
+
+PagedSelectiveSSMExecutor::PagedSelectiveSSMExecutor(const PagedSelectiveSSMAttrs&,
+                                                     const MemoryArgs& memory,
+                                                     ExecutorContext::CPtr context)
+    : m_context(std::move(context)) {
+    update(memory);
+}
+
+bool PagedSelectiveSSMExecutor::update_scratchpad(const MemoryArgs& memory) {
+    const auto& x_shape = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getShape();
+    const auto& state_shape = memory.at(ARG_PAGED_SSM_STATE)->getDescPtr()->getShape();
+    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+        return true;
+    }
+    const auto& x_dims = x_shape.getStaticDims();
+    const auto& state_dims = state_shape.getStaticDims();
+    OPENVINO_ASSERT(x_dims.size() == 3 && state_dims.size() == 4);
+    const auto head_dim = x_dims[2];
+    const auto state_size = state_dims[3];
+    const auto physical_blocks = state_dims[0];
+    OPENVINO_ASSERT(state_size > 0, "PagedSelectiveSSM state_size must be greater than zero.");
+    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    const auto scratch_head_dim = node::kernel::get_scratch_head_dim(head_dim, state_size, x_dims[1], thread_count);
+    if (m_state_scratch && m_block_owners && m_scratch_head_dim == scratch_head_dim &&
+        m_scratch_state_size == state_size && m_cached_physical_blocks == physical_blocks) {
+        return true;
+    }
+
+    const auto state_desc =
+        std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
+                                               ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});
+    const auto owner_desc =
+        std::make_shared<CpuBlockedMemoryDesc>(ov::element::i32,
+                                               ov::intel_cpu::Shape{std::max(size_t{1}, physical_blocks)});
+    m_state_scratch = m_context->getScratchPad()->createScratchPadMem(state_desc);
+    m_block_owners = m_context->getScratchPad()->createScratchPadMem(owner_desc);
+    m_scratch_head_dim = scratch_head_dim;
+    m_scratch_state_size = state_size;
+    m_cached_physical_blocks = physical_blocks;
+    return m_state_scratch != nullptr && m_block_owners != nullptr;
+}
+
+bool PagedSelectiveSSMExecutor::update(const MemoryArgs& memory) {
+    return update_scratchpad(memory);
+}
+
+void PagedSelectiveSSMExecutor::execute(const MemoryArgs& memory) {
+    const auto& B_dims = memory.at(ARG_PAGED_SSM_B)->getStaticDims();
+    const auto& x_dims = memory.at(ARG_PAGED_SSM_X)->getStaticDims();
+    const auto& state_dims = memory.at(ARG_PAGED_SSM_STATE)->getStaticDims();
+    const auto& subsequence_dims = memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getStaticDims();
+    const auto& block_indices_dims = memory.at(ARG_PAGED_SSM_BLOCK_INDICES)->getStaticDims();
+    const auto& block_begins_dims = memory.at(ARG_PAGED_SSM_BLOCK_INDICES_BEGINS)->getStaticDims();
+    const auto& processed_dims = memory.at(ARG_PAGED_SSM_NUM_PROCESSED_TOKENS)->getStaticDims();
+    const auto& interval_dims = memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getStaticDims();
+    OPENVINO_ASSERT(B_dims.size() == 3 && x_dims.size() == 3 && state_dims.size() == 4);
+    OPENVINO_ASSERT(subsequence_dims.size() == 1 && subsequence_dims[0] >= 1 && block_indices_dims.size() == 1);
+    const auto sequence_count = subsequence_dims[0] - 1;
+    OPENVINO_ASSERT(block_begins_dims.size() == 1 && processed_dims.size() == 1 && interval_dims.size() == 1 &&
+                        block_begins_dims[0] == sequence_count + 1 && processed_dims[0] == sequence_count &&
+                        interval_dims[0] == sequence_count,
+                    "PagedSelectiveSSM metadata tensor lengths are inconsistent.");
+    if (!m_state_scratch || !m_block_owners || m_scratch_state_size != state_dims[3] ||
+        m_cached_physical_blocks != state_dims[0]) {
+        OPENVINO_ASSERT(update_scratchpad(memory));
+    }
+
+    const node::kernel::PagedSelectiveSSMShape shape{x_dims[0],
+                                                     x_dims[1],
+                                                     x_dims[2],
+                                                     B_dims[1],
+                                                     B_dims[2],
+                                                     state_dims[0],
+                                                     block_indices_dims[0],
+                                                     sequence_count};
+    node::kernel::paged_selective_ssm(memory.at(ARG_PAGED_SSM_A)->getData(),
+                                      memory.at(ARG_PAGED_SSM_DT)->getData(),
+                                      memory.at(ARG_PAGED_SSM_B)->getData(),
+                                      memory.at(ARG_PAGED_SSM_X)->getData(),
+                                      memory.at(ARG_PAGED_SSM_C)->getData(),
+                                      memory.at(ARG_PAGED_SSM_STATE)->getData(),
+                                      memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getData(),
+                                      memory.at(ARG_PAGED_SSM_BLOCK_INDICES)->getData(),
+                                      memory.at(ARG_PAGED_SSM_BLOCK_INDICES_BEGINS)->getData(),
+                                      memory.at(ARG_PAGED_SSM_NUM_PROCESSED_TOKENS)->getData(),
+                                      memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getData(),
+                                      memory.at(ARG_PAGED_SSM_OUT)->getData(),
+                                      shape,
+                                      memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getPrecision(),
+                                      memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDescPtr()->getPrecision(),
+                                      m_state_scratch->getDataAs<float>(),
+                                      m_scratch_head_dim,
+                                      m_block_owners->getDataAs<int32_t>(),
+                                      m_context->getCpuParallel());
+}
+
+impl_desc_type PagedSelectiveSSMExecutor::implType() const {
+    return impl_desc_type::ref_any;
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "memory_desc/cpu_blocked_memory_desc.h"
+#include "nodes/common/cpu_convert.h"
 #include "nodes/executors/memory_arguments.hpp"
 #include "nodes/kernels/selective_ssm.hpp"
 #include "openvino/core/except.hpp"
@@ -68,36 +69,61 @@ PagedSelectiveSSMExecutor::PagedSelectiveSSMExecutor(const PagedSelectiveSSMAttr
 
 bool PagedSelectiveSSMExecutor::update_scratchpad(const MemoryArgs& memory) {
     const auto& x_shape = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getShape();
+    const auto& B_shape = memory.at(ARG_PAGED_SSM_B)->getDescPtr()->getShape();
     const auto& state_shape = memory.at(ARG_PAGED_SSM_STATE)->getDescPtr()->getShape();
-    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+    const auto& subsequence_shape = memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDescPtr()->getShape();
+    if (x_shape.isDynamic() || B_shape.isDynamic() || state_shape.isDynamic() || subsequence_shape.isDynamic()) {
         return true;
     }
     const auto& x_dims = x_shape.getStaticDims();
+    const auto& B_dims = B_shape.getStaticDims();
     const auto& state_dims = state_shape.getStaticDims();
-    OPENVINO_ASSERT(x_dims.size() == 3 && state_dims.size() == 4);
+    const auto& subsequence_dims = subsequence_shape.getStaticDims();
+    const auto precision = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getPrecision();
+    OPENVINO_ASSERT(x_dims.size() == 3 && B_dims.size() == 3 && state_dims.size() == 4 &&
+                    subsequence_dims.size() == 1 && subsequence_dims[0] >= 1);
     const auto head_dim = x_dims[2];
     const auto state_size = state_dims[3];
     const auto physical_blocks = state_dims[0];
-    OPENVINO_ASSERT(state_size > 0, "PagedSelectiveSSM state_size must be greater than zero.");
+    const node::kernel::PagedSelectiveSSMShape
+        shape{x_dims[0], x_dims[1], head_dim, B_dims[1], state_size, physical_blocks, 0, 0};
+    node::kernel::validate_paged_selective_ssm_shape(shape);
     const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
-    const auto scratch_head_dim = node::kernel::get_scratch_head_dim(head_dim, state_size, x_dims[1], thread_count);
-    if (m_state_scratch && m_block_owners && m_scratch_head_dim == scratch_head_dim &&
-        m_scratch_state_size == state_size && m_cached_physical_blocks == physical_blocks) {
+    const auto sequence_count = subsequence_dims[0] - 1;
+    const auto outer_work = node::kernel::checked_size_product({sequence_count, x_dims[1]}, "outer work items");
+    const auto scratch_head_dim = node::kernel::get_scratch_head_dim(head_dim, state_size, outer_work, thread_count);
+    const auto scratch_elements =
+        node::kernel::checked_size_product({scratch_head_dim, state_size}, "state scratch per worker");
+    const auto state_scratch_elements =
+        node::kernel::checked_size_product({thread_count, scratch_elements}, "state scratch");
+    const auto projection_elements =
+        node::kernel::checked_size_product({B_dims[0], B_dims[1], B_dims[2]}, "B/C projection");
+    const auto projection_scratch_elements =
+        precision == ov::element::f32
+            ? size_t{0}
+            : node::kernel::checked_size_product({size_t{2}, projection_elements}, "B/C projection scratch");
+    if (m_scratch && m_scratch_head_dim == scratch_head_dim && m_scratch_state_size == state_size &&
+        m_state_scratch_elements == state_scratch_elements &&
+        m_projection_scratch_elements == projection_scratch_elements && m_cached_physical_blocks == physical_blocks &&
+        m_cached_projection_elements == projection_elements) {
         return true;
     }
 
-    const auto state_desc =
+    static_assert(sizeof(float) == sizeof(int32_t) && alignof(float) == alignof(int32_t));
+    const auto total_scratch_elements =
+        node::kernel::checked_size_sum({state_scratch_elements, projection_scratch_elements, physical_blocks},
+                                       "combined state, B/C projection, and block-owner scratch");
+    const auto scratch_desc =
         std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
-                                               ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});
-    const auto owner_desc =
-        std::make_shared<CpuBlockedMemoryDesc>(ov::element::i32,
-                                               ov::intel_cpu::Shape{std::max(size_t{1}, physical_blocks)});
-    m_state_scratch = m_context->getScratchPad()->createScratchPadMem(state_desc);
-    m_block_owners = m_context->getScratchPad()->createScratchPadMem(owner_desc);
+                                               ov::intel_cpu::Shape{std::max(size_t{1}, total_scratch_elements)});
+    m_scratch = m_context->getScratchPad()->createScratchPadMem(scratch_desc);
     m_scratch_head_dim = scratch_head_dim;
     m_scratch_state_size = state_size;
+    m_state_scratch_elements = state_scratch_elements;
+    m_projection_scratch_elements = projection_scratch_elements;
     m_cached_physical_blocks = physical_blocks;
-    return m_state_scratch != nullptr && m_block_owners != nullptr;
+    m_cached_projection_elements = projection_elements;
+    return m_scratch != nullptr;
 }
 
 bool PagedSelectiveSSMExecutor::update(const MemoryArgs& memory) {
@@ -115,13 +141,26 @@ void PagedSelectiveSSMExecutor::execute(const MemoryArgs& memory) {
     const auto& interval_dims = memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getStaticDims();
     OPENVINO_ASSERT(B_dims.size() == 3 && x_dims.size() == 3 && state_dims.size() == 4);
     OPENVINO_ASSERT(subsequence_dims.size() == 1 && subsequence_dims[0] >= 1 && block_indices_dims.size() == 1);
+    const auto precision = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getPrecision();
+    const auto projection_elements =
+        node::kernel::checked_size_product({B_dims[0], B_dims[1], B_dims[2]}, "B/C projection");
     const auto sequence_count = subsequence_dims[0] - 1;
+    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    const auto outer_work = node::kernel::checked_size_product({sequence_count, x_dims[1]}, "outer work items");
+    const auto expected_scratch_head_dim =
+        node::kernel::get_scratch_head_dim(x_dims[2], state_dims[3], outer_work, thread_count);
+    const auto expected_projection_scratch_elements =
+        precision == ov::element::f32
+            ? size_t{0}
+            : node::kernel::checked_size_product({size_t{2}, projection_elements}, "B/C projection scratch");
     OPENVINO_ASSERT(block_begins_dims.size() == 1 && processed_dims.size() == 1 && interval_dims.size() == 1 &&
                         block_begins_dims[0] == sequence_count + 1 && processed_dims[0] == sequence_count &&
                         interval_dims[0] == sequence_count,
                     "PagedSelectiveSSM metadata tensor lengths are inconsistent.");
-    if (!m_state_scratch || !m_block_owners || m_scratch_state_size != state_dims[3] ||
-        m_cached_physical_blocks != state_dims[0]) {
+    if (!m_scratch || m_scratch_state_size != state_dims[3] || m_scratch_head_dim != expected_scratch_head_dim ||
+        m_cached_physical_blocks != state_dims[0] ||
+        m_projection_scratch_elements != expected_projection_scratch_elements ||
+        m_cached_projection_elements != projection_elements) {
         OPENVINO_ASSERT(update_scratchpad(memory));
     }
 
@@ -133,6 +172,26 @@ void PagedSelectiveSSMExecutor::execute(const MemoryArgs& memory) {
                                                      state_dims[0],
                                                      block_indices_dims[0],
                                                      sequence_count};
+    auto* state_scratch = m_scratch->getDataAs<float>();
+    const float* converted_B = nullptr;
+    const float* converted_C = nullptr;
+    if (precision != ov::element::f32 && projection_elements > 0) {
+        auto* projection_scratch = state_scratch + m_state_scratch_elements;
+        converted_B = projection_scratch;
+        converted_C = projection_scratch + projection_elements;
+        cpu_parallel_convert(memory.at(ARG_PAGED_SSM_B)->getData(),
+                             projection_scratch,
+                             precision,
+                             ov::element::f32,
+                             projection_elements);
+        cpu_parallel_convert(memory.at(ARG_PAGED_SSM_C)->getData(),
+                             projection_scratch + projection_elements,
+                             precision,
+                             ov::element::f32,
+                             projection_elements);
+    }
+    auto* block_owners =
+        reinterpret_cast<int32_t*>(state_scratch + m_state_scratch_elements + m_projection_scratch_elements);
     node::kernel::paged_selective_ssm(memory.at(ARG_PAGED_SSM_A)->getData(),
                                       memory.at(ARG_PAGED_SSM_DT)->getData(),
                                       memory.at(ARG_PAGED_SSM_B)->getData(),
@@ -146,12 +205,14 @@ void PagedSelectiveSSMExecutor::execute(const MemoryArgs& memory) {
                                       memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getData(),
                                       memory.at(ARG_PAGED_SSM_OUT)->getData(),
                                       shape,
-                                      memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getPrecision(),
+                                      precision,
                                       memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDescPtr()->getPrecision(),
-                                      m_state_scratch->getDataAs<float>(),
+                                      state_scratch,
                                       m_scratch_head_dim,
-                                      m_block_owners->getDataAs<int32_t>(),
-                                      m_context->getCpuParallel());
+                                      block_owners,
+                                      m_context->getCpuParallel(),
+                                      converted_B,
+                                      converted_C);
 }
 
 impl_desc_type PagedSelectiveSSMExecutor::implType() const {

--- a/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.hpp
@@ -28,11 +28,13 @@ private:
     bool update_scratchpad(const MemoryArgs& memory);
 
     ExecutorContext::CPtr m_context;
-    MemoryPtr m_state_scratch;
-    MemoryPtr m_block_owners;
+    MemoryPtr m_scratch;
     size_t m_scratch_head_dim = 0;
     size_t m_scratch_state_size = 0;
+    size_t m_state_scratch_elements = 0;
+    size_t m_projection_scratch_elements = 0;
     size_t m_cached_physical_blocks = 0;
+    size_t m_cached_projection_elements = 0;
 };
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+
+#include "cpu_memory.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/paged_selective_ssm_config.hpp"
+
+namespace ov::intel_cpu {
+
+class PagedSelectiveSSMExecutor : public Executor {
+public:
+    static bool supports(const PagedSelectiveSSMConfig& config);
+
+    PagedSelectiveSSMExecutor(const PagedSelectiveSSMAttrs& attrs,
+                              const MemoryArgs& memory,
+                              ExecutorContext::CPtr context);
+
+    bool update(const MemoryArgs& memory) override;
+    void execute(const MemoryArgs& memory) override;
+    [[nodiscard]] impl_desc_type implType() const override;
+
+private:
+    bool update_scratchpad(const MemoryArgs& memory);
+
+    ExecutorContext::CPtr m_context;
+    MemoryPtr m_state_scratch;
+    MemoryPtr m_block_owners;
+    size_t m_scratch_head_dim = 0;
+    size_t m_scratch_state_size = 0;
+    size_t m_cached_physical_blocks = 0;
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "memory_desc/cpu_blocked_memory_desc.h"
+#include "nodes/common/cpu_convert.h"
 #include "nodes/executors/memory_arguments.hpp"
 #include "nodes/kernels/selective_ssm.hpp"
 #include "openvino/core/except.hpp"
@@ -47,30 +48,54 @@ SelectiveSSMExecutor::SelectiveSSMExecutor(const SelectiveSSMAttrs&,
 
 bool SelectiveSSMExecutor::update_scratchpad(const MemoryArgs& memory) {
     const auto& x_shape = memory.at(ARG_SSM_X)->getDescPtr()->getShape();
+    const auto& B_shape = memory.at(ARG_SSM_B)->getDescPtr()->getShape();
     const auto& state_shape = memory.at(ARG_SSM_STATE)->getDescPtr()->getShape();
-    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+    if (x_shape.isDynamic() || B_shape.isDynamic() || state_shape.isDynamic()) {
         return true;
     }
     const auto& x_dims = x_shape.getStaticDims();
+    const auto& B_dims = B_shape.getStaticDims();
     const auto& state_dims = state_shape.getStaticDims();
-    OPENVINO_ASSERT(x_dims.size() == 4 && state_dims.size() == 4);
+    const auto precision = memory.at(ARG_SSM_X)->getDescPtr()->getPrecision();
+    OPENVINO_ASSERT(x_dims.size() == 4 && B_dims.size() == 4 && state_dims.size() == 4);
     const auto head_dim = x_dims[3];
     const auto state_size = state_dims[3];
-    OPENVINO_ASSERT(state_size > 0, "SelectiveSSM state_size must be greater than zero.");
+    const node::kernel::SelectiveSSMShape shape{x_dims[0], x_dims[1], x_dims[2], head_dim, B_dims[2], state_size};
+    node::kernel::validate_selective_ssm_shape(shape);
     const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
-    const auto scratch_head_dim =
-        node::kernel::get_scratch_head_dim(head_dim, state_size, x_dims[0] * x_dims[2], thread_count);
-    if (m_state_scratch && m_scratch_head_dim == scratch_head_dim && m_scratch_state_size == state_size) {
+    const auto outer_work = node::kernel::checked_size_product({x_dims[0], x_dims[2]}, "outer work items");
+    const auto scratch_head_dim = node::kernel::get_scratch_head_dim(head_dim, state_size, outer_work, thread_count);
+    const auto needs_state_scratch = precision != ov::element::f32 && x_dims[1] > 1;
+    const auto state_scratch_elements =
+        needs_state_scratch
+            ? node::kernel::checked_size_product({thread_count, scratch_head_dim, state_size}, "state scratch")
+            : size_t{0};
+    const auto projection_elements =
+        node::kernel::checked_size_product({B_dims[0], B_dims[1], B_dims[2], B_dims[3]}, "B/C projection");
+    const auto projection_scratch_elements =
+        precision == ov::element::f32
+            ? size_t{0}
+            : node::kernel::checked_size_product({size_t{2}, projection_elements}, "B/C projection scratch");
+    if (m_scratch && m_scratch_head_dim == scratch_head_dim && m_scratch_state_size == state_size &&
+        m_state_scratch_elements == state_scratch_elements &&
+        m_projection_scratch_elements == projection_scratch_elements &&
+        m_cached_projection_elements == projection_elements) {
         return true;
     }
 
+    const auto total_scratch_elements =
+        node::kernel::checked_size_sum({state_scratch_elements, projection_scratch_elements},
+                                       "combined state and B/C projection scratch");
     const auto desc =
         std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
-                                               ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});
-    m_state_scratch = m_context->getScratchPad()->createScratchPadMem(desc);
+                                               ov::intel_cpu::Shape{std::max(size_t{1}, total_scratch_elements)});
+    m_scratch = m_context->getScratchPad()->createScratchPadMem(desc);
     m_scratch_head_dim = scratch_head_dim;
     m_scratch_state_size = state_size;
-    return m_state_scratch != nullptr;
+    m_state_scratch_elements = state_scratch_elements;
+    m_projection_scratch_elements = projection_scratch_elements;
+    m_cached_projection_elements = projection_elements;
+    return m_scratch != nullptr;
 }
 
 bool SelectiveSSMExecutor::update(const MemoryArgs& memory) {
@@ -82,12 +107,48 @@ void SelectiveSSMExecutor::execute(const MemoryArgs& memory) {
     const auto& B_dims = memory.at(ARG_SSM_B)->getStaticDims();
     const auto& state_dims = memory.at(ARG_SSM_STATE)->getStaticDims();
     OPENVINO_ASSERT(x_dims.size() == 4 && B_dims.size() == 4 && state_dims.size() == 4);
-    if (!m_state_scratch || m_scratch_state_size != state_dims[3] || m_scratch_head_dim > x_dims[3]) {
+    const auto precision = memory.at(ARG_SSM_X)->getDescPtr()->getPrecision();
+    const auto projection_elements =
+        node::kernel::checked_size_product({B_dims[0], B_dims[1], B_dims[2], B_dims[3]}, "B/C projection");
+    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    const auto outer_work = node::kernel::checked_size_product({x_dims[0], x_dims[2]}, "outer work items");
+    const auto expected_scratch_head_dim =
+        node::kernel::get_scratch_head_dim(x_dims[3], state_dims[3], outer_work, thread_count);
+    const auto expected_state_scratch_elements =
+        precision != ov::element::f32 && x_dims[1] > 1
+            ? node::kernel::checked_size_product({thread_count, expected_scratch_head_dim, state_dims[3]},
+                                                 "state scratch")
+            : size_t{0};
+    const auto expected_projection_scratch_elements =
+        precision == ov::element::f32
+            ? size_t{0}
+            : node::kernel::checked_size_product({size_t{2}, projection_elements}, "B/C projection scratch");
+    if (!m_scratch || m_scratch_state_size != state_dims[3] || m_scratch_head_dim != expected_scratch_head_dim ||
+        m_state_scratch_elements != expected_state_scratch_elements ||
+        m_projection_scratch_elements != expected_projection_scratch_elements ||
+        m_cached_projection_elements != projection_elements) {
         OPENVINO_ASSERT(update_scratchpad(memory));
     }
 
     node::kernel::SelectiveSSMShape shape{x_dims[0], x_dims[1], x_dims[2], x_dims[3], B_dims[2], B_dims[3]};
-    const auto precision = memory.at(ARG_SSM_X)->getDescPtr()->getPrecision();
+    auto* state_scratch = m_scratch->getDataAs<float>();
+    const float* converted_B = nullptr;
+    const float* converted_C = nullptr;
+    if (precision != ov::element::f32 && projection_elements > 0) {
+        auto* projection_scratch = state_scratch + m_state_scratch_elements;
+        converted_B = projection_scratch;
+        converted_C = projection_scratch + projection_elements;
+        cpu_parallel_convert(memory.at(ARG_SSM_B)->getData(),
+                             projection_scratch,
+                             precision,
+                             ov::element::f32,
+                             projection_elements);
+        cpu_parallel_convert(memory.at(ARG_SSM_C)->getData(),
+                             projection_scratch + projection_elements,
+                             precision,
+                             ov::element::f32,
+                             projection_elements);
+    }
     node::kernel::selective_ssm(memory.at(ARG_SSM_A)->getData(),
                                 memory.at(ARG_SSM_DT)->getData(),
                                 memory.at(ARG_SSM_B)->getData(),
@@ -98,9 +159,11 @@ void SelectiveSSMExecutor::execute(const MemoryArgs& memory) {
                                 memory.at(ARG_SSM_OUT_STATE)->getData(),
                                 shape,
                                 precision,
-                                m_state_scratch->getDataAs<float>(),
+                                state_scratch,
                                 m_scratch_head_dim,
-                                m_context->getCpuParallel());
+                                m_context->getCpuParallel(),
+                                converted_B,
+                                converted_C);
 }
 
 impl_desc_type SelectiveSSMExecutor::implType() const {

--- a/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.cpp
@@ -18,8 +18,6 @@
 namespace ov::intel_cpu {
 namespace {
 
-constexpr size_t target_scratch_elements = 8192;
-
 bool is_supported_precision(const ov::element::Type& precision) {
     return precision == ov::element::f32 || precision == ov::element::f16 || precision == ov::element::bf16;
 }
@@ -59,12 +57,13 @@ bool SelectiveSSMExecutor::update_scratchpad(const MemoryArgs& memory) {
     const auto head_dim = x_dims[3];
     const auto state_size = state_dims[3];
     OPENVINO_ASSERT(state_size > 0, "SelectiveSSM state_size must be greater than zero.");
-    const auto scratch_head_dim = std::max(size_t{1}, std::min(head_dim, target_scratch_elements / state_size));
+    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    const auto scratch_head_dim =
+        node::kernel::get_scratch_head_dim(head_dim, state_size, x_dims[0] * x_dims[2], thread_count);
     if (m_state_scratch && m_scratch_head_dim == scratch_head_dim && m_scratch_state_size == state_size) {
         return true;
     }
 
-    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
     const auto desc =
         std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
                                                ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});

--- a/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.cpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "selective_ssm_executor.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "memory_desc/cpu_blocked_memory_desc.h"
+#include "nodes/executors/memory_arguments.hpp"
+#include "nodes/kernels/selective_ssm.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov::intel_cpu {
+namespace {
+
+constexpr size_t target_scratch_elements = 8192;
+
+bool is_supported_precision(const ov::element::Type& precision) {
+    return precision == ov::element::f32 || precision == ov::element::f16 || precision == ov::element::bf16;
+}
+
+}  // namespace
+
+bool SelectiveSSMExecutor::supports(const SelectiveSSMConfig& config) {
+    const auto precision = config.descs.at(ARG_SSM_A)->getPrecision();
+    if (!is_supported_precision(precision)) {
+        return false;
+    }
+    for (const auto arg :
+         {ARG_SSM_DT, ARG_SSM_B, ARG_SSM_X, ARG_SSM_C, ARG_SSM_STATE, ARG_SSM_OUT, ARG_SSM_OUT_STATE}) {
+        if (config.descs.at(arg)->getPrecision() != precision) {
+            return false;
+        }
+    }
+    return true;
+}
+
+SelectiveSSMExecutor::SelectiveSSMExecutor(const SelectiveSSMAttrs&,
+                                           const MemoryArgs& memory,
+                                           ExecutorContext::CPtr context)
+    : m_context(std::move(context)) {
+    update(memory);
+}
+
+bool SelectiveSSMExecutor::update_scratchpad(const MemoryArgs& memory) {
+    const auto& x_shape = memory.at(ARG_SSM_X)->getDescPtr()->getShape();
+    const auto& state_shape = memory.at(ARG_SSM_STATE)->getDescPtr()->getShape();
+    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+        return true;
+    }
+    const auto& x_dims = x_shape.getStaticDims();
+    const auto& state_dims = state_shape.getStaticDims();
+    OPENVINO_ASSERT(x_dims.size() == 4 && state_dims.size() == 4);
+    const auto head_dim = x_dims[3];
+    const auto state_size = state_dims[3];
+    OPENVINO_ASSERT(state_size > 0, "SelectiveSSM state_size must be greater than zero.");
+    const auto scratch_head_dim = std::max(size_t{1}, std::min(head_dim, target_scratch_elements / state_size));
+    if (m_state_scratch && m_scratch_head_dim == scratch_head_dim && m_scratch_state_size == state_size) {
+        return true;
+    }
+
+    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    const auto desc =
+        std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
+                                               ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});
+    m_state_scratch = m_context->getScratchPad()->createScratchPadMem(desc);
+    m_scratch_head_dim = scratch_head_dim;
+    m_scratch_state_size = state_size;
+    return m_state_scratch != nullptr;
+}
+
+bool SelectiveSSMExecutor::update(const MemoryArgs& memory) {
+    return update_scratchpad(memory);
+}
+
+void SelectiveSSMExecutor::execute(const MemoryArgs& memory) {
+    const auto& x_dims = memory.at(ARG_SSM_X)->getStaticDims();
+    const auto& B_dims = memory.at(ARG_SSM_B)->getStaticDims();
+    const auto& state_dims = memory.at(ARG_SSM_STATE)->getStaticDims();
+    OPENVINO_ASSERT(x_dims.size() == 4 && B_dims.size() == 4 && state_dims.size() == 4);
+    if (!m_state_scratch || m_scratch_state_size != state_dims[3] || m_scratch_head_dim > x_dims[3]) {
+        OPENVINO_ASSERT(update_scratchpad(memory));
+    }
+
+    node::kernel::SelectiveSSMShape shape{x_dims[0], x_dims[1], x_dims[2], x_dims[3], B_dims[2], B_dims[3]};
+    const auto precision = memory.at(ARG_SSM_X)->getDescPtr()->getPrecision();
+    node::kernel::selective_ssm(memory.at(ARG_SSM_A)->getData(),
+                                memory.at(ARG_SSM_DT)->getData(),
+                                memory.at(ARG_SSM_B)->getData(),
+                                memory.at(ARG_SSM_X)->getData(),
+                                memory.at(ARG_SSM_C)->getData(),
+                                memory.at(ARG_SSM_STATE)->getData(),
+                                memory.at(ARG_SSM_OUT)->getData(),
+                                memory.at(ARG_SSM_OUT_STATE)->getData(),
+                                shape,
+                                precision,
+                                m_state_scratch->getDataAs<float>(),
+                                m_scratch_head_dim,
+                                m_context->getCpuParallel());
+}
+
+impl_desc_type SelectiveSSMExecutor::implType() const {
+    return impl_desc_type::ref_any;
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+
+#include "cpu_memory.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/selective_ssm_config.hpp"
+
+namespace ov::intel_cpu {
+
+class SelectiveSSMExecutor : public Executor {
+public:
+    static bool supports(const SelectiveSSMConfig& config);
+
+    SelectiveSSMExecutor(const SelectiveSSMAttrs& attrs, const MemoryArgs& memory, ExecutorContext::CPtr context);
+
+    bool update(const MemoryArgs& memory) override;
+    void execute(const MemoryArgs& memory) override;
+    [[nodiscard]] impl_desc_type implType() const override;
+
+private:
+    bool update_scratchpad(const MemoryArgs& memory);
+
+    ExecutorContext::CPtr m_context;
+    MemoryPtr m_state_scratch;
+    size_t m_scratch_head_dim = 0;
+    size_t m_scratch_state_size = 0;
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.hpp
@@ -26,9 +26,12 @@ private:
     bool update_scratchpad(const MemoryArgs& memory);
 
     ExecutorContext::CPtr m_context;
-    MemoryPtr m_state_scratch;
+    MemoryPtr m_scratch;
     size_t m_scratch_head_dim = 0;
     size_t m_scratch_state_size = 0;
+    size_t m_state_scratch_elements = 0;
+    size_t m_projection_scratch_elements = 0;
+    size_t m_cached_projection_elements = 0;
 };
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -48,7 +48,8 @@ enum class OperationType : uint8_t {
     Eltwise,
     GatherMatmul,
     GatedDeltaNet,
-    SelectiveSSM
+    SelectiveSSM,
+    PagedSelectiveSSM
 };
 
 std::string ExecutorTypeToString(ExecutorType type);

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -41,7 +41,15 @@ enum class ExecutorType : uint8_t {
     Kleidiai,
 };
 
-enum class OperationType : uint8_t { FullyConnected, MatMul, Convolution, Eltwise, GatherMatmul, GatedDeltaNet };
+enum class OperationType : uint8_t {
+    FullyConnected,
+    MatMul,
+    Convolution,
+    Eltwise,
+    GatherMatmul,
+    GatedDeltaNet,
+    SelectiveSSM
+};
 
 std::string ExecutorTypeToString(ExecutorType type);
 ExecutorType ExecutorTypeFromString(const std::string& typeStr);

--- a/src/plugins/intel_cpu/src/nodes/executors/implementations.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/implementations.hpp
@@ -14,6 +14,7 @@
 #include "nodes/executors/gated_delta_net_config.hpp"
 #include "nodes/executors/gathermatmul_config.hpp"
 #include "nodes/executors/matmul_config.hpp"
+#include "nodes/executors/paged_selective_ssm_config.hpp"
 #include "nodes/executors/selective_ssm_config.hpp"
 
 namespace ov::intel_cpu {
@@ -51,6 +52,10 @@ const std::vector<ExecutorImplementation<GatedDeltaNetAttrs>>& getImplementation
 // SelectiveSSM
 template <>
 const std::vector<ExecutorImplementation<SelectiveSSMAttrs>>& getImplementations();
+
+// PagedSelectiveSSM
+template <>
+const std::vector<ExecutorImplementation<PagedSelectiveSSMAttrs>>& getImplementations();
 
 // MatMul
 template <>

--- a/src/plugins/intel_cpu/src/nodes/executors/implementations.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/implementations.hpp
@@ -14,6 +14,7 @@
 #include "nodes/executors/gated_delta_net_config.hpp"
 #include "nodes/executors/gathermatmul_config.hpp"
 #include "nodes/executors/matmul_config.hpp"
+#include "nodes/executors/selective_ssm_config.hpp"
 
 namespace ov::intel_cpu {
 
@@ -46,6 +47,10 @@ const std::vector<ExecutorImplementation<GatherMatmulAttrs>>& getImplementations
 // GatedDeltaNet
 template <>
 const std::vector<ExecutorImplementation<GatedDeltaNetAttrs>>& getImplementations();
+
+// SelectiveSSM
+template <>
+const std::vector<ExecutorImplementation<SelectiveSSMAttrs>>& getImplementations();
 
 // MatMul
 template <>

--- a/src/plugins/intel_cpu/src/nodes/executors/paged_selective_ssm_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/paged_selective_ssm_config.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+
+#include "executor_config.hpp"
+#include "nodes/executors/memory_arguments.hpp"
+
+namespace ov::intel_cpu {
+
+struct PagedSelectiveSSMAttrs {};
+
+using PagedSelectiveSSMConfig = executor::Config<PagedSelectiveSSMAttrs>;
+
+enum PagedSelectiveSSMArgId : uint8_t {
+    ARG_PAGED_SSM_A = ARG_SRC_0,
+    ARG_PAGED_SSM_DT = ARG_SRC_1,
+    ARG_PAGED_SSM_B = ARG_SRC_2,
+    ARG_PAGED_SSM_X = ARG_SRC_3,
+    ARG_PAGED_SSM_C = ARG_SRC_4,
+    ARG_PAGED_SSM_STATE = ARG_SRC_5,
+    ARG_PAGED_SSM_SUBSEQUENCE_BEGINS = ARG_SRC_6,
+    ARG_PAGED_SSM_BLOCK_INDICES = ARG_SRC_7,
+    ARG_PAGED_SSM_BLOCK_INDICES_BEGINS = ARG_SRC_8,
+    ARG_PAGED_SSM_NUM_PROCESSED_TOKENS = ARG_SRC_9,
+    ARG_PAGED_SSM_CACHE_INTERVAL = ARG_SRC_9 + 1,
+    ARG_PAGED_SSM_OUT = ARG_DST_0,
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/paged_selective_ssm_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/paged_selective_ssm_implementations.cpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "nodes/executors/common/paged_selective_ssm_executor.hpp"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/executor_implementation.hpp"
+#include "nodes/executors/implementation_utils.hpp"
+#include "nodes/executors/implementations.hpp"
+#include "nodes/executors/paged_selective_ssm_config.hpp"
+#include "utils/arch_macros.h"
+
+#if defined(OPENVINO_ARCH_X86_64)
+#    include "nodes/executors/x64/paged_selective_ssm_jit_executor.hpp"
+#endif
+
+namespace ov::intel_cpu {
+
+// clang-format off
+template <>
+const std::vector<ExecutorImplementation<PagedSelectiveSSMAttrs>>& getImplementations() {
+    static const std::vector<ExecutorImplementation<PagedSelectiveSSMAttrs>> implementations {
+        OV_CPU_INSTANCE_X64(
+            "paged_selective_ssm_jit_executor",
+            ExecutorType::Jit,
+            OperationType::PagedSelectiveSSM,
+            [](const PagedSelectiveSSMConfig& config) -> bool {
+                return PagedSelectiveSSMJitExecutor::supports(config);
+            },
+            HasNoOptimalConfig<PagedSelectiveSSMAttrs>{},
+            AcceptsAnyShape<PagedSelectiveSSMAttrs>,
+            CreateDefault<PagedSelectiveSSMJitExecutor, PagedSelectiveSSMAttrs>{}
+        )
+        OV_CPU_INSTANCE_COMMON(
+            "paged_selective_ssm_common_executor",
+            ExecutorType::Common,
+            OperationType::PagedSelectiveSSM,
+            [](const PagedSelectiveSSMConfig& config) -> bool {
+                return PagedSelectiveSSMExecutor::supports(config);
+            },
+            HasNoOptimalConfig<PagedSelectiveSSMAttrs>{},
+            AcceptsAnyShape<PagedSelectiveSSMAttrs>,
+            CreateDefault<PagedSelectiveSSMExecutor, PagedSelectiveSSMAttrs>{}
+        )
+    };
+
+    return implementations;
+}
+// clang-format on
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/selective_ssm_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/selective_ssm_config.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+
+#include "executor_config.hpp"
+#include "nodes/executors/memory_arguments.hpp"
+
+namespace ov::intel_cpu {
+
+struct SelectiveSSMAttrs {};
+
+using SelectiveSSMConfig = executor::Config<SelectiveSSMAttrs>;
+
+enum SelectiveSSMArgId : uint8_t {
+    ARG_SSM_A = ARG_SRC_0,
+    ARG_SSM_DT = ARG_SRC_1,
+    ARG_SSM_B = ARG_SRC_2,
+    ARG_SSM_X = ARG_SRC_3,
+    ARG_SSM_C = ARG_SRC_4,
+    ARG_SSM_STATE = ARG_SRC_5,
+    ARG_SSM_OUT = ARG_DST_0,
+    ARG_SSM_OUT_STATE = ARG_DST_0 + 1,
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/selective_ssm_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/selective_ssm_implementations.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "nodes/executors/common/selective_ssm_executor.hpp"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/executor_implementation.hpp"
+#include "nodes/executors/implementation_utils.hpp"
+#include "nodes/executors/implementations.hpp"
+#include "nodes/executors/selective_ssm_config.hpp"
+#include "utils/arch_macros.h"
+
+namespace ov::intel_cpu {
+
+// clang-format off
+template <>
+const std::vector<ExecutorImplementation<SelectiveSSMAttrs>>& getImplementations() {
+    static const std::vector<ExecutorImplementation<SelectiveSSMAttrs>> implementations {
+        OV_CPU_INSTANCE_COMMON(
+            "selective_ssm_common_executor",
+            ExecutorType::Common,
+            OperationType::SelectiveSSM,
+            [](const SelectiveSSMConfig& config) -> bool {
+                return SelectiveSSMExecutor::supports(config);
+            },
+            HasNoOptimalConfig<SelectiveSSMAttrs>{},
+            AcceptsAnyShape<SelectiveSSMAttrs>,
+            CreateDefault<SelectiveSSMExecutor, SelectiveSSMAttrs>{}
+        )
+    };
+
+    return implementations;
+}
+// clang-format on
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/selective_ssm_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/selective_ssm_implementations.cpp
@@ -12,12 +12,27 @@
 #include "nodes/executors/selective_ssm_config.hpp"
 #include "utils/arch_macros.h"
 
+#if defined(OPENVINO_ARCH_X86_64)
+#    include "nodes/executors/x64/selective_ssm_jit_executor.hpp"
+#endif
+
 namespace ov::intel_cpu {
 
 // clang-format off
 template <>
 const std::vector<ExecutorImplementation<SelectiveSSMAttrs>>& getImplementations() {
     static const std::vector<ExecutorImplementation<SelectiveSSMAttrs>> implementations {
+        OV_CPU_INSTANCE_X64(
+            "selective_ssm_jit_executor",
+            ExecutorType::Jit,
+            OperationType::SelectiveSSM,
+            [](const SelectiveSSMConfig& config) -> bool {
+                return SelectiveSSMJitExecutor::supports(config);
+            },
+            HasNoOptimalConfig<SelectiveSSMAttrs>{},
+            AcceptsAnyShape<SelectiveSSMAttrs>,
+            CreateDefault<SelectiveSSMJitExecutor, SelectiveSSMAttrs>{}
+        )
         OV_CPU_INSTANCE_COMMON(
             "selective_ssm_common_executor",
             ExecutorType::Common,

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 #include "common/utils.hpp"
@@ -20,7 +21,9 @@
 #include "nodes/kernels/x64/selective_ssm_jit_kernel.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/parallel.hpp"
+#include "openvino/core/type/bfloat16.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/type/float16.hpp"
 
 using namespace dnnl::impl::cpu::x64;
 
@@ -30,36 +33,79 @@ namespace {
 struct PagedSelectiveSSMJitKey {
     size_t state_size;
     bool prefer_avx512;
+    kernel::jit_selective_ssm_data_type data_type;
 
     [[nodiscard]] size_t hash() const {
         size_t seed = dnnl::impl::hash_combine(0, state_size);
-        return dnnl::impl::hash_combine(seed, prefer_avx512);
+        seed = dnnl::impl::hash_combine(seed, prefer_avx512);
+        return dnnl::impl::hash_combine(seed, static_cast<uint8_t>(data_type));
     }
 
     bool operator==(const PagedSelectiveSSMJitKey& rhs) const {
-        return state_size == rhs.state_size && prefer_avx512 == rhs.prefer_avx512;
+        return state_size == rhs.state_size && prefer_avx512 == rhs.prefer_avx512 && data_type == rhs.data_type;
     }
 };
 
-template <typename IndexT>
-void paged_selective_ssm_jit_f32(const float* A,
-                                 const float* dt,
-                                 const float* B,
-                                 const float* x,
-                                 const float* C,
-                                 float* recurrent_state_table,
-                                 const IndexT* subsequence_begins,
-                                 const IndexT* block_indices,
-                                 const IndexT* block_indices_begins,
-                                 const IndexT* num_processed_tokens,
-                                 const IndexT* cache_interval,
-                                 float* output,
-                                 const node::kernel::PagedSelectiveSSMShape& shape,
-                                 float* state_scratch,
-                                 size_t scratch_head_dim,
-                                 const CpuParallelPtr& cpu_parallel,
-                                 const std::shared_ptr<kernel::JitKernelBase>& jit_kernel,
-                                 const std::shared_ptr<kernel::JitKernelBase>& decode_jit_kernel) {
+bool is_supported_data_precision(const ov::element::Type& precision) {
+    return precision == ov::element::f32 || precision == ov::element::f16 || precision == ov::element::bf16;
+}
+
+bool is_supported_index_precision(const ov::element::Type& precision) {
+    return precision == ov::element::i32 || precision == ov::element::i64;
+}
+
+kernel::jit_selective_ssm_data_type get_jit_data_type(const ov::element::Type& precision) {
+    if (precision == ov::element::f32) {
+        return kernel::jit_selective_ssm_data_type::f32;
+    }
+    if (precision == ov::element::f16) {
+        return kernel::jit_selective_ssm_data_type::f16;
+    }
+    OPENVINO_ASSERT(precision == ov::element::bf16);
+    return kernel::jit_selective_ssm_data_type::bf16;
+}
+
+template <typename DataT>
+void copy_state_to_float(float* destination, const DataT* source, size_t count) {
+    if constexpr (std::is_same_v<DataT, float>) {
+        std::memcpy(destination, source, count * sizeof(float));
+    } else {
+        for (size_t i = 0; i < count; ++i) {
+            destination[i] = static_cast<float>(source[i]);
+        }
+    }
+}
+
+template <typename DataT>
+void copy_state_from_float(DataT* destination, const float* source, size_t count) {
+    if constexpr (std::is_same_v<DataT, float>) {
+        std::memcpy(destination, source, count * sizeof(float));
+    } else {
+        for (size_t i = 0; i < count; ++i) {
+            destination[i] = static_cast<DataT>(source[i]);
+        }
+    }
+}
+
+template <typename DataT, typename IndexT>
+void paged_selective_ssm_jit(const DataT* A,
+                             const DataT* dt,
+                             const DataT* B,
+                             const DataT* x,
+                             const DataT* C,
+                             DataT* recurrent_state_table,
+                             const IndexT* subsequence_begins,
+                             const IndexT* block_indices,
+                             const IndexT* block_indices_begins,
+                             const IndexT* num_processed_tokens,
+                             const IndexT* cache_interval,
+                             DataT* output,
+                             const node::kernel::PagedSelectiveSSMShape& shape,
+                             float* state_scratch,
+                             size_t scratch_head_dim,
+                             const CpuParallelPtr& cpu_parallel,
+                             const std::shared_ptr<kernel::JitKernelBase>& jit_kernel,
+                             const std::shared_ptr<kernel::JitKernelBase>& decode_jit_kernel) {
     const auto block_stride = shape.num_heads * shape.head_dim * shape.state_size;
     const auto head_stride = shape.head_dim * shape.state_size;
     const auto scratch_stride = scratch_head_dim * shape.state_size;
@@ -83,12 +129,9 @@ void paged_selective_ssm_jit_f32(const float* A,
             const auto group = head / heads_per_group;
             const auto logical_block_begin = static_cast<size_t>(block_indices_begins[sequence]);
             const auto read_block = static_cast<size_t>(block_indices[logical_block_begin]);
-            auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
             const auto state_slice = head * head_stride + p_begin * shape.state_size;
             const auto* initial_state = recurrent_state_table + read_block * block_stride + state_slice;
-            std::memcpy(local_state, initial_state, p_count * shape.state_size * sizeof(float));
-
-            const float A_head = A[head];
+            const float A_head = static_cast<float>(A[head]);
             const auto interval = cache_interval[sequence];
             const bool cache_enabled = interval > 0;
             const uint64_t positive_interval = cache_enabled ? static_cast<uint64_t>(interval) : 1;
@@ -99,12 +142,35 @@ void paged_selective_ssm_jit_f32(const float* A,
             auto x_base = token_head * shape.head_dim + p_begin;
             const auto projection_stride = shape.num_groups * shape.state_size;
             const auto x_stride = shape.num_heads * shape.head_dim;
-            uint64_t tokens_until_boundary = cache_enabled ? positive_interval - cache_offset : 0;
-            size_t write_slot = 1;
             const auto& selected_kernel = token_end - token_begin == 1 ? decode_jit_kernel : jit_kernel;
 
+            if constexpr (std::is_same_v<DataT, float>) {
+                if (token_end - token_begin == 1 && cache_enabled) {
+                    const float delta = dt[token_head];
+                    const float decay = std::exp(A_head * delta);
+                    const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + 1]);
+                    auto* state_destination = recurrent_state_table + write_block * block_stride + state_slice;
+                    kernel::jit_selective_ssm_call_args args{initial_state,
+                                                             state_destination,
+                                                             B + projection_base,
+                                                             C + projection_base,
+                                                             decay,
+                                                             delta,
+                                                             x + x_base,
+                                                             p_count,
+                                                             output + x_base};
+                    (*decode_jit_kernel)(&args);
+                    return;
+                }
+            }
+
+            auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
+            copy_state_to_float(local_state, initial_state, p_count * shape.state_size);
+            uint64_t tokens_until_boundary = cache_enabled ? positive_interval - cache_offset : 0;
+            size_t write_slot = 1;
+
             for (size_t token = token_begin; token < token_end; ++token) {
-                const float delta = dt[token_head];
+                const float delta = static_cast<float>(dt[token_head]);
                 const float decay = std::exp(A_head * delta);
                 kernel::jit_selective_ssm_call_args args{local_state,
                                                          local_state,
@@ -123,7 +189,7 @@ void paged_selective_ssm_jit_f32(const float* A,
                     if (is_boundary || is_last) {
                         const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + write_slot++]);
                         auto* snapshot = recurrent_state_table + write_block * block_stride + state_slice;
-                        std::memcpy(snapshot, local_state, p_count * shape.state_size * sizeof(float));
+                        copy_state_from_float(snapshot, local_state, p_count * shape.state_size);
                     }
                     if (is_boundary) {
                         tokens_until_boundary = positive_interval;
@@ -136,24 +202,23 @@ void paged_selective_ssm_jit_f32(const float* A,
         });
 }
 
-bool is_supported_index_precision(const ov::element::Type& precision) {
-    return precision == ov::element::i32 || precision == ov::element::i64;
-}
-
 }  // namespace
 
 bool PagedSelectiveSSMJitExecutor::supports(const PagedSelectiveSSMConfig& config) {
     if (!mayiuse(dnnl::impl::cpu::x64::avx2)) {
         return false;
     }
-    for (const auto arg : {ARG_PAGED_SSM_A,
-                           ARG_PAGED_SSM_DT,
+    const auto data_precision = config.descs.at(ARG_PAGED_SSM_A)->getPrecision();
+    if (!is_supported_data_precision(data_precision)) {
+        return false;
+    }
+    for (const auto arg : {ARG_PAGED_SSM_DT,
                            ARG_PAGED_SSM_B,
                            ARG_PAGED_SSM_X,
                            ARG_PAGED_SSM_C,
                            ARG_PAGED_SSM_STATE,
                            ARG_PAGED_SSM_OUT}) {
-        if (config.descs.at(arg)->getPrecision() != ov::element::f32) {
+        if (config.descs.at(arg)->getPrecision() != data_precision) {
             return false;
         }
     }
@@ -228,24 +293,31 @@ bool PagedSelectiveSSMJitExecutor::update(const MemoryArgs& memory) {
     const auto state_size = state_dims[3];
     m_cached_token_count = x_dims[0];
     m_cached_sequence_count = subsequence_dims[0] - 1;
-    if (m_jit_kernel && m_decode_jit_kernel && m_cached_state_size == state_size) {
+    const auto precision = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getPrecision();
+    const auto data_type = get_jit_data_type(precision);
+    const auto data_type_key = static_cast<uint8_t>(data_type);
+    if (m_jit_kernel && m_decode_jit_kernel && m_cached_state_size == state_size &&
+        m_cached_data_type == data_type_key) {
         return true;
     }
 
-    const PagedSelectiveSSMJitKey key{state_size, true};
+    const PagedSelectiveSSMJitKey key{state_size, true, data_type};
     auto builder = [](const PagedSelectiveSSMJitKey& compile_key) {
-        return kernel::create_selective_ssm_jit_kernel(compile_key.state_size, compile_key.prefer_avx512);
+        return kernel::create_selective_ssm_jit_kernel(compile_key.state_size,
+                                                       compile_key.prefer_avx512,
+                                                       compile_key.data_type);
     };
     const auto result = m_context->getRuntimeCache()->getOrCreate(key, builder);
     m_jit_kernel = result.first;
     if (mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
-        const PagedSelectiveSSMJitKey decode_key{state_size, false};
+        const PagedSelectiveSSMJitKey decode_key{state_size, false, data_type};
         const auto decode_result = m_context->getRuntimeCache()->getOrCreate(decode_key, builder);
         m_decode_jit_kernel = decode_result.first;
     } else {
         m_decode_jit_kernel = m_jit_kernel;
     }
     m_cached_state_size = state_size;
+    m_cached_data_type = data_type_key;
     return m_jit_kernel != nullptr && m_decode_jit_kernel != nullptr;
 }
 
@@ -265,8 +337,11 @@ void PagedSelectiveSSMJitExecutor::execute(const MemoryArgs& memory) {
                         block_begins_dims[0] == sequence_count + 1 && processed_dims[0] == sequence_count &&
                         interval_dims[0] == sequence_count,
                     "PagedSelectiveSSM metadata tensor lengths are inconsistent.");
+    const auto precision = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getPrecision();
+    const auto data_type_key = static_cast<uint8_t>(get_jit_data_type(precision));
     if (!m_jit_kernel || !m_decode_jit_kernel || !m_state_scratch || !m_block_owners ||
-        m_cached_state_size != state_dims[3] || m_cached_physical_blocks != state_dims[0]) {
+        m_cached_state_size != state_dims[3] || m_cached_physical_blocks != state_dims[0] ||
+        m_cached_data_type != data_type_key) {
         OPENVINO_ASSERT(update(memory));
     }
 
@@ -288,30 +363,39 @@ void PagedSelectiveSSMJitExecutor::execute(const MemoryArgs& memory) {
                                                         index_precision,
                                                         m_block_owners->getDataAs<int32_t>());
 
-#define OV_CPU_PAGED_SSM_JIT_CALL(IndexT)                                                                 \
-    paged_selective_ssm_jit_f32(memory.at(ARG_PAGED_SSM_A)->getDataAs<const float>(),                     \
-                                memory.at(ARG_PAGED_SSM_DT)->getDataAs<const float>(),                    \
-                                memory.at(ARG_PAGED_SSM_B)->getDataAs<const float>(),                     \
-                                memory.at(ARG_PAGED_SSM_X)->getDataAs<const float>(),                     \
-                                memory.at(ARG_PAGED_SSM_C)->getDataAs<const float>(),                     \
-                                memory.at(ARG_PAGED_SSM_STATE)->getDataAs<float>(),                       \
-                                memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDataAs<const IndexT>(),   \
-                                memory.at(ARG_PAGED_SSM_BLOCK_INDICES)->getDataAs<const IndexT>(),        \
-                                memory.at(ARG_PAGED_SSM_BLOCK_INDICES_BEGINS)->getDataAs<const IndexT>(), \
-                                memory.at(ARG_PAGED_SSM_NUM_PROCESSED_TOKENS)->getDataAs<const IndexT>(), \
-                                memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getDataAs<const IndexT>(),       \
-                                memory.at(ARG_PAGED_SSM_OUT)->getDataAs<float>(),                         \
-                                shape,                                                                    \
-                                m_state_scratch->getDataAs<float>(),                                      \
-                                m_scratch_head_dim,                                                       \
-                                m_context->getCpuParallel(),                                              \
-                                m_jit_kernel,                                                             \
-                                m_decode_jit_kernel)
-    if (index_precision == ov::element::i32) {
-        OV_CPU_PAGED_SSM_JIT_CALL(int32_t);
-    } else {
-        OV_CPU_PAGED_SSM_JIT_CALL(int64_t);
+#define OV_CPU_PAGED_SSM_JIT_CALL(DataT, IndexT)                                                      \
+    paged_selective_ssm_jit(memory.at(ARG_PAGED_SSM_A)->getDataAs<const DataT>(),                     \
+                            memory.at(ARG_PAGED_SSM_DT)->getDataAs<const DataT>(),                    \
+                            memory.at(ARG_PAGED_SSM_B)->getDataAs<const DataT>(),                     \
+                            memory.at(ARG_PAGED_SSM_X)->getDataAs<const DataT>(),                     \
+                            memory.at(ARG_PAGED_SSM_C)->getDataAs<const DataT>(),                     \
+                            memory.at(ARG_PAGED_SSM_STATE)->getDataAs<DataT>(),                       \
+                            memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDataAs<const IndexT>(),   \
+                            memory.at(ARG_PAGED_SSM_BLOCK_INDICES)->getDataAs<const IndexT>(),        \
+                            memory.at(ARG_PAGED_SSM_BLOCK_INDICES_BEGINS)->getDataAs<const IndexT>(), \
+                            memory.at(ARG_PAGED_SSM_NUM_PROCESSED_TOKENS)->getDataAs<const IndexT>(), \
+                            memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getDataAs<const IndexT>(),       \
+                            memory.at(ARG_PAGED_SSM_OUT)->getDataAs<DataT>(),                         \
+                            shape,                                                                    \
+                            m_state_scratch->getDataAs<float>(),                                      \
+                            m_scratch_head_dim,                                                       \
+                            m_context->getCpuParallel(),                                              \
+                            m_jit_kernel,                                                             \
+                            m_decode_jit_kernel)
+#define OV_CPU_PAGED_SSM_JIT_DISPATCH_INDEX(DataT) \
+    if (index_precision == ov::element::i32) {     \
+        OV_CPU_PAGED_SSM_JIT_CALL(DataT, int32_t); \
+    } else {                                       \
+        OV_CPU_PAGED_SSM_JIT_CALL(DataT, int64_t); \
     }
+    if (precision == ov::element::f32) {
+        OV_CPU_PAGED_SSM_JIT_DISPATCH_INDEX(float);
+    } else if (precision == ov::element::f16) {
+        OV_CPU_PAGED_SSM_JIT_DISPATCH_INDEX(ov::float16);
+    } else {
+        OV_CPU_PAGED_SSM_JIT_DISPATCH_INDEX(ov::bfloat16);
+    }
+#undef OV_CPU_PAGED_SSM_JIT_DISPATCH_INDEX
 #undef OV_CPU_PAGED_SSM_JIT_CALL
 }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.cpp
@@ -106,11 +106,15 @@ void paged_selective_ssm_jit(const DataT* A,
                              const CpuParallelPtr& cpu_parallel,
                              const std::shared_ptr<kernel::JitKernelBase>& jit_kernel,
                              const std::shared_ptr<kernel::JitKernelBase>& decode_jit_kernel) {
-    const auto block_stride = shape.num_heads * shape.head_dim * shape.state_size;
-    const auto head_stride = shape.head_dim * shape.state_size;
-    const auto scratch_stride = scratch_head_dim * shape.state_size;
+    const auto block_stride =
+        node::kernel::checked_size_product({shape.num_heads, shape.head_dim, shape.state_size}, "state block");
+    const auto head_stride =
+        node::kernel::checked_size_product({shape.head_dim, shape.state_size}, "state head");
+    const auto scratch_stride =
+        node::kernel::checked_size_product({scratch_head_dim, shape.state_size}, "state scratch");
     const auto heads_per_group = shape.num_heads / shape.num_groups;
-    const auto p_block_count = (shape.head_dim + scratch_head_dim - 1) / scratch_head_dim;
+    const auto p_block_count =
+        shape.head_dim / scratch_head_dim + static_cast<size_t>(shape.head_dim % scratch_head_dim != 0);
 
     cpu_parallel->parallel_for3d(
         shape.sequence_count,
@@ -124,7 +128,7 @@ void paged_selective_ssm_jit(const DataT* A,
             }
 
             const auto p_begin = pb * scratch_head_dim;
-            const auto p_end = std::min(p_begin + scratch_head_dim, shape.head_dim);
+            const auto p_end = p_begin + std::min(scratch_head_dim, shape.head_dim - p_begin);
             const auto p_count = p_end - p_begin;
             const auto group = head / heads_per_group;
             const auto logical_block_begin = static_cast<size_t>(block_indices_begins[sequence]);
@@ -247,19 +251,32 @@ PagedSelectiveSSMJitExecutor::PagedSelectiveSSMJitExecutor(const PagedSelectiveS
 
 bool PagedSelectiveSSMJitExecutor::update_scratchpad(const MemoryArgs& memory) {
     const auto& x_shape = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getShape();
+    const auto& B_shape = memory.at(ARG_PAGED_SSM_B)->getDescPtr()->getShape();
     const auto& state_shape = memory.at(ARG_PAGED_SSM_STATE)->getDescPtr()->getShape();
-    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+    if (x_shape.isDynamic() || B_shape.isDynamic() || state_shape.isDynamic()) {
         return true;
     }
     const auto& x_dims = x_shape.getStaticDims();
+    const auto& B_dims = B_shape.getStaticDims();
     const auto& state_dims = state_shape.getStaticDims();
-    OPENVINO_ASSERT(x_dims.size() == 3 && state_dims.size() == 4);
+    OPENVINO_ASSERT(x_dims.size() == 3 && B_dims.size() == 3 && state_dims.size() == 4);
     const auto head_dim = x_dims[2];
     const auto state_size = state_dims[3];
     const auto physical_blocks = state_dims[0];
-    OPENVINO_ASSERT(state_size > 0, "PagedSelectiveSSM state_size must be greater than zero.");
+    const node::kernel::PagedSelectiveSSMShape shape{x_dims[0],
+                                                     x_dims[1],
+                                                     head_dim,
+                                                     B_dims[1],
+                                                     state_size,
+                                                     physical_blocks,
+                                                     0,
+                                                     0};
+    node::kernel::validate_paged_selective_ssm_shape(shape);
     const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
     const auto scratch_head_dim = node::kernel::get_scratch_head_dim(head_dim, state_size, x_dims[1], thread_count);
+    const auto scratch_elements =
+        node::kernel::checked_size_product({scratch_head_dim, state_size}, "JIT state scratch per worker");
+    node::kernel::checked_size_product({thread_count, scratch_elements}, "JIT state scratch");
     if (m_state_scratch && m_block_owners && m_scratch_head_dim == scratch_head_dim &&
         m_cached_state_size == state_size && m_cached_physical_blocks == physical_blocks) {
         return true;
@@ -267,7 +284,7 @@ bool PagedSelectiveSSMJitExecutor::update_scratchpad(const MemoryArgs& memory) {
 
     const auto state_desc =
         std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
-                                               ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});
+                                               ov::intel_cpu::Shape{thread_count, scratch_elements});
     const auto owner_desc =
         std::make_shared<CpuBlockedMemoryDesc>(ov::element::i32,
                                                ov::intel_cpu::Shape{std::max(size_t{1}, physical_blocks)});
@@ -353,6 +370,7 @@ void PagedSelectiveSSMJitExecutor::execute(const MemoryArgs& memory) {
                                                      state_dims[0],
                                                      block_indices_dims[0],
                                                      sequence_count};
+    node::kernel::validate_paged_selective_ssm_shape(shape);
     const auto index_precision = memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDescPtr()->getPrecision();
     node::kernel::validate_paged_selective_ssm_metadata(memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getData(),
                                                         memory.at(ARG_PAGED_SSM_BLOCK_INDICES)->getData(),

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.cpp
@@ -1,0 +1,325 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "paged_selective_ssm_jit_executor.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <utility>
+
+#include "common/utils.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "memory_desc/cpu_blocked_memory_desc.h"
+#include "nodes/executors/memory_arguments.hpp"
+#include "nodes/kernels/selective_ssm.hpp"
+#include "nodes/kernels/x64/selective_ssm_jit_kernel.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/parallel.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+using namespace dnnl::impl::cpu::x64;
+
+namespace ov::intel_cpu {
+namespace {
+
+struct PagedSelectiveSSMJitKey {
+    size_t state_size;
+    bool prefer_avx512;
+
+    [[nodiscard]] size_t hash() const {
+        size_t seed = dnnl::impl::hash_combine(0, state_size);
+        return dnnl::impl::hash_combine(seed, prefer_avx512);
+    }
+
+    bool operator==(const PagedSelectiveSSMJitKey& rhs) const {
+        return state_size == rhs.state_size && prefer_avx512 == rhs.prefer_avx512;
+    }
+};
+
+template <typename IndexT>
+void paged_selective_ssm_jit_f32(const float* A,
+                                 const float* dt,
+                                 const float* B,
+                                 const float* x,
+                                 const float* C,
+                                 float* recurrent_state_table,
+                                 const IndexT* subsequence_begins,
+                                 const IndexT* block_indices,
+                                 const IndexT* block_indices_begins,
+                                 const IndexT* num_processed_tokens,
+                                 const IndexT* cache_interval,
+                                 float* output,
+                                 const node::kernel::PagedSelectiveSSMShape& shape,
+                                 float* state_scratch,
+                                 size_t scratch_head_dim,
+                                 const CpuParallelPtr& cpu_parallel,
+                                 const std::shared_ptr<kernel::JitKernelBase>& jit_kernel,
+                                 const std::shared_ptr<kernel::JitKernelBase>& decode_jit_kernel) {
+    const auto block_stride = shape.num_heads * shape.head_dim * shape.state_size;
+    const auto head_stride = shape.head_dim * shape.state_size;
+    const auto scratch_stride = scratch_head_dim * shape.state_size;
+    const auto heads_per_group = shape.num_heads / shape.num_groups;
+    const auto p_block_count = (shape.head_dim + scratch_head_dim - 1) / scratch_head_dim;
+
+    cpu_parallel->parallel_for3d(
+        shape.sequence_count,
+        shape.num_heads,
+        p_block_count,
+        [&](size_t sequence, size_t head, size_t pb) {
+            const auto token_begin = static_cast<size_t>(subsequence_begins[sequence]);
+            const auto token_end = static_cast<size_t>(subsequence_begins[sequence + 1]);
+            if (token_begin == token_end) {
+                return;
+            }
+
+            const auto p_begin = pb * scratch_head_dim;
+            const auto p_end = std::min(p_begin + scratch_head_dim, shape.head_dim);
+            const auto p_count = p_end - p_begin;
+            const auto group = head / heads_per_group;
+            const auto logical_block_begin = static_cast<size_t>(block_indices_begins[sequence]);
+            const auto read_block = static_cast<size_t>(block_indices[logical_block_begin]);
+            auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
+            const auto state_slice = head * head_stride + p_begin * shape.state_size;
+            const auto* initial_state = recurrent_state_table + read_block * block_stride + state_slice;
+            std::memcpy(local_state, initial_state, p_count * shape.state_size * sizeof(float));
+
+            const float A_head = A[head];
+            const auto interval = cache_interval[sequence];
+            const bool cache_enabled = interval > 0;
+            const uint64_t positive_interval = cache_enabled ? static_cast<uint64_t>(interval) : 1;
+            const uint64_t cache_offset =
+                cache_enabled ? static_cast<uint64_t>(num_processed_tokens[sequence]) % positive_interval : 0;
+            auto token_head = token_begin * shape.num_heads + head;
+            auto projection_base = (token_begin * shape.num_groups + group) * shape.state_size;
+            auto x_base = token_head * shape.head_dim + p_begin;
+            const auto projection_stride = shape.num_groups * shape.state_size;
+            const auto x_stride = shape.num_heads * shape.head_dim;
+            uint64_t tokens_until_boundary = cache_enabled ? positive_interval - cache_offset : 0;
+            size_t write_slot = 1;
+            const auto& selected_kernel = token_end - token_begin == 1 ? decode_jit_kernel : jit_kernel;
+
+            for (size_t token = token_begin; token < token_end; ++token) {
+                const float delta = dt[token_head];
+                const float decay = std::exp(A_head * delta);
+                kernel::jit_selective_ssm_call_args args{local_state,
+                                                         local_state,
+                                                         B + projection_base,
+                                                         C + projection_base,
+                                                         decay,
+                                                         delta,
+                                                         x + x_base,
+                                                         p_count,
+                                                         output + x_base};
+                (*selected_kernel)(&args);
+
+                if (cache_enabled) {
+                    const bool is_boundary = --tokens_until_boundary == 0;
+                    const bool is_last = token + 1 == token_end;
+                    if (is_boundary || is_last) {
+                        const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + write_slot++]);
+                        auto* snapshot = recurrent_state_table + write_block * block_stride + state_slice;
+                        std::memcpy(snapshot, local_state, p_count * shape.state_size * sizeof(float));
+                    }
+                    if (is_boundary) {
+                        tokens_until_boundary = positive_interval;
+                    }
+                }
+                token_head += shape.num_heads;
+                projection_base += projection_stride;
+                x_base += x_stride;
+            }
+        });
+}
+
+bool is_supported_index_precision(const ov::element::Type& precision) {
+    return precision == ov::element::i32 || precision == ov::element::i64;
+}
+
+}  // namespace
+
+bool PagedSelectiveSSMJitExecutor::supports(const PagedSelectiveSSMConfig& config) {
+    if (!mayiuse(dnnl::impl::cpu::x64::avx2)) {
+        return false;
+    }
+    for (const auto arg : {ARG_PAGED_SSM_A,
+                           ARG_PAGED_SSM_DT,
+                           ARG_PAGED_SSM_B,
+                           ARG_PAGED_SSM_X,
+                           ARG_PAGED_SSM_C,
+                           ARG_PAGED_SSM_STATE,
+                           ARG_PAGED_SSM_OUT}) {
+        if (config.descs.at(arg)->getPrecision() != ov::element::f32) {
+            return false;
+        }
+    }
+
+    const auto index_precision = config.descs.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getPrecision();
+    if (!is_supported_index_precision(index_precision)) {
+        return false;
+    }
+    for (const auto arg : {ARG_PAGED_SSM_BLOCK_INDICES,
+                           ARG_PAGED_SSM_BLOCK_INDICES_BEGINS,
+                           ARG_PAGED_SSM_NUM_PROCESSED_TOKENS,
+                           ARG_PAGED_SSM_CACHE_INTERVAL}) {
+        if (config.descs.at(arg)->getPrecision() != index_precision) {
+            return false;
+        }
+    }
+    return true;
+}
+
+PagedSelectiveSSMJitExecutor::PagedSelectiveSSMJitExecutor(const PagedSelectiveSSMAttrs&,
+                                                           const MemoryArgs& memory,
+                                                           ExecutorContext::CPtr context)
+    : m_context(std::move(context)) {
+    update(memory);
+}
+
+bool PagedSelectiveSSMJitExecutor::update_scratchpad(const MemoryArgs& memory) {
+    const auto& x_shape = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getShape();
+    const auto& state_shape = memory.at(ARG_PAGED_SSM_STATE)->getDescPtr()->getShape();
+    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+        return true;
+    }
+    const auto& x_dims = x_shape.getStaticDims();
+    const auto& state_dims = state_shape.getStaticDims();
+    OPENVINO_ASSERT(x_dims.size() == 3 && state_dims.size() == 4);
+    const auto head_dim = x_dims[2];
+    const auto state_size = state_dims[3];
+    const auto physical_blocks = state_dims[0];
+    OPENVINO_ASSERT(state_size > 0, "PagedSelectiveSSM state_size must be greater than zero.");
+    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    const auto scratch_head_dim = node::kernel::get_scratch_head_dim(head_dim, state_size, x_dims[1], thread_count);
+    if (m_state_scratch && m_block_owners && m_scratch_head_dim == scratch_head_dim &&
+        m_cached_state_size == state_size && m_cached_physical_blocks == physical_blocks) {
+        return true;
+    }
+
+    const auto state_desc =
+        std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
+                                               ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});
+    const auto owner_desc =
+        std::make_shared<CpuBlockedMemoryDesc>(ov::element::i32,
+                                               ov::intel_cpu::Shape{std::max(size_t{1}, physical_blocks)});
+    m_state_scratch = m_context->getScratchPad()->createScratchPadMem(state_desc);
+    m_block_owners = m_context->getScratchPad()->createScratchPadMem(owner_desc);
+    m_scratch_head_dim = scratch_head_dim;
+    m_cached_physical_blocks = physical_blocks;
+    return m_state_scratch != nullptr && m_block_owners != nullptr;
+}
+
+bool PagedSelectiveSSMJitExecutor::update(const MemoryArgs& memory) {
+    const auto& x_shape = memory.at(ARG_PAGED_SSM_X)->getDescPtr()->getShape();
+    const auto& state_shape = memory.at(ARG_PAGED_SSM_STATE)->getDescPtr()->getShape();
+    const auto& subsequence_shape = memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDescPtr()->getShape();
+    if (x_shape.isDynamic() || state_shape.isDynamic() || subsequence_shape.isDynamic()) {
+        return true;
+    }
+    OPENVINO_ASSERT(update_scratchpad(memory));
+
+    const auto& x_dims = x_shape.getStaticDims();
+    const auto& state_dims = state_shape.getStaticDims();
+    const auto& subsequence_dims = subsequence_shape.getStaticDims();
+    const auto state_size = state_dims[3];
+    m_cached_token_count = x_dims[0];
+    m_cached_sequence_count = subsequence_dims[0] - 1;
+    if (m_jit_kernel && m_decode_jit_kernel && m_cached_state_size == state_size) {
+        return true;
+    }
+
+    const PagedSelectiveSSMJitKey key{state_size, true};
+    auto builder = [](const PagedSelectiveSSMJitKey& compile_key) {
+        return kernel::create_selective_ssm_jit_kernel(compile_key.state_size, compile_key.prefer_avx512);
+    };
+    const auto result = m_context->getRuntimeCache()->getOrCreate(key, builder);
+    m_jit_kernel = result.first;
+    if (mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+        const PagedSelectiveSSMJitKey decode_key{state_size, false};
+        const auto decode_result = m_context->getRuntimeCache()->getOrCreate(decode_key, builder);
+        m_decode_jit_kernel = decode_result.first;
+    } else {
+        m_decode_jit_kernel = m_jit_kernel;
+    }
+    m_cached_state_size = state_size;
+    return m_jit_kernel != nullptr && m_decode_jit_kernel != nullptr;
+}
+
+void PagedSelectiveSSMJitExecutor::execute(const MemoryArgs& memory) {
+    const auto& B_dims = memory.at(ARG_PAGED_SSM_B)->getStaticDims();
+    const auto& x_dims = memory.at(ARG_PAGED_SSM_X)->getStaticDims();
+    const auto& state_dims = memory.at(ARG_PAGED_SSM_STATE)->getStaticDims();
+    const auto& subsequence_dims = memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getStaticDims();
+    const auto& block_indices_dims = memory.at(ARG_PAGED_SSM_BLOCK_INDICES)->getStaticDims();
+    const auto& block_begins_dims = memory.at(ARG_PAGED_SSM_BLOCK_INDICES_BEGINS)->getStaticDims();
+    const auto& processed_dims = memory.at(ARG_PAGED_SSM_NUM_PROCESSED_TOKENS)->getStaticDims();
+    const auto& interval_dims = memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getStaticDims();
+    OPENVINO_ASSERT(B_dims.size() == 3 && x_dims.size() == 3 && state_dims.size() == 4);
+    OPENVINO_ASSERT(subsequence_dims.size() == 1 && subsequence_dims[0] >= 1 && block_indices_dims.size() == 1);
+    const auto sequence_count = subsequence_dims[0] - 1;
+    OPENVINO_ASSERT(block_begins_dims.size() == 1 && processed_dims.size() == 1 && interval_dims.size() == 1 &&
+                        block_begins_dims[0] == sequence_count + 1 && processed_dims[0] == sequence_count &&
+                        interval_dims[0] == sequence_count,
+                    "PagedSelectiveSSM metadata tensor lengths are inconsistent.");
+    if (!m_jit_kernel || !m_decode_jit_kernel || !m_state_scratch || !m_block_owners ||
+        m_cached_state_size != state_dims[3] || m_cached_physical_blocks != state_dims[0]) {
+        OPENVINO_ASSERT(update(memory));
+    }
+
+    const node::kernel::PagedSelectiveSSMShape shape{x_dims[0],
+                                                     x_dims[1],
+                                                     x_dims[2],
+                                                     B_dims[1],
+                                                     B_dims[2],
+                                                     state_dims[0],
+                                                     block_indices_dims[0],
+                                                     sequence_count};
+    const auto index_precision = memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDescPtr()->getPrecision();
+    node::kernel::validate_paged_selective_ssm_metadata(memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getData(),
+                                                        memory.at(ARG_PAGED_SSM_BLOCK_INDICES)->getData(),
+                                                        memory.at(ARG_PAGED_SSM_BLOCK_INDICES_BEGINS)->getData(),
+                                                        memory.at(ARG_PAGED_SSM_NUM_PROCESSED_TOKENS)->getData(),
+                                                        memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getData(),
+                                                        shape,
+                                                        index_precision,
+                                                        m_block_owners->getDataAs<int32_t>());
+
+#define OV_CPU_PAGED_SSM_JIT_CALL(IndexT)                                                                 \
+    paged_selective_ssm_jit_f32(memory.at(ARG_PAGED_SSM_A)->getDataAs<const float>(),                     \
+                                memory.at(ARG_PAGED_SSM_DT)->getDataAs<const float>(),                    \
+                                memory.at(ARG_PAGED_SSM_B)->getDataAs<const float>(),                     \
+                                memory.at(ARG_PAGED_SSM_X)->getDataAs<const float>(),                     \
+                                memory.at(ARG_PAGED_SSM_C)->getDataAs<const float>(),                     \
+                                memory.at(ARG_PAGED_SSM_STATE)->getDataAs<float>(),                       \
+                                memory.at(ARG_PAGED_SSM_SUBSEQUENCE_BEGINS)->getDataAs<const IndexT>(),   \
+                                memory.at(ARG_PAGED_SSM_BLOCK_INDICES)->getDataAs<const IndexT>(),        \
+                                memory.at(ARG_PAGED_SSM_BLOCK_INDICES_BEGINS)->getDataAs<const IndexT>(), \
+                                memory.at(ARG_PAGED_SSM_NUM_PROCESSED_TOKENS)->getDataAs<const IndexT>(), \
+                                memory.at(ARG_PAGED_SSM_CACHE_INTERVAL)->getDataAs<const IndexT>(),       \
+                                memory.at(ARG_PAGED_SSM_OUT)->getDataAs<float>(),                         \
+                                shape,                                                                    \
+                                m_state_scratch->getDataAs<float>(),                                      \
+                                m_scratch_head_dim,                                                       \
+                                m_context->getCpuParallel(),                                              \
+                                m_jit_kernel,                                                             \
+                                m_decode_jit_kernel)
+    if (index_precision == ov::element::i32) {
+        OV_CPU_PAGED_SSM_JIT_CALL(int32_t);
+    } else {
+        OV_CPU_PAGED_SSM_JIT_CALL(int64_t);
+    }
+#undef OV_CPU_PAGED_SSM_JIT_CALL
+}
+
+impl_desc_type PagedSelectiveSSMJitExecutor::implType() const {
+    if (mayiuse(dnnl::impl::cpu::x64::avx512_core) && m_cached_token_count > m_cached_sequence_count) {
+        return impl_desc_type::jit_avx512;
+    }
+    return impl_desc_type::jit_avx2;
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include "cpu_memory.h"
@@ -42,6 +43,7 @@ private:
     size_t m_cached_physical_blocks = 0;
     size_t m_cached_token_count = 0;
     size_t m_cached_sequence_count = 0;
+    uint8_t m_cached_data_type = 0xFF;
 };
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/paged_selective_ssm_jit_executor.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "cpu_memory.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/paged_selective_ssm_config.hpp"
+
+namespace ov::intel_cpu::kernel {
+class JitKernelBase;
+}
+
+namespace ov::intel_cpu {
+
+class PagedSelectiveSSMJitExecutor : public Executor {
+public:
+    static bool supports(const PagedSelectiveSSMConfig& config);
+
+    PagedSelectiveSSMJitExecutor(const PagedSelectiveSSMAttrs& attrs,
+                                 const MemoryArgs& memory,
+                                 ExecutorContext::CPtr context);
+
+    bool update(const MemoryArgs& memory) override;
+    void execute(const MemoryArgs& memory) override;
+    [[nodiscard]] impl_desc_type implType() const override;
+
+private:
+    bool update_scratchpad(const MemoryArgs& memory);
+
+    ExecutorContext::CPtr m_context;
+    MemoryPtr m_state_scratch;
+    MemoryPtr m_block_owners;
+    std::shared_ptr<kernel::JitKernelBase> m_jit_kernel;
+    std::shared_ptr<kernel::JitKernelBase> m_decode_jit_kernel;
+    size_t m_scratch_head_dim = 0;
+    size_t m_cached_state_size = 0;
+    size_t m_cached_physical_blocks = 0;
+    size_t m_cached_token_count = 0;
+    size_t m_cached_sequence_count = 0;
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.cpp
@@ -90,16 +90,20 @@ void selective_ssm_jit(const DataT* A,
                        const CpuParallelPtr& cpu_parallel,
                        const std::shared_ptr<kernel::JitKernelBase>& jit_kernel) {
     OPENVINO_ASSERT(jit_kernel);
-    const auto state_batch_stride = shape.num_heads * shape.head_dim * shape.state_size;
-    const auto state_head_stride = shape.head_dim * shape.state_size;
-    const auto scratch_stride = block_head_dim * shape.state_size;
+    const auto state_batch_stride = node::kernel::checked_size_product(
+        {shape.num_heads, shape.head_dim, shape.state_size}, "recurrent state batch");
+    const auto state_head_stride =
+        node::kernel::checked_size_product({shape.head_dim, shape.state_size}, "state head");
+    const auto scratch_stride =
+        node::kernel::checked_size_product({block_head_dim, shape.state_size}, "state scratch");
     const auto heads_per_group = shape.num_heads / shape.num_groups;
-    const auto p_block_count = (shape.head_dim + block_head_dim - 1) / block_head_dim;
+    const auto p_block_count =
+        shape.head_dim / block_head_dim + static_cast<size_t>(shape.head_dim % block_head_dim != 0);
 
     cpu_parallel
         ->parallel_for3d(shape.batch_size, shape.num_heads, p_block_count, [&](size_t batch, size_t head, size_t pb) {
             const auto p_begin = pb * block_head_dim;
-            const auto p_end = std::min(p_begin + block_head_dim, shape.head_dim);
+            const auto p_end = p_begin + std::min(block_head_dim, shape.head_dim - p_begin);
             const auto p_count = p_end - p_begin;
             const auto group = head / heads_per_group;
             const auto state_base = batch * state_batch_stride + head * state_head_stride + p_begin * shape.state_size;
@@ -194,9 +198,12 @@ bool SelectiveSSMJitExecutor::update_scratchpad(const MemoryArgs& memory, size_t
     }
 
     const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    const auto scratch_elements =
+        node::kernel::checked_size_product({block_head_dim, state_size}, "JIT state scratch per worker");
+    node::kernel::checked_size_product({thread_count, scratch_elements}, "JIT state scratch");
     const auto state_desc =
         std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
-                                               ov::intel_cpu::Shape{thread_count, block_head_dim * state_size});
+                                               ov::intel_cpu::Shape{thread_count, scratch_elements});
     m_state_scratch = m_context->getScratchPad()->createScratchPadMem(state_desc);
     m_cached_scratch_head_dim = block_head_dim;
     return m_state_scratch != nullptr;
@@ -204,18 +211,23 @@ bool SelectiveSSMJitExecutor::update_scratchpad(const MemoryArgs& memory, size_t
 
 bool SelectiveSSMJitExecutor::update(const MemoryArgs& memory) {
     const auto& x_shape = memory.at(ARG_SSM_X)->getDescPtr()->getShape();
+    const auto& B_shape = memory.at(ARG_SSM_B)->getDescPtr()->getShape();
     const auto& state_shape = memory.at(ARG_SSM_STATE)->getDescPtr()->getShape();
-    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+    if (x_shape.isDynamic() || B_shape.isDynamic() || state_shape.isDynamic()) {
         return true;
     }
 
     const auto& x_dims = x_shape.getStaticDims();
+    const auto& B_dims = B_shape.getStaticDims();
     const auto& state_dims = state_shape.getStaticDims();
-    OPENVINO_ASSERT(x_dims.size() == 4 && state_dims.size() == 4);
+    OPENVINO_ASSERT(x_dims.size() == 4 && B_dims.size() == 4 && state_dims.size() == 4);
     const auto state_size = state_dims[3];
+    const node::kernel::SelectiveSSMShape shape{x_dims[0], x_dims[1], x_dims[2], x_dims[3], B_dims[2], state_size};
+    node::kernel::validate_selective_ssm_shape(shape);
     const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
     m_cached_sequence_length = x_dims[1];
-    m_block_head_dim = node::kernel::get_scratch_head_dim(x_dims[3], state_size, x_dims[0] * x_dims[2], thread_count);
+    const auto outer_work = node::kernel::checked_size_product({x_dims[0], x_dims[2]}, "outer work items");
+    m_block_head_dim = node::kernel::get_scratch_head_dim(x_dims[3], state_size, outer_work, thread_count);
     OPENVINO_ASSERT(update_scratchpad(memory, state_size, m_block_head_dim));
 
     const auto precision = memory.at(ARG_SSM_X)->getDescPtr()->getPrecision();
@@ -259,6 +271,7 @@ void SelectiveSSMJitExecutor::execute(const MemoryArgs& memory) {
     }
 
     const node::kernel::SelectiveSSMShape shape{x_dims[0], x_dims[1], x_dims[2], x_dims[3], B_dims[2], B_dims[3]};
+    node::kernel::validate_selective_ssm_shape(shape);
     const auto& jit_kernel = shape.sequence_length == 1 ? m_decode_jit_kernel : m_jit_kernel;
     float* state_scratch = m_state_scratch ? m_state_scratch->getDataAs<float>() : nullptr;
 #define OV_CPU_SELECTIVE_SSM_JIT_CALL(DataT)                              \

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.cpp
@@ -7,17 +7,23 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 #include "common/utils.hpp"
 #include "cpu/x64/cpu_isa_traits.hpp"
+#include "memory_desc/cpu_blocked_memory_desc.h"
 #include "nodes/executors/memory_arguments.hpp"
 #include "nodes/kernels/selective_ssm.hpp"
 #include "nodes/kernels/x64/selective_ssm_jit_kernel.hpp"
 #include "openvino/core/except.hpp"
+#include "openvino/core/parallel.hpp"
+#include "openvino/core/type/bfloat16.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/type/float16.hpp"
 
 using namespace dnnl::impl::cpu::x64;
 
@@ -27,32 +33,66 @@ namespace {
 struct SelectiveSSMJitKey {
     size_t state_size;
     bool prefer_avx512;
+    kernel::jit_selective_ssm_data_type data_type;
 
     [[nodiscard]] size_t hash() const {
         size_t seed = dnnl::impl::hash_combine(0, state_size);
-        return dnnl::impl::hash_combine(seed, prefer_avx512);
+        seed = dnnl::impl::hash_combine(seed, prefer_avx512);
+        return dnnl::impl::hash_combine(seed, static_cast<uint8_t>(data_type));
     }
 
     bool operator==(const SelectiveSSMJitKey& rhs) const {
-        return state_size == rhs.state_size && prefer_avx512 == rhs.prefer_avx512;
+        return state_size == rhs.state_size && prefer_avx512 == rhs.prefer_avx512 && data_type == rhs.data_type;
     }
 };
 
-void selective_ssm_jit_f32(const float* A,
-                           const float* dt,
-                           const float* B,
-                           const float* x,
-                           const float* C,
-                           const float* recurrent_state,
-                           float* output,
-                           float* output_recurrent_state,
-                           const node::kernel::SelectiveSSMShape& shape,
-                           size_t block_head_dim,
-                           const CpuParallelPtr& cpu_parallel,
-                           const std::shared_ptr<kernel::JitKernelBase>& jit_kernel) {
+bool is_supported_data_precision(const ov::element::Type& precision) {
+    return precision == ov::element::f32 || precision == ov::element::f16 || precision == ov::element::bf16;
+}
+
+kernel::jit_selective_ssm_data_type get_jit_data_type(const ov::element::Type& precision) {
+    if (precision == ov::element::f32) {
+        return kernel::jit_selective_ssm_data_type::f32;
+    }
+    if (precision == ov::element::f16) {
+        return kernel::jit_selective_ssm_data_type::f16;
+    }
+    OPENVINO_ASSERT(precision == ov::element::bf16);
+    return kernel::jit_selective_ssm_data_type::bf16;
+}
+
+template <typename DataT>
+void copy_state_to_float(float* destination, const DataT* source, size_t count) {
+    for (size_t i = 0; i < count; ++i) {
+        destination[i] = static_cast<float>(source[i]);
+    }
+}
+
+template <typename DataT>
+void copy_state_from_float(DataT* destination, const float* source, size_t count) {
+    for (size_t i = 0; i < count; ++i) {
+        destination[i] = static_cast<DataT>(source[i]);
+    }
+}
+
+template <typename DataT>
+void selective_ssm_jit(const DataT* A,
+                       const DataT* dt,
+                       const DataT* B,
+                       const DataT* x,
+                       const DataT* C,
+                       const DataT* recurrent_state,
+                       DataT* output,
+                       DataT* output_recurrent_state,
+                       const node::kernel::SelectiveSSMShape& shape,
+                       size_t block_head_dim,
+                       float* state_scratch,
+                       const CpuParallelPtr& cpu_parallel,
+                       const std::shared_ptr<kernel::JitKernelBase>& jit_kernel) {
     OPENVINO_ASSERT(jit_kernel);
     const auto state_batch_stride = shape.num_heads * shape.head_dim * shape.state_size;
     const auto state_head_stride = shape.head_dim * shape.state_size;
+    const auto scratch_stride = block_head_dim * shape.state_size;
     const auto heads_per_group = shape.num_heads / shape.num_groups;
     const auto p_block_count = (shape.head_dim + block_head_dim - 1) / block_head_dim;
 
@@ -68,23 +108,35 @@ void selective_ssm_jit_f32(const float* A,
                 auto* final_state = output_recurrent_state + state_base;
                 const auto* initial_state = recurrent_state + state_base;
                 if (final_state != initial_state) {
-                    std::memcpy(final_state, initial_state, p_count * shape.state_size * sizeof(float));
+                    std::memcpy(final_state, initial_state, p_count * shape.state_size * sizeof(DataT));
                 }
                 return;
             }
 
-            const float A_head = A[head];
+            float* working_state = nullptr;
+            const float* state_source = nullptr;
+            if constexpr (std::is_same_v<DataT, float>) {
+                working_state = output_recurrent_state + state_base;
+                state_source = recurrent_state + state_base;
+            } else {
+                OPENVINO_ASSERT(state_scratch);
+                working_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
+                copy_state_to_float(working_state, recurrent_state + state_base, p_count * shape.state_size);
+                state_source = working_state;
+            }
+
+            const float A_head = static_cast<float>(A[head]);
             auto token_head = (batch * shape.sequence_length) * shape.num_heads + head;
             auto projection_base = ((batch * shape.sequence_length) * shape.num_groups + group) * shape.state_size;
             auto x_base = token_head * shape.head_dim + p_begin;
             const auto projection_stride = shape.num_groups * shape.state_size;
             const auto x_stride = shape.num_heads * shape.head_dim;
 
-            auto execute_token = [&](const float* state_source) {
-                const float delta = dt[token_head];
+            for (size_t token = 0; token < shape.sequence_length; ++token) {
+                const float delta = static_cast<float>(dt[token_head]);
                 const float decay = std::exp(A_head * delta);
                 kernel::jit_selective_ssm_call_args args{state_source,
-                                                         output_recurrent_state + state_base,
+                                                         working_state,
                                                          B + projection_base,
                                                          C + projection_base,
                                                          decay,
@@ -93,17 +145,14 @@ void selective_ssm_jit_f32(const float* A,
                                                          p_count,
                                                          output + x_base};
                 (*jit_kernel)(&args);
-            };
-
-            execute_token(recurrent_state + state_base);
-            token_head += shape.num_heads;
-            projection_base += projection_stride;
-            x_base += x_stride;
-            for (size_t token = 1; token < shape.sequence_length; ++token) {
-                execute_token(output_recurrent_state + state_base);
+                state_source = working_state;
                 token_head += shape.num_heads;
                 projection_base += projection_stride;
                 x_base += x_stride;
+            }
+
+            if constexpr (!std::is_same_v<DataT, float>) {
+                copy_state_from_float(output_recurrent_state + state_base, working_state, p_count * shape.state_size);
             }
         });
 }
@@ -114,9 +163,13 @@ bool SelectiveSSMJitExecutor::supports(const SelectiveSSMConfig& config) {
     if (!mayiuse(dnnl::impl::cpu::x64::avx2)) {
         return false;
     }
+    const auto precision = config.descs.at(ARG_SSM_A)->getPrecision();
+    if (!is_supported_data_precision(precision)) {
+        return false;
+    }
     for (const auto arg :
-         {ARG_SSM_A, ARG_SSM_DT, ARG_SSM_B, ARG_SSM_X, ARG_SSM_C, ARG_SSM_STATE, ARG_SSM_OUT, ARG_SSM_OUT_STATE}) {
-        if (config.descs.at(arg)->getPrecision() != ov::element::f32) {
+         {ARG_SSM_DT, ARG_SSM_B, ARG_SSM_X, ARG_SSM_C, ARG_SSM_STATE, ARG_SSM_OUT, ARG_SSM_OUT_STATE}) {
+        if (config.descs.at(arg)->getPrecision() != precision) {
             return false;
         }
     }
@@ -128,6 +181,25 @@ SelectiveSSMJitExecutor::SelectiveSSMJitExecutor(const SelectiveSSMAttrs&,
                                                  ExecutorContext::CPtr context)
     : m_context(std::move(context)) {
     update(memory);
+}
+
+bool SelectiveSSMJitExecutor::update_scratchpad(const MemoryArgs& memory, size_t state_size, size_t block_head_dim) {
+    const auto precision = memory.at(ARG_SSM_X)->getDescPtr()->getPrecision();
+    if (precision == ov::element::f32) {
+        return true;
+    }
+
+    if (m_state_scratch && m_cached_scratch_head_dim == block_head_dim && m_cached_state_size == state_size) {
+        return true;
+    }
+
+    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    const auto state_desc =
+        std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
+                                               ov::intel_cpu::Shape{thread_count, block_head_dim * state_size});
+    m_state_scratch = m_context->getScratchPad()->createScratchPadMem(state_desc);
+    m_cached_scratch_head_dim = block_head_dim;
+    return m_state_scratch != nullptr;
 }
 
 bool SelectiveSSMJitExecutor::update(const MemoryArgs& memory) {
@@ -144,25 +216,33 @@ bool SelectiveSSMJitExecutor::update(const MemoryArgs& memory) {
     const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
     m_cached_sequence_length = x_dims[1];
     m_block_head_dim = node::kernel::get_scratch_head_dim(x_dims[3], state_size, x_dims[0] * x_dims[2], thread_count);
+    OPENVINO_ASSERT(update_scratchpad(memory, state_size, m_block_head_dim));
 
-    if (m_jit_kernel && m_decode_jit_kernel && m_cached_state_size == state_size) {
+    const auto precision = memory.at(ARG_SSM_X)->getDescPtr()->getPrecision();
+    const auto data_type = get_jit_data_type(precision);
+    const auto data_type_key = static_cast<uint8_t>(data_type);
+    if (m_jit_kernel && m_decode_jit_kernel && m_cached_state_size == state_size &&
+        m_cached_data_type == data_type_key) {
         return true;
     }
 
-    const SelectiveSSMJitKey key{state_size, true};
+    const SelectiveSSMJitKey key{state_size, true, data_type};
     auto builder = [](const SelectiveSSMJitKey& compile_key) {
-        return kernel::create_selective_ssm_jit_kernel(compile_key.state_size, compile_key.prefer_avx512);
+        return kernel::create_selective_ssm_jit_kernel(compile_key.state_size,
+                                                       compile_key.prefer_avx512,
+                                                       compile_key.data_type);
     };
     const auto result = m_context->getRuntimeCache()->getOrCreate(key, builder);
     m_jit_kernel = result.first;
     if (mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
-        const SelectiveSSMJitKey decode_key{state_size, false};
+        const SelectiveSSMJitKey decode_key{state_size, false, data_type};
         const auto decode_result = m_context->getRuntimeCache()->getOrCreate(decode_key, builder);
         m_decode_jit_kernel = decode_result.first;
     } else {
         m_decode_jit_kernel = m_jit_kernel;
     }
     m_cached_state_size = state_size;
+    m_cached_data_type = data_type_key;
     return m_jit_kernel != nullptr && m_decode_jit_kernel != nullptr;
 }
 
@@ -171,24 +251,38 @@ void SelectiveSSMJitExecutor::execute(const MemoryArgs& memory) {
     const auto& B_dims = memory.at(ARG_SSM_B)->getStaticDims();
     const auto& state_dims = memory.at(ARG_SSM_STATE)->getStaticDims();
     OPENVINO_ASSERT(x_dims.size() == 4 && B_dims.size() == 4 && state_dims.size() == 4);
-    if (!m_jit_kernel || m_cached_state_size != state_dims[3]) {
+    const auto precision = memory.at(ARG_SSM_X)->getDescPtr()->getPrecision();
+    const auto data_type_key = static_cast<uint8_t>(get_jit_data_type(precision));
+    if (!m_jit_kernel || !m_decode_jit_kernel || m_cached_state_size != state_dims[3] ||
+        m_cached_data_type != data_type_key || (precision != ov::element::f32 && !m_state_scratch)) {
         OPENVINO_ASSERT(update(memory));
     }
 
     const node::kernel::SelectiveSSMShape shape{x_dims[0], x_dims[1], x_dims[2], x_dims[3], B_dims[2], B_dims[3]};
     const auto& jit_kernel = shape.sequence_length == 1 ? m_decode_jit_kernel : m_jit_kernel;
-    selective_ssm_jit_f32(memory.at(ARG_SSM_A)->getDataAs<const float>(),
-                          memory.at(ARG_SSM_DT)->getDataAs<const float>(),
-                          memory.at(ARG_SSM_B)->getDataAs<const float>(),
-                          memory.at(ARG_SSM_X)->getDataAs<const float>(),
-                          memory.at(ARG_SSM_C)->getDataAs<const float>(),
-                          memory.at(ARG_SSM_STATE)->getDataAs<const float>(),
-                          memory.at(ARG_SSM_OUT)->getDataAs<float>(),
-                          memory.at(ARG_SSM_OUT_STATE)->getDataAs<float>(),
-                          shape,
-                          m_block_head_dim,
-                          m_context->getCpuParallel(),
-                          jit_kernel);
+    float* state_scratch = m_state_scratch ? m_state_scratch->getDataAs<float>() : nullptr;
+#define OV_CPU_SELECTIVE_SSM_JIT_CALL(DataT)                              \
+    selective_ssm_jit(memory.at(ARG_SSM_A)->getDataAs<const DataT>(),     \
+                      memory.at(ARG_SSM_DT)->getDataAs<const DataT>(),    \
+                      memory.at(ARG_SSM_B)->getDataAs<const DataT>(),     \
+                      memory.at(ARG_SSM_X)->getDataAs<const DataT>(),     \
+                      memory.at(ARG_SSM_C)->getDataAs<const DataT>(),     \
+                      memory.at(ARG_SSM_STATE)->getDataAs<const DataT>(), \
+                      memory.at(ARG_SSM_OUT)->getDataAs<DataT>(),         \
+                      memory.at(ARG_SSM_OUT_STATE)->getDataAs<DataT>(),   \
+                      shape,                                              \
+                      m_block_head_dim,                                   \
+                      state_scratch,                                      \
+                      m_context->getCpuParallel(),                        \
+                      jit_kernel)
+    if (precision == ov::element::f32) {
+        OV_CPU_SELECTIVE_SSM_JIT_CALL(float);
+    } else if (precision == ov::element::f16) {
+        OV_CPU_SELECTIVE_SSM_JIT_CALL(ov::float16);
+    } else {
+        OV_CPU_SELECTIVE_SSM_JIT_CALL(ov::bfloat16);
+    }
+#undef OV_CPU_SELECTIVE_SSM_JIT_CALL
 }
 
 impl_desc_type SelectiveSSMJitExecutor::implType() const {

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.cpp
@@ -1,0 +1,201 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "selective_ssm_jit_executor.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <memory>
+#include <utility>
+
+#include "common/utils.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "nodes/executors/memory_arguments.hpp"
+#include "nodes/kernels/selective_ssm.hpp"
+#include "nodes/kernels/x64/selective_ssm_jit_kernel.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+using namespace dnnl::impl::cpu::x64;
+
+namespace ov::intel_cpu {
+namespace {
+
+struct SelectiveSSMJitKey {
+    size_t state_size;
+    bool prefer_avx512;
+
+    [[nodiscard]] size_t hash() const {
+        size_t seed = dnnl::impl::hash_combine(0, state_size);
+        return dnnl::impl::hash_combine(seed, prefer_avx512);
+    }
+
+    bool operator==(const SelectiveSSMJitKey& rhs) const {
+        return state_size == rhs.state_size && prefer_avx512 == rhs.prefer_avx512;
+    }
+};
+
+void selective_ssm_jit_f32(const float* A,
+                           const float* dt,
+                           const float* B,
+                           const float* x,
+                           const float* C,
+                           const float* recurrent_state,
+                           float* output,
+                           float* output_recurrent_state,
+                           const node::kernel::SelectiveSSMShape& shape,
+                           size_t block_head_dim,
+                           const CpuParallelPtr& cpu_parallel,
+                           const std::shared_ptr<kernel::JitKernelBase>& jit_kernel) {
+    OPENVINO_ASSERT(jit_kernel);
+    const auto state_batch_stride = shape.num_heads * shape.head_dim * shape.state_size;
+    const auto state_head_stride = shape.head_dim * shape.state_size;
+    const auto heads_per_group = shape.num_heads / shape.num_groups;
+    const auto p_block_count = (shape.head_dim + block_head_dim - 1) / block_head_dim;
+
+    cpu_parallel
+        ->parallel_for3d(shape.batch_size, shape.num_heads, p_block_count, [&](size_t batch, size_t head, size_t pb) {
+            const auto p_begin = pb * block_head_dim;
+            const auto p_end = std::min(p_begin + block_head_dim, shape.head_dim);
+            const auto p_count = p_end - p_begin;
+            const auto group = head / heads_per_group;
+            const auto state_base = batch * state_batch_stride + head * state_head_stride + p_begin * shape.state_size;
+
+            if (shape.sequence_length == 0) {
+                auto* final_state = output_recurrent_state + state_base;
+                const auto* initial_state = recurrent_state + state_base;
+                if (final_state != initial_state) {
+                    std::memcpy(final_state, initial_state, p_count * shape.state_size * sizeof(float));
+                }
+                return;
+            }
+
+            const float A_head = A[head];
+            auto token_head = (batch * shape.sequence_length) * shape.num_heads + head;
+            auto projection_base = ((batch * shape.sequence_length) * shape.num_groups + group) * shape.state_size;
+            auto x_base = token_head * shape.head_dim + p_begin;
+            const auto projection_stride = shape.num_groups * shape.state_size;
+            const auto x_stride = shape.num_heads * shape.head_dim;
+
+            auto execute_token = [&](const float* state_source) {
+                const float delta = dt[token_head];
+                const float decay = std::exp(A_head * delta);
+                kernel::jit_selective_ssm_call_args args{state_source,
+                                                         output_recurrent_state + state_base,
+                                                         B + projection_base,
+                                                         C + projection_base,
+                                                         decay,
+                                                         delta,
+                                                         x + x_base,
+                                                         p_count,
+                                                         output + x_base};
+                (*jit_kernel)(&args);
+            };
+
+            execute_token(recurrent_state + state_base);
+            token_head += shape.num_heads;
+            projection_base += projection_stride;
+            x_base += x_stride;
+            for (size_t token = 1; token < shape.sequence_length; ++token) {
+                execute_token(output_recurrent_state + state_base);
+                token_head += shape.num_heads;
+                projection_base += projection_stride;
+                x_base += x_stride;
+            }
+        });
+}
+
+}  // namespace
+
+bool SelectiveSSMJitExecutor::supports(const SelectiveSSMConfig& config) {
+    if (!mayiuse(dnnl::impl::cpu::x64::avx2)) {
+        return false;
+    }
+    for (const auto arg :
+         {ARG_SSM_A, ARG_SSM_DT, ARG_SSM_B, ARG_SSM_X, ARG_SSM_C, ARG_SSM_STATE, ARG_SSM_OUT, ARG_SSM_OUT_STATE}) {
+        if (config.descs.at(arg)->getPrecision() != ov::element::f32) {
+            return false;
+        }
+    }
+    return true;
+}
+
+SelectiveSSMJitExecutor::SelectiveSSMJitExecutor(const SelectiveSSMAttrs&,
+                                                 const MemoryArgs& memory,
+                                                 ExecutorContext::CPtr context)
+    : m_context(std::move(context)) {
+    update(memory);
+}
+
+bool SelectiveSSMJitExecutor::update(const MemoryArgs& memory) {
+    const auto& x_shape = memory.at(ARG_SSM_X)->getDescPtr()->getShape();
+    const auto& state_shape = memory.at(ARG_SSM_STATE)->getDescPtr()->getShape();
+    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+        return true;
+    }
+
+    const auto& x_dims = x_shape.getStaticDims();
+    const auto& state_dims = state_shape.getStaticDims();
+    OPENVINO_ASSERT(x_dims.size() == 4 && state_dims.size() == 4);
+    const auto state_size = state_dims[3];
+    const auto thread_count = static_cast<size_t>(m_context->getCpuParallel()->get_num_worker_threads());
+    m_cached_sequence_length = x_dims[1];
+    m_block_head_dim = node::kernel::get_scratch_head_dim(x_dims[3], state_size, x_dims[0] * x_dims[2], thread_count);
+
+    if (m_jit_kernel && m_decode_jit_kernel && m_cached_state_size == state_size) {
+        return true;
+    }
+
+    const SelectiveSSMJitKey key{state_size, true};
+    auto builder = [](const SelectiveSSMJitKey& compile_key) {
+        return kernel::create_selective_ssm_jit_kernel(compile_key.state_size, compile_key.prefer_avx512);
+    };
+    const auto result = m_context->getRuntimeCache()->getOrCreate(key, builder);
+    m_jit_kernel = result.first;
+    if (mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
+        const SelectiveSSMJitKey decode_key{state_size, false};
+        const auto decode_result = m_context->getRuntimeCache()->getOrCreate(decode_key, builder);
+        m_decode_jit_kernel = decode_result.first;
+    } else {
+        m_decode_jit_kernel = m_jit_kernel;
+    }
+    m_cached_state_size = state_size;
+    return m_jit_kernel != nullptr && m_decode_jit_kernel != nullptr;
+}
+
+void SelectiveSSMJitExecutor::execute(const MemoryArgs& memory) {
+    const auto& x_dims = memory.at(ARG_SSM_X)->getStaticDims();
+    const auto& B_dims = memory.at(ARG_SSM_B)->getStaticDims();
+    const auto& state_dims = memory.at(ARG_SSM_STATE)->getStaticDims();
+    OPENVINO_ASSERT(x_dims.size() == 4 && B_dims.size() == 4 && state_dims.size() == 4);
+    if (!m_jit_kernel || m_cached_state_size != state_dims[3]) {
+        OPENVINO_ASSERT(update(memory));
+    }
+
+    const node::kernel::SelectiveSSMShape shape{x_dims[0], x_dims[1], x_dims[2], x_dims[3], B_dims[2], B_dims[3]};
+    const auto& jit_kernel = shape.sequence_length == 1 ? m_decode_jit_kernel : m_jit_kernel;
+    selective_ssm_jit_f32(memory.at(ARG_SSM_A)->getDataAs<const float>(),
+                          memory.at(ARG_SSM_DT)->getDataAs<const float>(),
+                          memory.at(ARG_SSM_B)->getDataAs<const float>(),
+                          memory.at(ARG_SSM_X)->getDataAs<const float>(),
+                          memory.at(ARG_SSM_C)->getDataAs<const float>(),
+                          memory.at(ARG_SSM_STATE)->getDataAs<const float>(),
+                          memory.at(ARG_SSM_OUT)->getDataAs<float>(),
+                          memory.at(ARG_SSM_OUT_STATE)->getDataAs<float>(),
+                          shape,
+                          m_block_head_dim,
+                          m_context->getCpuParallel(),
+                          jit_kernel);
+}
+
+impl_desc_type SelectiveSSMJitExecutor::implType() const {
+    if (mayiuse(dnnl::impl::cpu::x64::avx512_core) && m_cached_sequence_length != 1) {
+        return impl_desc_type::jit_avx512;
+    }
+    return impl_desc_type::jit_avx2;
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/selective_ssm_config.hpp"
+
+namespace ov::intel_cpu::kernel {
+class JitKernelBase;
+}
+
+namespace ov::intel_cpu {
+
+class SelectiveSSMJitExecutor : public Executor {
+public:
+    static bool supports(const SelectiveSSMConfig& config);
+
+    SelectiveSSMJitExecutor(const SelectiveSSMAttrs& attrs, const MemoryArgs& memory, ExecutorContext::CPtr context);
+
+    bool update(const MemoryArgs& memory) override;
+    void execute(const MemoryArgs& memory) override;
+    [[nodiscard]] impl_desc_type implType() const override;
+
+private:
+    ExecutorContext::CPtr m_context;
+    std::shared_ptr<kernel::JitKernelBase> m_jit_kernel;
+    std::shared_ptr<kernel::JitKernelBase> m_decode_jit_kernel;
+    size_t m_cached_state_size = 0;
+    size_t m_cached_sequence_length = 0;
+    size_t m_block_head_dim = 0;
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/selective_ssm_jit_executor.hpp
@@ -5,8 +5,10 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
+#include "cpu_memory.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/selective_ssm_config.hpp"
 
@@ -27,12 +29,17 @@ public:
     [[nodiscard]] impl_desc_type implType() const override;
 
 private:
+    bool update_scratchpad(const MemoryArgs& memory, size_t state_size, size_t block_head_dim);
+
     ExecutorContext::CPtr m_context;
+    MemoryPtr m_state_scratch;
     std::shared_ptr<kernel::JitKernelBase> m_jit_kernel;
     std::shared_ptr<kernel::JitKernelBase> m_decode_jit_kernel;
     size_t m_cached_state_size = 0;
     size_t m_cached_sequence_length = 0;
     size_t m_block_head_dim = 0;
+    size_t m_cached_scratch_head_dim = 0;
+    uint8_t m_cached_data_type = 0xFF;
 };
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <type_traits>
 
 #include "openvino/core/except.hpp"
 #include "openvino/core/parallel.hpp"
@@ -26,6 +27,55 @@ inline float load(const T* ptr) {
 template <typename T>
 inline void store(T* ptr, float value) {
     *ptr = static_cast<T>(value);
+}
+
+template <typename DataT>
+inline void copy_state_to_float(float* dst, const DataT* src, size_t count) {
+    if constexpr (std::is_same_v<DataT, float>) {
+        if (dst == src) {
+            return;
+        }
+    }
+    for (size_t i = 0; i < count; ++i) {
+        dst[i] = load(src + i);
+    }
+}
+
+template <typename DataT>
+inline float update_state_and_reduce(float* state,
+                                     const DataT* B,
+                                     const DataT* C,
+                                     float decay,
+                                     float input_scale,
+                                     size_t state_size) {
+    // Keep four independent reduction chains to expose instruction-level parallelism to any optimizing compiler
+    // without relying on a target ISA. Fusing the update and reduction also keeps the new state cache-resident.
+    float result0 = 0.F;
+    float result1 = 0.F;
+    float result2 = 0.F;
+    float result3 = 0.F;
+    size_t n = 0;
+    for (; n + 4 <= state_size; n += 4) {
+        const float updated_state0 = state[n] * decay + input_scale * load(B + n);
+        const float updated_state1 = state[n + 1] * decay + input_scale * load(B + n + 1);
+        const float updated_state2 = state[n + 2] * decay + input_scale * load(B + n + 2);
+        const float updated_state3 = state[n + 3] * decay + input_scale * load(B + n + 3);
+        state[n] = updated_state0;
+        state[n + 1] = updated_state1;
+        state[n + 2] = updated_state2;
+        state[n + 3] = updated_state3;
+        result0 += updated_state0 * load(C + n);
+        result1 += updated_state1 * load(C + n + 1);
+        result2 += updated_state2 * load(C + n + 2);
+        result3 += updated_state3 * load(C + n + 3);
+    }
+    float result = (result0 + result1) + (result2 + result3);
+    for (; n < state_size; ++n) {
+        const float updated_state = state[n] * decay + input_scale * load(B + n);
+        state[n] = updated_state;
+        result += updated_state * load(C + n);
+    }
+    return result;
 }
 
 template <typename DataT>
@@ -53,48 +103,53 @@ void selective_ssm_typed(const DataT* A,
             const auto p_end = std::min(p_begin + scratch_head_dim, shape.head_dim);
             const auto p_count = p_end - p_begin;
             const auto group = head / heads_per_group;
-            auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
             const auto state_base = batch * BHS + head * HS + p_begin * shape.state_size;
+            float* local_state = nullptr;
+            if constexpr (std::is_same_v<DataT, float>) {
+                // FP32 can use the final state as its working buffer. Lower precisions retain FP32 scratch to avoid
+                // quantizing the recurrent state at every token.
+                local_state = output_recurrent_state + state_base;
+            } else {
+                local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
+            }
 
             for (size_t p = 0; p < p_count; ++p) {
                 const auto* src = recurrent_state + state_base + p * shape.state_size;
                 auto* dst = local_state + p * shape.state_size;
-                for (size_t n = 0; n < shape.state_size; ++n) {
-                    dst[n] = load(src + n);
-                }
+                copy_state_to_float(dst, src, shape.state_size);
             }
 
+            const float A_head = load(A + head);
+            auto token_head = (batch * shape.sequence_length) * shape.num_heads + head;
+            auto projection_base = ((batch * shape.sequence_length) * shape.num_groups + group) * shape.state_size;
+            auto x_base = token_head * shape.head_dim + p_begin;
+            const auto projection_stride = shape.num_groups * shape.state_size;
+            const auto x_stride = shape.num_heads * shape.head_dim;
             for (size_t token = 0; token < shape.sequence_length; ++token) {
-                const auto token_head = (batch * shape.sequence_length + token) * shape.num_heads + head;
                 const float delta = load(dt + token_head);
-                const float decay = std::exp(load(A + head) * delta);
-                const auto projection_base =
-                    ((batch * shape.sequence_length + token) * shape.num_groups + group) * shape.state_size;
+                const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                const auto x_base = token_head * shape.head_dim + p_begin;
-                const auto output_base = x_base;
 
                 for (size_t p = 0; p < p_count; ++p) {
                     auto* state = local_state + p * shape.state_size;
                     const float input_scale = load(x + x_base + p) * delta;
-                    for (size_t n = 0; n < shape.state_size; ++n) {
-                        state[n] = state[n] * decay + input_scale * load(B_token + n);
-                    }
-
-                    float result = 0.F;
-                    for (size_t n = 0; n < shape.state_size; ++n) {
-                        result += state[n] * load(C_token + n);
-                    }
-                    store(output + output_base + p, result);
+                    const float result =
+                        update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
+                    store(output + x_base + p, result);
                 }
+                token_head += shape.num_heads;
+                projection_base += projection_stride;
+                x_base += x_stride;
             }
 
-            for (size_t p = 0; p < p_count; ++p) {
-                const auto* src = local_state + p * shape.state_size;
-                auto* dst = output_recurrent_state + state_base + p * shape.state_size;
-                for (size_t n = 0; n < shape.state_size; ++n) {
-                    store(dst + n, src[n]);
+            if constexpr (!std::is_same_v<DataT, float>) {
+                for (size_t p = 0; p < p_count; ++p) {
+                    const auto* src = local_state + p * shape.state_size;
+                    auto* dst = output_recurrent_state + state_base + p * shape.state_size;
+                    for (size_t n = 0; n < shape.state_size; ++n) {
+                        store(dst + n, src[n]);
+                    }
                 }
             }
         });
@@ -310,41 +365,39 @@ void paged_selective_ssm_typed(const DataT* A,
                 }
             }
 
+            const float A_head = load(A + head);
             const auto interval = cache_interval[sequence];
+            const bool cache_enabled = interval > 0;
+            const uint64_t positive_interval = cache_enabled ? static_cast<uint64_t>(interval) : 1;
             const uint64_t cache_offset =
-                interval > 0 ? static_cast<uint64_t>(num_processed_tokens[sequence]) % static_cast<uint64_t>(interval)
-                             : 0;
+                cache_enabled ? static_cast<uint64_t>(num_processed_tokens[sequence]) % positive_interval : 0;
+            auto token_head = token_begin * shape.num_heads + head;
+            auto projection_base = (token_begin * shape.num_groups + group) * shape.state_size;
+            auto x_base = token_head * shape.head_dim + p_begin;
+            const auto projection_stride = shape.num_groups * shape.state_size;
+            const auto x_stride = shape.num_heads * shape.head_dim;
+            // Track cache boundaries incrementally to keep integer division out of the token loop.
+            uint64_t tokens_until_boundary = cache_enabled ? positive_interval - cache_offset : 0;
+            size_t write_slot = 1;
             for (size_t token = token_begin; token < token_end; ++token) {
-                const auto token_head = token * shape.num_heads + head;
                 const float delta = load(dt + token_head);
-                const float decay = std::exp(load(A + head) * delta);
-                const auto projection_base = (token * shape.num_groups + group) * shape.state_size;
+                const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                const auto x_base = token_head * shape.head_dim + p_begin;
 
                 for (size_t p = 0; p < p_count; ++p) {
                     auto* state = local_state + p * shape.state_size;
                     const float input_scale = load(x + x_base + p) * delta;
-                    for (size_t n = 0; n < shape.state_size; ++n) {
-                        state[n] = state[n] * decay + input_scale * load(B_token + n);
-                    }
-                    float result = 0.F;
-                    for (size_t n = 0; n < shape.state_size; ++n) {
-                        result += state[n] * load(C_token + n);
-                    }
+                    const float result =
+                        update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
                     store(output + x_base + p, result);
                 }
 
-                if (interval > 0) {
-                    const auto local_token = token - token_begin;
-                    const auto positive_interval = static_cast<uint64_t>(interval);
-                    const auto cached_tokens = cache_offset + local_token + 1;
-                    const bool is_boundary = cached_tokens % positive_interval == 0;
+                if (cache_enabled) {
+                    const bool is_boundary = --tokens_until_boundary == 0;
                     const bool is_last = token + 1 == token_end;
                     if (is_boundary || is_last) {
-                        const auto slot = static_cast<size_t>(1 + (cached_tokens - 1) / positive_interval);
-                        const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + slot]);
+                        const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + write_slot++]);
                         auto* snapshot = recurrent_state_table + write_block * block_stride + state_slice;
                         for (size_t p = 0; p < p_count; ++p) {
                             const auto* src = local_state + p * shape.state_size;
@@ -354,7 +407,13 @@ void paged_selective_ssm_typed(const DataT* A,
                             }
                         }
                     }
+                    if (is_boundary) {
+                        tokens_until_boundary = positive_interval;
+                    }
                 }
+                token_head += shape.num_heads;
+                projection_base += projection_stride;
+                x_base += x_stride;
             }
         });
 }

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
@@ -1,0 +1,535 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "selective_ssm.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include "openvino/core/except.hpp"
+#include "openvino/core/parallel.hpp"
+#include "openvino/core/type/bfloat16.hpp"
+#include "openvino/core/type/float16.hpp"
+
+namespace ov::intel_cpu::node::kernel {
+namespace {
+
+template <typename T>
+inline float load(const T* ptr) {
+    return static_cast<float>(*ptr);
+}
+
+template <typename T>
+inline void store(T* ptr, float value) {
+    *ptr = static_cast<T>(value);
+}
+
+template <typename DataT>
+void selective_ssm_typed(const DataT* A,
+                         const DataT* dt,
+                         const DataT* B,
+                         const DataT* x,
+                         const DataT* C,
+                         const DataT* recurrent_state,
+                         DataT* output,
+                         DataT* output_recurrent_state,
+                         const SelectiveSSMShape& shape,
+                         float* state_scratch,
+                         size_t scratch_head_dim,
+                         const CpuParallelPtr& cpu_parallel) {
+    const auto BHS = shape.num_heads * shape.head_dim * shape.state_size;
+    const auto HS = shape.head_dim * shape.state_size;
+    const auto scratch_stride = scratch_head_dim * shape.state_size;
+    const auto heads_per_group = shape.num_heads / shape.num_groups;
+    const auto p_block_count = (shape.head_dim + scratch_head_dim - 1) / scratch_head_dim;
+
+    cpu_parallel
+        ->parallel_for3d(shape.batch_size, shape.num_heads, p_block_count, [&](size_t batch, size_t head, size_t pb) {
+            const auto p_begin = pb * scratch_head_dim;
+            const auto p_end = std::min(p_begin + scratch_head_dim, shape.head_dim);
+            const auto p_count = p_end - p_begin;
+            const auto group = head / heads_per_group;
+            auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
+            const auto state_base = batch * BHS + head * HS + p_begin * shape.state_size;
+
+            for (size_t p = 0; p < p_count; ++p) {
+                const auto* src = recurrent_state + state_base + p * shape.state_size;
+                auto* dst = local_state + p * shape.state_size;
+                for (size_t n = 0; n < shape.state_size; ++n) {
+                    dst[n] = load(src + n);
+                }
+            }
+
+            for (size_t token = 0; token < shape.sequence_length; ++token) {
+                const auto token_head = (batch * shape.sequence_length + token) * shape.num_heads + head;
+                const float delta = load(dt + token_head);
+                const float decay = std::exp(load(A + head) * delta);
+                const auto projection_base =
+                    ((batch * shape.sequence_length + token) * shape.num_groups + group) * shape.state_size;
+                const auto* B_token = B + projection_base;
+                const auto* C_token = C + projection_base;
+                const auto x_base = token_head * shape.head_dim + p_begin;
+                const auto output_base = x_base;
+
+                for (size_t p = 0; p < p_count; ++p) {
+                    auto* state = local_state + p * shape.state_size;
+                    const float input_scale = load(x + x_base + p) * delta;
+                    for (size_t n = 0; n < shape.state_size; ++n) {
+                        state[n] = state[n] * decay + input_scale * load(B_token + n);
+                    }
+
+                    float result = 0.F;
+                    for (size_t n = 0; n < shape.state_size; ++n) {
+                        result += state[n] * load(C_token + n);
+                    }
+                    store(output + output_base + p, result);
+                }
+            }
+
+            for (size_t p = 0; p < p_count; ++p) {
+                const auto* src = local_state + p * shape.state_size;
+                auto* dst = output_recurrent_state + state_base + p * shape.state_size;
+                for (size_t n = 0; n < shape.state_size; ++n) {
+                    store(dst + n, src[n]);
+                }
+            }
+        });
+}
+
+template <typename IndexT>
+size_t checked_index(IndexT value, size_t limit, const char* name, size_t position) {
+    OPENVINO_ASSERT(value >= 0, "PagedSelectiveSSM: ", name, "[", position, "] must be non-negative, got ", value, ".");
+    const auto result = static_cast<uint64_t>(value);
+    OPENVINO_ASSERT(result < limit,
+                    "PagedSelectiveSSM: ",
+                    name,
+                    "[",
+                    position,
+                    "] is out of range: ",
+                    value,
+                    " not in [0, ",
+                    limit,
+                    ").");
+    return static_cast<size_t>(result);
+}
+
+template <typename IndexT>
+void validate_paged_metadata(const IndexT* subsequence_begins,
+                             const IndexT* block_indices,
+                             const IndexT* block_indices_begins,
+                             const IndexT* num_processed_tokens,
+                             const IndexT* cache_interval,
+                             const PagedSelectiveSSMShape& shape,
+                             int32_t* block_owners) {
+    OPENVINO_ASSERT(subsequence_begins[0] == 0,
+                    "PagedSelectiveSSM: subsequence_begins[0] must be 0, got ",
+                    subsequence_begins[0],
+                    ".");
+    OPENVINO_ASSERT(block_indices_begins[0] == 0,
+                    "PagedSelectiveSSM: block_indices_begins[0] must be 0, got ",
+                    block_indices_begins[0],
+                    ".");
+
+    for (size_t s = 0; s < shape.sequence_count; ++s) {
+        OPENVINO_ASSERT(subsequence_begins[s] >= 0 && subsequence_begins[s + 1] >= subsequence_begins[s],
+                        "PagedSelectiveSSM: subsequence_begins must be non-negative and non-decreasing at sequence ",
+                        s,
+                        ".");
+        OPENVINO_ASSERT(block_indices_begins[s] >= 0 && block_indices_begins[s + 1] >= block_indices_begins[s],
+                        "PagedSelectiveSSM: block_indices_begins must be non-negative and non-decreasing at sequence ",
+                        s,
+                        ".");
+        OPENVINO_ASSERT(num_processed_tokens[s] >= 0,
+                        "PagedSelectiveSSM: num_processed_tokens[",
+                        s,
+                        "] must be non-negative, got ",
+                        num_processed_tokens[s],
+                        ".");
+    }
+
+    OPENVINO_ASSERT(static_cast<uint64_t>(subsequence_begins[shape.sequence_count]) == shape.token_count,
+                    "PagedSelectiveSSM: the last subsequence offset must equal token_count (",
+                    shape.token_count,
+                    "), got ",
+                    subsequence_begins[shape.sequence_count],
+                    ".");
+    OPENVINO_ASSERT(static_cast<uint64_t>(block_indices_begins[shape.sequence_count]) == shape.logical_block_count,
+                    "PagedSelectiveSSM: the last block offset must equal logical_block_count (",
+                    shape.logical_block_count,
+                    "), got ",
+                    block_indices_begins[shape.sequence_count],
+                    ".");
+
+    for (size_t i = 0; i < shape.logical_block_count; ++i) {
+        checked_index(block_indices[i], shape.physical_block_count, "block_indices", i);
+    }
+    OPENVINO_ASSERT(shape.sequence_count <= static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+                    "PagedSelectiveSSM supports at most INT32_MAX sequences.");
+    if (shape.physical_block_count > 0) {
+        std::fill(block_owners, block_owners + shape.physical_block_count, int32_t{-1});
+    }
+
+    // First register all physical blocks that will be written. Two different sequences
+    // must never write the same block, even when their head/head-dim slices are disjoint tasks.
+    for (size_t s = 0; s < shape.sequence_count; ++s) {
+        const auto token_begin = static_cast<uint64_t>(subsequence_begins[s]);
+        const auto token_end = static_cast<uint64_t>(subsequence_begins[s + 1]);
+        const auto token_count = token_end - token_begin;
+        if (token_count == 0) {
+            continue;
+        }
+
+        const auto block_begin = static_cast<uint64_t>(block_indices_begins[s]);
+        const auto block_end = static_cast<uint64_t>(block_indices_begins[s + 1]);
+        OPENVINO_ASSERT(block_end > block_begin,
+                        "PagedSelectiveSSM: non-empty sequence ",
+                        s,
+                        " requires a read block.");
+
+        const auto interval = cache_interval[s];
+        if (interval <= 0) {
+            continue;
+        }
+        const auto positive_interval = static_cast<uint64_t>(interval);
+        const auto offset = static_cast<uint64_t>(num_processed_tokens[s]) % positive_interval;
+        OPENVINO_ASSERT(token_count <= std::numeric_limits<uint64_t>::max() - offset,
+                        "PagedSelectiveSSM: token count overflow at sequence ",
+                        s,
+                        ".");
+        const auto cached_token_count = offset + token_count;
+        const auto write_count = (cached_token_count - 1) / positive_interval + 1;
+        OPENVINO_ASSERT(block_end - block_begin >= write_count + 1,
+                        "PagedSelectiveSSM: sequence ",
+                        s,
+                        " requires ",
+                        write_count + 1,
+                        " logical blocks (one read plus ",
+                        write_count,
+                        " writes), got ",
+                        block_end - block_begin,
+                        ".");
+
+        for (uint64_t slot = 1; slot <= write_count; ++slot) {
+            const auto logical = static_cast<size_t>(block_begin + slot);
+            const auto physical =
+                checked_index(block_indices[logical], shape.physical_block_count, "block_indices", logical);
+            OPENVINO_ASSERT(block_owners[physical] == -1 || block_owners[physical] == static_cast<int32_t>(s),
+                            "PagedSelectiveSSM: physical block ",
+                            physical,
+                            " is written by multiple sequences (",
+                            block_owners[physical],
+                            " and ",
+                            s,
+                            ").");
+            block_owners[physical] = static_cast<int32_t>(s);
+        }
+    }
+
+    // A read may alias this sequence's first write (the documented in-place case), but it
+    // must not race with another sequence's writer. Read/read sharing is harmless.
+    for (size_t s = 0; s < shape.sequence_count; ++s) {
+        if (subsequence_begins[s + 1] == subsequence_begins[s]) {
+            continue;
+        }
+        const auto logical = static_cast<size_t>(block_indices_begins[s]);
+        const auto physical =
+            checked_index(block_indices[logical], shape.physical_block_count, "block_indices", logical);
+        OPENVINO_ASSERT(block_owners[physical] == -1 || block_owners[physical] == static_cast<int32_t>(s),
+                        "PagedSelectiveSSM: sequence ",
+                        s,
+                        " reads physical block ",
+                        physical,
+                        " while sequence ",
+                        block_owners[physical],
+                        " writes it.");
+    }
+}
+
+template <typename DataT, typename IndexT>
+void paged_selective_ssm_typed(const DataT* A,
+                               const DataT* dt,
+                               const DataT* B,
+                               const DataT* x,
+                               const DataT* C,
+                               DataT* recurrent_state_table,
+                               const IndexT* subsequence_begins,
+                               const IndexT* block_indices,
+                               const IndexT* block_indices_begins,
+                               const IndexT* num_processed_tokens,
+                               const IndexT* cache_interval,
+                               DataT* output,
+                               const PagedSelectiveSSMShape& shape,
+                               float* state_scratch,
+                               size_t scratch_head_dim,
+                               int32_t* block_owners,
+                               const CpuParallelPtr& cpu_parallel) {
+    validate_paged_metadata(subsequence_begins,
+                            block_indices,
+                            block_indices_begins,
+                            num_processed_tokens,
+                            cache_interval,
+                            shape,
+                            block_owners);
+
+    const auto block_stride = shape.num_heads * shape.head_dim * shape.state_size;
+    const auto head_stride = shape.head_dim * shape.state_size;
+    const auto scratch_stride = scratch_head_dim * shape.state_size;
+    const auto heads_per_group = shape.num_heads / shape.num_groups;
+    const auto p_block_count = (shape.head_dim + scratch_head_dim - 1) / scratch_head_dim;
+
+    cpu_parallel->parallel_for3d(
+        shape.sequence_count,
+        shape.num_heads,
+        p_block_count,
+        [&](size_t sequence, size_t head, size_t pb) {
+            const auto token_begin = static_cast<size_t>(subsequence_begins[sequence]);
+            const auto token_end = static_cast<size_t>(subsequence_begins[sequence + 1]);
+            if (token_begin == token_end) {
+                return;
+            }
+
+            const auto p_begin = pb * scratch_head_dim;
+            const auto p_end = std::min(p_begin + scratch_head_dim, shape.head_dim);
+            const auto p_count = p_end - p_begin;
+            const auto group = head / heads_per_group;
+            const auto logical_block_begin = static_cast<size_t>(block_indices_begins[sequence]);
+            const auto read_block = static_cast<size_t>(block_indices[logical_block_begin]);
+            auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
+            const auto state_slice = head * head_stride + p_begin * shape.state_size;
+            const auto* initial_state = recurrent_state_table + read_block * block_stride + state_slice;
+
+            for (size_t p = 0; p < p_count; ++p) {
+                const auto* src = initial_state + p * shape.state_size;
+                auto* dst = local_state + p * shape.state_size;
+                for (size_t n = 0; n < shape.state_size; ++n) {
+                    dst[n] = load(src + n);
+                }
+            }
+
+            const auto interval = cache_interval[sequence];
+            const uint64_t cache_offset =
+                interval > 0 ? static_cast<uint64_t>(num_processed_tokens[sequence]) % static_cast<uint64_t>(interval)
+                             : 0;
+            for (size_t token = token_begin; token < token_end; ++token) {
+                const auto token_head = token * shape.num_heads + head;
+                const float delta = load(dt + token_head);
+                const float decay = std::exp(load(A + head) * delta);
+                const auto projection_base = (token * shape.num_groups + group) * shape.state_size;
+                const auto* B_token = B + projection_base;
+                const auto* C_token = C + projection_base;
+                const auto x_base = token_head * shape.head_dim + p_begin;
+
+                for (size_t p = 0; p < p_count; ++p) {
+                    auto* state = local_state + p * shape.state_size;
+                    const float input_scale = load(x + x_base + p) * delta;
+                    for (size_t n = 0; n < shape.state_size; ++n) {
+                        state[n] = state[n] * decay + input_scale * load(B_token + n);
+                    }
+                    float result = 0.F;
+                    for (size_t n = 0; n < shape.state_size; ++n) {
+                        result += state[n] * load(C_token + n);
+                    }
+                    store(output + x_base + p, result);
+                }
+
+                if (interval > 0) {
+                    const auto local_token = token - token_begin;
+                    const auto positive_interval = static_cast<uint64_t>(interval);
+                    const auto cached_tokens = cache_offset + local_token + 1;
+                    const bool is_boundary = cached_tokens % positive_interval == 0;
+                    const bool is_last = token + 1 == token_end;
+                    if (is_boundary || is_last) {
+                        const auto slot = static_cast<size_t>(1 + (cached_tokens - 1) / positive_interval);
+                        const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + slot]);
+                        auto* snapshot = recurrent_state_table + write_block * block_stride + state_slice;
+                        for (size_t p = 0; p < p_count; ++p) {
+                            const auto* src = local_state + p * shape.state_size;
+                            auto* dst = snapshot + p * shape.state_size;
+                            for (size_t n = 0; n < shape.state_size; ++n) {
+                                store(dst + n, src[n]);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+}
+
+template <typename DataT>
+void dispatch_paged_index(const void* A,
+                          const void* dt,
+                          const void* B,
+                          const void* x,
+                          const void* C,
+                          void* recurrent_state_table,
+                          const void* subsequence_begins,
+                          const void* block_indices,
+                          const void* block_indices_begins,
+                          const void* num_processed_tokens,
+                          const void* cache_interval,
+                          void* output,
+                          const PagedSelectiveSSMShape& shape,
+                          const ov::element::Type& index_precision,
+                          float* state_scratch,
+                          size_t scratch_head_dim,
+                          int32_t* block_owners,
+                          const CpuParallelPtr& cpu_parallel) {
+#define OV_CPU_PAGED_SSM_CALL(IndexT)                                           \
+    paged_selective_ssm_typed(static_cast<const DataT*>(A),                     \
+                              static_cast<const DataT*>(dt),                    \
+                              static_cast<const DataT*>(B),                     \
+                              static_cast<const DataT*>(x),                     \
+                              static_cast<const DataT*>(C),                     \
+                              static_cast<DataT*>(recurrent_state_table),       \
+                              static_cast<const IndexT*>(subsequence_begins),   \
+                              static_cast<const IndexT*>(block_indices),        \
+                              static_cast<const IndexT*>(block_indices_begins), \
+                              static_cast<const IndexT*>(num_processed_tokens), \
+                              static_cast<const IndexT*>(cache_interval),       \
+                              static_cast<DataT*>(output),                      \
+                              shape,                                            \
+                              state_scratch,                                    \
+                              scratch_head_dim,                                 \
+                              block_owners,                                     \
+                              cpu_parallel)
+    if (index_precision == ov::element::i32) {
+        OV_CPU_PAGED_SSM_CALL(int32_t);
+    } else if (index_precision == ov::element::i64) {
+        OV_CPU_PAGED_SSM_CALL(int64_t);
+    } else {
+        OPENVINO_THROW("PagedSelectiveSSM supports only i32/i64 metadata, got ", index_precision, ".");
+    }
+#undef OV_CPU_PAGED_SSM_CALL
+}
+
+}  // namespace
+
+void selective_ssm(const void* A,
+                   const void* dt,
+                   const void* B,
+                   const void* x,
+                   const void* C,
+                   const void* recurrent_state,
+                   void* output,
+                   void* output_recurrent_state,
+                   const SelectiveSSMShape& shape,
+                   const ov::element::Type& precision,
+                   float* state_scratch,
+                   size_t scratch_head_dim,
+                   const CpuParallelPtr& cpu_parallel) {
+    OPENVINO_ASSERT(shape.num_groups > 0 && shape.num_heads % shape.num_groups == 0);
+    OPENVINO_ASSERT(shape.state_size > 0 && scratch_head_dim > 0 && state_scratch != nullptr);
+#define OV_CPU_SSM_CALL(DataT)                                       \
+    selective_ssm_typed(static_cast<const DataT*>(A),                \
+                        static_cast<const DataT*>(dt),               \
+                        static_cast<const DataT*>(B),                \
+                        static_cast<const DataT*>(x),                \
+                        static_cast<const DataT*>(C),                \
+                        static_cast<const DataT*>(recurrent_state),  \
+                        static_cast<DataT*>(output),                 \
+                        static_cast<DataT*>(output_recurrent_state), \
+                        shape,                                       \
+                        state_scratch,                               \
+                        scratch_head_dim,                            \
+                        cpu_parallel)
+    if (precision == ov::element::f32) {
+        OV_CPU_SSM_CALL(float);
+    } else if (precision == ov::element::f16) {
+        OV_CPU_SSM_CALL(ov::float16);
+    } else if (precision == ov::element::bf16) {
+        OV_CPU_SSM_CALL(ov::bfloat16);
+    } else {
+        OPENVINO_THROW("SelectiveSSM supports only f32/f16/bf16, got ", precision, ".");
+    }
+#undef OV_CPU_SSM_CALL
+}
+
+void paged_selective_ssm(const void* A,
+                         const void* dt,
+                         const void* B,
+                         const void* x,
+                         const void* C,
+                         void* recurrent_state_table,
+                         const void* subsequence_begins,
+                         const void* block_indices,
+                         const void* block_indices_begins,
+                         const void* num_processed_tokens,
+                         const void* cache_interval,
+                         void* output,
+                         const PagedSelectiveSSMShape& shape,
+                         const ov::element::Type& precision,
+                         const ov::element::Type& index_precision,
+                         float* state_scratch,
+                         size_t scratch_head_dim,
+                         int32_t* block_owners,
+                         const CpuParallelPtr& cpu_parallel) {
+    OPENVINO_ASSERT(shape.num_groups > 0 && shape.num_heads % shape.num_groups == 0);
+    OPENVINO_ASSERT(shape.state_size > 0 && scratch_head_dim > 0 && state_scratch != nullptr);
+    OPENVINO_ASSERT(shape.physical_block_count == 0 || block_owners != nullptr);
+    if (precision == ov::element::f32) {
+        dispatch_paged_index<float>(A,
+                                    dt,
+                                    B,
+                                    x,
+                                    C,
+                                    recurrent_state_table,
+                                    subsequence_begins,
+                                    block_indices,
+                                    block_indices_begins,
+                                    num_processed_tokens,
+                                    cache_interval,
+                                    output,
+                                    shape,
+                                    index_precision,
+                                    state_scratch,
+                                    scratch_head_dim,
+                                    block_owners,
+                                    cpu_parallel);
+    } else if (precision == ov::element::f16) {
+        dispatch_paged_index<ov::float16>(A,
+                                          dt,
+                                          B,
+                                          x,
+                                          C,
+                                          recurrent_state_table,
+                                          subsequence_begins,
+                                          block_indices,
+                                          block_indices_begins,
+                                          num_processed_tokens,
+                                          cache_interval,
+                                          output,
+                                          shape,
+                                          index_precision,
+                                          state_scratch,
+                                          scratch_head_dim,
+                                          block_owners,
+                                          cpu_parallel);
+    } else if (precision == ov::element::bf16) {
+        dispatch_paged_index<ov::bfloat16>(A,
+                                           dt,
+                                           B,
+                                           x,
+                                           C,
+                                           recurrent_state_table,
+                                           subsequence_begins,
+                                           block_indices,
+                                           block_indices_begins,
+                                           num_processed_tokens,
+                                           cache_interval,
+                                           output,
+                                           shape,
+                                           index_precision,
+                                           state_scratch,
+                                           scratch_head_dim,
+                                           block_owners,
+                                           cpu_parallel);
+    } else {
+        OPENVINO_THROW("PagedSelectiveSSM supports only f32/f16/bf16, got ", precision, ".");
+    }
+}
+
+}  // namespace ov::intel_cpu::node::kernel

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
@@ -623,6 +623,35 @@ void selective_ssm(const void* A,
 #undef OV_CPU_SSM_CALL
 }
 
+void validate_paged_selective_ssm_metadata(const void* subsequence_begins,
+                                           const void* block_indices,
+                                           const void* block_indices_begins,
+                                           const void* num_processed_tokens,
+                                           const void* cache_interval,
+                                           const PagedSelectiveSSMShape& shape,
+                                           const ov::element::Type& index_precision,
+                                           int32_t* block_owners) {
+    if (index_precision == ov::element::i32) {
+        validate_paged_metadata(static_cast<const int32_t*>(subsequence_begins),
+                                static_cast<const int32_t*>(block_indices),
+                                static_cast<const int32_t*>(block_indices_begins),
+                                static_cast<const int32_t*>(num_processed_tokens),
+                                static_cast<const int32_t*>(cache_interval),
+                                shape,
+                                block_owners);
+    } else if (index_precision == ov::element::i64) {
+        validate_paged_metadata(static_cast<const int64_t*>(subsequence_begins),
+                                static_cast<const int64_t*>(block_indices),
+                                static_cast<const int64_t*>(block_indices_begins),
+                                static_cast<const int64_t*>(num_processed_tokens),
+                                static_cast<const int64_t*>(cache_interval),
+                                shape,
+                                block_owners);
+    } else {
+        OPENVINO_THROW("PagedSelectiveSSM supports only i32/i64 metadata, got ", index_precision, ".");
+    }
+}
+
 void paged_selective_ssm(const void* A,
                          const void* dt,
                          const void* B,

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <type_traits>
 
@@ -32,12 +33,26 @@ inline void store(T* ptr, float value) {
 template <typename DataT>
 inline void copy_state_to_float(float* dst, const DataT* src, size_t count) {
     if constexpr (std::is_same_v<DataT, float>) {
-        if (dst == src) {
-            return;
+        if (dst != src) {
+            std::memcpy(dst, src, count * sizeof(float));
+        }
+    } else {
+        for (size_t i = 0; i < count; ++i) {
+            dst[i] = load(src + i);
         }
     }
-    for (size_t i = 0; i < count; ++i) {
-        dst[i] = load(src + i);
+}
+
+template <typename DataT>
+inline void copy_state_from_float(DataT* dst, const float* src, size_t count) {
+    if constexpr (std::is_same_v<DataT, float>) {
+        if (dst != src) {
+            std::memcpy(dst, src, count * sizeof(float));
+        }
+    } else {
+        for (size_t i = 0; i < count; ++i) {
+            store(dst + i, src[i]);
+        }
     }
 }
 
@@ -113,11 +128,7 @@ void selective_ssm_typed(const DataT* A,
                 local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
             }
 
-            for (size_t p = 0; p < p_count; ++p) {
-                const auto* src = recurrent_state + state_base + p * shape.state_size;
-                auto* dst = local_state + p * shape.state_size;
-                copy_state_to_float(dst, src, shape.state_size);
-            }
+            copy_state_to_float(local_state, recurrent_state + state_base, p_count * shape.state_size);
 
             const float A_head = load(A + head);
             auto token_head = (batch * shape.sequence_length) * shape.num_heads + head;
@@ -144,13 +155,9 @@ void selective_ssm_typed(const DataT* A,
             }
 
             if constexpr (!std::is_same_v<DataT, float>) {
-                for (size_t p = 0; p < p_count; ++p) {
-                    const auto* src = local_state + p * shape.state_size;
-                    auto* dst = output_recurrent_state + state_base + p * shape.state_size;
-                    for (size_t n = 0; n < shape.state_size; ++n) {
-                        store(dst + n, src[n]);
-                    }
-                }
+                copy_state_from_float(output_recurrent_state + state_base,
+                                      local_state,
+                                      p_count * shape.state_size);
             }
         });
 }
@@ -357,13 +364,7 @@ void paged_selective_ssm_typed(const DataT* A,
             const auto state_slice = head * head_stride + p_begin * shape.state_size;
             const auto* initial_state = recurrent_state_table + read_block * block_stride + state_slice;
 
-            for (size_t p = 0; p < p_count; ++p) {
-                const auto* src = initial_state + p * shape.state_size;
-                auto* dst = local_state + p * shape.state_size;
-                for (size_t n = 0; n < shape.state_size; ++n) {
-                    dst[n] = load(src + n);
-                }
-            }
+            copy_state_to_float(local_state, initial_state, p_count * shape.state_size);
 
             const float A_head = load(A + head);
             const auto interval = cache_interval[sequence];
@@ -399,13 +400,7 @@ void paged_selective_ssm_typed(const DataT* A,
                     if (is_boundary || is_last) {
                         const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + write_slot++]);
                         auto* snapshot = recurrent_state_table + write_block * block_stride + state_slice;
-                        for (size_t p = 0; p < p_count; ++p) {
-                            const auto* src = local_state + p * shape.state_size;
-                            auto* dst = snapshot + p * shape.state_size;
-                            for (size_t n = 0; n < shape.state_size; ++n) {
-                                store(dst + n, src[n]);
-                            }
-                        }
+                        copy_state_from_float(snapshot, local_state, p_count * shape.state_size);
                     }
                     if (is_boundary) {
                         tokens_until_boundary = positive_interval;

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <limits>
 #include <type_traits>
+#include <utility>
 
 #include "openvino/core/except.hpp"
 #include "openvino/core/parallel.hpp"
@@ -94,6 +95,111 @@ inline float initialize_state_and_reduce(float* state,
         result += updated_state * load(C + n);
     }
     return result;
+}
+
+template <typename DataT>
+inline float initialize_output_state_and_reduce(DataT* state,
+                                                const DataT* initial_state,
+                                                const DataT* B,
+                                                const DataT* C,
+                                                float decay,
+                                                float input_scale,
+                                                size_t state_size) {
+    float result0 = 0.F;
+    float result1 = 0.F;
+    float result2 = 0.F;
+    float result3 = 0.F;
+    size_t n = 0;
+    for (; n + 4 <= state_size; n += 4) {
+        const float updated_state0 = load(initial_state + n) * decay + input_scale * load(B + n);
+        const float updated_state1 = load(initial_state + n + 1) * decay + input_scale * load(B + n + 1);
+        const float updated_state2 = load(initial_state + n + 2) * decay + input_scale * load(B + n + 2);
+        const float updated_state3 = load(initial_state + n + 3) * decay + input_scale * load(B + n + 3);
+        store(state + n, updated_state0);
+        store(state + n + 1, updated_state1);
+        store(state + n + 2, updated_state2);
+        store(state + n + 3, updated_state3);
+        result0 += updated_state0 * load(C + n);
+        result1 += updated_state1 * load(C + n + 1);
+        result2 += updated_state2 * load(C + n + 2);
+        result3 += updated_state3 * load(C + n + 3);
+    }
+    float result = (result0 + result1) + (result2 + result3);
+    for (; n < state_size; ++n) {
+        const float updated_state = load(initial_state + n) * decay + input_scale * load(B + n);
+        store(state + n, updated_state);
+        result += updated_state * load(C + n);
+    }
+    return result;
+}
+
+template <typename StateOutT, typename StateInT, typename DataT>
+inline std::pair<float, float> update_state_pair_and_reduce(StateOutT* state0,
+                                                            StateOutT* state1,
+                                                            const StateInT* input_state0,
+                                                            const StateInT* input_state1,
+                                                            const DataT* B,
+                                                            const DataT* C,
+                                                            float decay,
+                                                            float input_scale0,
+                                                            float input_scale1,
+                                                            size_t state_size) {
+    float result00 = 0.F;
+    float result01 = 0.F;
+    float result02 = 0.F;
+    float result03 = 0.F;
+    float result10 = 0.F;
+    float result11 = 0.F;
+    float result12 = 0.F;
+    float result13 = 0.F;
+    size_t n = 0;
+    for (; n + 4 <= state_size; n += 4) {
+        const float b0 = load(B + n);
+        const float b1 = load(B + n + 1);
+        const float b2 = load(B + n + 2);
+        const float b3 = load(B + n + 3);
+        const float c0 = load(C + n);
+        const float c1 = load(C + n + 1);
+        const float c2 = load(C + n + 2);
+        const float c3 = load(C + n + 3);
+        const float updated00 = load(input_state0 + n) * decay + input_scale0 * b0;
+        const float updated01 = load(input_state0 + n + 1) * decay + input_scale0 * b1;
+        const float updated02 = load(input_state0 + n + 2) * decay + input_scale0 * b2;
+        const float updated03 = load(input_state0 + n + 3) * decay + input_scale0 * b3;
+        const float updated10 = load(input_state1 + n) * decay + input_scale1 * b0;
+        const float updated11 = load(input_state1 + n + 1) * decay + input_scale1 * b1;
+        const float updated12 = load(input_state1 + n + 2) * decay + input_scale1 * b2;
+        const float updated13 = load(input_state1 + n + 3) * decay + input_scale1 * b3;
+        store(state0 + n, updated00);
+        store(state0 + n + 1, updated01);
+        store(state0 + n + 2, updated02);
+        store(state0 + n + 3, updated03);
+        store(state1 + n, updated10);
+        store(state1 + n + 1, updated11);
+        store(state1 + n + 2, updated12);
+        store(state1 + n + 3, updated13);
+        result00 += updated00 * c0;
+        result01 += updated01 * c1;
+        result02 += updated02 * c2;
+        result03 += updated03 * c3;
+        result10 += updated10 * c0;
+        result11 += updated11 * c1;
+        result12 += updated12 * c2;
+        result13 += updated13 * c3;
+    }
+    float result0 = (result00 + result01) + (result02 + result03);
+    float result1 = (result10 + result11) + (result12 + result13);
+    for (; n < state_size; ++n) {
+        const float b = load(B + n);
+        const float c = load(C + n);
+        const float updated0 = load(input_state0 + n) * decay + input_scale0 * b;
+        const float updated1 = load(input_state1 + n) * decay + input_scale1 * b;
+        store(state0 + n, updated0);
+        store(state1 + n, updated1);
+        result0 += updated0 * c;
+        result1 += updated1 * c;
+    }
+    return {result0, result1};
 }
 
 template <typename DataT>
@@ -190,7 +296,26 @@ void selective_ssm_typed(const DataT* A,
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                for (size_t p = 0; p < p_count; ++p) {
+                size_t p = 0;
+                for (; p + 1 < p_count; p += 2) {
+                    auto* state0 = local_state + p * shape.state_size;
+                    auto* state1 = state0 + shape.state_size;
+                    const float input_scale0 = load(x + x_base + p) * delta;
+                    const float input_scale1 = load(x + x_base + p + 1) * delta;
+                    const auto result = update_state_pair_and_reduce(state0,
+                                                                     state1,
+                                                                     state0,
+                                                                     state1,
+                                                                     B_token,
+                                                                     C_token,
+                                                                     decay,
+                                                                     input_scale0,
+                                                                     input_scale1,
+                                                                     shape.state_size);
+                    store(output + x_base + p, result.first);
+                    store(output + x_base + p + 1, result.second);
+                }
+                if (p < p_count) {
                     auto* state = local_state + p * shape.state_size;
                     const float input_scale = load(x + x_base + p) * delta;
                     const float result =
@@ -211,7 +336,28 @@ void selective_ssm_typed(const DataT* A,
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                for (size_t p = 0; p < p_count; ++p) {
+                size_t p = 0;
+                for (; p + 1 < p_count; p += 2) {
+                    auto* state0 = local_state + p * shape.state_size;
+                    auto* state1 = state0 + shape.state_size;
+                    const auto* input_state0 = recurrent_state + state_base + p * shape.state_size;
+                    const auto* input_state1 = input_state0 + shape.state_size;
+                    const float input_scale0 = load(x + x_base + p) * delta;
+                    const float input_scale1 = load(x + x_base + p + 1) * delta;
+                    const auto result = update_state_pair_and_reduce(state0,
+                                                                     state1,
+                                                                     input_state0,
+                                                                     input_state1,
+                                                                     B_token,
+                                                                     C_token,
+                                                                     decay,
+                                                                     input_scale0,
+                                                                     input_scale1,
+                                                                     shape.state_size);
+                    store(output + x_base + p, result.first);
+                    store(output + x_base + p + 1, result.second);
+                }
+                if (p < p_count) {
                     auto* state = local_state + p * shape.state_size;
                     const float input_scale = load(x + x_base + p) * delta;
                     const float result =
@@ -234,7 +380,26 @@ void selective_ssm_typed(const DataT* A,
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                for (size_t p = 0; p < p_count; ++p) {
+                size_t p = 0;
+                for (; p + 1 < p_count; p += 2) {
+                    auto* state0 = local_state + p * shape.state_size;
+                    auto* state1 = state0 + shape.state_size;
+                    const float input_scale0 = load(x + x_base + p) * delta;
+                    const float input_scale1 = load(x + x_base + p + 1) * delta;
+                    const auto result = update_state_pair_and_reduce(state0,
+                                                                     state1,
+                                                                     state0,
+                                                                     state1,
+                                                                     B_token,
+                                                                     C_token,
+                                                                     decay,
+                                                                     input_scale0,
+                                                                     input_scale1,
+                                                                     shape.state_size);
+                    store(output + x_base + p, result.first);
+                    store(output + x_base + p + 1, result.second);
+                }
+                if (p < p_count) {
                     auto* state = local_state + p * shape.state_size;
                     const float input_scale = load(x + x_base + p) * delta;
                     const float result =
@@ -450,23 +615,64 @@ void paged_selective_ssm_typed(const DataT* A,
             const auto group = head / heads_per_group;
             const auto logical_block_begin = static_cast<size_t>(block_indices_begins[sequence]);
             const auto read_block = static_cast<size_t>(block_indices[logical_block_begin]);
-            auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
             const auto state_slice = head * head_stride + p_begin * shape.state_size;
             const auto* initial_state = recurrent_state_table + read_block * block_stride + state_slice;
-
-            copy_state_to_float(local_state, initial_state, p_count * shape.state_size);
-
             const float A_head = load(A + head);
             const auto interval = cache_interval[sequence];
             const bool cache_enabled = interval > 0;
-            const uint64_t positive_interval = cache_enabled ? static_cast<uint64_t>(interval) : 1;
-            const uint64_t cache_offset =
-                cache_enabled ? static_cast<uint64_t>(num_processed_tokens[sequence]) % positive_interval : 0;
             auto token_head = token_begin * shape.num_heads + head;
             auto projection_base = (token_begin * shape.num_groups + group) * shape.state_size;
             auto x_base = token_head * shape.head_dim + p_begin;
             const auto projection_stride = shape.num_groups * shape.state_size;
             const auto x_stride = shape.num_heads * shape.head_dim;
+
+            if (token_end - token_begin == 1 && cache_enabled) {
+                const float delta = load(dt + token_head);
+                const float decay = std::exp(A_head * delta);
+                const auto* B_token = B + projection_base;
+                const auto* C_token = C + projection_base;
+                const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + 1]);
+                auto* state_destination = recurrent_state_table + write_block * block_stride + state_slice;
+                size_t p = 0;
+                for (; p + 1 < p_count; p += 2) {
+                    auto* state0 = state_destination + p * shape.state_size;
+                    auto* state1 = state0 + shape.state_size;
+                    const auto* input_state0 = initial_state + p * shape.state_size;
+                    const auto* input_state1 = input_state0 + shape.state_size;
+                    const float input_scale0 = load(x + x_base + p) * delta;
+                    const float input_scale1 = load(x + x_base + p + 1) * delta;
+                    const auto result = update_state_pair_and_reduce(state0,
+                                                                     state1,
+                                                                     input_state0,
+                                                                     input_state1,
+                                                                     B_token,
+                                                                     C_token,
+                                                                     decay,
+                                                                     input_scale0,
+                                                                     input_scale1,
+                                                                     shape.state_size);
+                    store(output + x_base + p, result.first);
+                    store(output + x_base + p + 1, result.second);
+                }
+                if (p < p_count) {
+                    const float input_scale = load(x + x_base + p) * delta;
+                    const float result = initialize_output_state_and_reduce(state_destination + p * shape.state_size,
+                                                                            initial_state + p * shape.state_size,
+                                                                            B_token,
+                                                                            C_token,
+                                                                            decay,
+                                                                            input_scale,
+                                                                            shape.state_size);
+                    store(output + x_base + p, result);
+                }
+                return;
+            }
+
+            auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
+            copy_state_to_float(local_state, initial_state, p_count * shape.state_size);
+            const uint64_t positive_interval = cache_enabled ? static_cast<uint64_t>(interval) : 1;
+            const uint64_t cache_offset =
+                cache_enabled ? static_cast<uint64_t>(num_processed_tokens[sequence]) % positive_interval : 0;
             // Track cache boundaries incrementally to keep integer division out of the token loop.
             uint64_t tokens_until_boundary = cache_enabled ? positive_interval - cache_offset : 0;
             size_t write_slot = 1;
@@ -476,17 +682,31 @@ void paged_selective_ssm_typed(const DataT* A,
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                for (size_t p = 0; p < p_count; ++p) {
+                size_t p = 0;
+                for (; p + 1 < p_count; p += 2) {
+                    auto* state0 = local_state + p * shape.state_size;
+                    auto* state1 = state0 + shape.state_size;
+                    const float input_scale0 = load(x + x_base + p) * delta;
+                    const float input_scale1 = load(x + x_base + p + 1) * delta;
+                    const auto result = update_state_pair_and_reduce(state0,
+                                                                     state1,
+                                                                     state0,
+                                                                     state1,
+                                                                     B_token,
+                                                                     C_token,
+                                                                     decay,
+                                                                     input_scale0,
+                                                                     input_scale1,
+                                                                     shape.state_size);
+                    store(output + x_base + p, result.first);
+                    store(output + x_base + p + 1, result.second);
+                }
+                if (p < p_count) {
                     auto* state = local_state + p * shape.state_size;
                     const float input_scale = load(x + x_base + p) * delta;
                     const float result =
                         update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
                     store(output + x_base + p, result);
-                }
-                if (cache_enabled) {
-                    const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + write_slot]);
-                    auto* snapshot = recurrent_state_table + write_block * block_stride + state_slice;
-                    copy_state_from_float(snapshot, local_state, p_count * shape.state_size);
                 }
                 return;
             }
@@ -497,7 +717,26 @@ void paged_selective_ssm_typed(const DataT* A,
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
 
-                for (size_t p = 0; p < p_count; ++p) {
+                size_t p = 0;
+                for (; p + 1 < p_count; p += 2) {
+                    auto* state0 = local_state + p * shape.state_size;
+                    auto* state1 = state0 + shape.state_size;
+                    const float input_scale0 = load(x + x_base + p) * delta;
+                    const float input_scale1 = load(x + x_base + p + 1) * delta;
+                    const auto result = update_state_pair_and_reduce(state0,
+                                                                     state1,
+                                                                     state0,
+                                                                     state1,
+                                                                     B_token,
+                                                                     C_token,
+                                                                     decay,
+                                                                     input_scale0,
+                                                                     input_scale1,
+                                                                     shape.state_size);
+                    store(output + x_base + p, result.first);
+                    store(output + x_base + p + 1, result.second);
+                }
+                if (p < p_count) {
                     auto* state = local_state + p * shape.state_size;
                     const float input_scale = load(x + x_base + p) * delta;
                     const float result =

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
@@ -20,6 +20,8 @@
 namespace ov::intel_cpu::node::kernel {
 namespace {
 
+constexpr size_t target_scratch_elements = 8192;
+
 template <typename T>
 inline float load(const T* ptr) {
     return static_cast<float>(*ptr);
@@ -54,6 +56,44 @@ inline void copy_state_from_float(DataT* dst, const float* src, size_t count) {
             store(dst + i, src[i]);
         }
     }
+}
+
+template <typename DataT>
+inline float initialize_state_and_reduce(float* state,
+                                         const DataT* initial_state,
+                                         const DataT* B,
+                                         const DataT* C,
+                                         float decay,
+                                         float input_scale,
+                                         size_t state_size) {
+    // The first token can initialize the working state directly from the recurrent-state input. This avoids an
+    // otherwise redundant full-state copy followed immediately by a read/modify/write pass over the same buffer.
+    float result0 = 0.F;
+    float result1 = 0.F;
+    float result2 = 0.F;
+    float result3 = 0.F;
+    size_t n = 0;
+    for (; n + 4 <= state_size; n += 4) {
+        const float updated_state0 = load(initial_state + n) * decay + input_scale * load(B + n);
+        const float updated_state1 = load(initial_state + n + 1) * decay + input_scale * load(B + n + 1);
+        const float updated_state2 = load(initial_state + n + 2) * decay + input_scale * load(B + n + 2);
+        const float updated_state3 = load(initial_state + n + 3) * decay + input_scale * load(B + n + 3);
+        state[n] = updated_state0;
+        state[n + 1] = updated_state1;
+        state[n + 2] = updated_state2;
+        state[n + 3] = updated_state3;
+        result0 += updated_state0 * load(C + n);
+        result1 += updated_state1 * load(C + n + 1);
+        result2 += updated_state2 * load(C + n + 2);
+        result3 += updated_state3 * load(C + n + 3);
+    }
+    float result = (result0 + result1) + (result2 + result3);
+    for (; n < state_size; ++n) {
+        const float updated_state = load(initial_state + n) * decay + input_scale * load(B + n);
+        state[n] = updated_state;
+        result += updated_state * load(C + n);
+    }
+    return result;
 }
 
 template <typename DataT>
@@ -128,7 +168,14 @@ void selective_ssm_typed(const DataT* A,
                 local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
             }
 
-            copy_state_to_float(local_state, recurrent_state + state_base, p_count * shape.state_size);
+            if (shape.sequence_length == 0) {
+                auto* final_state = output_recurrent_state + state_base;
+                const auto* initial_state = recurrent_state + state_base;
+                if (final_state != initial_state) {
+                    std::memcpy(final_state, initial_state, p_count * shape.state_size * sizeof(DataT));
+                }
+                return;
+            }
 
             const float A_head = load(A + head);
             auto token_head = (batch * shape.sequence_length) * shape.num_heads + head;
@@ -136,12 +183,57 @@ void selective_ssm_typed(const DataT* A,
             auto x_base = token_head * shape.head_dim + p_begin;
             const auto projection_stride = shape.num_groups * shape.state_size;
             const auto x_stride = shape.num_heads * shape.head_dim;
-            for (size_t token = 0; token < shape.sequence_length; ++token) {
+
+            if (shape.sequence_length == 1) {
+                copy_state_to_float(local_state, recurrent_state + state_base, p_count * shape.state_size);
                 const float delta = load(dt + token_head);
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
+                for (size_t p = 0; p < p_count; ++p) {
+                    auto* state = local_state + p * shape.state_size;
+                    const float input_scale = load(x + x_base + p) * delta;
+                    const float result =
+                        update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
+                    store(output + x_base + p, result);
+                }
+                if constexpr (!std::is_same_v<DataT, float>) {
+                    copy_state_from_float(output_recurrent_state + state_base, local_state, p_count * shape.state_size);
+                }
+                return;
+            }
 
+            // Initialize the working state directly while processing the first token. Apart from removing a full
+            // state copy, keeping the first iteration out of the recurrent loop removes the first-token condition
+            // from longer sequences. Decode keeps the memcpy-based path above because it is faster on some CPUs.
+            {
+                const float delta = load(dt + token_head);
+                const float decay = std::exp(A_head * delta);
+                const auto* B_token = B + projection_base;
+                const auto* C_token = C + projection_base;
+                for (size_t p = 0; p < p_count; ++p) {
+                    auto* state = local_state + p * shape.state_size;
+                    const float input_scale = load(x + x_base + p) * delta;
+                    const float result =
+                        initialize_state_and_reduce(state,
+                                                    recurrent_state + state_base + p * shape.state_size,
+                                                    B_token,
+                                                    C_token,
+                                                    decay,
+                                                    input_scale,
+                                                    shape.state_size);
+                    store(output + x_base + p, result);
+                }
+            }
+
+            token_head += shape.num_heads;
+            projection_base += projection_stride;
+            x_base += x_stride;
+            for (size_t token = 1; token < shape.sequence_length; ++token) {
+                const float delta = load(dt + token_head);
+                const float decay = std::exp(A_head * delta);
+                const auto* B_token = B + projection_base;
+                const auto* C_token = C + projection_base;
                 for (size_t p = 0; p < p_count; ++p) {
                     auto* state = local_state + p * shape.state_size;
                     const float input_scale = load(x + x_base + p) * delta;
@@ -155,9 +247,7 @@ void selective_ssm_typed(const DataT* A,
             }
 
             if constexpr (!std::is_same_v<DataT, float>) {
-                copy_state_from_float(output_recurrent_state + state_base,
-                                      local_state,
-                                      p_count * shape.state_size);
+                copy_state_from_float(output_recurrent_state + state_base, local_state, p_count * shape.state_size);
             }
         });
 }
@@ -380,6 +470,27 @@ void paged_selective_ssm_typed(const DataT* A,
             // Track cache boundaries incrementally to keep integer division out of the token loop.
             uint64_t tokens_until_boundary = cache_enabled ? positive_interval - cache_offset : 0;
             size_t write_slot = 1;
+
+            if (token_end - token_begin == 1) {
+                const float delta = load(dt + token_head);
+                const float decay = std::exp(A_head * delta);
+                const auto* B_token = B + projection_base;
+                const auto* C_token = C + projection_base;
+                for (size_t p = 0; p < p_count; ++p) {
+                    auto* state = local_state + p * shape.state_size;
+                    const float input_scale = load(x + x_base + p) * delta;
+                    const float result =
+                        update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
+                    store(output + x_base + p, result);
+                }
+                if (cache_enabled) {
+                    const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + write_slot]);
+                    auto* snapshot = recurrent_state_table + write_block * block_stride + state_slice;
+                    copy_state_from_float(snapshot, local_state, p_count * shape.state_size);
+                }
+                return;
+            }
+
             for (size_t token = token_begin; token < token_end; ++token) {
                 const float delta = load(dt + token_head);
                 const float decay = std::exp(A_head * delta);
@@ -461,6 +572,16 @@ void dispatch_paged_index(const void* A,
 }
 
 }  // namespace
+
+size_t get_scratch_head_dim(size_t head_dim, size_t state_size, size_t outer_work_items, size_t thread_count) {
+    OPENVINO_ASSERT(head_dim > 0 && state_size > 0);
+    const auto cache_limited = std::max(size_t{1}, std::min(head_dim, target_scratch_elements / state_size));
+    const auto outer_work = std::max(size_t{1}, outer_work_items);
+    const auto workers = std::max(size_t{1}, thread_count);
+    const auto blocks_for_parallelism = (workers + outer_work - 1) / outer_work;
+    const auto parallelism_limited = (head_dim + blocks_for_parallelism - 1) / blocks_for_parallelism;
+    return std::max(size_t{1}, std::min(cache_limited, parallelism_limited));
+}
 
 void selective_ssm(const void* A,
                    const void* dt,

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
@@ -17,20 +17,118 @@
 #include "openvino/core/parallel.hpp"
 #include "openvino/core/type/bfloat16.hpp"
 #include "openvino/core/type/float16.hpp"
+#include "utils/cpp/bit_cast.hpp"
 
 namespace ov::intel_cpu::node::kernel {
 namespace {
 
 constexpr size_t target_scratch_elements = 8192;
 
+size_t ceil_div(size_t value, size_t divisor) {
+    return value / divisor + static_cast<size_t>(value % divisor != 0);
+}
+
 template <typename T>
 inline float load(const T* ptr) {
     return static_cast<float>(*ptr);
 }
 
+template <>
+inline float load(const ov::float16* ptr) {
+    const auto value = bit_cast<uint16_t>(*ptr);
+    uint32_t exponent = 0x1FU & (value >> ov::float16::frac_size);
+    uint32_t float_exponent = exponent + 127U - ov::float16::exp_bias;
+    uint32_t fraction = value & 0x03FFU;
+    if (exponent == 0) {
+        if (fraction == 0) {
+            float_exponent = 0;
+        } else {
+            ++float_exponent;
+            while ((fraction & 0x0400U) == 0) {
+                --float_exponent;
+                fraction <<= 1U;
+            }
+            fraction &= 0x03FFU;
+        }
+    } else if (exponent == 0x1FU) {
+        float_exponent = 0xFFU;
+    }
+    fraction <<= 23U - ov::float16::frac_size;
+    const uint32_t bits = (static_cast<uint32_t>(value & 0x8000U) << 16U) | (float_exponent << 23U) | fraction;
+    return bit_cast<float>(bits);
+}
+
+template <>
+inline float load(const ov::bfloat16* ptr) {
+    const auto value = bit_cast<uint16_t>(*ptr);
+    const uint32_t bits = static_cast<uint32_t>(value) << 16U;
+    return bit_cast<float>(bits);
+}
+
 template <typename T>
 inline void store(T* ptr, float value) {
     *ptr = static_cast<T>(value);
+}
+
+template <>
+inline void store(ov::float16* ptr, float value) {
+    const auto bits = bit_cast<uint32_t>(value);
+    constexpr uint32_t sign_mask = 0x80000000U;
+    constexpr uint32_t f32_exponent_mask = 0x7F800000U;
+    constexpr uint32_t f32_fraction_mask = 0x007FFFFFU;
+    constexpr uint32_t f16_exponent_mask = 0x7C000000U;
+    constexpr uint32_t f16_fraction_mask = 0x03FF0000U;
+    constexpr uint32_t half_round_mask = 0x0001FFFFU;
+    constexpr uint32_t normal_round_mask = 0x00007FFFU;
+    constexpr uint32_t even_round_bit = 0x00008000U;
+    constexpr uint32_t odd_round_value = 0x00018000U;
+
+    const uint32_t biased_exponent_f32 = bits & f32_exponent_mask;
+    uint32_t fraction = (bits & f32_fraction_mask) << 3U;
+    uint16_t result = 0;
+    if (biased_exponent_f32 == f32_exponent_mask) {
+        if (fraction != 0) {
+            fraction &= f16_fraction_mask;
+            if (fraction == 0) {
+                fraction = 0x00010000U;
+            }
+        }
+        result = static_cast<uint16_t>(((bits & sign_mask) | f16_exponent_mask | fraction) >> 16U);
+    } else if (biased_exponent_f32 == 0) {
+        result = static_cast<uint16_t>((bits & sign_mask) >> 16U);
+    } else {
+        int16_t biased_exponent_f16 = static_cast<int16_t>(static_cast<int32_t>(biased_exponent_f32 >> 23U) - 127 +
+                                                           static_cast<int32_t>(ov::float16::exp_bias));
+        if ((fraction & half_round_mask) == odd_round_value || (fraction & normal_round_mask) != 0) {
+            fraction += even_round_bit;
+            if ((fraction & f16_exponent_mask) != 0) {
+                fraction &= f16_exponent_mask;
+                ++biased_exponent_f16;
+            }
+        }
+        fraction &= f16_fraction_mask;
+        if (biased_exponent_f16 > 30) {
+            result = static_cast<uint16_t>(((bits & sign_mask) | f16_exponent_mask) >> 16U);
+        } else if (biased_exponent_f16 > 0) {
+            result = static_cast<uint16_t>(
+                ((bits & sign_mask) | (static_cast<uint32_t>(biased_exponent_f16) << 26U) | fraction) >> 16U);
+        } else {
+            fraction = 0x04000000U | ((bits & f32_fraction_mask) << 3U);
+            const uint32_t shift = biased_exponent_f16 < -30 ? 0U : (uint32_t{1} << (1 - biased_exponent_f16));
+            const uint32_t sticky = (fraction & (shift - 1U)) != 0 ? 1U : 0U;
+            if (1 + (-biased_exponent_f16) > 31) {
+                fraction = 0;
+            } else {
+                fraction >>= 1 + (-biased_exponent_f16);
+            }
+            fraction |= sticky;
+            if ((fraction & half_round_mask) == odd_round_value || (fraction & normal_round_mask) != 0) {
+                fraction += even_round_bit;
+            }
+            result = static_cast<uint16_t>(((bits & sign_mask) | fraction) >> 16U);
+        }
+    }
+    *ptr = ov::float16::from_bits(result);
 }
 
 template <typename DataT>
@@ -59,30 +157,32 @@ inline void copy_state_from_float(DataT* dst, const float* src, size_t count) {
     }
 }
 
-template <typename DataT>
-inline float initialize_state_and_reduce(float* state,
-                                         const DataT* initial_state,
-                                         const DataT* B,
-                                         const DataT* C,
-                                         float decay,
-                                         float input_scale,
-                                         size_t state_size) {
-    // The first token can initialize the working state directly from the recurrent-state input. This avoids an
-    // otherwise redundant full-state copy followed immediately by a read/modify/write pass over the same buffer.
+template <bool StoreState = true, typename StateOutT, typename StateInT, typename ProjectionT>
+inline float update_state_and_reduce(StateOutT* state,
+                                     const StateInT* input_state,
+                                     const ProjectionT* B,
+                                     const ProjectionT* C,
+                                     float decay,
+                                     float input_scale,
+                                     size_t state_size) {
+    // Four independent reduction chains expose instruction-level parallelism to any optimizing compiler. Supporting
+    // different input/output types also lets decode write its final state directly without an intermediate copy.
     float result0 = 0.F;
     float result1 = 0.F;
     float result2 = 0.F;
     float result3 = 0.F;
     size_t n = 0;
     for (; n + 4 <= state_size; n += 4) {
-        const float updated_state0 = load(initial_state + n) * decay + input_scale * load(B + n);
-        const float updated_state1 = load(initial_state + n + 1) * decay + input_scale * load(B + n + 1);
-        const float updated_state2 = load(initial_state + n + 2) * decay + input_scale * load(B + n + 2);
-        const float updated_state3 = load(initial_state + n + 3) * decay + input_scale * load(B + n + 3);
-        state[n] = updated_state0;
-        state[n + 1] = updated_state1;
-        state[n + 2] = updated_state2;
-        state[n + 3] = updated_state3;
+        const float updated_state0 = load(input_state + n) * decay + input_scale * load(B + n);
+        const float updated_state1 = load(input_state + n + 1) * decay + input_scale * load(B + n + 1);
+        const float updated_state2 = load(input_state + n + 2) * decay + input_scale * load(B + n + 2);
+        const float updated_state3 = load(input_state + n + 3) * decay + input_scale * load(B + n + 3);
+        if constexpr (StoreState) {
+            store(state + n, updated_state0);
+            store(state + n + 1, updated_state1);
+            store(state + n + 2, updated_state2);
+            store(state + n + 3, updated_state3);
+        }
         result0 += updated_state0 * load(C + n);
         result1 += updated_state1 * load(C + n + 1);
         result2 += updated_state2 * load(C + n + 2);
@@ -90,56 +190,22 @@ inline float initialize_state_and_reduce(float* state,
     }
     float result = (result0 + result1) + (result2 + result3);
     for (; n < state_size; ++n) {
-        const float updated_state = load(initial_state + n) * decay + input_scale * load(B + n);
-        state[n] = updated_state;
+        const float updated_state = load(input_state + n) * decay + input_scale * load(B + n);
+        if constexpr (StoreState) {
+            store(state + n, updated_state);
+        }
         result += updated_state * load(C + n);
     }
     return result;
 }
 
-template <typename DataT>
-inline float initialize_output_state_and_reduce(DataT* state,
-                                                const DataT* initial_state,
-                                                const DataT* B,
-                                                const DataT* C,
-                                                float decay,
-                                                float input_scale,
-                                                size_t state_size) {
-    float result0 = 0.F;
-    float result1 = 0.F;
-    float result2 = 0.F;
-    float result3 = 0.F;
-    size_t n = 0;
-    for (; n + 4 <= state_size; n += 4) {
-        const float updated_state0 = load(initial_state + n) * decay + input_scale * load(B + n);
-        const float updated_state1 = load(initial_state + n + 1) * decay + input_scale * load(B + n + 1);
-        const float updated_state2 = load(initial_state + n + 2) * decay + input_scale * load(B + n + 2);
-        const float updated_state3 = load(initial_state + n + 3) * decay + input_scale * load(B + n + 3);
-        store(state + n, updated_state0);
-        store(state + n + 1, updated_state1);
-        store(state + n + 2, updated_state2);
-        store(state + n + 3, updated_state3);
-        result0 += updated_state0 * load(C + n);
-        result1 += updated_state1 * load(C + n + 1);
-        result2 += updated_state2 * load(C + n + 2);
-        result3 += updated_state3 * load(C + n + 3);
-    }
-    float result = (result0 + result1) + (result2 + result3);
-    for (; n < state_size; ++n) {
-        const float updated_state = load(initial_state + n) * decay + input_scale * load(B + n);
-        store(state + n, updated_state);
-        result += updated_state * load(C + n);
-    }
-    return result;
-}
-
-template <typename StateOutT, typename StateInT, typename DataT>
+template <bool StoreState = true, typename StateOutT, typename StateInT, typename ProjectionT>
 inline std::pair<float, float> update_state_pair_and_reduce(StateOutT* state0,
                                                             StateOutT* state1,
                                                             const StateInT* input_state0,
                                                             const StateInT* input_state1,
-                                                            const DataT* B,
-                                                            const DataT* C,
+                                                            const ProjectionT* B,
+                                                            const ProjectionT* C,
                                                             float decay,
                                                             float input_scale0,
                                                             float input_scale1,
@@ -170,14 +236,16 @@ inline std::pair<float, float> update_state_pair_and_reduce(StateOutT* state0,
         const float updated11 = load(input_state1 + n + 1) * decay + input_scale1 * b1;
         const float updated12 = load(input_state1 + n + 2) * decay + input_scale1 * b2;
         const float updated13 = load(input_state1 + n + 3) * decay + input_scale1 * b3;
-        store(state0 + n, updated00);
-        store(state0 + n + 1, updated01);
-        store(state0 + n + 2, updated02);
-        store(state0 + n + 3, updated03);
-        store(state1 + n, updated10);
-        store(state1 + n + 1, updated11);
-        store(state1 + n + 2, updated12);
-        store(state1 + n + 3, updated13);
+        if constexpr (StoreState) {
+            store(state0 + n, updated00);
+            store(state0 + n + 1, updated01);
+            store(state0 + n + 2, updated02);
+            store(state0 + n + 3, updated03);
+            store(state1 + n, updated10);
+            store(state1 + n + 1, updated11);
+            store(state1 + n + 2, updated12);
+            store(state1 + n + 3, updated13);
+        }
         result00 += updated00 * c0;
         result01 += updated01 * c1;
         result02 += updated02 * c2;
@@ -194,57 +262,76 @@ inline std::pair<float, float> update_state_pair_and_reduce(StateOutT* state0,
         const float c = load(C + n);
         const float updated0 = load(input_state0 + n) * decay + input_scale0 * b;
         const float updated1 = load(input_state1 + n) * decay + input_scale1 * b;
-        store(state0 + n, updated0);
-        store(state1 + n, updated1);
+        if constexpr (StoreState) {
+            store(state0 + n, updated0);
+            store(state1 + n, updated1);
+        }
         result0 += updated0 * c;
         result1 += updated1 * c;
     }
     return {result0, result1};
 }
 
-template <typename DataT>
-inline float update_state_and_reduce(float* state,
-                                     const DataT* B,
-                                     const DataT* C,
-                                     float decay,
-                                     float input_scale,
-                                     size_t state_size) {
-    // Keep four independent reduction chains to expose instruction-level parallelism to any optimizing compiler
-    // without relying on a target ISA. Fusing the update and reduction also keeps the new state cache-resident.
-    float result0 = 0.F;
-    float result1 = 0.F;
-    float result2 = 0.F;
-    float result3 = 0.F;
-    size_t n = 0;
-    for (; n + 4 <= state_size; n += 4) {
-        const float updated_state0 = state[n] * decay + input_scale * load(B + n);
-        const float updated_state1 = state[n + 1] * decay + input_scale * load(B + n + 1);
-        const float updated_state2 = state[n + 2] * decay + input_scale * load(B + n + 2);
-        const float updated_state3 = state[n + 3] * decay + input_scale * load(B + n + 3);
-        state[n] = updated_state0;
-        state[n + 1] = updated_state1;
-        state[n + 2] = updated_state2;
-        state[n + 3] = updated_state3;
-        result0 += updated_state0 * load(C + n);
-        result1 += updated_state1 * load(C + n + 1);
-        result2 += updated_state2 * load(C + n + 2);
-        result3 += updated_state3 * load(C + n + 3);
+template <bool StoreState = true, typename StateOutT, typename StateInT, typename DataT, typename ProjectionT>
+inline void update_state_slices_and_reduce(StateOutT* state,
+                                           const StateInT* input_state,
+                                           const DataT* x,
+                                           DataT* output,
+                                           const ProjectionT* B,
+                                           const ProjectionT* C,
+                                           float decay,
+                                           float delta,
+                                           size_t x_base,
+                                           size_t p_count,
+                                           size_t state_size) {
+    size_t p = 0;
+    for (; p + 1 < p_count; p += 2) {
+        StateOutT* state0 = nullptr;
+        StateOutT* state1 = nullptr;
+        if constexpr (StoreState) {
+            state0 = state + p * state_size;
+            state1 = state0 + state_size;
+        }
+        const auto* input_state0 = input_state + p * state_size;
+        const auto* input_state1 = input_state0 + state_size;
+        const float input_scale0 = load(x + x_base + p) * delta;
+        const float input_scale1 = load(x + x_base + p + 1) * delta;
+        const auto result = update_state_pair_and_reduce<StoreState>(state0,
+                                                                     state1,
+                                                                     input_state0,
+                                                                     input_state1,
+                                                                     B,
+                                                                     C,
+                                                                     decay,
+                                                                     input_scale0,
+                                                                     input_scale1,
+                                                                     state_size);
+        store(output + x_base + p, result.first);
+        store(output + x_base + p + 1, result.second);
     }
-    float result = (result0 + result1) + (result2 + result3);
-    for (; n < state_size; ++n) {
-        const float updated_state = state[n] * decay + input_scale * load(B + n);
-        state[n] = updated_state;
-        result += updated_state * load(C + n);
+    if (p < p_count) {
+        const float input_scale = load(x + x_base + p) * delta;
+        StateOutT* state_tail = nullptr;
+        if constexpr (StoreState) {
+            state_tail = state + p * state_size;
+        }
+        const float result = update_state_and_reduce<StoreState>(state_tail,
+                                                                 input_state + p * state_size,
+                                                                 B,
+                                                                 C,
+                                                                 decay,
+                                                                 input_scale,
+                                                                 state_size);
+        store(output + x_base + p, result);
     }
-    return result;
 }
 
-template <typename DataT>
+template <typename DataT, typename ProjectionT>
 void selective_ssm_typed(const DataT* A,
                          const DataT* dt,
-                         const DataT* B,
+                         const ProjectionT* B,
                          const DataT* x,
-                         const DataT* C,
+                         const ProjectionT* C,
                          const DataT* recurrent_state,
                          DataT* output,
                          DataT* output_recurrent_state,
@@ -252,16 +339,16 @@ void selective_ssm_typed(const DataT* A,
                          float* state_scratch,
                          size_t scratch_head_dim,
                          const CpuParallelPtr& cpu_parallel) {
-    const auto BHS = shape.num_heads * shape.head_dim * shape.state_size;
-    const auto HS = shape.head_dim * shape.state_size;
-    const auto scratch_stride = scratch_head_dim * shape.state_size;
+    const auto BHS = checked_size_product({shape.num_heads, shape.head_dim, shape.state_size}, "recurrent state batch");
+    const auto HS = checked_size_product({shape.head_dim, shape.state_size}, "recurrent state head");
+    const auto scratch_stride = checked_size_product({scratch_head_dim, shape.state_size}, "state scratch");
     const auto heads_per_group = shape.num_heads / shape.num_groups;
-    const auto p_block_count = (shape.head_dim + scratch_head_dim - 1) / scratch_head_dim;
+    const auto p_block_count = ceil_div(shape.head_dim, scratch_head_dim);
 
     cpu_parallel
         ->parallel_for3d(shape.batch_size, shape.num_heads, p_block_count, [&](size_t batch, size_t head, size_t pb) {
             const auto p_begin = pb * scratch_head_dim;
-            const auto p_end = std::min(p_begin + scratch_head_dim, shape.head_dim);
+            const auto p_end = p_begin + std::min(scratch_head_dim, shape.head_dim - p_begin);
             const auto p_count = p_end - p_begin;
             const auto group = head / heads_per_group;
             const auto state_base = batch * BHS + head * HS + p_begin * shape.state_size;
@@ -291,85 +378,60 @@ void selective_ssm_typed(const DataT* A,
             const auto x_stride = shape.num_heads * shape.head_dim;
 
             if (shape.sequence_length == 1) {
-                copy_state_to_float(local_state, recurrent_state + state_base, p_count * shape.state_size);
                 const float delta = load(dt + token_head);
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                size_t p = 0;
-                for (; p + 1 < p_count; p += 2) {
-                    auto* state0 = local_state + p * shape.state_size;
-                    auto* state1 = state0 + shape.state_size;
-                    const float input_scale0 = load(x + x_base + p) * delta;
-                    const float input_scale1 = load(x + x_base + p + 1) * delta;
-                    const auto result = update_state_pair_and_reduce(state0,
-                                                                     state1,
-                                                                     state0,
-                                                                     state1,
-                                                                     B_token,
-                                                                     C_token,
-                                                                     decay,
-                                                                     input_scale0,
-                                                                     input_scale1,
-                                                                     shape.state_size);
-                    store(output + x_base + p, result.first);
-                    store(output + x_base + p + 1, result.second);
-                }
-                if (p < p_count) {
-                    auto* state = local_state + p * shape.state_size;
-                    const float input_scale = load(x + x_base + p) * delta;
-                    const float result =
-                        update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
-                    store(output + x_base + p, result);
-                }
-                if constexpr (!std::is_same_v<DataT, float>) {
-                    copy_state_from_float(output_recurrent_state + state_base, local_state, p_count * shape.state_size);
+                if constexpr (std::is_same_v<DataT, float>) {
+                    copy_state_to_float(local_state, recurrent_state + state_base, p_count * shape.state_size);
+                    update_state_slices_and_reduce(local_state,
+                                                   local_state,
+                                                   x,
+                                                   output,
+                                                   B_token,
+                                                   C_token,
+                                                   decay,
+                                                   delta,
+                                                   x_base,
+                                                   p_count,
+                                                   shape.state_size);
+                } else {
+                    // Unlike prefill, decode does not need persistent FP32 state between tokens. Write the final
+                    // low-precision state directly and avoid conversion passes through the per-worker scratchpad.
+                    update_state_slices_and_reduce(output_recurrent_state + state_base,
+                                                   recurrent_state + state_base,
+                                                   x,
+                                                   output,
+                                                   B_token,
+                                                   C_token,
+                                                   decay,
+                                                   delta,
+                                                   x_base,
+                                                   p_count,
+                                                   shape.state_size);
                 }
                 return;
             }
 
             // Initialize the working state directly while processing the first token. Apart from removing a full
             // state copy, keeping the first iteration out of the recurrent loop removes the first-token condition
-            // from longer sequences. Decode keeps the memcpy-based path above because it is faster on some CPUs.
+            // from longer sequences.
             {
                 const float delta = load(dt + token_head);
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                size_t p = 0;
-                for (; p + 1 < p_count; p += 2) {
-                    auto* state0 = local_state + p * shape.state_size;
-                    auto* state1 = state0 + shape.state_size;
-                    const auto* input_state0 = recurrent_state + state_base + p * shape.state_size;
-                    const auto* input_state1 = input_state0 + shape.state_size;
-                    const float input_scale0 = load(x + x_base + p) * delta;
-                    const float input_scale1 = load(x + x_base + p + 1) * delta;
-                    const auto result = update_state_pair_and_reduce(state0,
-                                                                     state1,
-                                                                     input_state0,
-                                                                     input_state1,
-                                                                     B_token,
-                                                                     C_token,
-                                                                     decay,
-                                                                     input_scale0,
-                                                                     input_scale1,
-                                                                     shape.state_size);
-                    store(output + x_base + p, result.first);
-                    store(output + x_base + p + 1, result.second);
-                }
-                if (p < p_count) {
-                    auto* state = local_state + p * shape.state_size;
-                    const float input_scale = load(x + x_base + p) * delta;
-                    const float result =
-                        initialize_state_and_reduce(state,
-                                                    recurrent_state + state_base + p * shape.state_size,
-                                                    B_token,
-                                                    C_token,
-                                                    decay,
-                                                    input_scale,
-                                                    shape.state_size);
-                    store(output + x_base + p, result);
-                }
+                update_state_slices_and_reduce(local_state,
+                                               recurrent_state + state_base,
+                                               x,
+                                               output,
+                                               B_token,
+                                               C_token,
+                                               decay,
+                                               delta,
+                                               x_base,
+                                               p_count,
+                                               shape.state_size);
             }
 
             token_head += shape.num_heads;
@@ -380,32 +442,17 @@ void selective_ssm_typed(const DataT* A,
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                size_t p = 0;
-                for (; p + 1 < p_count; p += 2) {
-                    auto* state0 = local_state + p * shape.state_size;
-                    auto* state1 = state0 + shape.state_size;
-                    const float input_scale0 = load(x + x_base + p) * delta;
-                    const float input_scale1 = load(x + x_base + p + 1) * delta;
-                    const auto result = update_state_pair_and_reduce(state0,
-                                                                     state1,
-                                                                     state0,
-                                                                     state1,
-                                                                     B_token,
-                                                                     C_token,
-                                                                     decay,
-                                                                     input_scale0,
-                                                                     input_scale1,
-                                                                     shape.state_size);
-                    store(output + x_base + p, result.first);
-                    store(output + x_base + p + 1, result.second);
-                }
-                if (p < p_count) {
-                    auto* state = local_state + p * shape.state_size;
-                    const float input_scale = load(x + x_base + p) * delta;
-                    const float result =
-                        update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
-                    store(output + x_base + p, result);
-                }
+                update_state_slices_and_reduce(local_state,
+                                               local_state,
+                                               x,
+                                               output,
+                                               B_token,
+                                               C_token,
+                                               decay,
+                                               delta,
+                                               x_base,
+                                               p_count,
+                                               shape.state_size);
                 token_head += shape.num_heads;
                 projection_base += projection_stride;
                 x_base += x_stride;
@@ -519,15 +566,13 @@ void validate_paged_metadata(const IndexT* subsequence_begins,
                         ".");
         const auto cached_token_count = offset + token_count;
         const auto write_count = (cached_token_count - 1) / positive_interval + 1;
-        OPENVINO_ASSERT(block_end - block_begin >= write_count + 1,
+        OPENVINO_ASSERT(block_end - block_begin - 1 >= write_count,
                         "PagedSelectiveSSM: sequence ",
                         s,
                         " requires ",
-                        write_count + 1,
-                        " logical blocks (one read plus ",
                         write_count,
-                        " writes), got ",
-                        block_end - block_begin,
+                        " writable logical blocks after the read block, got ",
+                        block_end - block_begin - 1,
                         ".");
 
         for (uint64_t slot = 1; slot <= write_count; ++slot) {
@@ -566,12 +611,12 @@ void validate_paged_metadata(const IndexT* subsequence_begins,
     }
 }
 
-template <typename DataT, typename IndexT>
+template <typename DataT, typename ProjectionT, typename IndexT>
 void paged_selective_ssm_typed(const DataT* A,
                                const DataT* dt,
-                               const DataT* B,
+                               const ProjectionT* B,
                                const DataT* x,
-                               const DataT* C,
+                               const ProjectionT* C,
                                DataT* recurrent_state_table,
                                const IndexT* subsequence_begins,
                                const IndexT* block_indices,
@@ -592,11 +637,11 @@ void paged_selective_ssm_typed(const DataT* A,
                             shape,
                             block_owners);
 
-    const auto block_stride = shape.num_heads * shape.head_dim * shape.state_size;
-    const auto head_stride = shape.head_dim * shape.state_size;
-    const auto scratch_stride = scratch_head_dim * shape.state_size;
+    const auto block_stride = checked_size_product({shape.num_heads, shape.head_dim, shape.state_size}, "state block");
+    const auto head_stride = checked_size_product({shape.head_dim, shape.state_size}, "state head");
+    const auto scratch_stride = checked_size_product({scratch_head_dim, shape.state_size}, "state scratch");
     const auto heads_per_group = shape.num_heads / shape.num_groups;
-    const auto p_block_count = (shape.head_dim + scratch_head_dim - 1) / scratch_head_dim;
+    const auto p_block_count = ceil_div(shape.head_dim, scratch_head_dim);
 
     cpu_parallel->parallel_for3d(
         shape.sequence_count,
@@ -610,7 +655,7 @@ void paged_selective_ssm_typed(const DataT* A,
             }
 
             const auto p_begin = pb * scratch_head_dim;
-            const auto p_end = std::min(p_begin + scratch_head_dim, shape.head_dim);
+            const auto p_end = p_begin + std::min(scratch_head_dim, shape.head_dim - p_begin);
             const auto p_count = p_end - p_begin;
             const auto group = head / heads_per_group;
             const auto logical_block_begin = static_cast<size_t>(block_indices_begins[sequence]);
@@ -626,50 +671,45 @@ void paged_selective_ssm_typed(const DataT* A,
             const auto projection_stride = shape.num_groups * shape.state_size;
             const auto x_stride = shape.num_heads * shape.head_dim;
 
-            if (token_end - token_begin == 1 && cache_enabled) {
+            const auto sequence_length = token_end - token_begin;
+            if (sequence_length == 1) {
                 const float delta = load(dt + token_head);
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + 1]);
-                auto* state_destination = recurrent_state_table + write_block * block_stride + state_slice;
-                size_t p = 0;
-                for (; p + 1 < p_count; p += 2) {
-                    auto* state0 = state_destination + p * shape.state_size;
-                    auto* state1 = state0 + shape.state_size;
-                    const auto* input_state0 = initial_state + p * shape.state_size;
-                    const auto* input_state1 = input_state0 + shape.state_size;
-                    const float input_scale0 = load(x + x_base + p) * delta;
-                    const float input_scale1 = load(x + x_base + p + 1) * delta;
-                    const auto result = update_state_pair_and_reduce(state0,
-                                                                     state1,
-                                                                     input_state0,
-                                                                     input_state1,
-                                                                     B_token,
-                                                                     C_token,
-                                                                     decay,
-                                                                     input_scale0,
-                                                                     input_scale1,
-                                                                     shape.state_size);
-                    store(output + x_base + p, result.first);
-                    store(output + x_base + p + 1, result.second);
-                }
-                if (p < p_count) {
-                    const float input_scale = load(x + x_base + p) * delta;
-                    const float result = initialize_output_state_and_reduce(state_destination + p * shape.state_size,
-                                                                            initial_state + p * shape.state_size,
-                                                                            B_token,
-                                                                            C_token,
-                                                                            decay,
-                                                                            input_scale,
-                                                                            shape.state_size);
-                    store(output + x_base + p, result);
+                if (cache_enabled) {
+                    const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + 1]);
+                    auto* state_destination = recurrent_state_table + write_block * block_stride + state_slice;
+                    update_state_slices_and_reduce(state_destination,
+                                                   initial_state,
+                                                   x,
+                                                   output,
+                                                   B_token,
+                                                   C_token,
+                                                   decay,
+                                                   delta,
+                                                   x_base,
+                                                   p_count,
+                                                   shape.state_size);
+                } else {
+                    // With no cache destination and no following token, the updated state is dead. Reuse the exact
+                    // same recurrence with stores disabled at compile time and produce only the reduced output.
+                    update_state_slices_and_reduce<false>(static_cast<float*>(nullptr),
+                                                          initial_state,
+                                                          x,
+                                                          output,
+                                                          B_token,
+                                                          C_token,
+                                                          decay,
+                                                          delta,
+                                                          x_base,
+                                                          p_count,
+                                                          shape.state_size);
                 }
                 return;
             }
 
             auto* local_state = state_scratch + static_cast<size_t>(parallel_get_thread_num()) * scratch_stride;
-            copy_state_to_float(local_state, initial_state, p_count * shape.state_size);
             const uint64_t positive_interval = cache_enabled ? static_cast<uint64_t>(interval) : 1;
             const uint64_t cache_offset =
                 cache_enabled ? static_cast<uint64_t>(num_processed_tokens[sequence]) % positive_interval : 0;
@@ -677,72 +717,52 @@ void paged_selective_ssm_typed(const DataT* A,
             uint64_t tokens_until_boundary = cache_enabled ? positive_interval - cache_offset : 0;
             size_t write_slot = 1;
 
-            if (token_end - token_begin == 1) {
+            // Form the FP32 working state directly from the initial state and the first token. This removes the
+            // complete initial-state copy and keeps the remaining token loop type-homogeneous.
+            {
                 const float delta = load(dt + token_head);
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-                size_t p = 0;
-                for (; p + 1 < p_count; p += 2) {
-                    auto* state0 = local_state + p * shape.state_size;
-                    auto* state1 = state0 + shape.state_size;
-                    const float input_scale0 = load(x + x_base + p) * delta;
-                    const float input_scale1 = load(x + x_base + p + 1) * delta;
-                    const auto result = update_state_pair_and_reduce(state0,
-                                                                     state1,
-                                                                     state0,
-                                                                     state1,
-                                                                     B_token,
-                                                                     C_token,
-                                                                     decay,
-                                                                     input_scale0,
-                                                                     input_scale1,
-                                                                     shape.state_size);
-                    store(output + x_base + p, result.first);
-                    store(output + x_base + p + 1, result.second);
+                update_state_slices_and_reduce(local_state,
+                                               initial_state,
+                                               x,
+                                               output,
+                                               B_token,
+                                               C_token,
+                                               decay,
+                                               delta,
+                                               x_base,
+                                               p_count,
+                                               shape.state_size);
+
+                if (cache_enabled && --tokens_until_boundary == 0) {
+                    const auto write_block = static_cast<size_t>(block_indices[logical_block_begin + write_slot++]);
+                    auto* snapshot = recurrent_state_table + write_block * block_stride + state_slice;
+                    copy_state_from_float(snapshot, local_state, p_count * shape.state_size);
+                    tokens_until_boundary = positive_interval;
                 }
-                if (p < p_count) {
-                    auto* state = local_state + p * shape.state_size;
-                    const float input_scale = load(x + x_base + p) * delta;
-                    const float result =
-                        update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
-                    store(output + x_base + p, result);
-                }
-                return;
             }
 
-            for (size_t token = token_begin; token < token_end; ++token) {
+            token_head += shape.num_heads;
+            projection_base += projection_stride;
+            x_base += x_stride;
+            for (size_t token = token_begin + 1; token < token_end; ++token) {
                 const float delta = load(dt + token_head);
                 const float decay = std::exp(A_head * delta);
                 const auto* B_token = B + projection_base;
                 const auto* C_token = C + projection_base;
-
-                size_t p = 0;
-                for (; p + 1 < p_count; p += 2) {
-                    auto* state0 = local_state + p * shape.state_size;
-                    auto* state1 = state0 + shape.state_size;
-                    const float input_scale0 = load(x + x_base + p) * delta;
-                    const float input_scale1 = load(x + x_base + p + 1) * delta;
-                    const auto result = update_state_pair_and_reduce(state0,
-                                                                     state1,
-                                                                     state0,
-                                                                     state1,
-                                                                     B_token,
-                                                                     C_token,
-                                                                     decay,
-                                                                     input_scale0,
-                                                                     input_scale1,
-                                                                     shape.state_size);
-                    store(output + x_base + p, result.first);
-                    store(output + x_base + p + 1, result.second);
-                }
-                if (p < p_count) {
-                    auto* state = local_state + p * shape.state_size;
-                    const float input_scale = load(x + x_base + p) * delta;
-                    const float result =
-                        update_state_and_reduce(state, B_token, C_token, decay, input_scale, shape.state_size);
-                    store(output + x_base + p, result);
-                }
+                update_state_slices_and_reduce(local_state,
+                                               local_state,
+                                               x,
+                                               output,
+                                               B_token,
+                                               C_token,
+                                               decay,
+                                               delta,
+                                               x_base,
+                                               p_count,
+                                               shape.state_size);
 
                 if (cache_enabled) {
                     const bool is_boundary = --tokens_until_boundary == 0;
@@ -764,6 +784,42 @@ void paged_selective_ssm_typed(const DataT* A,
 }
 
 template <typename DataT>
+void dispatch_selective_projection(const void* A,
+                                   const void* dt,
+                                   const void* B,
+                                   const void* x,
+                                   const void* C,
+                                   const void* recurrent_state,
+                                   void* output,
+                                   void* output_recurrent_state,
+                                   const SelectiveSSMShape& shape,
+                                   float* state_scratch,
+                                   size_t scratch_head_dim,
+                                   const CpuParallelPtr& cpu_parallel,
+                                   const float* converted_B,
+                                   const float* converted_C) {
+#define OV_CPU_SSM_CALL(ProjectionT, BData, CData)                   \
+    selective_ssm_typed(static_cast<const DataT*>(A),                \
+                        static_cast<const DataT*>(dt),               \
+                        static_cast<const ProjectionT*>(BData),      \
+                        static_cast<const DataT*>(x),                \
+                        static_cast<const ProjectionT*>(CData),      \
+                        static_cast<const DataT*>(recurrent_state),  \
+                        static_cast<DataT*>(output),                 \
+                        static_cast<DataT*>(output_recurrent_state), \
+                        shape,                                       \
+                        state_scratch,                               \
+                        scratch_head_dim,                            \
+                        cpu_parallel)
+    if (converted_B != nullptr) {
+        OV_CPU_SSM_CALL(float, converted_B, converted_C);
+    } else {
+        OV_CPU_SSM_CALL(DataT, B, C);
+    }
+#undef OV_CPU_SSM_CALL
+}
+
+template <typename DataT, typename ProjectionT>
 void dispatch_paged_index(const void* A,
                           const void* dt,
                           const void* B,
@@ -785,9 +841,9 @@ void dispatch_paged_index(const void* A,
 #define OV_CPU_PAGED_SSM_CALL(IndexT)                                           \
     paged_selective_ssm_typed(static_cast<const DataT*>(A),                     \
                               static_cast<const DataT*>(dt),                    \
-                              static_cast<const DataT*>(B),                     \
+                              static_cast<const ProjectionT*>(B),               \
                               static_cast<const DataT*>(x),                     \
-                              static_cast<const DataT*>(C),                     \
+                              static_cast<const ProjectionT*>(C),               \
                               static_cast<DataT*>(recurrent_state_table),       \
                               static_cast<const IndexT*>(subsequence_begins),   \
                               static_cast<const IndexT*>(block_indices),        \
@@ -810,15 +866,120 @@ void dispatch_paged_index(const void* A,
 #undef OV_CPU_PAGED_SSM_CALL
 }
 
+template <typename DataT>
+void dispatch_paged_projection(const void* A,
+                               const void* dt,
+                               const void* B,
+                               const void* x,
+                               const void* C,
+                               void* recurrent_state_table,
+                               const void* subsequence_begins,
+                               const void* block_indices,
+                               const void* block_indices_begins,
+                               const void* num_processed_tokens,
+                               const void* cache_interval,
+                               void* output,
+                               const PagedSelectiveSSMShape& shape,
+                               const ov::element::Type& index_precision,
+                               float* state_scratch,
+                               size_t scratch_head_dim,
+                               int32_t* block_owners,
+                               const CpuParallelPtr& cpu_parallel,
+                               const float* converted_B,
+                               const float* converted_C) {
+#define OV_CPU_PAGED_SSM_CALL(ProjectionT, BData, CData)            \
+    dispatch_paged_index<DataT, ProjectionT>(A,                     \
+                                             dt,                    \
+                                             BData,                 \
+                                             x,                     \
+                                             CData,                 \
+                                             recurrent_state_table, \
+                                             subsequence_begins,    \
+                                             block_indices,         \
+                                             block_indices_begins,  \
+                                             num_processed_tokens,  \
+                                             cache_interval,        \
+                                             output,                \
+                                             shape,                 \
+                                             index_precision,       \
+                                             state_scratch,         \
+                                             scratch_head_dim,      \
+                                             block_owners,          \
+                                             cpu_parallel)
+    if (converted_B != nullptr) {
+        OV_CPU_PAGED_SSM_CALL(float, converted_B, converted_C);
+    } else {
+        OV_CPU_PAGED_SSM_CALL(DataT, B, C);
+    }
+#undef OV_CPU_PAGED_SSM_CALL
+}
+
 }  // namespace
 
+size_t checked_size_product(std::initializer_list<size_t> dimensions, const char* tensor_name) {
+    if (std::find(dimensions.begin(), dimensions.end(), size_t{0}) != dimensions.end()) {
+        return 0;
+    }
+
+    size_t result = 1;
+    for (const auto dimension : dimensions) {
+        OPENVINO_ASSERT(result <= std::numeric_limits<size_t>::max() / dimension,
+                        "SelectiveSSM size overflow while calculating ",
+                        tensor_name,
+                        ".");
+        result *= dimension;
+    }
+    return result;
+}
+
+size_t checked_size_sum(std::initializer_list<size_t> values, const char* buffer_name) {
+    size_t result = 0;
+    for (const auto value : values) {
+        OPENVINO_ASSERT(result <= std::numeric_limits<size_t>::max() - value,
+                        "SelectiveSSM size overflow while calculating ",
+                        buffer_name,
+                        ".");
+        result += value;
+    }
+    return result;
+}
+
+void validate_selective_ssm_shape(const SelectiveSSMShape& shape) {
+    OPENVINO_ASSERT(shape.num_groups > 0, "SelectiveSSM num_groups must be greater than zero.");
+    OPENVINO_ASSERT(shape.num_heads % shape.num_groups == 0, "SelectiveSSM num_heads must be divisible by num_groups.");
+    OPENVINO_ASSERT(shape.state_size > 0, "SelectiveSSM state_size must be greater than zero.");
+
+    checked_size_product({shape.num_heads}, "A");
+    checked_size_product({shape.batch_size, shape.sequence_length, shape.num_heads}, "dt");
+    checked_size_product({shape.batch_size, shape.sequence_length, shape.num_groups, shape.state_size}, "B/C");
+    checked_size_product({shape.batch_size, shape.sequence_length, shape.num_heads, shape.head_dim}, "x/output");
+    checked_size_product({shape.batch_size, shape.num_heads, shape.head_dim, shape.state_size}, "recurrent state");
+}
+
+void validate_paged_selective_ssm_shape(const PagedSelectiveSSMShape& shape) {
+    OPENVINO_ASSERT(shape.num_groups > 0, "PagedSelectiveSSM num_groups must be greater than zero.");
+    OPENVINO_ASSERT(shape.num_heads % shape.num_groups == 0,
+                    "PagedSelectiveSSM num_heads must be divisible by num_groups.");
+    OPENVINO_ASSERT(shape.state_size > 0, "PagedSelectiveSSM state_size must be greater than zero.");
+
+    checked_size_product({shape.num_heads}, "A");
+    checked_size_product({shape.token_count, shape.num_heads}, "dt");
+    checked_size_product({shape.token_count, shape.num_groups, shape.state_size}, "B/C");
+    checked_size_product({shape.token_count, shape.num_heads, shape.head_dim}, "x/output");
+    checked_size_product({shape.physical_block_count, shape.num_heads, shape.head_dim, shape.state_size},
+                         "recurrent state table");
+}
+
 size_t get_scratch_head_dim(size_t head_dim, size_t state_size, size_t outer_work_items, size_t thread_count) {
-    OPENVINO_ASSERT(head_dim > 0 && state_size > 0);
+    OPENVINO_ASSERT(state_size > 0);
+    if (head_dim == 0) {
+        return 1;
+    }
     const auto cache_limited = std::max(size_t{1}, std::min(head_dim, target_scratch_elements / state_size));
     const auto outer_work = std::max(size_t{1}, outer_work_items);
     const auto workers = std::max(size_t{1}, thread_count);
-    const auto blocks_for_parallelism = (workers + outer_work - 1) / outer_work;
-    const auto parallelism_limited = (head_dim + blocks_for_parallelism - 1) / blocks_for_parallelism;
+    const auto blocks_for_parallelism = ceil_div(workers, outer_work);
+    const auto parallelism_limited = ceil_div(head_dim, blocks_for_parallelism);
     return std::max(size_t{1}, std::min(cache_limited, parallelism_limited));
 }
 
@@ -834,22 +995,28 @@ void selective_ssm(const void* A,
                    const ov::element::Type& precision,
                    float* state_scratch,
                    size_t scratch_head_dim,
-                   const CpuParallelPtr& cpu_parallel) {
-    OPENVINO_ASSERT(shape.num_groups > 0 && shape.num_heads % shape.num_groups == 0);
-    OPENVINO_ASSERT(shape.state_size > 0 && scratch_head_dim > 0 && state_scratch != nullptr);
-#define OV_CPU_SSM_CALL(DataT)                                       \
-    selective_ssm_typed(static_cast<const DataT*>(A),                \
-                        static_cast<const DataT*>(dt),               \
-                        static_cast<const DataT*>(B),                \
-                        static_cast<const DataT*>(x),                \
-                        static_cast<const DataT*>(C),                \
-                        static_cast<const DataT*>(recurrent_state),  \
-                        static_cast<DataT*>(output),                 \
-                        static_cast<DataT*>(output_recurrent_state), \
-                        shape,                                       \
-                        state_scratch,                               \
-                        scratch_head_dim,                            \
-                        cpu_parallel)
+                   const CpuParallelPtr& cpu_parallel,
+                   const float* converted_B,
+                   const float* converted_C) {
+    validate_selective_ssm_shape(shape);
+    OPENVINO_ASSERT(scratch_head_dim > 0 && state_scratch != nullptr);
+    OPENVINO_ASSERT((converted_B == nullptr) == (converted_C == nullptr));
+    checked_size_product({scratch_head_dim, shape.state_size}, "state scratch");
+#define OV_CPU_SSM_CALL(DataT)                                   \
+    dispatch_selective_projection<DataT>(A,                      \
+                                         dt,                     \
+                                         B,                      \
+                                         x,                      \
+                                         C,                      \
+                                         recurrent_state,        \
+                                         output,                 \
+                                         output_recurrent_state, \
+                                         shape,                  \
+                                         state_scratch,          \
+                                         scratch_head_dim,       \
+                                         cpu_parallel,           \
+                                         converted_B,            \
+                                         converted_C)
     if (precision == ov::element::f32) {
         OV_CPU_SSM_CALL(float);
     } else if (precision == ov::element::f16) {
@@ -909,70 +1076,45 @@ void paged_selective_ssm(const void* A,
                          float* state_scratch,
                          size_t scratch_head_dim,
                          int32_t* block_owners,
-                         const CpuParallelPtr& cpu_parallel) {
-    OPENVINO_ASSERT(shape.num_groups > 0 && shape.num_heads % shape.num_groups == 0);
-    OPENVINO_ASSERT(shape.state_size > 0 && scratch_head_dim > 0 && state_scratch != nullptr);
+                         const CpuParallelPtr& cpu_parallel,
+                         const float* converted_B,
+                         const float* converted_C) {
+    validate_paged_selective_ssm_shape(shape);
+    OPENVINO_ASSERT(scratch_head_dim > 0 && state_scratch != nullptr);
     OPENVINO_ASSERT(shape.physical_block_count == 0 || block_owners != nullptr);
+    OPENVINO_ASSERT((converted_B == nullptr) == (converted_C == nullptr));
+    checked_size_product({scratch_head_dim, shape.state_size}, "state scratch");
+#define OV_CPU_PAGED_SSM_CALL(DataT)                        \
+    dispatch_paged_projection<DataT>(A,                     \
+                                     dt,                    \
+                                     B,                     \
+                                     x,                     \
+                                     C,                     \
+                                     recurrent_state_table, \
+                                     subsequence_begins,    \
+                                     block_indices,         \
+                                     block_indices_begins,  \
+                                     num_processed_tokens,  \
+                                     cache_interval,        \
+                                     output,                \
+                                     shape,                 \
+                                     index_precision,       \
+                                     state_scratch,         \
+                                     scratch_head_dim,      \
+                                     block_owners,          \
+                                     cpu_parallel,          \
+                                     converted_B,           \
+                                     converted_C)
     if (precision == ov::element::f32) {
-        dispatch_paged_index<float>(A,
-                                    dt,
-                                    B,
-                                    x,
-                                    C,
-                                    recurrent_state_table,
-                                    subsequence_begins,
-                                    block_indices,
-                                    block_indices_begins,
-                                    num_processed_tokens,
-                                    cache_interval,
-                                    output,
-                                    shape,
-                                    index_precision,
-                                    state_scratch,
-                                    scratch_head_dim,
-                                    block_owners,
-                                    cpu_parallel);
+        OV_CPU_PAGED_SSM_CALL(float);
     } else if (precision == ov::element::f16) {
-        dispatch_paged_index<ov::float16>(A,
-                                          dt,
-                                          B,
-                                          x,
-                                          C,
-                                          recurrent_state_table,
-                                          subsequence_begins,
-                                          block_indices,
-                                          block_indices_begins,
-                                          num_processed_tokens,
-                                          cache_interval,
-                                          output,
-                                          shape,
-                                          index_precision,
-                                          state_scratch,
-                                          scratch_head_dim,
-                                          block_owners,
-                                          cpu_parallel);
+        OV_CPU_PAGED_SSM_CALL(ov::float16);
     } else if (precision == ov::element::bf16) {
-        dispatch_paged_index<ov::bfloat16>(A,
-                                           dt,
-                                           B,
-                                           x,
-                                           C,
-                                           recurrent_state_table,
-                                           subsequence_begins,
-                                           block_indices,
-                                           block_indices_begins,
-                                           num_processed_tokens,
-                                           cache_interval,
-                                           output,
-                                           shape,
-                                           index_precision,
-                                           state_scratch,
-                                           scratch_head_dim,
-                                           block_owners,
-                                           cpu_parallel);
+        OV_CPU_PAGED_SSM_CALL(ov::bfloat16);
     } else {
         OPENVINO_THROW("PagedSelectiveSSM supports only f32/f16/bf16, got ", precision, ".");
     }
+#undef OV_CPU_PAGED_SSM_CALL
 }
 
 }  // namespace ov::intel_cpu::node::kernel

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <initializer_list>
 
 #include "cpu_parallel.hpp"
 #include "openvino/core/type/element_type.hpp"
@@ -31,6 +32,14 @@ struct PagedSelectiveSSMShape {
     size_t sequence_count = 0;
 };
 
+size_t checked_size_product(std::initializer_list<size_t> dimensions, const char* tensor_name);
+
+size_t checked_size_sum(std::initializer_list<size_t> values, const char* buffer_name);
+
+void validate_selective_ssm_shape(const SelectiveSSMShape& shape);
+
+void validate_paged_selective_ssm_shape(const PagedSelectiveSSMShape& shape);
+
 size_t get_scratch_head_dim(size_t head_dim, size_t state_size, size_t outer_work_items, size_t thread_count);
 
 void selective_ssm(const void* A,
@@ -45,7 +54,9 @@ void selective_ssm(const void* A,
                    const ov::element::Type& precision,
                    float* state_scratch,
                    size_t scratch_head_dim,
-                   const CpuParallelPtr& cpu_parallel);
+                   const CpuParallelPtr& cpu_parallel,
+                   const float* converted_B = nullptr,
+                   const float* converted_C = nullptr);
 
 void validate_paged_selective_ssm_metadata(const void* subsequence_begins,
                                            const void* block_indices,
@@ -74,6 +85,8 @@ void paged_selective_ssm(const void* A,
                          float* state_scratch,
                          size_t scratch_head_dim,
                          int32_t* block_owners,
-                         const CpuParallelPtr& cpu_parallel);
+                         const CpuParallelPtr& cpu_parallel,
+                         const float* converted_B = nullptr,
+                         const float* converted_C = nullptr);
 
 }  // namespace ov::intel_cpu::node::kernel

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.hpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+
+#include "cpu_parallel.hpp"
+#include "openvino/core/type/element_type.hpp"
+
+namespace ov::intel_cpu::node::kernel {
+
+struct SelectiveSSMShape {
+    size_t batch_size = 0;
+    size_t sequence_length = 0;
+    size_t num_heads = 0;
+    size_t head_dim = 0;
+    size_t num_groups = 0;
+    size_t state_size = 0;
+};
+
+struct PagedSelectiveSSMShape {
+    size_t token_count = 0;
+    size_t num_heads = 0;
+    size_t head_dim = 0;
+    size_t num_groups = 0;
+    size_t state_size = 0;
+    size_t physical_block_count = 0;
+    size_t logical_block_count = 0;
+    size_t sequence_count = 0;
+};
+
+void selective_ssm(const void* A,
+                   const void* dt,
+                   const void* B,
+                   const void* x,
+                   const void* C,
+                   const void* recurrent_state,
+                   void* output,
+                   void* output_recurrent_state,
+                   const SelectiveSSMShape& shape,
+                   const ov::element::Type& precision,
+                   float* state_scratch,
+                   size_t scratch_head_dim,
+                   const CpuParallelPtr& cpu_parallel);
+
+void paged_selective_ssm(const void* A,
+                         const void* dt,
+                         const void* B,
+                         const void* x,
+                         const void* C,
+                         void* recurrent_state_table,
+                         const void* subsequence_begins,
+                         const void* block_indices,
+                         const void* block_indices_begins,
+                         const void* num_processed_tokens,
+                         const void* cache_interval,
+                         void* output,
+                         const PagedSelectiveSSMShape& shape,
+                         const ov::element::Type& precision,
+                         const ov::element::Type& index_precision,
+                         float* state_scratch,
+                         size_t scratch_head_dim,
+                         int32_t* block_owners,
+                         const CpuParallelPtr& cpu_parallel);
+
+}  // namespace ov::intel_cpu::node::kernel

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.hpp
@@ -31,6 +31,8 @@ struct PagedSelectiveSSMShape {
     size_t sequence_count = 0;
 };
 
+size_t get_scratch_head_dim(size_t head_dim, size_t state_size, size_t outer_work_items, size_t thread_count);
+
 void selective_ssm(const void* A,
                    const void* dt,
                    const void* B,

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.hpp
@@ -47,6 +47,15 @@ void selective_ssm(const void* A,
                    size_t scratch_head_dim,
                    const CpuParallelPtr& cpu_parallel);
 
+void validate_paged_selective_ssm_metadata(const void* subsequence_begins,
+                                           const void* block_indices,
+                                           const void* block_indices_begins,
+                                           const void* num_processed_tokens,
+                                           const void* cache_interval,
+                                           const PagedSelectiveSSMShape& shape,
+                                           const ov::element::Type& index_precision,
+                                           int32_t* block_owners);
+
 void paged_selective_ssm(const void* A,
                          const void* dt,
                          const void* B,

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/selective_ssm_jit_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/selective_ssm_jit_kernel.cpp
@@ -1,0 +1,140 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "selective_ssm_jit_kernel.hpp"
+
+#include <xbyak/xbyak.h>
+
+#include <cpu/x64/cpu_isa_traits.hpp>
+#include <cstddef>
+#include <memory>
+
+using namespace dnnl::impl::cpu::x64;
+
+namespace ov::intel_cpu::kernel {
+
+#define GET_OFF(field) offsetof(jit_selective_ssm_call_args, field)
+
+template <cpu_isa_t isa>
+void jit_selective_ssm_kernel<isa>::generate() {
+    preamble();
+
+    mov(reg_args, abi_param1);
+    mov(reg_state_src, ptr[reg_args + GET_OFF(state_src)]);
+    mov(reg_state_dst, ptr[reg_args + GET_OFF(state_dst)]);
+    mov(reg_B, ptr[reg_args + GET_OFF(B)]);
+    mov(reg_C, ptr[reg_args + GET_OFF(C)]);
+    mov(reg_x, ptr[reg_args + GET_OFF(x)]);
+    mov(reg_p_count, ptr[reg_args + GET_OFF(p_count)]);
+    mov(reg_output, ptr[reg_args + GET_OFF(output)]);
+    vbroadcastss(v_decay, ptr[reg_args + GET_OFF(decay)]);
+    vbroadcastss(v_delta, ptr[reg_args + GET_OFF(delta)]);
+
+    Xbyak::Label p_loop;
+    Xbyak::Label p_end;
+    test(reg_p_count, reg_p_count);
+    jz(p_end, T_NEAR);
+
+    L(p_loop);
+    vbroadcastss(v_input_scale, ptr[reg_x]);
+    vmulps(v_input_scale, v_input_scale, v_delta);
+    uni_vpxor(x_acc, x_acc, x_acc);
+
+    const size_t vec_count = m_jcp.state_size / vec_size;
+    for (size_t i = 0; i < vec_count; ++i) {
+        const size_t offset = i * vec_bytes;
+        vmovups(v_state, ptr[reg_state_src + offset]);
+        vmovups(v_B, ptr[reg_B + offset]);
+        vmulps(v_state, v_state, v_decay);
+        vmulps(v_B, v_B, v_input_scale);
+        vaddps(v_state, v_state, v_B);
+        vmovups(ptr[reg_state_dst + offset], v_state);
+        vmovups(v_C, ptr[reg_C + offset]);
+        vmulps(v_C, v_C, v_state);
+
+        vaddps(x_acc, x_acc, Xbyak::Xmm(v_C.getIdx()));
+        if constexpr (isa == avx2) {
+            vextractf128(x_tmp, Xbyak::Ymm(v_C.getIdx()), 1);
+            vaddps(x_acc, x_acc, x_tmp);
+        } else {
+            for (int quarter = 1; quarter < 4; ++quarter) {
+                vextractf32x4(x_tmp, Xbyak::Zmm(v_C.getIdx()), quarter);
+                vaddps(x_acc, x_acc, x_tmp);
+            }
+        }
+    }
+
+    const size_t vectorized = vec_count * vec_size;
+    const size_t four_count = (m_jcp.state_size - vectorized) / 4;
+    for (size_t i = 0; i < four_count; ++i) {
+        const size_t offset = (vectorized + i * 4) * sizeof(float);
+        vmovups(Xbyak::Xmm(v_state.getIdx()), ptr[reg_state_src + offset]);
+        vmovups(Xbyak::Xmm(v_B.getIdx()), ptr[reg_B + offset]);
+        vmulps(Xbyak::Xmm(v_state.getIdx()), Xbyak::Xmm(v_state.getIdx()), Xbyak::Xmm(v_decay.getIdx()));
+        vmulps(Xbyak::Xmm(v_B.getIdx()), Xbyak::Xmm(v_B.getIdx()), Xbyak::Xmm(v_input_scale.getIdx()));
+        vaddps(Xbyak::Xmm(v_state.getIdx()), Xbyak::Xmm(v_state.getIdx()), Xbyak::Xmm(v_B.getIdx()));
+        vmovups(ptr[reg_state_dst + offset], Xbyak::Xmm(v_state.getIdx()));
+        vmovups(Xbyak::Xmm(v_C.getIdx()), ptr[reg_C + offset]);
+        vmulps(Xbyak::Xmm(v_C.getIdx()), Xbyak::Xmm(v_C.getIdx()), Xbyak::Xmm(v_state.getIdx()));
+        vaddps(x_acc, x_acc, Xbyak::Xmm(v_C.getIdx()));
+    }
+
+    const size_t scalar_begin = vectorized + four_count * 4;
+    const size_t scalar_count = m_jcp.state_size - scalar_begin;
+    for (size_t i = 0; i < scalar_count; ++i) {
+        const size_t offset = (scalar_begin + i) * sizeof(float);
+        vmovss(x_state, ptr[reg_state_src + offset]);
+        vmovss(x_B, ptr[reg_B + offset]);
+        vmulss(x_state, x_state, Xbyak::Xmm(v_decay.getIdx()));
+        vmulss(x_B, x_B, Xbyak::Xmm(v_input_scale.getIdx()));
+        vaddss(x_state, x_state, x_B);
+        vmovss(ptr[reg_state_dst + offset], x_state);
+        vmovss(x_C, ptr[reg_C + offset]);
+        vmulss(x_C, x_C, x_state);
+        uni_vpxor(x_tmp, x_tmp, x_tmp);
+        vinsertps(x_tmp, x_tmp, x_C, static_cast<uint8_t>(i << 4));
+        vaddps(x_acc, x_acc, x_tmp);
+    }
+
+    vpermilps(x_tmp, x_acc, 0xB1);
+    vaddps(x_sum, x_acc, x_tmp);
+    vpermilps(x_tmp, x_sum, 0x4E);
+    vaddss(x_sum, x_sum, x_tmp);
+    vmovss(ptr[reg_output], x_sum);
+
+    add(reg_state_src, m_jcp.state_size * sizeof(float));
+    add(reg_state_dst, m_jcp.state_size * sizeof(float));
+    add(reg_x, sizeof(float));
+    add(reg_output, sizeof(float));
+    dec(reg_p_count);
+    jnz(p_loop, T_NEAR);
+
+    L(p_end);
+    postamble();
+}
+
+std::shared_ptr<JitKernelBase> create_selective_ssm_jit_kernel(size_t state_size, bool prefer_avx512) {
+    if (state_size == 0) {
+        return nullptr;
+    }
+
+    jit_selective_ssm_compile_params jcp{state_size};
+    std::shared_ptr<JitKernelBase> kernel;
+    if (prefer_avx512 && mayiuse(avx512_core)) {
+        kernel = std::make_shared<jit_selective_ssm_kernel<avx512_core>>(jcp);
+    } else if (mayiuse(avx2)) {
+        kernel = std::make_shared<jit_selective_ssm_kernel<avx2>>(jcp);
+    }
+    if (kernel) {
+        kernel->create_kernel();
+    }
+    return kernel;
+}
+
+template struct jit_selective_ssm_kernel<avx2>;
+template struct jit_selective_ssm_kernel<avx512_core>;
+
+#undef GET_OFF
+
+}  // namespace ov::intel_cpu::kernel

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/selective_ssm_jit_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/selective_ssm_jit_kernel.cpp
@@ -17,6 +17,96 @@ namespace ov::intel_cpu::kernel {
 #define GET_OFF(field) offsetof(jit_selective_ssm_call_args, field)
 
 template <cpu_isa_t isa>
+size_t jit_selective_ssm_kernel<isa>::data_size() const {
+    return m_jcp.data_type == jit_selective_ssm_data_type::f32 ? sizeof(float) : sizeof(uint16_t);
+}
+
+template <cpu_isa_t isa>
+void jit_selective_ssm_kernel<isa>::load_data_vector(const Vmm& dst, const Xbyak::Reg64& base, size_t element_offset) {
+    const auto offset = element_offset * data_size();
+    if (m_jcp.data_type == jit_selective_ssm_data_type::f32) {
+        vmovups(dst, ptr[base + offset]);
+    } else if (m_jcp.data_type == jit_selective_ssm_data_type::f16) {
+        if constexpr (isa == avx2) {
+            vcvtph2ps(dst, xword[base + offset]);
+        } else {
+            vcvtph2ps(dst, yword[base + offset]);
+        }
+    } else {
+        if constexpr (isa == avx2) {
+            vpmovzxwd(dst, xword[base + offset]);
+        } else {
+            vpmovzxwd(dst, yword[base + offset]);
+        }
+        vpslld(dst, dst, 16);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_selective_ssm_kernel<isa>::load_data_xmm(const Xbyak::Xmm& dst,
+                                                  const Xbyak::Reg64& base,
+                                                  size_t element_offset) {
+    const auto offset = element_offset * data_size();
+    if (m_jcp.data_type == jit_selective_ssm_data_type::f32) {
+        vmovups(dst, ptr[base + offset]);
+    } else if (m_jcp.data_type == jit_selective_ssm_data_type::f16) {
+        vcvtph2ps(dst, qword[base + offset]);
+    } else {
+        vpmovzxwd(dst, qword[base + offset]);
+        vpslld(dst, dst, 16);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_selective_ssm_kernel<isa>::load_data_scalar(const Xbyak::Xmm& dst,
+                                                     const Xbyak::Reg64& base,
+                                                     size_t element_offset) {
+    const auto offset = element_offset * data_size();
+    if (m_jcp.data_type == jit_selective_ssm_data_type::f32) {
+        vmovss(dst, ptr[base + offset]);
+        return;
+    }
+
+    movzx(reg_tmp.cvt32(), word[base + offset]);
+    if (m_jcp.data_type == jit_selective_ssm_data_type::bf16) {
+        shl(reg_tmp.cvt32(), 16);
+    }
+    vmovd(dst, reg_tmp.cvt32());
+    if (m_jcp.data_type == jit_selective_ssm_data_type::f16) {
+        vcvtph2ps(dst, dst);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_selective_ssm_kernel<isa>::broadcast_data(const Vmm& dst, const Xbyak::Reg64& base) {
+    if (m_jcp.data_type == jit_selective_ssm_data_type::f32) {
+        vbroadcastss(dst, ptr[base]);
+    } else {
+        load_data_scalar(x_tmp, base, 0);
+        vbroadcastss(dst, x_tmp);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_selective_ssm_kernel<isa>::store_data_scalar(const Xbyak::Reg64& base, const Xbyak::Xmm& value) {
+    if (m_jcp.data_type == jit_selective_ssm_data_type::f32) {
+        vmovss(ptr[base], value);
+    } else if (m_jcp.data_type == jit_selective_ssm_data_type::f16) {
+        vcvtps2ph(x_tmp, value, 0x4);
+        vmovd(reg_tmp.cvt32(), x_tmp);
+        mov(word[base], reg_tmp.cvt16());
+    } else {
+        vmovd(reg_tmp.cvt32(), value);
+        mov(reg_round.cvt32(), reg_tmp.cvt32());
+        and_(reg_round.cvt32(), 0x00010000);
+        shr(reg_round.cvt32(), 1);
+        add(reg_tmp.cvt32(), reg_round.cvt32());
+        shr(reg_tmp.cvt32(), 16);
+        mov(word[base], reg_tmp.cvt16());
+    }
+}
+
+template <cpu_isa_t isa>
 void jit_selective_ssm_kernel<isa>::generate() {
     preamble();
 
@@ -37,22 +127,26 @@ void jit_selective_ssm_kernel<isa>::generate() {
     jz(p_end, T_NEAR);
 
     L(p_loop);
-    vbroadcastss(v_input_scale, ptr[reg_x]);
+    broadcast_data(v_input_scale, reg_x);
     vmulps(v_input_scale, v_input_scale, v_delta);
     uni_vpxor(x_acc, x_acc, x_acc);
 
     const size_t vec_count = m_jcp.state_size / vec_size;
     for (size_t i = 0; i < vec_count; ++i) {
-        const size_t offset = i * vec_bytes;
-        vmovups(v_state, ptr[reg_state_src + offset]);
-        vmovups(v_B, ptr[reg_B + offset]);
+        const size_t state_offset = i * vec_bytes;
+        const size_t element_offset = i * vec_size;
+        vmovups(v_state, ptr[reg_state_src + state_offset]);
+        load_data_vector(v_B, reg_B, element_offset);
         vmulps(v_state, v_state, v_decay);
-        vmulps(v_B, v_B, v_input_scale);
-        vaddps(v_state, v_state, v_B);
-        vmovups(ptr[reg_state_dst + offset], v_state);
-        vmovups(v_C, ptr[reg_C + offset]);
+        if (m_jcp.data_type == jit_selective_ssm_data_type::f32) {
+            vmulps(v_B, v_B, v_input_scale);
+            vaddps(v_state, v_state, v_B);
+        } else {
+            vfmadd231ps(v_state, v_B, v_input_scale);
+        }
+        vmovups(ptr[reg_state_dst + state_offset], v_state);
+        load_data_vector(v_C, reg_C, element_offset);
         vmulps(v_C, v_C, v_state);
-
         vaddps(x_acc, x_acc, Xbyak::Xmm(v_C.getIdx()));
         if constexpr (isa == avx2) {
             vextractf128(x_tmp, Xbyak::Ymm(v_C.getIdx()), 1);
@@ -68,45 +162,51 @@ void jit_selective_ssm_kernel<isa>::generate() {
     const size_t vectorized = vec_count * vec_size;
     const size_t four_count = (m_jcp.state_size - vectorized) / 4;
     for (size_t i = 0; i < four_count; ++i) {
-        const size_t offset = (vectorized + i * 4) * sizeof(float);
-        vmovups(Xbyak::Xmm(v_state.getIdx()), ptr[reg_state_src + offset]);
-        vmovups(Xbyak::Xmm(v_B.getIdx()), ptr[reg_B + offset]);
-        vmulps(Xbyak::Xmm(v_state.getIdx()), Xbyak::Xmm(v_state.getIdx()), Xbyak::Xmm(v_decay.getIdx()));
-        vmulps(Xbyak::Xmm(v_B.getIdx()), Xbyak::Xmm(v_B.getIdx()), Xbyak::Xmm(v_input_scale.getIdx()));
-        vaddps(Xbyak::Xmm(v_state.getIdx()), Xbyak::Xmm(v_state.getIdx()), Xbyak::Xmm(v_B.getIdx()));
-        vmovups(ptr[reg_state_dst + offset], Xbyak::Xmm(v_state.getIdx()));
-        vmovups(Xbyak::Xmm(v_C.getIdx()), ptr[reg_C + offset]);
-        vmulps(Xbyak::Xmm(v_C.getIdx()), Xbyak::Xmm(v_C.getIdx()), Xbyak::Xmm(v_state.getIdx()));
-        vaddps(x_acc, x_acc, Xbyak::Xmm(v_C.getIdx()));
+        const size_t element_offset = vectorized + i * 4;
+        const size_t state_offset = element_offset * sizeof(float);
+        vmovups(x_state, ptr[reg_state_src + state_offset]);
+        load_data_xmm(Xbyak::Xmm(v_B.getIdx()), reg_B, element_offset);
+        vmulps(x_state, x_state, Xbyak::Xmm(v_decay.getIdx()));
+        if (m_jcp.data_type == jit_selective_ssm_data_type::f32) {
+            vmulps(Xbyak::Xmm(v_B.getIdx()), Xbyak::Xmm(v_B.getIdx()), Xbyak::Xmm(v_input_scale.getIdx()));
+            vaddps(x_state, x_state, Xbyak::Xmm(v_B.getIdx()));
+        } else {
+            vfmadd231ps(x_state, Xbyak::Xmm(v_B.getIdx()), Xbyak::Xmm(v_input_scale.getIdx()));
+        }
+        vmovups(ptr[reg_state_dst + state_offset], x_state);
+        load_data_xmm(Xbyak::Xmm(v_C.getIdx()), reg_C, element_offset);
+        vfmadd231ps(x_acc, Xbyak::Xmm(v_C.getIdx()), x_state);
     }
 
     const size_t scalar_begin = vectorized + four_count * 4;
     const size_t scalar_count = m_jcp.state_size - scalar_begin;
     for (size_t i = 0; i < scalar_count; ++i) {
-        const size_t offset = (scalar_begin + i) * sizeof(float);
-        vmovss(x_state, ptr[reg_state_src + offset]);
-        vmovss(x_B, ptr[reg_B + offset]);
+        const size_t element_offset = scalar_begin + i;
+        const size_t state_offset = element_offset * sizeof(float);
+        vmovss(x_state, ptr[reg_state_src + state_offset]);
+        load_data_scalar(x_B, reg_B, element_offset);
         vmulss(x_state, x_state, Xbyak::Xmm(v_decay.getIdx()));
-        vmulss(x_B, x_B, Xbyak::Xmm(v_input_scale.getIdx()));
-        vaddss(x_state, x_state, x_B);
-        vmovss(ptr[reg_state_dst + offset], x_state);
-        vmovss(x_C, ptr[reg_C + offset]);
-        vmulss(x_C, x_C, x_state);
-        uni_vpxor(x_tmp, x_tmp, x_tmp);
-        vinsertps(x_tmp, x_tmp, x_C, static_cast<uint8_t>(i << 4));
-        vaddps(x_acc, x_acc, x_tmp);
+        if (m_jcp.data_type == jit_selective_ssm_data_type::f32) {
+            vmulss(x_B, x_B, Xbyak::Xmm(v_input_scale.getIdx()));
+            vaddss(x_state, x_state, x_B);
+        } else {
+            vfmadd231ss(x_state, x_B, Xbyak::Xmm(v_input_scale.getIdx()));
+        }
+        vmovss(ptr[reg_state_dst + state_offset], x_state);
+        load_data_scalar(x_C, reg_C, element_offset);
+        vfmadd231ss(x_acc, x_C, x_state);
     }
 
     vpermilps(x_tmp, x_acc, 0xB1);
     vaddps(x_sum, x_acc, x_tmp);
     vpermilps(x_tmp, x_sum, 0x4E);
     vaddss(x_sum, x_sum, x_tmp);
-    vmovss(ptr[reg_output], x_sum);
+    store_data_scalar(reg_output, x_sum);
 
     add(reg_state_src, m_jcp.state_size * sizeof(float));
     add(reg_state_dst, m_jcp.state_size * sizeof(float));
-    add(reg_x, sizeof(float));
-    add(reg_output, sizeof(float));
+    add(reg_x, data_size());
+    add(reg_output, data_size());
     dec(reg_p_count);
     jnz(p_loop, T_NEAR);
 
@@ -114,12 +214,14 @@ void jit_selective_ssm_kernel<isa>::generate() {
     postamble();
 }
 
-std::shared_ptr<JitKernelBase> create_selective_ssm_jit_kernel(size_t state_size, bool prefer_avx512) {
+std::shared_ptr<JitKernelBase> create_selective_ssm_jit_kernel(size_t state_size,
+                                                               bool prefer_avx512,
+                                                               jit_selective_ssm_data_type data_type) {
     if (state_size == 0) {
         return nullptr;
     }
 
-    jit_selective_ssm_compile_params jcp{state_size};
+    jit_selective_ssm_compile_params jcp{state_size, data_type};
     std::shared_ptr<JitKernelBase> kernel;
     if (prefer_avx512 && mayiuse(avx512_core)) {
         kernel = std::make_shared<jit_selective_ssm_kernel<avx512_core>>(jcp);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/selective_ssm_jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/selective_ssm_jit_kernel.hpp
@@ -8,6 +8,7 @@
 
 #include <cpu/x64/cpu_isa_traits.hpp>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <type_traits>
 
@@ -15,20 +16,27 @@
 
 namespace ov::intel_cpu::kernel {
 
+enum class jit_selective_ssm_data_type : uint8_t {
+    f32,
+    f16,
+    bf16,
+};
+
 struct jit_selective_ssm_compile_params {
     size_t state_size = 0;
+    jit_selective_ssm_data_type data_type = jit_selective_ssm_data_type::f32;
 };
 
 struct jit_selective_ssm_call_args {
     const float* state_src = nullptr;
     float* state_dst = nullptr;
-    const float* B = nullptr;
-    const float* C = nullptr;
+    const void* B = nullptr;
+    const void* C = nullptr;
     float decay = 0.F;
     float delta = 0.F;
-    const float* x = nullptr;
+    const void* x = nullptr;
     size_t p_count = 0;
-    float* output = nullptr;
+    void* output = nullptr;
 };
 
 template <dnnl::impl::cpu::x64::cpu_isa_t isa>
@@ -52,6 +60,8 @@ private:
     const Xbyak::Reg64 reg_x = r12;
     const Xbyak::Reg64 reg_p_count = r13;
     const Xbyak::Reg64 reg_output = rax;
+    const Xbyak::Reg64 reg_tmp = r14;
+    const Xbyak::Reg64 reg_round = r15;
 
     const Vmm v_decay = Vmm(0);
     const Vmm v_input_scale = Vmm(1);
@@ -61,15 +71,23 @@ private:
     const Vmm v_B = Vmm(4);
     const Vmm v_C = Vmm(5);
 
-    const Xbyak::Xmm x_state = Xbyak::Xmm(6);
+    const Xbyak::Xmm x_state = Xbyak::Xmm(v_state.getIdx());
     const Xbyak::Xmm x_B = Xbyak::Xmm(7);
     const Xbyak::Xmm x_C = Xbyak::Xmm(8);
     const Xbyak::Xmm x_sum = Xbyak::Xmm(9);
     const Xbyak::Xmm x_tmp = Xbyak::Xmm(10);
 
+    [[nodiscard]] size_t data_size() const;
+    void load_data_vector(const Vmm& dst, const Xbyak::Reg64& base, size_t element_offset);
+    void load_data_xmm(const Xbyak::Xmm& dst, const Xbyak::Reg64& base, size_t element_offset);
+    void load_data_scalar(const Xbyak::Xmm& dst, const Xbyak::Reg64& base, size_t element_offset);
+    void broadcast_data(const Vmm& dst, const Xbyak::Reg64& base);
+    void store_data_scalar(const Xbyak::Reg64& base, const Xbyak::Xmm& value);
     void generate() override;
 };
 
-std::shared_ptr<JitKernelBase> create_selective_ssm_jit_kernel(size_t state_size, bool prefer_avx512);
+std::shared_ptr<JitKernelBase> create_selective_ssm_jit_kernel(size_t state_size,
+                                                               bool prefer_avx512,
+                                                               jit_selective_ssm_data_type data_type);
 
 }  // namespace ov::intel_cpu::kernel

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/selective_ssm_jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/selective_ssm_jit_kernel.hpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <xbyak/xbyak.h>
+
+#include <cpu/x64/cpu_isa_traits.hpp>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+#include "jit_kernel_base.hpp"
+
+namespace ov::intel_cpu::kernel {
+
+struct jit_selective_ssm_compile_params {
+    size_t state_size = 0;
+};
+
+struct jit_selective_ssm_call_args {
+    const float* state_src = nullptr;
+    float* state_dst = nullptr;
+    const float* B = nullptr;
+    const float* C = nullptr;
+    float decay = 0.F;
+    float delta = 0.F;
+    const float* x = nullptr;
+    size_t p_count = 0;
+    float* output = nullptr;
+};
+
+template <dnnl::impl::cpu::x64::cpu_isa_t isa>
+struct jit_selective_ssm_kernel : public JitKernel<jit_selective_ssm_compile_params, jit_selective_ssm_call_args> {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_selective_ssm_kernel)
+
+    explicit jit_selective_ssm_kernel(const jit_selective_ssm_compile_params& jcp)
+        : JitKernel<jit_selective_ssm_compile_params, jit_selective_ssm_call_args>(jit_name(), jcp, isa) {}
+
+private:
+    using Vmm = std::conditional_t<isa == dnnl::impl::cpu::x64::avx2, Xbyak::Ymm, Xbyak::Zmm>;
+
+    static constexpr size_t vec_size = dnnl::impl::cpu::x64::cpu_isa_traits_t<isa>::vlen / sizeof(float);
+    static constexpr size_t vec_bytes = vec_size * sizeof(float);
+
+    const Xbyak::Reg64 reg_args = rbx;
+    const Xbyak::Reg64 reg_state_src = r8;
+    const Xbyak::Reg64 reg_state_dst = r9;
+    const Xbyak::Reg64 reg_B = r10;
+    const Xbyak::Reg64 reg_C = r11;
+    const Xbyak::Reg64 reg_x = r12;
+    const Xbyak::Reg64 reg_p_count = r13;
+    const Xbyak::Reg64 reg_output = rax;
+
+    const Vmm v_decay = Vmm(0);
+    const Vmm v_input_scale = Vmm(1);
+    const Vmm v_delta = Vmm(11);
+    const Xbyak::Xmm x_acc = Xbyak::Xmm(2);
+    const Vmm v_state = Vmm(3);
+    const Vmm v_B = Vmm(4);
+    const Vmm v_C = Vmm(5);
+
+    const Xbyak::Xmm x_state = Xbyak::Xmm(6);
+    const Xbyak::Xmm x_B = Xbyak::Xmm(7);
+    const Xbyak::Xmm x_C = Xbyak::Xmm(8);
+    const Xbyak::Xmm x_sum = Xbyak::Xmm(9);
+    const Xbyak::Xmm x_tmp = Xbyak::Xmm(10);
+
+    void generate() override;
+};
+
+std::shared_ptr<JitKernelBase> create_selective_ssm_jit_kernel(size_t state_size, bool prefer_avx512);
+
+}  // namespace ov::intel_cpu::kernel

--- a/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.cpp
@@ -23,11 +23,6 @@
 #include "utils/general_utils.h"
 
 namespace ov::intel_cpu::node {
-namespace {
-
-constexpr size_t target_scratch_elements = 8192;
-
-}  // namespace
 
 PagedSelectiveSSM::PagedSelectiveSSM(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
     : Node(op, context, NgraphShapeInferFactory(op)) {
@@ -86,13 +81,13 @@ void PagedSelectiveSSM::update_scratchpad() {
     const auto state_size = state_dims[3];
     const auto physical_blocks = state_dims[0];
     OPENVINO_ASSERT(state_size > 0, "PagedSelectiveSSM state_size must be greater than zero.");
-    const auto scratch_head_dim = std::max(size_t{1}, std::min(head_dim, target_scratch_elements / state_size));
+    const auto thread_count = static_cast<size_t>(context->getCpuParallel()->get_num_worker_threads());
+    const auto scratch_head_dim = kernel::get_scratch_head_dim(head_dim, state_size, x_dims[1], thread_count);
     if (m_state_scratch && m_block_owners && m_scratch_head_dim == scratch_head_dim &&
         m_scratch_state_size == state_size && m_cached_physical_blocks == physical_blocks) {
         return;
     }
 
-    const auto thread_count = static_cast<size_t>(context->getCpuParallel()->get_num_worker_threads());
     const auto state_desc =
         std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
                                                ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});

--- a/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.cpp
@@ -1,0 +1,179 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "paged_selective_ssm.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cpu_memory.h"
+#include "graph_context.h"
+#include "memory_desc/cpu_blocked_memory_desc.h"
+#include "memory_desc/cpu_memory_desc.h"
+#include "node.h"
+#include "nodes/kernels/selective_ssm.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
+#include "shape_inference/shape_inference_cpu.hpp"
+#include "utils/general_utils.h"
+
+namespace ov::intel_cpu::node {
+namespace {
+
+constexpr size_t target_scratch_elements = 8192;
+
+}  // namespace
+
+PagedSelectiveSSM::PagedSelectiveSSM(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
+    : Node(op, context, NgraphShapeInferFactory(op)) {
+    std::string errorMessage;
+    if (!isSupportedOperation(op, errorMessage)) {
+        OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
+    }
+}
+
+void PagedSelectiveSSM::initSupportedPrimitiveDescriptors() {
+    if (!supportedPrimitiveDescriptors.empty()) {
+        return;
+    }
+    const auto data_precision = getOriginalInputPrecisionAtPort(0);
+    OPENVINO_ASSERT(any_of(data_precision, ov::element::f32, ov::element::f16, ov::element::bf16),
+                    "PagedSelectiveSSM supports only f32/f16/bf16 data, got ",
+                    data_precision,
+                    ".");
+    for (size_t port = 1; port <= 5; ++port) {
+        OPENVINO_ASSERT(getOriginalInputPrecisionAtPort(port) == data_precision,
+                        "PagedSelectiveSSM requires one data precision on ports 0..5.");
+    }
+    const auto index_precision = getOriginalInputPrecisionAtPort(6);
+    OPENVINO_ASSERT(any_of(index_precision, ov::element::i32, ov::element::i64),
+                    "PagedSelectiveSSM supports only i32/i64 metadata, got ",
+                    index_precision,
+                    ".");
+    for (size_t port = 7; port <= 10; ++port) {
+        OPENVINO_ASSERT(getOriginalInputPrecisionAtPort(port) == index_precision,
+                        "PagedSelectiveSSM requires one metadata precision on ports 6..10.");
+    }
+
+    std::vector<PortConfigurator> input_configs;
+    input_configs.reserve(11);
+    for (size_t port = 0; port <= 5; ++port) {
+        input_configs.emplace_back(LayoutType::ncsp, data_precision, getInputShapeAtPort(port), false, -1);
+    }
+    for (size_t port = 6; port <= 10; ++port) {
+        input_configs.emplace_back(LayoutType::ncsp, index_precision, getInputShapeAtPort(port), false, -1);
+    }
+    std::vector<PortConfigurator> output_configs = {
+        PortConfigurator{LayoutType::ncsp, data_precision, getOutputShapeAtPort(0), false, -1}};
+    addSupportedPrimDesc(input_configs, output_configs, impl_desc_type::ref_any);
+}
+
+void PagedSelectiveSSM::update_scratchpad() {
+    const auto& x_shape = getSrcMemoryAtPort(3)->getDescPtr()->getShape();
+    const auto& state_shape = getSrcMemoryAtPort(5)->getDescPtr()->getShape();
+    if (x_shape.isDynamic() || state_shape.isDynamic()) {
+        return;
+    }
+    const auto& x_dims = x_shape.getStaticDims();
+    const auto& state_dims = state_shape.getStaticDims();
+    OPENVINO_ASSERT(x_dims.size() == 3 && state_dims.size() == 4);
+    const auto head_dim = x_dims[2];
+    const auto state_size = state_dims[3];
+    const auto physical_blocks = state_dims[0];
+    OPENVINO_ASSERT(state_size > 0, "PagedSelectiveSSM state_size must be greater than zero.");
+    const auto scratch_head_dim = std::max(size_t{1}, std::min(head_dim, target_scratch_elements / state_size));
+    if (m_state_scratch && m_block_owners && m_scratch_head_dim == scratch_head_dim &&
+        m_scratch_state_size == state_size && m_cached_physical_blocks == physical_blocks) {
+        return;
+    }
+
+    const auto thread_count = static_cast<size_t>(context->getCpuParallel()->get_num_worker_threads());
+    const auto state_desc =
+        std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
+                                               ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});
+    const auto owner_desc =
+        std::make_shared<CpuBlockedMemoryDesc>(ov::element::i32,
+                                               ov::intel_cpu::Shape{std::max(size_t{1}, physical_blocks)});
+    m_state_scratch = context->getScratchPad()->createScratchPadMem(state_desc);
+    m_block_owners = context->getScratchPad()->createScratchPadMem(owner_desc);
+    m_scratch_head_dim = scratch_head_dim;
+    m_scratch_state_size = state_size;
+    m_cached_physical_blocks = physical_blocks;
+}
+
+void PagedSelectiveSSM::createPrimitive() {
+    update_scratchpad();
+}
+
+void PagedSelectiveSSM::prepareParams() {
+    update_scratchpad();
+}
+
+void PagedSelectiveSSM::execute([[maybe_unused]] const dnnl::stream& strm) {
+    update_scratchpad();
+    OPENVINO_ASSERT(m_state_scratch && m_block_owners);
+
+    const auto& dt_dims = getSrcMemoryAtPort(1)->getStaticDims();
+    const auto& B_dims = getSrcMemoryAtPort(2)->getStaticDims();
+    const auto& x_dims = getSrcMemoryAtPort(3)->getStaticDims();
+    const auto& state_dims = getSrcMemoryAtPort(5)->getStaticDims();
+    const auto& subsequence_dims = getSrcMemoryAtPort(6)->getStaticDims();
+    const auto& block_indices_dims = getSrcMemoryAtPort(7)->getStaticDims();
+    const auto& block_begins_dims = getSrcMemoryAtPort(8)->getStaticDims();
+    const auto& processed_dims = getSrcMemoryAtPort(9)->getStaticDims();
+    const auto& interval_dims = getSrcMemoryAtPort(10)->getStaticDims();
+    OPENVINO_ASSERT(dt_dims.size() == 2 && B_dims.size() == 3 && x_dims.size() == 3 && state_dims.size() == 4);
+    OPENVINO_ASSERT(subsequence_dims.size() == 1 && block_indices_dims.size() == 1 && block_begins_dims.size() == 1 &&
+                    processed_dims.size() == 1 && interval_dims.size() == 1);
+    OPENVINO_ASSERT(subsequence_dims[0] >= 1);
+    const auto sequence_count = subsequence_dims[0] - 1;
+    OPENVINO_ASSERT(block_begins_dims[0] == sequence_count + 1 && processed_dims[0] == sequence_count &&
+                        interval_dims[0] == sequence_count,
+                    "PagedSelectiveSSM metadata tensor lengths are inconsistent.");
+
+    kernel::PagedSelectiveSSMShape shape{x_dims[0],
+                                         x_dims[1],
+                                         x_dims[2],
+                                         B_dims[1],
+                                         B_dims[2],
+                                         state_dims[0],
+                                         block_indices_dims[0],
+                                         sequence_count};
+    const auto precision = getSrcMemoryAtPort(0)->getDescPtr()->getPrecision();
+    const auto index_precision = getSrcMemoryAtPort(6)->getDescPtr()->getPrecision();
+    kernel::paged_selective_ssm(getSrcMemoryAtPort(0)->getData(),
+                                getSrcMemoryAtPort(1)->getData(),
+                                getSrcMemoryAtPort(2)->getData(),
+                                getSrcMemoryAtPort(3)->getData(),
+                                getSrcMemoryAtPort(4)->getData(),
+                                getSrcMemoryAtPort(5)->getData(),
+                                getSrcMemoryAtPort(6)->getData(),
+                                getSrcMemoryAtPort(7)->getData(),
+                                getSrcMemoryAtPort(8)->getData(),
+                                getSrcMemoryAtPort(9)->getData(),
+                                getSrcMemoryAtPort(10)->getData(),
+                                getDstMemoryAtPort(0)->getData(),
+                                shape,
+                                precision,
+                                index_precision,
+                                m_state_scratch->getDataAs<float>(),
+                                m_scratch_head_dim,
+                                m_block_owners->getDataAs<int32_t>(),
+                                context->getCpuParallel());
+}
+
+bool PagedSelectiveSSM::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
+                                             std::string& errorMessage) noexcept {
+    if (op == nullptr || !ov::is_type<ov::op::internal::PagedSelectiveSSM>(op)) {
+        errorMessage = "Node is not an instance of ov::op::internal::PagedSelectiveSSM.";
+        return false;
+    }
+    return true;
+}
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.cpp
@@ -4,18 +4,19 @@
 
 #include "paged_selective_ssm.h"
 
-#include <algorithm>
-#include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "cpu_memory.h"
 #include "graph_context.h"
-#include "memory_desc/cpu_blocked_memory_desc.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "node.h"
-#include "nodes/kernels/selective_ssm.hpp"
+#include "nodes/common/blocked_desc_creator.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/executor_factory.hpp"
+#include "nodes/executors/memory_arguments.hpp"
+#include "nodes/executors/paged_selective_ssm_config.hpp"
+#include "nodes/node_config.h"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/paged_selective_ssm.hpp"
@@ -30,12 +31,21 @@ PagedSelectiveSSM::PagedSelectiveSSM(const std::shared_ptr<ov::Node>& op, const 
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
+
+    m_atoi[ARG_PAGED_SSM_A] = 0;
+    m_atoi[ARG_PAGED_SSM_DT] = 1;
+    m_atoi[ARG_PAGED_SSM_B] = 2;
+    m_atoi[ARG_PAGED_SSM_X] = 3;
+    m_atoi[ARG_PAGED_SSM_C] = 4;
+    m_atoi[ARG_PAGED_SSM_STATE] = 5;
+    m_atoi[ARG_PAGED_SSM_SUBSEQUENCE_BEGINS] = 6;
+    m_atoi[ARG_PAGED_SSM_BLOCK_INDICES] = 7;
+    m_atoi[ARG_PAGED_SSM_BLOCK_INDICES_BEGINS] = 8;
+    m_atoi[ARG_PAGED_SSM_NUM_PROCESSED_TOKENS] = 9;
+    m_atoi[ARG_PAGED_SSM_CACHE_INTERVAL] = 10;
 }
 
 void PagedSelectiveSSM::initSupportedPrimitiveDescriptors() {
-    if (!supportedPrimitiveDescriptors.empty()) {
-        return;
-    }
     const auto data_precision = getOriginalInputPrecisionAtPort(0);
     OPENVINO_ASSERT(any_of(data_precision, ov::element::f32, ov::element::f16, ov::element::bf16),
                     "PagedSelectiveSSM supports only f32/f16/bf16 data, got ",
@@ -55,111 +65,60 @@ void PagedSelectiveSSM::initSupportedPrimitiveDescriptors() {
                         "PagedSelectiveSSM requires one metadata precision on ports 6..10.");
     }
 
-    std::vector<PortConfigurator> input_configs;
-    input_configs.reserve(11);
-    for (size_t port = 0; port <= 5; ++port) {
-        input_configs.emplace_back(LayoutType::ncsp, data_precision, getInputShapeAtPort(port), false, -1);
+    const auto& creators_map = BlockedDescCreator::getCommonCreators();
+    MemoryDescArgs descs;
+    for (const auto& [arg_id, port_id] : m_atoi) {
+        descs[arg_id] = creators_map.at(LayoutType::ncsp)
+                            ->createSharedDesc(getOriginalInputPrecisionAtPort(port_id), getInputShapeAtPort(port_id));
     }
-    for (size_t port = 6; port <= 10; ++port) {
-        input_configs.emplace_back(LayoutType::ncsp, index_precision, getInputShapeAtPort(port), false, -1);
-    }
-    std::vector<PortConfigurator> output_configs = {
-        PortConfigurator{LayoutType::ncsp, data_precision, getOutputShapeAtPort(0), false, -1}};
-    addSupportedPrimDesc(input_configs, output_configs, impl_desc_type::ref_any);
-}
+    descs[ARG_PAGED_SSM_OUT] = creators_map.at(LayoutType::ncsp)
+                                   ->createSharedDesc(getOriginalOutputPrecisionAtPort(0), getOutputShapeAtPort(0));
 
-void PagedSelectiveSSM::update_scratchpad() {
-    const auto& x_shape = getSrcMemoryAtPort(3)->getDescPtr()->getShape();
-    const auto& state_shape = getSrcMemoryAtPort(5)->getDescPtr()->getShape();
-    if (x_shape.isDynamic() || state_shape.isDynamic()) {
-        return;
-    }
-    const auto& x_dims = x_shape.getStaticDims();
-    const auto& state_dims = state_shape.getStaticDims();
-    OPENVINO_ASSERT(x_dims.size() == 3 && state_dims.size() == 4);
-    const auto head_dim = x_dims[2];
-    const auto state_size = state_dims[3];
-    const auto physical_blocks = state_dims[0];
-    OPENVINO_ASSERT(state_size > 0, "PagedSelectiveSSM state_size must be greater than zero.");
-    const auto thread_count = static_cast<size_t>(context->getCpuParallel()->get_num_worker_threads());
-    const auto scratch_head_dim = kernel::get_scratch_head_dim(head_dim, state_size, x_dims[1], thread_count);
-    if (m_state_scratch && m_block_owners && m_scratch_head_dim == scratch_head_dim &&
-        m_scratch_state_size == state_size && m_cached_physical_blocks == physical_blocks) {
-        return;
-    }
+    auto execution_context = std::make_shared<ExecutorContext>(context, getImplPriority(), privateWeightCache);
+    m_factory = std::make_shared<ExecutorFactory<PagedSelectiveSSMAttrs>>(m_attrs, execution_context, descs);
 
-    const auto state_desc =
-        std::make_shared<CpuBlockedMemoryDesc>(ov::element::f32,
-                                               ov::intel_cpu::Shape{thread_count, scratch_head_dim * state_size});
-    const auto owner_desc =
-        std::make_shared<CpuBlockedMemoryDesc>(ov::element::i32,
-                                               ov::intel_cpu::Shape{std::max(size_t{1}, physical_blocks)});
-    m_state_scratch = context->getScratchPad()->createScratchPadMem(state_desc);
-    m_block_owners = context->getScratchPad()->createScratchPadMem(owner_desc);
-    m_scratch_head_dim = scratch_head_dim;
-    m_scratch_state_size = state_size;
-    m_cached_physical_blocks = physical_blocks;
+    const auto node_descriptors_list = m_factory->getProperMemoryDescriptors(descs);
+    for (const auto& node_descriptors : node_descriptors_list) {
+        NodeConfig node_config;
+        node_config.inConfs.resize(getParentEdges().size());
+        for (const auto& [arg_id, port_id] : m_atoi) {
+            if (node_descriptors.count(arg_id)) {
+                node_config.inConfs[port_id] = PortConfig{node_descriptors.at(arg_id)};
+            }
+        }
+        node_config.outConfs.emplace_back(node_descriptors.at(ARG_PAGED_SSM_OUT));
+        supportedPrimitiveDescriptors.emplace_back(node_config, impl_desc_type::undef);
+    }
 }
 
 void PagedSelectiveSSM::createPrimitive() {
-    update_scratchpad();
+    for (const auto& [arg_id, port_id] : m_atoi) {
+        m_memory[arg_id] = getSrcMemoryAtPort(port_id);
+    }
+    m_memory[ARG_PAGED_SSM_OUT] = getDstMemoryAtPort(0);
+
+    m_executor = m_factory->make(m_memory);
+    Node::createPrimitive();
+    getSelectedPrimitiveDescriptor()->setImplementationType(m_executor->implType());
 }
 
 void PagedSelectiveSSM::prepareParams() {
-    update_scratchpad();
+    for (const auto& [arg_id, port_id] : m_atoi) {
+        m_memory[arg_id] = getSrcMemoryAtPort(port_id);
+    }
+    m_memory[ARG_PAGED_SSM_OUT] = getDstMemoryAtPort(0);
+
+    m_executor->update(m_memory);
+    getSelectedPrimitiveDescriptor()->setImplementationType(m_executor->implType());
 }
 
 void PagedSelectiveSSM::execute([[maybe_unused]] const dnnl::stream& strm) {
-    update_scratchpad();
-    OPENVINO_ASSERT(m_state_scratch && m_block_owners);
+    for (const auto& [arg_id, port_id] : m_atoi) {
+        m_memory[arg_id] = getSrcMemoryAtPort(port_id);
+    }
+    m_memory[ARG_PAGED_SSM_OUT] = getDstMemoryAtPort(0);
 
-    const auto& dt_dims = getSrcMemoryAtPort(1)->getStaticDims();
-    const auto& B_dims = getSrcMemoryAtPort(2)->getStaticDims();
-    const auto& x_dims = getSrcMemoryAtPort(3)->getStaticDims();
-    const auto& state_dims = getSrcMemoryAtPort(5)->getStaticDims();
-    const auto& subsequence_dims = getSrcMemoryAtPort(6)->getStaticDims();
-    const auto& block_indices_dims = getSrcMemoryAtPort(7)->getStaticDims();
-    const auto& block_begins_dims = getSrcMemoryAtPort(8)->getStaticDims();
-    const auto& processed_dims = getSrcMemoryAtPort(9)->getStaticDims();
-    const auto& interval_dims = getSrcMemoryAtPort(10)->getStaticDims();
-    OPENVINO_ASSERT(dt_dims.size() == 2 && B_dims.size() == 3 && x_dims.size() == 3 && state_dims.size() == 4);
-    OPENVINO_ASSERT(subsequence_dims.size() == 1 && block_indices_dims.size() == 1 && block_begins_dims.size() == 1 &&
-                    processed_dims.size() == 1 && interval_dims.size() == 1);
-    OPENVINO_ASSERT(subsequence_dims[0] >= 1);
-    const auto sequence_count = subsequence_dims[0] - 1;
-    OPENVINO_ASSERT(block_begins_dims[0] == sequence_count + 1 && processed_dims[0] == sequence_count &&
-                        interval_dims[0] == sequence_count,
-                    "PagedSelectiveSSM metadata tensor lengths are inconsistent.");
-
-    kernel::PagedSelectiveSSMShape shape{x_dims[0],
-                                         x_dims[1],
-                                         x_dims[2],
-                                         B_dims[1],
-                                         B_dims[2],
-                                         state_dims[0],
-                                         block_indices_dims[0],
-                                         sequence_count};
-    const auto precision = getSrcMemoryAtPort(0)->getDescPtr()->getPrecision();
-    const auto index_precision = getSrcMemoryAtPort(6)->getDescPtr()->getPrecision();
-    kernel::paged_selective_ssm(getSrcMemoryAtPort(0)->getData(),
-                                getSrcMemoryAtPort(1)->getData(),
-                                getSrcMemoryAtPort(2)->getData(),
-                                getSrcMemoryAtPort(3)->getData(),
-                                getSrcMemoryAtPort(4)->getData(),
-                                getSrcMemoryAtPort(5)->getData(),
-                                getSrcMemoryAtPort(6)->getData(),
-                                getSrcMemoryAtPort(7)->getData(),
-                                getSrcMemoryAtPort(8)->getData(),
-                                getSrcMemoryAtPort(9)->getData(),
-                                getSrcMemoryAtPort(10)->getData(),
-                                getDstMemoryAtPort(0)->getData(),
-                                shape,
-                                precision,
-                                index_precision,
-                                m_state_scratch->getDataAs<float>(),
-                                m_scratch_head_dim,
-                                m_block_owners->getDataAs<int32_t>(),
-                                context->getCpuParallel());
+    m_executor->execute(m_memory);
 }
 
 bool PagedSelectiveSSM::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,

--- a/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.h
+++ b/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.h
@@ -4,15 +4,17 @@
 
 #pragma once
 
-#include <cstddef>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
+#include <unordered_map>
 
-#include "cpu_memory.h"
 #include "cpu_types.h"
 #include "graph_context.h"
 #include "node.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/executor_factory.hpp"
+#include "nodes/executors/paged_selective_ssm_config.hpp"
 #include "openvino/core/node.hpp"
 
 namespace ov::intel_cpu::node {
@@ -42,13 +44,11 @@ public:
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 private:
-    void update_scratchpad();
-
-    MemoryPtr m_state_scratch;
-    MemoryPtr m_block_owners;
-    size_t m_scratch_head_dim = 0;
-    size_t m_scratch_state_size = 0;
-    size_t m_cached_physical_blocks = 0;
+    PagedSelectiveSSMAttrs m_attrs;
+    ExecutorFactoryPtr<PagedSelectiveSSMAttrs> m_factory;
+    ExecutorPtr m_executor;
+    MemoryArgs m_memory;
+    std::unordered_map<int, int> m_atoi;
 };
 
 }  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.h
+++ b/src/plugins/intel_cpu/src/nodes/paged_selective_ssm.h
@@ -1,0 +1,54 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <oneapi/dnnl/dnnl_common.hpp>
+#include <string>
+
+#include "cpu_memory.h"
+#include "cpu_types.h"
+#include "graph_context.h"
+#include "node.h"
+#include "openvino/core/node.hpp"
+
+namespace ov::intel_cpu::node {
+
+class PagedSelectiveSSM : public Node {
+public:
+    PagedSelectiveSSM(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
+
+    void getSupportedDescriptors() override {}
+    bool created() const override {
+        return getType() == Type::PagedSelectiveSSM;
+    }
+    bool isExecutable() const override {
+        return !isInputTensorAtPortEmpty(3);
+    }
+    bool needPrepareParams() const override {
+        return true;
+    }
+
+    void createPrimitive() override;
+    void prepareParams() override;
+    void executeDynamicImpl(const dnnl::stream& strm) override {
+        execute(strm);
+    }
+    void initSupportedPrimitiveDescriptors() override;
+    void execute(const dnnl::stream& strm) override;
+    static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
+
+private:
+    void update_scratchpad();
+
+    MemoryPtr m_state_scratch;
+    MemoryPtr m_block_owners;
+    size_t m_scratch_head_dim = 0;
+    size_t m_scratch_state_size = 0;
+    size_t m_cached_physical_blocks = 0;
+};
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/selective_ssm.cpp
@@ -1,0 +1,114 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "selective_ssm.h"
+
+#include <memory>
+#include <vector>
+
+#include "graph_context.h"
+#include "memory_desc/cpu_memory_desc.h"
+#include "node.h"
+#include "nodes/common/blocked_desc_creator.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/executor_factory.hpp"
+#include "nodes/executors/memory_arguments.hpp"
+#include "nodes/executors/selective_ssm_config.hpp"
+#include "nodes/node_config.h"
+#include "openvino/core/except.hpp"
+#include "openvino/op/selective_ssm.hpp"
+#include "shape_inference/shape_inference_cpu.hpp"
+
+namespace ov::intel_cpu::node {
+
+SelectiveSSM::SelectiveSSM(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
+    : Node(op, context, NgraphShapeInferFactory(op)) {
+    std::string errorMessage;
+    if (!isSupportedOperation(op, errorMessage)) {
+        OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
+    }
+
+    m_atoi[ARG_SSM_A] = 0;
+    m_atoi[ARG_SSM_DT] = 1;
+    m_atoi[ARG_SSM_B] = 2;
+    m_atoi[ARG_SSM_X] = 3;
+    m_atoi[ARG_SSM_C] = 4;
+    m_atoi[ARG_SSM_STATE] = 5;
+}
+
+void SelectiveSSM::initSupportedPrimitiveDescriptors() {
+    const auto& creatorsMap = BlockedDescCreator::getCommonCreators();
+
+    MemoryDescArgs descs;
+    for (const auto& [argId, portId] : m_atoi) {
+        descs[argId] = creatorsMap.at(LayoutType::ncsp)
+                           ->createSharedDesc(getOriginalInputPrecisionAtPort(portId), getInputShapeAtPort(portId));
+    }
+    descs[ARG_SSM_OUT] = creatorsMap.at(LayoutType::ncsp)
+                             ->createSharedDesc(getOriginalOutputPrecisionAtPort(0), getOutputShapeAtPort(0));
+    descs[ARG_SSM_OUT_STATE] = creatorsMap.at(LayoutType::ncsp)
+                                   ->createSharedDesc(getOriginalOutputPrecisionAtPort(1), getOutputShapeAtPort(1));
+
+    auto executionContext = std::make_shared<ExecutorContext>(context, getImplPriority(), privateWeightCache);
+    m_factory = std::make_shared<ExecutorFactory<SelectiveSSMAttrs>>(m_attrs, executionContext, descs);
+
+    const auto nodeDescriptorsList = m_factory->getProperMemoryDescriptors(descs);
+    for (const auto& nodeDescriptors : nodeDescriptorsList) {
+        NodeConfig nodeConfig;
+        nodeConfig.inConfs.resize(getParentEdges().size());
+
+        for (const auto& [argId, portId] : m_atoi) {
+            if (nodeDescriptors.count(argId)) {
+                nodeConfig.inConfs[portId] = PortConfig{nodeDescriptors.at(argId)};
+            }
+        }
+
+        nodeConfig.outConfs.emplace_back(nodeDescriptors.at(ARG_SSM_OUT));
+        nodeConfig.outConfs.emplace_back(nodeDescriptors.at(ARG_SSM_OUT_STATE));
+        supportedPrimitiveDescriptors.emplace_back(nodeConfig, impl_desc_type::undef);
+    }
+}
+
+void SelectiveSSM::createPrimitive() {
+    for (const auto& [argId, portId] : m_atoi) {
+        m_memory[argId] = getSrcMemoryAtPort(portId);
+    }
+    m_memory[ARG_SSM_OUT] = getDstMemoryAtPort(0);
+    m_memory[ARG_SSM_OUT_STATE] = getDstMemoryAtPort(1);
+
+    m_executor = m_factory->make(m_memory);
+    Node::createPrimitive();
+    getSelectedPrimitiveDescriptor()->setImplementationType(m_executor->implType());
+}
+
+void SelectiveSSM::prepareParams() {
+    for (const auto& [argId, portId] : m_atoi) {
+        m_memory[argId] = getSrcMemoryAtPort(portId);
+    }
+    m_memory[ARG_SSM_OUT] = getDstMemoryAtPort(0);
+    m_memory[ARG_SSM_OUT_STATE] = getDstMemoryAtPort(1);
+
+    m_executor->update(m_memory);
+    getSelectedPrimitiveDescriptor()->setImplementationType(m_executor->implType());
+}
+
+void SelectiveSSM::execute([[maybe_unused]] const dnnl::stream& strm) {
+    for (const auto& [argId, portId] : m_atoi) {
+        m_memory[argId] = getSrcMemoryAtPort(portId);
+    }
+    m_memory[ARG_SSM_OUT] = getDstMemoryAtPort(0);
+    m_memory[ARG_SSM_OUT_STATE] = getDstMemoryAtPort(1);
+
+    m_executor->execute(m_memory);
+}
+
+bool SelectiveSSM::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
+    if (op == nullptr || !ov::is_type<ov::op::internal::SelectiveSSM>(op)) {
+        errorMessage = "Node is not an instance of ov::op::internal::SelectiveSSM.";
+        return false;
+    }
+    return true;
+}
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/selective_ssm.h
+++ b/src/plugins/intel_cpu/src/nodes/selective_ssm.h
@@ -1,0 +1,53 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <oneapi/dnnl/dnnl_common.hpp>
+#include <string>
+#include <unordered_map>
+
+#include "cpu_types.h"
+#include "graph_context.h"
+#include "node.h"
+#include "nodes/executors/executor.hpp"
+#include "nodes/executors/executor_factory.hpp"
+#include "nodes/executors/selective_ssm_config.hpp"
+#include "openvino/core/node.hpp"
+
+namespace ov::intel_cpu::node {
+
+class SelectiveSSM : public Node {
+public:
+    SelectiveSSM(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
+
+    void getSupportedDescriptors() override {}
+    bool created() const override {
+        return getType() == Type::SelectiveSSM;
+    }
+
+    bool isExecutable() const override {
+        return true;
+    }
+
+    void createPrimitive() override;
+    void prepareParams() override;
+
+    void executeDynamicImpl(const dnnl::stream& strm) override {
+        execute(strm);
+    }
+    void initSupportedPrimitiveDescriptors() override;
+    void execute(const dnnl::stream& strm) override;
+    static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
+
+private:
+    SelectiveSSMAttrs m_attrs;
+    ExecutorFactoryPtr<SelectiveSSMAttrs> m_factory;
+    ExecutorPtr m_executor;
+    MemoryArgs m_memory;
+    std::unordered_map<int, int> m_atoi;
+};
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes_factory.cpp
+++ b/src/plugins/intel_cpu/src/nodes_factory.cpp
@@ -70,6 +70,7 @@
 #include "nodes/pad.h"
 #include "nodes/paged_causal_conv1d.h"
 #include "nodes/paged_gated_delta_net.h"
+#include "nodes/paged_selective_ssm.h"
 #include "nodes/pooling.h"
 #include "nodes/priorbox.h"
 #include "nodes/priorbox_clustered.h"
@@ -94,6 +95,7 @@
 #include "nodes/scatter_update.h"
 #include "nodes/search_sorted.h"
 #include "nodes/segment_max.h"
+#include "nodes/selective_ssm.h"
 #include "nodes/shapeof.h"
 #include "nodes/shuffle_channels.h"
 #include "nodes/softmax.h"
@@ -249,6 +251,8 @@ Node::NodesFactory::NodesFactory() : Factory("NodesFactory") {
     INTEL_CPU_NODE(GatherMatmul, Type::GatherMatmul);
     INTEL_CPU_NODE(GatedDeltaNet, Type::GatedDeltaNet);
     INTEL_CPU_NODE(PagedGatedDeltaNet, Type::PagedGatedDeltaNet);
+    INTEL_CPU_NODE(SelectiveSSM, Type::SelectiveSSM);
+    INTEL_CPU_NODE(PagedSelectiveSSM, Type::PagedSelectiveSSM);
     INTEL_CPU_NODE(PagedCausalConv1D, Type::PagedCausalConv1D);
 #if defined(OPENVINO_ARCH_X86_64)
     INTEL_CPU_NODE(FakeQuantize, Type::FakeQuantize);

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -155,6 +155,7 @@
 #include "openvino/op/nv12_to_rgb.hpp"
 #include "openvino/op/one_hot.hpp"
 #include "openvino/op/pad.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/prelu.hpp"
 #include "openvino/op/prior_box.hpp"
@@ -192,6 +193,7 @@
 #include "openvino/op/search_sorted.hpp"
 #include "openvino/op/segment_max.hpp"
 #include "openvino/op/select.hpp"
+#include "openvino/op/selective_ssm.hpp"
 #include "openvino/op/selu.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/shuffle_channels.hpp"
@@ -222,6 +224,7 @@
 #include "ov_ops/augru_sequence.hpp"
 #include "ov_ops/glu.hpp"
 #include "pad_shape_inference.hpp"
+#include "paged_selective_ssm_shape_inference.hpp"
 #include "prior_box_clustered_shape_inference.hpp"
 #include "prior_box_shape_inference.hpp"
 #include "proposal_shape_inference.hpp"
@@ -247,6 +250,7 @@
 #include "search_sorted_shape_inference.hpp"
 #include "segment_max_shape_inference.hpp"
 #include "select_shape_inference.hpp"
+#include "selective_ssm_shape_inference.hpp"
 #include "shape_inference/shape_inference_cpu.hpp"
 #include "shape_inference/shape_inference_status.hpp"
 #include "shape_nodes.hpp"
@@ -563,7 +567,8 @@ std::shared_ptr<typename TShapeInfer::iface_type> make_shape_infer(std::shared_p
 using ShapeInferKey = ov::NodeTypeInfo;
 
 // Helper macros to make map entries
-#define _OV_OP_SHAPE_INFER_VA_REG(OP, ...)                  {OP::get_type_info_static(), make_shape_infer<__VA_ARGS__>}
+#define _OV_OP_SHAPE_INFER_VA_REG(OP, ...) \
+    { OP::get_type_info_static(), make_shape_infer<__VA_ARGS__> }
 #define OV_OP_SHAPE_INFER_MASK_REG(OP, SHAPE_INFER, MASK)   _OV_OP_SHAPE_INFER_VA_REG(OP, SHAPE_INFER, OP, MASK)
 #define OV_OP_SHAPE_INFER_NON_TEMPLATE_REG(OP, SHAPE_INFER) _OV_OP_SHAPE_INFER_VA_REG(OP, SHAPE_INFER)
 
@@ -754,6 +759,8 @@ const IStaticShapeInferFactory::TRegistry IStaticShapeInferFactory::registry{
     OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::AUGRUSequence, ShapeInferTA, util::bit::mask()),
     OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::RMSNorm, ShapeInferTA, util::bit::mask(1)),
     OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::GLU, ShapeInferTA, util::bit::mask()),
+    OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::SelectiveSSM, ShapeInferTA, util::bit::mask()),
+    OV_OP_SHAPE_INFER_MASK_REG(ov::op::internal::PagedSelectiveSSM, ShapeInferTA, util::bit::mask()),
 };
 // clang-format on
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -43,6 +43,7 @@
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/max_pool.hpp"
 #include "openvino/op/paged_attention.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
 #include "openvino/op/reduce_max.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/reshape.hpp"
@@ -129,6 +130,7 @@
 #include "transformations/op_conversions/unique_decomposition.hpp"
 #include "transformations/opset_conversions/convert_opset2_to_opset1.hpp"
 #include "transformations/paged_attention/convert_pagedattn_inputs.hpp"
+#include "transformations/rt_info/disable_precision_conversion.hpp"
 #include "transformations/rt_info/keep_const_precision.hpp"
 #include "transformations/smart_reshape/matmul_sr.hpp"
 #include "transformations/symbolic_transformations/symbolic_optimizations.hpp"
@@ -286,6 +288,30 @@
 namespace ov::intel_cpu {
 
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
+
+class PreservePagedSelectiveSSMPrecision final : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("PreservePagedSelectiveSSMPrecision");
+
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override {
+        for (const auto& node : model->get_ordered_ops()) {
+            if (!ov::is_type<ov::op::internal::PagedSelectiveSSM>(node)) {
+                continue;
+            }
+
+            // The state table is updated through input port 5. Changing the data precision would insert
+            // a conversion and redirect the side effect to a temporary buffer. Keep the operation and the
+            // producers of all same-T data inputs in their original precision.
+            ov::disable_conversion(node, ov::element::dynamic, ov::element::dynamic);
+            for (size_t input = 0; input < 6; ++input) {
+                ov::disable_conversion(node->get_input_node_shared_ptr(input),
+                                       ov::element::dynamic,
+                                       ov::element::dynamic);
+            }
+        }
+        return false;
+    }
+};
 
 bool Transformations::is_decompression_multiply(const_node_ptr& node) {
     auto is_1x1_conv = [](const ov::Node* node) {
@@ -627,6 +653,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     // supported, this may lead to inconsistency during element type propagation. This transformation is called before
     // the ConvertPrecision pass to align the actual precisions with the list of supported ones.
     constexpr bool convert_input_output_precision = false;
+    CPU_REGISTER_PASS_COMMON(manager, PreservePagedSelectiveSSMPrecision);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::InsertConvertAfterExtension, convert_input_output_precision);
     // Do not insert pass::Validate between pass::InsertConvertAfterExtension and pass::ConvertPrecision.
     // This may result in the loss of the original Element type of the Output .

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -48,6 +48,7 @@
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/result.hpp"
+#include "openvino/op/selective_ssm.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/util/attr_types.hpp"
 #include "ov_ops/gather_compressed.hpp"
@@ -66,6 +67,7 @@
 #include "transformations/common_optimizations/fq_mul_fusion.hpp"
 #include "transformations/common_optimizations/fuse_gated_delta_net.hpp"
 #include "transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp"
+#include "transformations/common_optimizations/fuse_selective_ssm.hpp"
 #include "transformations/common_optimizations/lora_subgraph_fusion.hpp"
 #include "transformations/common_optimizations/lstm_cell_fusion.hpp"
 #include "transformations/common_optimizations/mark_precision_sensitive_shapeof_subgraphs.hpp"
@@ -289,29 +291,23 @@ namespace ov::intel_cpu {
 
 using const_node_ptr = const std::shared_ptr<const ov::Node>;
 
-class PreservePagedSelectiveSSMPrecision final : public ov::pass::ModelPass {
-public:
-    OPENVINO_MODEL_PASS_RTTI("PreservePagedSelectiveSSMPrecision");
-
-    bool run_on_model(const std::shared_ptr<ov::Model>& model) override {
-        for (const auto& node : model->get_ordered_ops()) {
-            if (!ov::is_type<ov::op::internal::PagedSelectiveSSM>(node)) {
-                continue;
-            }
-
-            // The state table is updated through input port 5. Changing the data precision would insert
-            // a conversion and redirect the side effect to a temporary buffer. Keep the operation and the
-            // producers of all same-T data inputs in their original precision.
-            ov::disable_conversion(node, ov::element::dynamic, ov::element::dynamic);
-            for (size_t input = 0; input < 6; ++input) {
-                ov::disable_conversion(node->get_input_node_shared_ptr(input),
-                                       ov::element::dynamic,
-                                       ov::element::dynamic);
-            }
+bool PreserveSelectiveSSMPrecision::run_on_model(const std::shared_ptr<ov::Model>& model) {
+    for (const auto& node : model->get_ordered_ops()) {
+        if (!ov::is_type<ov::op::internal::SelectiveSSM>(node) &&
+            !ov::is_type<ov::op::internal::PagedSelectiveSSM>(node)) {
+            continue;
         }
-        return false;
+
+        // Changing the data precision may make same-T inputs inconsistent and, for the paged operation,
+        // redirect state-table updates to a temporary buffer. Keep both operations and the producers of
+        // all same-T data inputs in their original precision.
+        ov::disable_conversion(node, ov::element::dynamic, ov::element::dynamic);
+        for (size_t input = 0; input < 6; ++input) {
+            ov::disable_conversion(node->get_input_node_shared_ptr(input), ov::element::dynamic, ov::element::dynamic);
+        }
     }
-};
+    return false;
+}
 
 bool Transformations::is_decompression_multiply(const_node_ptr& node) {
     auto is_1x1_conv = [](const ov::Node* node) {
@@ -620,6 +616,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::AUGRUCellFusion);
     CPU_REGISTER_PASS_COMMON(manager, SDPASubgraphFusion);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::GatedDeltaNetFusion);
+    CPU_REGISTER_PASS_COMMON(manager, ov::pass::SelectiveSSMFusion);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::CommonOptimizations);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::KeepConstPrecision, decompression_precisions, false, true);
     CPU_SET_CALLBACK_COMMON(
@@ -653,7 +650,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     // supported, this may lead to inconsistency during element type propagation. This transformation is called before
     // the ConvertPrecision pass to align the actual precisions with the list of supported ones.
     constexpr bool convert_input_output_precision = false;
-    CPU_REGISTER_PASS_COMMON(manager, PreservePagedSelectiveSSMPrecision);
+    CPU_REGISTER_PASS_COMMON(manager, PreserveSelectiveSSMPrecision);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::InsertConvertAfterExtension, convert_input_output_precision);
     // Do not insert pass::Validate between pass::InsertConvertAfterExtension and pass::ConvertPrecision.
     // This may result in the loss of the original Element type of the Output .

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.h
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.h
@@ -12,9 +12,17 @@
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/pass/pass.hpp"
 #include "transformations/convert_precision.hpp"
 
 namespace ov::intel_cpu {
+
+class PreserveSelectiveSSMPrecision final : public ov::pass::ModelPass {
+public:
+    OPENVINO_MODEL_PASS_RTTI("PreserveSelectiveSSMPrecision");
+
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+};
 
 class Transformations {
 public:

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/paged_selective_ssm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/paged_selective_ssm.cpp
@@ -15,6 +15,8 @@ std::vector<PagedSelectiveSSMLayerParams> paged_selective_ssm_test_cases = {
     {4, 2, 5, 3, {0, 2, 1}, {7, 1, 0}, {2, 2, 4}, ov::element::f32, ov::element::i32, "CPU"},
     {4, 1, 3, 4, {3, 2}, {5, 9}, {0, -3}, ov::element::f32, ov::element::i32, "CPU"},
     {3, 3, 1, 1, {4}, {0}, {1}, ov::element::f32, ov::element::i64, "CPU"},
+    {64, 1, 64, 128, {1}, {0}, {1}, ov::element::f32, ov::element::i32, "CPU"},
+    {96, 8, 80, 80, {5}, {0}, {2}, ov::element::f32, ov::element::i64, "CPU"},
     {4, 2, 5, 3, {3, 1}, {1, 4}, {3, 2}, ov::element::f16, ov::element::i64, "CPU"},
     {4, 2, 5, 3, {3, 1}, {1, 4}, {3, 2}, ov::element::bf16, ov::element::i32, "CPU"},
 };

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/paged_selective_ssm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/paged_selective_ssm.cpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_op_tests/paged_selective_ssm.hpp"
+
+namespace ov::test {
+
+std::vector<PagedSelectiveSSMLayerParams> paged_selective_ssm_test_cases = {
+    {4, 2, 8, 8, {3, 2}, {2, 0}, ov::element::f32, "CPU"},
+    {4, 1, 8, 16, {2, 4, 1}, {1, 3, 2}, ov::element::f32, "CPU"},
+    {8, 2, 16, 16, {4, 3}, {2, 4}, ov::element::f32, "CPU"},
+    {4, 2, 8, 8, {3, 2}, {2, 0}, ov::element::f16, "CPU"},
+    {4, 2, 8, 8, {3, 2}, {2, 0}, ov::element::bf16, "CPU"},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_PagedSelectiveSSM,
+                         PagedSelectiveSSMLayerTest,
+                         ::testing::ValuesIn(paged_selective_ssm_test_cases),
+                         PagedSelectiveSSMLayerTest::getTestCaseName);
+
+}  // namespace ov::test

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/paged_selective_ssm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/paged_selective_ssm.cpp
@@ -15,10 +15,17 @@ std::vector<PagedSelectiveSSMLayerParams> paged_selective_ssm_test_cases = {
     {4, 2, 5, 3, {0, 2, 1}, {7, 1, 0}, {2, 2, 4}, ov::element::f32, ov::element::i32, "CPU"},
     {4, 1, 3, 4, {3, 2}, {5, 9}, {0, -3}, ov::element::f32, ov::element::i32, "CPU"},
     {3, 3, 1, 1, {4}, {0}, {1}, ov::element::f32, ov::element::i64, "CPU"},
+    {4, 2, 5, 3, {1}, {0}, {2}, ov::element::f32, ov::element::i64, "CPU"},
     {64, 1, 64, 128, {1}, {0}, {1}, ov::element::f32, ov::element::i32, "CPU"},
     {96, 8, 80, 80, {5}, {0}, {2}, ov::element::f32, ov::element::i64, "CPU"},
+    {4, 2, 5, 3, {1}, {0}, {2}, ov::element::f16, ov::element::i32, "CPU"},
+    {4, 2, 5, 3, {3, 1}, {1, 4}, {3, 2}, ov::element::f16, ov::element::i32, "CPU"},
+    {4, 2, 5, 3, {1}, {0}, {2}, ov::element::f16, ov::element::i64, "CPU"},
     {4, 2, 5, 3, {3, 1}, {1, 4}, {3, 2}, ov::element::f16, ov::element::i64, "CPU"},
+    {4, 2, 5, 3, {1}, {0}, {2}, ov::element::bf16, ov::element::i32, "CPU"},
     {4, 2, 5, 3, {3, 1}, {1, 4}, {3, 2}, ov::element::bf16, ov::element::i32, "CPU"},
+    {4, 2, 5, 3, {1}, {0}, {2}, ov::element::bf16, ov::element::i64, "CPU"},
+    {4, 2, 5, 3, {3, 1}, {1, 4}, {3, 2}, ov::element::bf16, ov::element::i64, "CPU"},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_PagedSelectiveSSM,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/paged_selective_ssm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/paged_selective_ssm.cpp
@@ -7,11 +7,16 @@
 namespace ov::test {
 
 std::vector<PagedSelectiveSSMLayerParams> paged_selective_ssm_test_cases = {
-    {4, 2, 8, 8, {3, 2}, {2, 0}, ov::element::f32, "CPU"},
-    {4, 1, 8, 16, {2, 4, 1}, {1, 3, 2}, ov::element::f32, "CPU"},
-    {8, 2, 16, 16, {4, 3}, {2, 4}, ov::element::f32, "CPU"},
-    {4, 2, 8, 8, {3, 2}, {2, 0}, ov::element::f16, "CPU"},
-    {4, 2, 8, 8, {3, 2}, {2, 0}, ov::element::bf16, "CPU"},
+    {4, 2, 5, 3, {3}, {0}, {2}, ov::element::f32, ov::element::i32, "CPU"},
+    {4, 2, 5, 3, {3}, {4}, {2}, ov::element::f32, ov::element::i32, "CPU"},
+    {4, 2, 5, 3, {4}, {1}, {3}, ov::element::f32, ov::element::i32, "CPU"},
+    {4, 2, 5, 3, {1}, {4}, {2}, ov::element::f32, ov::element::i32, "CPU"},
+    {4, 2, 5, 3, {1}, {3}, {2}, ov::element::f32, ov::element::i32, "CPU"},
+    {4, 2, 5, 3, {0, 2, 1}, {7, 1, 0}, {2, 2, 4}, ov::element::f32, ov::element::i32, "CPU"},
+    {4, 1, 3, 4, {3, 2}, {5, 9}, {0, -3}, ov::element::f32, ov::element::i32, "CPU"},
+    {3, 3, 1, 1, {4}, {0}, {1}, ov::element::f32, ov::element::i64, "CPU"},
+    {4, 2, 5, 3, {3, 1}, {1, 4}, {3, 2}, ov::element::f16, ov::element::i64, "CPU"},
+    {4, 2, 5, 3, {3, 1}, {1, 4}, {3, 2}, ov::element::bf16, ov::element::i32, "CPU"},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_PagedSelectiveSSM,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/selective_ssm.cpp
@@ -15,6 +15,8 @@ std::vector<selective_ssm_params> selective_ssm_test_cases = {
     {2, 3, 4, 1, 8, 8, ov::element::f32, "CPU"},
     {1, 4, 4, 2, 8, 16, ov::element::f16, "CPU"},
     {1, 4, 4, 2, 8, 16, ov::element::bf16, "CPU"},
+    {1, 1, 64, 1, 64, 128, ov::element::f32, "CPU"},
+    {1, 5, 96, 8, 80, 80, ov::element::f32, "CPU"},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_SelectiveSSM,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/selective_ssm.cpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "subgraph_tests/selective_ssm.hpp"
+
+namespace ov::test {
+
+std::vector<selective_ssm_params> selective_ssm_test_cases = {
+    {1, 4, 4, 2, 8, 16, ov::element::f32, "CPU"},
+    {2, 3, 4, 1, 8, 8, ov::element::f32, "CPU"},
+    {1, 6, 8, 2, 16, 16, ov::element::f32, "CPU"},
+    {1, 4, 4, 2, 8, 16, ov::element::f16, "CPU"},
+    {1, 4, 4, 2, 8, 16, ov::element::bf16, "CPU"},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_SelectiveSSM,
+                         SelectiveSSM,
+                         ::testing::ValuesIn(selective_ssm_test_cases),
+                         SelectiveSSM::getTestCaseName);
+
+}  // namespace ov::test

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/selective_ssm.cpp
@@ -14,7 +14,9 @@ std::vector<selective_ssm_params> selective_ssm_test_cases = {
     {1, 4, 4, 2, 8, 16, ov::element::f32, "CPU"},
     {2, 3, 4, 1, 8, 8, ov::element::f32, "CPU"},
     {1, 4, 4, 2, 8, 16, ov::element::f16, "CPU"},
+    {1, 1, 4, 2, 8, 16, ov::element::f16, "CPU"},
     {1, 4, 4, 2, 8, 16, ov::element::bf16, "CPU"},
+    {1, 1, 4, 2, 8, 16, ov::element::bf16, "CPU"},
     {1, 1, 64, 1, 64, 128, ov::element::f32, "CPU"},
     {1, 5, 96, 8, 80, 80, ov::element::f32, "CPU"},
 };

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/selective_ssm.cpp
@@ -7,9 +7,12 @@
 namespace ov::test {
 
 std::vector<selective_ssm_params> selective_ssm_test_cases = {
+    {1, 1, 1, 1, 1, 1, ov::element::f32, "CPU"},
+    {1, 0, 2, 1, 3, 4, ov::element::f32, "CPU"},
+    {1, 3, 4, 4, 5, 3, ov::element::f32, "CPU"},
+    {2, 5, 6, 3, 7, 5, ov::element::f32, "CPU"},
     {1, 4, 4, 2, 8, 16, ov::element::f32, "CPU"},
     {2, 3, 4, 1, 8, 8, ov::element::f32, "CPU"},
-    {1, 6, 8, 2, 16, 16, ov::element::f32, "CPU"},
     {1, 4, 4, 2, 8, 16, ov::element::f16, "CPU"},
     {1, 4, 4, 2, 8, 16, ov::element::bf16, "CPU"},
 };

--- a/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
@@ -1,0 +1,308 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "nodes/kernels/selective_ssm.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/type/bfloat16.hpp"
+#include "openvino/core/type/float16.hpp"
+
+namespace ov::intel_cpu::node::kernel::test {
+namespace {
+
+struct ReferenceResult {
+    std::vector<float> output;
+    std::vector<float> state;
+};
+
+std::vector<float> make_values(size_t count, float scale, float offset = 0.F) {
+    std::vector<float> values(count);
+    for (size_t i = 0; i < count; ++i) {
+        values[i] = offset + scale * static_cast<float>(static_cast<int>(i % 11) - 5);
+    }
+    return values;
+}
+
+template <typename T>
+std::vector<T> cast_values(const std::vector<float>& values) {
+    std::vector<T> result(values.size());
+    std::transform(values.begin(), values.end(), result.begin(), [](float value) {
+        return static_cast<T>(value);
+    });
+    return result;
+}
+
+template <typename T>
+std::vector<float> to_float(const std::vector<T>& values) {
+    std::vector<float> result(values.size());
+    std::transform(values.begin(), values.end(), result.begin(), [](T value) {
+        return static_cast<float>(value);
+    });
+    return result;
+}
+
+ReferenceResult reference_selective_ssm(const std::vector<float>& A,
+                                        const std::vector<float>& dt,
+                                        const std::vector<float>& B,
+                                        const std::vector<float>& x,
+                                        const std::vector<float>& C,
+                                        const std::vector<float>& initial_state,
+                                        const SelectiveSSMShape& shape) {
+    ReferenceResult result;
+    result.output.resize(shape.batch_size * shape.sequence_length * shape.num_heads * shape.head_dim);
+    result.state = initial_state;
+    const auto heads_per_group = shape.num_heads / shape.num_groups;
+    const auto state_batch_stride = shape.num_heads * shape.head_dim * shape.state_size;
+    const auto state_head_stride = shape.head_dim * shape.state_size;
+
+    for (size_t batch = 0; batch < shape.batch_size; ++batch) {
+        for (size_t token = 0; token < shape.sequence_length; ++token) {
+            for (size_t head = 0; head < shape.num_heads; ++head) {
+                const auto token_head = (batch * shape.sequence_length + token) * shape.num_heads + head;
+                const auto group = head / heads_per_group;
+                const auto projection_base =
+                    ((batch * shape.sequence_length + token) * shape.num_groups + group) * shape.state_size;
+                const auto state_base = batch * state_batch_stride + head * state_head_stride;
+                const auto x_base = token_head * shape.head_dim;
+                const float delta = dt[token_head];
+                const float decay = std::exp(A[head] * delta);
+                for (size_t p = 0; p < shape.head_dim; ++p) {
+                    float value = 0.F;
+                    for (size_t n = 0; n < shape.state_size; ++n) {
+                        auto& state = result.state[state_base + p * shape.state_size + n];
+                        state = state * decay + x[x_base + p] * delta * B[projection_base + n];
+                        value += state * C[projection_base + n];
+                    }
+                    result.output[x_base + p] = value;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+CpuParallelPtr make_parallel() {
+    return std::make_shared<CpuParallel>(TbbPartitioner::STATIC);
+}
+
+template <typename T>
+void run_selective_precision(const element::Type& precision, float tolerance) {
+    const SelectiveSSMShape shape{1, 3, 2, 3, 1, 4};
+    auto A = cast_values<T>({-0.2F, -0.35F});
+    auto dt = cast_values<T>(make_values(6, 0.015F, 0.12F));
+    auto B = cast_values<T>(make_values(12, 0.02F, 0.1F));
+    auto x = cast_values<T>(make_values(18, 0.025F, 0.05F));
+    auto C = cast_values<T>(make_values(12, 0.018F, -0.02F));
+    auto initial_state = cast_values<T>(make_values(24, 0.01F));
+    std::vector<T> output(18);
+    std::vector<T> output_state(24);
+    constexpr size_t scratch_head_dim = 2;
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim *
+                               shape.state_size);
+
+    selective_ssm(A.data(),
+                  dt.data(),
+                  B.data(),
+                  x.data(),
+                  C.data(),
+                  initial_state.data(),
+                  output.data(),
+                  output_state.data(),
+                  shape,
+                  precision,
+                  scratch.data(),
+                  scratch_head_dim,
+                  cpu_parallel);
+
+    const auto expected = reference_selective_ssm(to_float(A),
+                                                  to_float(dt),
+                                                  to_float(B),
+                                                  to_float(x),
+                                                  to_float(C),
+                                                  to_float(initial_state),
+                                                  shape);
+    for (size_t i = 0; i < output.size(); ++i) {
+        EXPECT_NEAR(static_cast<float>(output[i]), expected.output[i], tolerance) << "output index " << i;
+    }
+    for (size_t i = 0; i < output_state.size(); ++i) {
+        EXPECT_NEAR(static_cast<float>(output_state[i]), expected.state[i], tolerance) << "state index " << i;
+    }
+}
+
+TEST(SelectiveSSMKernel, SupportsF32F16AndBF16) {
+    run_selective_precision<float>(element::f32, 1e-6F);
+    run_selective_precision<float16>(element::f16, 2e-3F);
+    run_selective_precision<bfloat16>(element::bf16, 2e-2F);
+}
+
+TEST(PagedSelectiveSSMKernel, I64MetadataAndReadWriteAlias) {
+    const PagedSelectiveSSMShape shape{4, 2, 3, 1, 4, 2, 3, 1};
+    const SelectiveSSMShape reference_shape{1, 4, 2, 3, 1, 4};
+    const auto A = std::vector<float>{-0.2F, -0.35F};
+    const auto dt = make_values(8, 0.015F, 0.12F);
+    const auto B = make_values(16, 0.02F, 0.1F);
+    const auto x = make_values(24, 0.025F, 0.05F);
+    const auto C = make_values(16, 0.018F, -0.02F);
+    const auto initial_state = make_values(24, 0.01F);
+    std::vector<float> state_table(48, -100.F);
+    std::copy(initial_state.begin(), initial_state.end(), state_table.begin());
+    std::vector<float> output(24);
+    const std::vector<int64_t> subsequence_begins{0, 4};
+    const std::vector<int64_t> block_indices{0, 0, 1};
+    const std::vector<int64_t> block_indices_begins{0, 3};
+    const std::vector<int64_t> processed{0};
+    const std::vector<int64_t> interval{2};
+    constexpr size_t scratch_head_dim = 2;
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim * 4);
+    std::vector<int32_t> owners(2);
+
+    paged_selective_ssm(A.data(),
+                        dt.data(),
+                        B.data(),
+                        x.data(),
+                        C.data(),
+                        state_table.data(),
+                        subsequence_begins.data(),
+                        block_indices.data(),
+                        block_indices_begins.data(),
+                        processed.data(),
+                        interval.data(),
+                        output.data(),
+                        shape,
+                        element::f32,
+                        element::i64,
+                        scratch.data(),
+                        scratch_head_dim,
+                        owners.data(),
+                        cpu_parallel);
+
+    const auto expected = reference_selective_ssm(A, dt, B, x, C, initial_state, reference_shape);
+    for (size_t i = 0; i < output.size(); ++i) {
+        EXPECT_NEAR(output[i], expected.output[i], 1e-6F) << "output index " << i;
+    }
+    for (size_t i = 0; i < initial_state.size(); ++i) {
+        EXPECT_NEAR(state_table[initial_state.size() + i], expected.state[i], 1e-6F) << "final state index " << i;
+    }
+
+    const SelectiveSSMShape prefix_shape{1, 2, 2, 3, 1, 4};
+    const auto prefix = reference_selective_ssm(A,
+                                                std::vector<float>(dt.begin(), dt.begin() + 4),
+                                                std::vector<float>(B.begin(), B.begin() + 8),
+                                                std::vector<float>(x.begin(), x.begin() + 12),
+                                                std::vector<float>(C.begin(), C.begin() + 8),
+                                                initial_state,
+                                                prefix_shape);
+    for (size_t i = 0; i < initial_state.size(); ++i) {
+        EXPECT_NEAR(state_table[i], prefix.state[i], 1e-6F) << "aliased snapshot index " << i;
+    }
+}
+
+TEST(PagedSelectiveSSMKernel, DisabledCacheDoesNotWrite) {
+    const PagedSelectiveSSMShape shape{2, 1, 2, 1, 3, 2, 1, 1};
+    const SelectiveSSMShape reference_shape{1, 2, 1, 2, 1, 3};
+    const auto A = cast_values<bfloat16>({-0.25F});
+    const auto dt = cast_values<bfloat16>(make_values(2, 0.02F, 0.1F));
+    const auto B = cast_values<bfloat16>(make_values(6, 0.03F, 0.1F));
+    const auto x = cast_values<bfloat16>(make_values(4, 0.025F, 0.05F));
+    const auto C = cast_values<bfloat16>(make_values(6, 0.02F, -0.01F));
+    const auto initial_state = cast_values<bfloat16>(make_values(6, 0.01F));
+    std::vector<bfloat16> state_table(12, bfloat16(7.F));
+    std::copy(initial_state.begin(), initial_state.end(), state_table.begin());
+    const auto state_before = state_table;
+    std::vector<bfloat16> output(4);
+    const std::vector<int32_t> subsequence_begins{0, 2};
+    const std::vector<int32_t> block_indices{0};
+    const std::vector<int32_t> block_indices_begins{0, 1};
+    const std::vector<int32_t> processed{9};
+    const std::vector<int32_t> interval{0};
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * 2 * 3);
+    std::vector<int32_t> owners(2);
+
+    paged_selective_ssm(A.data(),
+                        dt.data(),
+                        B.data(),
+                        x.data(),
+                        C.data(),
+                        state_table.data(),
+                        subsequence_begins.data(),
+                        block_indices.data(),
+                        block_indices_begins.data(),
+                        processed.data(),
+                        interval.data(),
+                        output.data(),
+                        shape,
+                        element::bf16,
+                        element::i32,
+                        scratch.data(),
+                        2,
+                        owners.data(),
+                        cpu_parallel);
+
+    EXPECT_EQ(state_table, state_before);
+    const auto expected = reference_selective_ssm(to_float(A),
+                                                  to_float(dt),
+                                                  to_float(B),
+                                                  to_float(x),
+                                                  to_float(C),
+                                                  to_float(initial_state),
+                                                  reference_shape);
+    for (size_t i = 0; i < output.size(); ++i) {
+        EXPECT_NEAR(static_cast<float>(output[i]), expected.output[i], 2e-2F) << "output index " << i;
+    }
+}
+
+TEST(PagedSelectiveSSMKernel, RejectsCrossSequenceWriteConflict) {
+    const PagedSelectiveSSMShape shape{2, 1, 1, 1, 2, 3, 4, 2};
+    const std::vector<float> A{-0.2F};
+    const std::vector<float> dt{0.1F, 0.1F};
+    const std::vector<float> B{0.2F, 0.3F, 0.4F, 0.5F};
+    const std::vector<float> x{0.6F, 0.7F};
+    const std::vector<float> C{0.8F, 0.9F, 1.F, 1.1F};
+    std::vector<float> state_table(6);
+    std::vector<float> output(2);
+    const std::vector<int32_t> subsequence_begins{0, 1, 2};
+    const std::vector<int32_t> block_indices{0, 1, 2, 1};
+    const std::vector<int32_t> block_indices_begins{0, 2, 4};
+    const std::vector<int32_t> processed{0, 0};
+    const std::vector<int32_t> interval{1, 1};
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * 2);
+    std::vector<int32_t> owners(3);
+
+    EXPECT_THROW(paged_selective_ssm(A.data(),
+                                     dt.data(),
+                                     B.data(),
+                                     x.data(),
+                                     C.data(),
+                                     state_table.data(),
+                                     subsequence_begins.data(),
+                                     block_indices.data(),
+                                     block_indices_begins.data(),
+                                     processed.data(),
+                                     interval.data(),
+                                     output.data(),
+                                     shape,
+                                     element::f32,
+                                     element::i32,
+                                     scratch.data(),
+                                     1,
+                                     owners.data(),
+                                     cpu_parallel),
+                 ov::Exception);
+}
+
+}  // namespace
+}  // namespace ov::intel_cpu::node::kernel::test

--- a/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -96,7 +97,7 @@ CpuParallelPtr make_parallel() {
 }
 
 template <typename T>
-void run_selective_precision(const element::Type& precision, float tolerance) {
+void run_selective_precision(const element::Type& precision, float tolerance, bool use_converted_projections = false) {
     const SelectiveSSMShape shape{1, 3, 2, 3, 1, 4};
     auto A = cast_values<T>({-0.2F, -0.35F});
     auto dt = cast_values<T>(make_values(6, 0.015F, 0.12F));
@@ -110,6 +111,8 @@ void run_selective_precision(const element::Type& precision, float tolerance) {
     const auto cpu_parallel = make_parallel();
     std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim *
                                shape.state_size);
+    const auto converted_B = to_float(B);
+    const auto converted_C = to_float(C);
 
     selective_ssm(A.data(),
                   dt.data(),
@@ -123,7 +126,9 @@ void run_selective_precision(const element::Type& precision, float tolerance) {
                   precision,
                   scratch.data(),
                   scratch_head_dim,
-                  cpu_parallel);
+                  cpu_parallel,
+                  use_converted_projections ? converted_B.data() : nullptr,
+                  use_converted_projections ? converted_C.data() : nullptr);
 
     const auto expected = reference_selective_ssm(to_float(A),
                                                   to_float(dt),
@@ -141,7 +146,10 @@ void run_selective_precision(const element::Type& precision, float tolerance) {
 }
 
 template <typename DataT, typename IndexT>
-void run_paged_decode_precision(const element::Type& precision, const element::Type& index_precision, float tolerance) {
+void run_paged_decode_precision(const element::Type& precision,
+                                const element::Type& index_precision,
+                                float tolerance,
+                                bool use_converted_projections = false) {
     const PagedSelectiveSSMShape shape{1, 2, 3, 1, 4, 2, 2, 1};
     const SelectiveSSMShape reference_shape{1, 1, 2, 3, 1, 4};
     const auto A = cast_values<DataT>({-0.2F, -0.35F});
@@ -161,6 +169,8 @@ void run_paged_decode_precision(const element::Type& precision, const element::T
     const auto cpu_parallel = make_parallel();
     std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * 2 * 4);
     std::vector<int32_t> owners(2);
+    const auto converted_B = to_float(B);
+    const auto converted_C = to_float(C);
 
     paged_selective_ssm(A.data(),
                         dt.data(),
@@ -180,7 +190,9 @@ void run_paged_decode_precision(const element::Type& precision, const element::T
                         scratch.data(),
                         2,
                         owners.data(),
-                        cpu_parallel);
+                        cpu_parallel,
+                        use_converted_projections ? converted_B.data() : nullptr,
+                        use_converted_projections ? converted_C.data() : nullptr);
 
     const auto expected = reference_selective_ssm(to_float(A),
                                                   to_float(dt),
@@ -205,12 +217,199 @@ TEST(SelectiveSSMKernel, SupportsF32F16AndBF16) {
     run_selective_precision<bfloat16>(element::bf16, 2e-2F);
 }
 
+TEST(SelectiveSSMKernel, ConvertedProjectionsMatchReference) {
+    run_selective_precision<float16>(element::f16, 2e-3F, true);
+    run_selective_precision<bfloat16>(element::bf16, 2e-2F, true);
+    run_paged_decode_precision<float16, int32_t>(element::f16, element::i32, 2e-3F, true);
+    run_paged_decode_precision<bfloat16, int64_t>(element::bf16, element::i64, 2e-2F, true);
+}
+
+template <typename T>
+void run_selective_decode_alias(const element::Type& precision, float tolerance) {
+    const SelectiveSSMShape shape{1, 1, 2, 3, 1, 4};
+    const auto A = cast_values<T>({-0.2F, -0.35F});
+    const auto dt = cast_values<T>(make_values(2, 0.015F, 0.12F));
+    const auto B = cast_values<T>(make_values(4, 0.02F, 0.1F));
+    const auto x = cast_values<T>(make_values(6, 0.025F, 0.05F));
+    const auto C = cast_values<T>(make_values(4, 0.018F, -0.02F));
+    const auto initial_state = cast_values<T>(make_values(24, 0.01F));
+    auto aliased_state = initial_state;
+    std::vector<T> output(6);
+    constexpr size_t scratch_head_dim = 2;
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim *
+                               shape.state_size);
+    const auto converted_B = to_float(B);
+    const auto converted_C = to_float(C);
+
+    selective_ssm(A.data(),
+                  dt.data(),
+                  B.data(),
+                  x.data(),
+                  C.data(),
+                  aliased_state.data(),
+                  output.data(),
+                  aliased_state.data(),
+                  shape,
+                  precision,
+                  scratch.data(),
+                  scratch_head_dim,
+                  cpu_parallel,
+                  converted_B.data(),
+                  converted_C.data());
+
+    const auto expected = reference_selective_ssm(to_float(A),
+                                                  to_float(dt),
+                                                  converted_B,
+                                                  to_float(x),
+                                                  converted_C,
+                                                  to_float(initial_state),
+                                                  shape);
+    for (size_t i = 0; i < output.size(); ++i) {
+        EXPECT_NEAR(static_cast<float>(output[i]), expected.output[i], tolerance) << "output index " << i;
+    }
+    for (size_t i = 0; i < aliased_state.size(); ++i) {
+        EXPECT_NEAR(static_cast<float>(aliased_state[i]), expected.state[i], tolerance) << "state index " << i;
+    }
+}
+
+TEST(SelectiveSSMKernel, DirectDecodeSupportsAliasedLowPrecisionState) {
+    run_selective_decode_alias<float16>(element::f16, 2e-3F);
+    run_selective_decode_alias<bfloat16>(element::bf16, 2e-2F);
+}
+
+template <typename T>
+void verify_portable_conversion_for_every_encoding(const element::Type& precision) {
+    constexpr size_t encoding_count = size_t{1} << 16U;
+    constexpr size_t scratch_head_dim = 1024;
+    const SelectiveSSMShape shape{1, 1, 1, encoding_count, 1, 1};
+    const std::vector<T> A{static_cast<T>(0.F)};
+    const std::vector<T> dt{static_cast<T>(0.F)};
+    const std::vector<T> B{static_cast<T>(0.F)};
+    const std::vector<T> x(encoding_count, static_cast<T>(0.F));
+    const std::vector<T> C{static_cast<T>(0.F)};
+    std::vector<T> initial_state(encoding_count);
+    std::vector<T> output(encoding_count);
+    std::vector<T> output_state(encoding_count);
+    for (size_t i = 0; i < encoding_count; ++i) {
+        initial_state[i] = T::from_bits(static_cast<uint16_t>(i));
+    }
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim);
+
+    selective_ssm(A.data(),
+                  dt.data(),
+                  B.data(),
+                  x.data(),
+                  C.data(),
+                  initial_state.data(),
+                  output.data(),
+                  output_state.data(),
+                  shape,
+                  precision,
+                  scratch.data(),
+                  scratch_head_dim,
+                  cpu_parallel);
+
+    for (size_t i = 0; i < encoding_count; ++i) {
+        const float updated = static_cast<float>(initial_state[i]) * 1.F + 0.F * static_cast<float>(B[0]);
+        EXPECT_EQ(output_state[i].to_bits(), static_cast<T>(updated).to_bits()) << "encoding " << i;
+    }
+}
+
+TEST(SelectiveSSMKernel, PortableLowPrecisionConversionsPreserveEveryEncoding) {
+    verify_portable_conversion_for_every_encoding<float16>(element::f16);
+    verify_portable_conversion_for_every_encoding<bfloat16>(element::bf16);
+}
+
 TEST(SelectiveSSMKernel, ScratchBlockingBalancesParallelismAndCacheFootprint) {
     EXPECT_EQ(get_scratch_head_dim(64, 128, 64, 14), 64U);
     EXPECT_EQ(get_scratch_head_dim(64, 128, 1, 16), 4U);
     EXPECT_EQ(get_scratch_head_dim(7, 9000, 1, 16), 1U);
     EXPECT_EQ(get_scratch_head_dim(7, 3, 2, 8), 2U);
     EXPECT_EQ(get_scratch_head_dim(7, 3, 8, 8), 7U);
+}
+
+TEST(SelectiveSSMKernel, SizeArithmeticRejectsOverflowAndHonorsZeroDimensions) {
+    const auto max = std::numeric_limits<size_t>::max();
+    EXPECT_THROW(checked_size_product({max, 2}, "test tensor"), ov::Exception);
+    EXPECT_EQ(checked_size_product({max, 2, 0}, "empty tensor"), 0U);
+    EXPECT_THROW(checked_size_sum({max, 1}, "test buffer"), ov::Exception);
+    EXPECT_EQ(checked_size_sum({max - 1, 1}, "test buffer"), max);
+
+    EXPECT_THROW(validate_selective_ssm_shape(SelectiveSSMShape{max, 2, 2, 1, 1, 1}), ov::Exception);
+    EXPECT_THROW(validate_paged_selective_ssm_shape(PagedSelectiveSSMShape{max, 2, 1, 1, 1, 1, 0, 0}), ov::Exception);
+    EXPECT_EQ(get_scratch_head_dim(0, 4, max, max), 1U);
+}
+
+TEST(SelectiveSSMKernel, ZeroHeadDimensionIsSafeNoWork) {
+    const SelectiveSSMShape shape{2, 3, 2, 0, 1, 4};
+    const std::vector<float> A(2, -0.2F);
+    const std::vector<float> dt(12, 0.1F);
+    const std::vector<float> B(24, 0.2F);
+    const std::vector<float> C(24, 0.3F);
+    const std::vector<float> empty;
+    std::vector<float> output;
+    std::vector<float> output_state;
+    std::vector<float> scratch(4);
+    const auto cpu_parallel = make_parallel();
+
+    EXPECT_NO_THROW(selective_ssm(A.data(),
+                                  dt.data(),
+                                  B.data(),
+                                  empty.data(),
+                                  C.data(),
+                                  empty.data(),
+                                  output.data(),
+                                  output_state.data(),
+                                  shape,
+                                  element::f32,
+                                  scratch.data(),
+                                  1,
+                                  cpu_parallel));
+    EXPECT_TRUE(output.empty());
+    EXPECT_TRUE(output_state.empty());
+}
+
+TEST(PagedSelectiveSSMKernel, ZeroHeadDimensionValidatesMetadataAndDoesNoWork) {
+    const PagedSelectiveSSMShape shape{2, 2, 0, 1, 4, 2, 2, 1};
+    const std::vector<float> A(2, -0.2F);
+    const std::vector<float> dt(4, 0.1F);
+    const std::vector<float> B(8, 0.2F);
+    const std::vector<float> C(8, 0.3F);
+    const std::vector<float> empty;
+    std::vector<float> state_table;
+    std::vector<float> output;
+    const std::vector<int64_t> subsequence_begins{0, 2};
+    const std::vector<int64_t> block_indices{0, 1};
+    const std::vector<int64_t> block_indices_begins{0, 2};
+    const std::vector<int64_t> processed{0};
+    const std::vector<int64_t> interval{2};
+    std::vector<float> scratch(4);
+    std::vector<int32_t> owners(2);
+    const auto cpu_parallel = make_parallel();
+
+    EXPECT_NO_THROW(paged_selective_ssm(A.data(),
+                                        dt.data(),
+                                        B.data(),
+                                        empty.data(),
+                                        C.data(),
+                                        state_table.data(),
+                                        subsequence_begins.data(),
+                                        block_indices.data(),
+                                        block_indices_begins.data(),
+                                        processed.data(),
+                                        interval.data(),
+                                        output.data(),
+                                        shape,
+                                        element::f32,
+                                        element::i64,
+                                        scratch.data(),
+                                        1,
+                                        owners.data(),
+                                        cpu_parallel));
+    EXPECT_TRUE(output.empty());
+    EXPECT_TRUE(state_table.empty());
 }
 
 TEST(SelectiveSSMKernel, F32ReadWriteStateAliasMatchesReference) {
@@ -414,19 +613,8 @@ TEST(PagedSelectiveSSMKernel, I64MetadataAndReadWriteAlias) {
 }
 
 TEST(PagedSelectiveSSMKernel, DisabledCacheDoesNotWrite) {
-    const PagedSelectiveSSMShape shape{2, 1, 2, 1, 3, 2, 1, 1};
-    const SelectiveSSMShape reference_shape{1, 2, 1, 2, 1, 3};
     const auto A = cast_values<bfloat16>({-0.25F});
-    const auto dt = cast_values<bfloat16>(make_values(2, 0.02F, 0.1F));
-    const auto B = cast_values<bfloat16>(make_values(6, 0.03F, 0.1F));
-    const auto x = cast_values<bfloat16>(make_values(4, 0.025F, 0.05F));
-    const auto C = cast_values<bfloat16>(make_values(6, 0.02F, -0.01F));
     const auto initial_state = cast_values<bfloat16>(make_values(6, 0.01F));
-    std::vector<bfloat16> state_table(12, bfloat16(7.F));
-    std::copy(initial_state.begin(), initial_state.end(), state_table.begin());
-    const auto state_before = state_table;
-    std::vector<bfloat16> output(4);
-    const std::vector<int32_t> subsequence_begins{0, 2};
     const std::vector<int32_t> block_indices{0};
     const std::vector<int32_t> block_indices_begins{0, 1};
     const std::vector<int32_t> processed{9};
@@ -435,36 +623,51 @@ TEST(PagedSelectiveSSMKernel, DisabledCacheDoesNotWrite) {
     std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * 2 * 3);
     std::vector<int32_t> owners(2);
 
-    paged_selective_ssm(A.data(),
-                        dt.data(),
-                        B.data(),
-                        x.data(),
-                        C.data(),
-                        state_table.data(),
-                        subsequence_begins.data(),
-                        block_indices.data(),
-                        block_indices_begins.data(),
-                        processed.data(),
-                        interval.data(),
-                        output.data(),
-                        shape,
-                        element::bf16,
-                        element::i32,
-                        scratch.data(),
-                        2,
-                        owners.data(),
-                        cpu_parallel);
+    for (const size_t token_count : {size_t{1}, size_t{2}}) {
+        SCOPED_TRACE(testing::Message() << "token_count=" << token_count);
+        const PagedSelectiveSSMShape shape{token_count, 1, 2, 1, 3, 2, 1, 1};
+        const SelectiveSSMShape reference_shape{1, token_count, 1, 2, 1, 3};
+        const auto dt = cast_values<bfloat16>(make_values(token_count, 0.02F, 0.1F));
+        const auto B = cast_values<bfloat16>(make_values(token_count * 3, 0.03F, 0.1F));
+        const auto x = cast_values<bfloat16>(make_values(token_count * 2, 0.025F, 0.05F));
+        const auto C = cast_values<bfloat16>(make_values(token_count * 3, 0.02F, -0.01F));
+        std::vector<bfloat16> state_table(12, bfloat16(7.F));
+        std::copy(initial_state.begin(), initial_state.end(), state_table.begin());
+        const auto state_before = state_table;
+        std::vector<bfloat16> output(x.size());
+        const std::vector<int32_t> subsequence_begins{0, static_cast<int32_t>(token_count)};
 
-    EXPECT_EQ(state_table, state_before);
-    const auto expected = reference_selective_ssm(to_float(A),
-                                                  to_float(dt),
-                                                  to_float(B),
-                                                  to_float(x),
-                                                  to_float(C),
-                                                  to_float(initial_state),
-                                                  reference_shape);
-    for (size_t i = 0; i < output.size(); ++i) {
-        EXPECT_NEAR(static_cast<float>(output[i]), expected.output[i], 2e-2F) << "output index " << i;
+        paged_selective_ssm(A.data(),
+                            dt.data(),
+                            B.data(),
+                            x.data(),
+                            C.data(),
+                            state_table.data(),
+                            subsequence_begins.data(),
+                            block_indices.data(),
+                            block_indices_begins.data(),
+                            processed.data(),
+                            interval.data(),
+                            output.data(),
+                            shape,
+                            element::bf16,
+                            element::i32,
+                            scratch.data(),
+                            2,
+                            owners.data(),
+                            cpu_parallel);
+
+        EXPECT_EQ(state_table, state_before);
+        const auto expected = reference_selective_ssm(to_float(A),
+                                                      to_float(dt),
+                                                      to_float(B),
+                                                      to_float(x),
+                                                      to_float(C),
+                                                      to_float(initial_state),
+                                                      reference_shape);
+        for (size_t i = 0; i < output.size(); ++i) {
+            EXPECT_NEAR(static_cast<float>(output[i]), expected.output[i], 2e-2F) << "output index " << i;
+        }
     }
 }
 

--- a/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
@@ -146,6 +146,14 @@ TEST(SelectiveSSMKernel, SupportsF32F16AndBF16) {
     run_selective_precision<bfloat16>(element::bf16, 2e-2F);
 }
 
+TEST(SelectiveSSMKernel, ScratchBlockingBalancesParallelismAndCacheFootprint) {
+    EXPECT_EQ(get_scratch_head_dim(64, 128, 64, 14), 64U);
+    EXPECT_EQ(get_scratch_head_dim(64, 128, 1, 16), 4U);
+    EXPECT_EQ(get_scratch_head_dim(7, 9000, 1, 16), 1U);
+    EXPECT_EQ(get_scratch_head_dim(7, 3, 2, 8), 2U);
+    EXPECT_EQ(get_scratch_head_dim(7, 3, 8, 8), 7U);
+}
+
 TEST(SelectiveSSMKernel, F32ReadWriteStateAliasMatchesReference) {
     const SelectiveSSMShape shape{1, 4, 2, 3, 1, 5};
     const auto A = std::vector<float>{-0.2F, -0.35F};

--- a/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
@@ -146,6 +146,105 @@ TEST(SelectiveSSMKernel, SupportsF32F16AndBF16) {
     run_selective_precision<bfloat16>(element::bf16, 2e-2F);
 }
 
+TEST(SelectiveSSMKernel, EmptySequenceCopiesInitialState) {
+    const SelectiveSSMShape shape{2, 0, 3, 5, 3, 4};
+    const auto A = make_values(shape.num_heads, 0.02F, -0.2F);
+    const std::vector<float> empty;
+    const auto initial_state =
+        make_values(shape.batch_size * shape.num_heads * shape.head_dim * shape.state_size, 0.01F);
+    std::vector<float> output;
+    std::vector<float> output_state(initial_state.size(), -1.F);
+    constexpr size_t scratch_head_dim = 2;
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim *
+                               shape.state_size);
+
+    selective_ssm(A.data(),
+                  empty.data(),
+                  empty.data(),
+                  empty.data(),
+                  empty.data(),
+                  initial_state.data(),
+                  output.data(),
+                  output_state.data(),
+                  shape,
+                  element::f32,
+                  scratch.data(),
+                  scratch_head_dim,
+                  cpu_parallel);
+
+    EXPECT_TRUE(output.empty());
+    EXPECT_EQ(output_state, initial_state);
+}
+
+TEST(SelectiveSSMKernel, ChunkedExecutionMatchesFullSequence) {
+    const SelectiveSSMShape full_shape{1, 5, 4, 5, 2, 3};
+    const SelectiveSSMShape first_shape{1, 2, 4, 5, 2, 3};
+    const SelectiveSSMShape second_shape{1, 3, 4, 5, 2, 3};
+    const auto A = make_values(4, 0.02F, -0.25F);
+    const auto dt = make_values(20, 0.01F, 0.1F);
+    const auto B = make_values(30, 0.015F, 0.05F);
+    const auto x = make_values(100, 0.02F, -0.03F);
+    const auto C = make_values(30, 0.012F, 0.02F);
+    const auto initial_state = make_values(60, 0.01F, -0.01F);
+    std::vector<float> full_output(100);
+    std::vector<float> full_state(60);
+    std::vector<float> chunked_output(100);
+    std::vector<float> intermediate_state(60);
+    std::vector<float> chunked_state(60);
+    constexpr size_t scratch_head_dim = 2;
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim *
+                               full_shape.state_size);
+
+    selective_ssm(A.data(),
+                  dt.data(),
+                  B.data(),
+                  x.data(),
+                  C.data(),
+                  initial_state.data(),
+                  full_output.data(),
+                  full_state.data(),
+                  full_shape,
+                  element::f32,
+                  scratch.data(),
+                  scratch_head_dim,
+                  cpu_parallel);
+    selective_ssm(A.data(),
+                  dt.data(),
+                  B.data(),
+                  x.data(),
+                  C.data(),
+                  initial_state.data(),
+                  chunked_output.data(),
+                  intermediate_state.data(),
+                  first_shape,
+                  element::f32,
+                  scratch.data(),
+                  scratch_head_dim,
+                  cpu_parallel);
+    selective_ssm(A.data(),
+                  dt.data() + 8,
+                  B.data() + 12,
+                  x.data() + 40,
+                  C.data() + 12,
+                  intermediate_state.data(),
+                  chunked_output.data() + 40,
+                  chunked_state.data(),
+                  second_shape,
+                  element::f32,
+                  scratch.data(),
+                  scratch_head_dim,
+                  cpu_parallel);
+
+    for (size_t i = 0; i < full_output.size(); ++i) {
+        EXPECT_NEAR(chunked_output[i], full_output[i], 1e-6F) << "output index " << i;
+    }
+    for (size_t i = 0; i < full_state.size(); ++i) {
+        EXPECT_NEAR(chunked_state[i], full_state[i], 1e-6F) << "state index " << i;
+    }
+}
+
 TEST(PagedSelectiveSSMKernel, I64MetadataAndReadWriteAlias) {
     const PagedSelectiveSSMShape shape{4, 2, 3, 1, 4, 2, 3, 1};
     const SelectiveSSMShape reference_shape{1, 4, 2, 3, 1, 4};
@@ -264,23 +363,183 @@ TEST(PagedSelectiveSSMKernel, DisabledCacheDoesNotWrite) {
     }
 }
 
-TEST(PagedSelectiveSSMKernel, RejectsCrossSequenceWriteConflict) {
-    const PagedSelectiveSSMShape shape{2, 1, 1, 1, 2, 3, 4, 2};
-    const std::vector<float> A{-0.2F};
-    const std::vector<float> dt{0.1F, 0.1F};
-    const std::vector<float> B{0.2F, 0.3F, 0.4F, 0.5F};
-    const std::vector<float> x{0.6F, 0.7F};
-    const std::vector<float> C{0.8F, 0.9F, 1.F, 1.1F};
-    std::vector<float> state_table(6);
-    std::vector<float> output(2);
-    const std::vector<int32_t> subsequence_begins{0, 1, 2};
-    const std::vector<int32_t> block_indices{0, 1, 2, 1};
-    const std::vector<int32_t> block_indices_begins{0, 2, 4};
-    const std::vector<int32_t> processed{0, 0};
-    const std::vector<int32_t> interval{1, 1};
+TEST(PagedSelectiveSSMKernel, CoversAllCacheCasesAndPreservesSentinels) {
+    struct CacheCase {
+        size_t token_count;
+        int32_t processed;
+        int32_t interval;
+        std::vector<size_t> snapshot_prefixes;
+    };
+    const std::vector<CacheCase> cases{{3, 0, 2, {2, 3}},
+                                       {3, 4, 2, {2, 3}},
+                                       {4, 1, 3, {2, 4}},
+                                       {1, 4, 2, {1}},
+                                       {1, 3, 2, {1}}};
+    constexpr size_t num_heads = 2;
+    constexpr size_t head_dim = 3;
+    constexpr size_t num_groups = 1;
+    constexpr size_t state_size = 4;
+    constexpr size_t state_stride = num_heads * head_dim * state_size;
+    constexpr size_t physical_blocks = 5;
+    constexpr float sentinel = 1234.F;
+    const auto A = std::vector<float>{-0.2F, -0.35F};
+    const auto initial_state = make_values(state_stride, 0.01F, -0.02F);
+    const std::vector<int32_t> block_indices{4, 0, 2};
+    const std::vector<int32_t> block_indices_begins{0, 3};
     const auto cpu_parallel = make_parallel();
-    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * 2);
-    std::vector<int32_t> owners(3);
+    constexpr size_t scratch_head_dim = 2;
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim *
+                               state_size);
+    std::vector<int32_t> owners(physical_blocks);
+
+    for (const auto& cache_case : cases) {
+        SCOPED_TRACE(testing::Message() << "tokens=" << cache_case.token_count << ", processed=" << cache_case.processed
+                                        << ", interval=" << cache_case.interval);
+        const auto dt = make_values(cache_case.token_count * num_heads, 0.015F, 0.12F);
+        const auto B = make_values(cache_case.token_count * num_groups * state_size, 0.02F, 0.1F);
+        const auto x = make_values(cache_case.token_count * num_heads * head_dim, 0.025F, 0.05F);
+        const auto C = make_values(cache_case.token_count * num_groups * state_size, 0.018F, -0.02F);
+        std::vector<float> state_table(physical_blocks * state_stride, sentinel);
+        std::copy(initial_state.begin(), initial_state.end(), state_table.begin() + 4 * state_stride);
+        std::vector<float> output(x.size());
+        const std::vector<int32_t> subsequence_begins{0, static_cast<int32_t>(cache_case.token_count)};
+        const std::vector<int32_t> processed{cache_case.processed};
+        const std::vector<int32_t> interval{cache_case.interval};
+        const PagedSelectiveSSMShape shape{cache_case.token_count,
+                                           num_heads,
+                                           head_dim,
+                                           num_groups,
+                                           state_size,
+                                           physical_blocks,
+                                           block_indices.size(),
+                                           1};
+
+        paged_selective_ssm(A.data(),
+                            dt.data(),
+                            B.data(),
+                            x.data(),
+                            C.data(),
+                            state_table.data(),
+                            subsequence_begins.data(),
+                            block_indices.data(),
+                            block_indices_begins.data(),
+                            processed.data(),
+                            interval.data(),
+                            output.data(),
+                            shape,
+                            element::f32,
+                            element::i32,
+                            scratch.data(),
+                            scratch_head_dim,
+                            owners.data(),
+                            cpu_parallel);
+
+        const SelectiveSSMShape reference_shape{1, cache_case.token_count, num_heads, head_dim, num_groups, state_size};
+        const auto expected = reference_selective_ssm(A, dt, B, x, C, initial_state, reference_shape);
+        for (size_t i = 0; i < output.size(); ++i) {
+            EXPECT_NEAR(output[i], expected.output[i], 1e-6F) << "output index " << i;
+        }
+
+        for (size_t slot = 0; slot < cache_case.snapshot_prefixes.size(); ++slot) {
+            const auto prefix = cache_case.snapshot_prefixes[slot];
+            const SelectiveSSMShape prefix_shape{1, prefix, num_heads, head_dim, num_groups, state_size};
+            const auto prefix_result =
+                reference_selective_ssm(A,
+                                        std::vector<float>(dt.begin(), dt.begin() + prefix * num_heads),
+                                        std::vector<float>(B.begin(), B.begin() + prefix * num_groups * state_size),
+                                        std::vector<float>(x.begin(), x.begin() + prefix * num_heads * head_dim),
+                                        std::vector<float>(C.begin(), C.begin() + prefix * num_groups * state_size),
+                                        initial_state,
+                                        prefix_shape);
+            const auto physical = static_cast<size_t>(block_indices[slot + 1]);
+            for (size_t i = 0; i < state_stride; ++i) {
+                EXPECT_NEAR(state_table[physical * state_stride + i], prefix_result.state[i], 1e-6F)
+                    << "snapshot slot " << slot + 1 << ", state index " << i;
+            }
+        }
+
+        for (const size_t physical : {size_t{1}, size_t{3}}) {
+            for (size_t i = 0; i < state_stride; ++i) {
+                EXPECT_EQ(state_table[physical * state_stride + i], sentinel)
+                    << "unused physical block " << physical << ", state index " << i;
+            }
+        }
+        if (cache_case.snapshot_prefixes.size() == 1) {
+            for (size_t i = 0; i < state_stride; ++i) {
+                EXPECT_EQ(state_table[2 * state_stride + i], sentinel) << "unused write slot state index " << i;
+            }
+        }
+        for (size_t i = 0; i < state_stride; ++i) {
+            EXPECT_EQ(state_table[4 * state_stride + i], initial_state[i]) << "read block state index " << i;
+        }
+    }
+}
+
+TEST(PagedSelectiveSSMKernel, RejectsInvalidMetadataBeforeIndexing) {
+    const std::vector<float> A{-0.2F};
+    const std::vector<float> dt{0.1F};
+    const std::vector<float> B{0.2F};
+    const std::vector<float> x{0.3F};
+    const std::vector<float> C{0.4F};
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()));
+    std::vector<int32_t> owners(2);
+
+    const auto expect_invalid = [&](const std::vector<int32_t>& subsequence_begins,
+                                    const std::vector<int32_t>& block_indices,
+                                    const std::vector<int32_t>& block_indices_begins,
+                                    const std::vector<int32_t>& processed,
+                                    const std::vector<int32_t>& interval) {
+        std::vector<float> state_table(2, 0.F);
+        std::vector<float> output(1);
+        const PagedSelectiveSSMShape shape{1, 1, 1, 1, 1, 2, block_indices.size(), 1};
+        EXPECT_THROW(paged_selective_ssm(A.data(),
+                                         dt.data(),
+                                         B.data(),
+                                         x.data(),
+                                         C.data(),
+                                         state_table.data(),
+                                         subsequence_begins.data(),
+                                         block_indices.data(),
+                                         block_indices_begins.data(),
+                                         processed.data(),
+                                         interval.data(),
+                                         output.data(),
+                                         shape,
+                                         element::f32,
+                                         element::i32,
+                                         scratch.data(),
+                                         1,
+                                         owners.data(),
+                                         cpu_parallel),
+                     ov::Exception);
+    };
+
+    expect_invalid({-1, 1}, {0, 1}, {0, 2}, {0}, {1});
+    expect_invalid({0, 0}, {0, 1}, {0, 2}, {0}, {1});
+    expect_invalid({0, 1}, {-1, 1}, {0, 2}, {0}, {1});
+    expect_invalid({0, 1}, {0, 2}, {0, 2}, {0}, {1});
+    expect_invalid({0, 1}, {0, 1}, {0, 2}, {-1}, {1});
+    expect_invalid({0, 1}, {0}, {0, 1}, {0}, {1});
+}
+
+TEST(PagedSelectiveSSMKernel, RejectsLargeI64BlockIndexWithoutNarrowing) {
+    const PagedSelectiveSSMShape shape{1, 1, 1, 1, 1, 2, 2, 1};
+    const std::vector<float> A{-0.2F};
+    const std::vector<float> dt{0.1F};
+    const std::vector<float> B{0.2F};
+    const std::vector<float> x{0.3F};
+    const std::vector<float> C{0.4F};
+    std::vector<float> state_table(2, 0.F);
+    std::vector<float> output(1);
+    const std::vector<int64_t> subsequence_begins{0, 1};
+    const std::vector<int64_t> block_indices{0, int64_t{1} << 40};
+    const std::vector<int64_t> block_indices_begins{0, 2};
+    const std::vector<int64_t> processed{0};
+    const std::vector<int64_t> interval{1};
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()));
+    std::vector<int32_t> owners(2);
 
     EXPECT_THROW(paged_selective_ssm(A.data(),
                                      dt.data(),
@@ -296,12 +555,106 @@ TEST(PagedSelectiveSSMKernel, RejectsCrossSequenceWriteConflict) {
                                      output.data(),
                                      shape,
                                      element::f32,
-                                     element::i32,
+                                     element::i64,
                                      scratch.data(),
                                      1,
                                      owners.data(),
                                      cpu_parallel),
                  ov::Exception);
+}
+
+TEST(PagedSelectiveSSMKernel, ParallelExecutionIsDeterministic) {
+    const PagedSelectiveSSMShape shape{6, 4, 5, 2, 3, 8, 7, 3};
+    const auto A = make_values(4, 0.02F, -0.3F);
+    const auto dt = make_values(24, 0.01F, 0.1F);
+    const auto B = make_values(36, 0.015F, 0.05F);
+    const auto x = make_values(120, 0.02F, -0.03F);
+    const auto C = make_values(36, 0.012F, 0.02F);
+    const auto initial_table = make_values(8 * 4 * 5 * 3, 0.005F, -0.01F);
+    const std::vector<int32_t> subsequence_begins{0, 3, 4, 6};
+    const std::vector<int32_t> block_indices{7, 0, 3, 6, 2, 5, 1};
+    const std::vector<int32_t> block_indices_begins{0, 3, 5, 7};
+    const std::vector<int32_t> processed{0, 3, 1};
+    const std::vector<int32_t> interval{2, 1, 3};
+    const auto cpu_parallel = make_parallel();
+    constexpr size_t scratch_head_dim = 2;
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim * 3);
+    std::vector<int32_t> owners(8);
+    std::vector<float> expected_output;
+    std::vector<float> expected_state;
+
+    for (size_t iteration = 0; iteration < 10; ++iteration) {
+        auto state_table = initial_table;
+        std::vector<float> output(x.size());
+        paged_selective_ssm(A.data(),
+                            dt.data(),
+                            B.data(),
+                            x.data(),
+                            C.data(),
+                            state_table.data(),
+                            subsequence_begins.data(),
+                            block_indices.data(),
+                            block_indices_begins.data(),
+                            processed.data(),
+                            interval.data(),
+                            output.data(),
+                            shape,
+                            element::f32,
+                            element::i32,
+                            scratch.data(),
+                            scratch_head_dim,
+                            owners.data(),
+                            cpu_parallel);
+        if (iteration == 0) {
+            expected_output = output;
+            expected_state = state_table;
+        } else {
+            EXPECT_EQ(output, expected_output) << "iteration " << iteration;
+            EXPECT_EQ(state_table, expected_state) << "iteration " << iteration;
+        }
+    }
+}
+
+TEST(PagedSelectiveSSMKernel, RejectsCrossSequenceBlockConflicts) {
+    const PagedSelectiveSSMShape shape{2, 1, 1, 1, 2, 3, 4, 2};
+    const std::vector<float> A{-0.2F};
+    const std::vector<float> dt{0.1F, 0.1F};
+    const std::vector<float> B{0.2F, 0.3F, 0.4F, 0.5F};
+    const std::vector<float> x{0.6F, 0.7F};
+    const std::vector<float> C{0.8F, 0.9F, 1.F, 1.1F};
+    std::vector<float> state_table(6);
+    std::vector<float> output(2);
+    const std::vector<int32_t> subsequence_begins{0, 1, 2};
+    const std::vector<int32_t> block_indices_begins{0, 2, 4};
+    const std::vector<int32_t> processed{0, 0};
+    const std::vector<int32_t> interval{1, 1};
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * 2);
+    std::vector<int32_t> owners(3);
+
+    for (const std::vector<int32_t>& block_indices :
+         {std::vector<int32_t>{0, 1, 2, 1}, std::vector<int32_t>{0, 1, 1, 2}}) {
+        EXPECT_THROW(paged_selective_ssm(A.data(),
+                                         dt.data(),
+                                         B.data(),
+                                         x.data(),
+                                         C.data(),
+                                         state_table.data(),
+                                         subsequence_begins.data(),
+                                         block_indices.data(),
+                                         block_indices_begins.data(),
+                                         processed.data(),
+                                         interval.data(),
+                                         output.data(),
+                                         shape,
+                                         element::f32,
+                                         element::i32,
+                                         scratch.data(),
+                                         1,
+                                         owners.data(),
+                                         cpu_parallel),
+                     ov::Exception);
+    }
 }
 
 }  // namespace

--- a/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
@@ -140,6 +140,65 @@ void run_selective_precision(const element::Type& precision, float tolerance) {
     }
 }
 
+template <typename DataT, typename IndexT>
+void run_paged_decode_precision(const element::Type& precision, const element::Type& index_precision, float tolerance) {
+    const PagedSelectiveSSMShape shape{1, 2, 3, 1, 4, 2, 2, 1};
+    const SelectiveSSMShape reference_shape{1, 1, 2, 3, 1, 4};
+    const auto A = cast_values<DataT>({-0.2F, -0.35F});
+    const auto dt = cast_values<DataT>(make_values(2, 0.015F, 0.12F));
+    const auto B = cast_values<DataT>(make_values(4, 0.02F, 0.1F));
+    const auto x = cast_values<DataT>(make_values(6, 0.025F, 0.05F));
+    const auto C = cast_values<DataT>(make_values(4, 0.018F, -0.02F));
+    const auto initial_state = cast_values<DataT>(make_values(24, 0.01F));
+    std::vector<DataT> state_table(48, static_cast<DataT>(7.F));
+    std::copy(initial_state.begin(), initial_state.end(), state_table.begin());
+    std::vector<DataT> output(6);
+    const std::vector<IndexT> subsequence_begins{0, 1};
+    const std::vector<IndexT> block_indices{0, 1};
+    const std::vector<IndexT> block_indices_begins{0, 2};
+    const std::vector<IndexT> processed{0};
+    const std::vector<IndexT> interval{2};
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * 2 * 4);
+    std::vector<int32_t> owners(2);
+
+    paged_selective_ssm(A.data(),
+                        dt.data(),
+                        B.data(),
+                        x.data(),
+                        C.data(),
+                        state_table.data(),
+                        subsequence_begins.data(),
+                        block_indices.data(),
+                        block_indices_begins.data(),
+                        processed.data(),
+                        interval.data(),
+                        output.data(),
+                        shape,
+                        precision,
+                        index_precision,
+                        scratch.data(),
+                        2,
+                        owners.data(),
+                        cpu_parallel);
+
+    const auto expected = reference_selective_ssm(to_float(A),
+                                                  to_float(dt),
+                                                  to_float(B),
+                                                  to_float(x),
+                                                  to_float(C),
+                                                  to_float(initial_state),
+                                                  reference_shape);
+    for (size_t i = 0; i < output.size(); ++i) {
+        EXPECT_NEAR(static_cast<float>(output[i]), expected.output[i], tolerance) << "output index " << i;
+    }
+    for (size_t i = 0; i < initial_state.size(); ++i) {
+        EXPECT_EQ(state_table[i], initial_state[i]) << "read block state index " << i;
+        EXPECT_NEAR(static_cast<float>(state_table[initial_state.size() + i]), expected.state[i], tolerance)
+            << "write block state index " << i;
+    }
+}
+
 TEST(SelectiveSSMKernel, SupportsF32F16AndBF16) {
     run_selective_precision<float>(element::f32, 1e-6F);
     run_selective_precision<float16>(element::f16, 2e-3F);
@@ -407,6 +466,11 @@ TEST(PagedSelectiveSSMKernel, DisabledCacheDoesNotWrite) {
     for (size_t i = 0; i < output.size(); ++i) {
         EXPECT_NEAR(static_cast<float>(output[i]), expected.output[i], 2e-2F) << "output index " << i;
     }
+}
+
+TEST(PagedSelectiveSSMKernel, PortableDecodeSupportsLowPrecisionsAndIndexWidths) {
+    run_paged_decode_precision<float16, int32_t>(element::f16, element::i32, 2e-3F);
+    run_paged_decode_precision<bfloat16, int64_t>(element::bf16, element::i64, 2e-2F);
 }
 
 TEST(PagedSelectiveSSMKernel, CoversAllCacheCasesAndPreservesSentinels) {

--- a/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/selective_ssm_kernel_test.cpp
@@ -146,6 +146,44 @@ TEST(SelectiveSSMKernel, SupportsF32F16AndBF16) {
     run_selective_precision<bfloat16>(element::bf16, 2e-2F);
 }
 
+TEST(SelectiveSSMKernel, F32ReadWriteStateAliasMatchesReference) {
+    const SelectiveSSMShape shape{1, 4, 2, 3, 1, 5};
+    const auto A = std::vector<float>{-0.2F, -0.35F};
+    const auto dt = make_values(8, 0.015F, 0.12F);
+    const auto B = make_values(20, 0.02F, 0.1F);
+    const auto x = make_values(24, 0.025F, 0.05F);
+    const auto C = make_values(20, 0.018F, -0.02F);
+    const auto initial_state = make_values(30, 0.01F);
+    auto aliased_state = initial_state;
+    std::vector<float> output(24);
+    constexpr size_t scratch_head_dim = 2;
+    const auto cpu_parallel = make_parallel();
+    std::vector<float> scratch(static_cast<size_t>(cpu_parallel->get_num_worker_threads()) * scratch_head_dim *
+                               shape.state_size);
+
+    selective_ssm(A.data(),
+                  dt.data(),
+                  B.data(),
+                  x.data(),
+                  C.data(),
+                  aliased_state.data(),
+                  output.data(),
+                  aliased_state.data(),
+                  shape,
+                  element::f32,
+                  scratch.data(),
+                  scratch_head_dim,
+                  cpu_parallel);
+
+    const auto expected = reference_selective_ssm(A, dt, B, x, C, initial_state, shape);
+    for (size_t i = 0; i < output.size(); ++i) {
+        EXPECT_NEAR(output[i], expected.output[i], 1e-6F) << "output index " << i;
+    }
+    for (size_t i = 0; i < aliased_state.size(); ++i) {
+        EXPECT_NEAR(aliased_state[i], expected.state[i], 1e-6F) << "state index " << i;
+    }
+}
+
 TEST(SelectiveSSMKernel, EmptySequenceCopiesInitialState) {
     const SelectiveSSMShape shape{2, 0, 3, 5, 3, 4};
     const auto A = make_values(shape.num_heads, 0.02F, -0.2F);

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/selective_ssm_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/selective_ssm_shape_inference_test.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "openvino/op/paged_selective_ssm.hpp"
+#include "openvino/op/selective_ssm.hpp"
+#include "utils.hpp"
+
+using namespace ov;
+using namespace ov::intel_cpu;
+
+TEST(StaticShapeInferenceTest, SelectiveSSM) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(1));
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(3));
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    auto op = std::make_shared<op::internal::SelectiveSSM>(A, dt, B, x, C, state);
+
+    const std::vector<StaticShape> input_shapes = {StaticShape{4},
+                                                   StaticShape{2, 5, 4},
+                                                   StaticShape{2, 5, 2, 16},
+                                                   StaticShape{2, 5, 4, 8},
+                                                   StaticShape{2, 5, 2, 16},
+                                                   StaticShape{2, 4, 8, 16}};
+    const auto output_shapes = shape_inference(op.get(), input_shapes);
+    EXPECT_EQ(output_shapes[0], StaticShape({2, 5, 4, 8}));
+    EXPECT_EQ(output_shapes[1], StaticShape({2, 4, 8, 16}));
+}
+
+TEST(StaticShapeInferenceTest, PagedSelectiveSSMLogicalAndPhysicalBlocksDiffer) {
+    auto A = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(1));
+    auto dt = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(2));
+    auto B = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(3));
+    auto x = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(3));
+    auto C = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(3));
+    auto state = std::make_shared<op::v0::Parameter>(element::f32, PartialShape::dynamic(4));
+    auto subsequence_begins = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    auto block_indices = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    auto block_indices_begins = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    auto processed = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    auto interval = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    auto op = std::make_shared<op::internal::PagedSelectiveSSM>(A,
+                                                                dt,
+                                                                B,
+                                                                x,
+                                                                C,
+                                                                state,
+                                                                subsequence_begins,
+                                                                block_indices,
+                                                                block_indices_begins,
+                                                                processed,
+                                                                interval);
+
+    const std::vector<StaticShape> input_shapes = {StaticShape{4},
+                                                   StaticShape{6, 4},
+                                                   StaticShape{6, 2, 16},
+                                                   StaticShape{6, 4, 8},
+                                                   StaticShape{6, 2, 16},
+                                                   StaticShape{3, 4, 8, 16},
+                                                   StaticShape{3},
+                                                   StaticShape{5},
+                                                   StaticShape{3},
+                                                   StaticShape{2},
+                                                   StaticShape{2}};
+    const auto output_shapes = shape_inference(op.get(), input_shapes);
+    EXPECT_EQ(output_shapes[0], StaticShape({6, 4, 8}));
+}

--- a/src/plugins/intel_cpu/tests/unit/transformations/preserve_selective_ssm_precision_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/preserve_selective_ssm_precision_test.cpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "openvino/op/paged_selective_ssm.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/selective_ssm.hpp"
+#include "transformations/rt_info/disable_precision_conversion.hpp"
+#include "transformations/transformation_pipeline.h"
+
+namespace ov::intel_cpu::test {
+namespace {
+
+void expect_conversion_disabled(const std::shared_ptr<ov::Node>& node) {
+    EXPECT_TRUE(ov::is_conversion_disabled(node, ov::element::dynamic, ov::element::dynamic));
+}
+
+TEST(PreserveSelectiveSSMPrecisionTest, MarksSelectiveSSMAndSamePrecisionInputs) {
+    const auto A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{4});
+    const auto dt = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 4});
+    const auto B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 2, 3});
+    const auto x = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 4, 5});
+    const auto C = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 2, 3});
+    const auto state = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 4, 5, 3});
+    const ov::ParameterVector parameters{A, dt, B, x, C, state};
+    const auto ssm = std::make_shared<ov::op::internal::SelectiveSSM>(A, dt, B, x, C, state);
+    const auto model = std::make_shared<ov::Model>(ssm->outputs(), parameters);
+
+    PreserveSelectiveSSMPrecision pass;
+    EXPECT_FALSE(pass.run_on_model(model));
+
+    expect_conversion_disabled(ssm);
+    for (const auto& parameter : parameters) {
+        expect_conversion_disabled(parameter);
+    }
+}
+
+TEST(PreserveSelectiveSSMPrecisionTest, MarksPagedSelectiveSSMDataInputsOnly) {
+    const auto A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{4});
+    const auto dt = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 4});
+    const auto B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 2, 3});
+    const auto x = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 4, 5});
+    const auto C = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 2, 3});
+    const auto state_table = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{2, 4, 5, 3});
+    const auto subsequence_begins = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{2});
+    const auto block_indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{2});
+    const auto block_indices_begins = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{2});
+    const auto num_processed_tokens = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
+    const auto cache_interval = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
+    const ov::ParameterVector data_parameters{A, dt, B, x, C, state_table};
+    const ov::ParameterVector metadata_parameters{
+        subsequence_begins,
+        block_indices,
+        block_indices_begins,
+        num_processed_tokens,
+        cache_interval,
+    };
+    ov::ParameterVector parameters = data_parameters;
+    parameters.insert(parameters.end(), metadata_parameters.begin(), metadata_parameters.end());
+    const auto ssm = std::make_shared<ov::op::internal::PagedSelectiveSSM>(A,
+                                                                           dt,
+                                                                           B,
+                                                                           x,
+                                                                           C,
+                                                                           state_table,
+                                                                           subsequence_begins,
+                                                                           block_indices,
+                                                                           block_indices_begins,
+                                                                           num_processed_tokens,
+                                                                           cache_interval);
+    const auto model = std::make_shared<ov::Model>(ssm->outputs(), parameters);
+
+    PreserveSelectiveSSMPrecision pass;
+    EXPECT_FALSE(pass.run_on_model(model));
+
+    expect_conversion_disabled(ssm);
+    for (const auto& parameter : data_parameters) {
+        expect_conversion_disabled(parameter);
+    }
+    for (const auto& parameter : metadata_parameters) {
+        EXPECT_FALSE(ov::is_conversion_disabled(parameter, ov::element::dynamic, ov::element::dynamic));
+    }
+}
+
+}  // namespace
+}  // namespace ov::intel_cpu::test

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/single_op/paged_selective_ssm.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/single_op/paged_selective_ssm.hpp
@@ -21,10 +21,12 @@ using PagedSelectiveSSMLayerParams = std::tuple<int32_t,
                                                 int32_t,
                                                 std::vector<int32_t>,
                                                 std::vector<int32_t>,
+                                                std::vector<int32_t>,
+                                                ov::element::Type,
                                                 ov::element::Type,
                                                 std::string>;  // num_heads, num_groups, head_dim, state_size,
-                                                               // seq_lengths, cache_intervals, element_type,
-                                                               // target_device
+                                                               // seq_lengths, num_processed_tokens, cache_intervals,
+                                                               // element_type, index_type, target_device
 
 class PagedSelectiveSSMLayerTest : public testing::WithParamInterface<PagedSelectiveSSMLayerParams>,
                                    virtual public ov::test::SubgraphBaseTest {

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/single_op/paged_selective_ssm.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/single_op/paged_selective_ssm.hpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov::test {
+
+using PagedSelectiveSSMLayerParams = std::tuple<int32_t,
+                                                int32_t,
+                                                int32_t,
+                                                int32_t,
+                                                std::vector<int32_t>,
+                                                std::vector<int32_t>,
+                                                ov::element::Type,
+                                                std::string>;  // num_heads, num_groups, head_dim, state_size,
+                                                               // seq_lengths, cache_intervals, element_type,
+                                                               // target_device
+
+class PagedSelectiveSSMLayerTest : public testing::WithParamInterface<PagedSelectiveSSMLayerParams>,
+                                   virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<PagedSelectiveSSMLayerParams>& obj);
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
+
+protected:
+    std::vector<ov::Tensor> calculate_refs() override;
+    std::vector<ov::Tensor> get_plugin_outputs() override;
+    void compare(const std::vector<ov::Tensor>& expected, const std::vector<ov::Tensor>& actual) override;
+    void SetUp() override;
+
+private:
+    std::map<std::shared_ptr<ov::Node>, ov::Tensor> host_inputs;
+    ov::element::Type data_type;
+};
+
+}  // namespace ov::test

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/selective_ssm.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/selective_ssm.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov::test {
+
+using selective_ssm_params = std::tuple<int32_t,            // B
+                                        int32_t,            // T
+                                        int32_t,            // H
+                                        int32_t,            // G
+                                        int32_t,            // P
+                                        int32_t,            // N
+                                        ov::element::Type,  // infer_precision
+                                        std::string         // device
+                                        >;
+
+class SelectiveSSM : public testing::WithParamInterface<selective_ssm_params>, public ov::test::SubgraphBaseTest {
+public:
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
+    static std::string getTestCaseName(const testing::TestParamInfo<selective_ssm_params>& obj);
+
+protected:
+    std::vector<ov::Tensor> calculate_refs() override;
+    void compare(const std::vector<ov::Tensor>& expected, const std::vector<ov::Tensor>& actual) override;
+    void SetUp() override;
+};
+
+}  // namespace ov::test

--- a/src/tests/functional/plugin/shared/include/single_op_tests/paged_selective_ssm.hpp
+++ b/src/tests/functional/plugin/shared/include/single_op_tests/paged_selective_ssm.hpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/single_op/paged_selective_ssm.hpp"
+
+namespace ov::test {
+
+TEST_P(PagedSelectiveSSMLayerTest, Inference) {
+    run();
+}
+
+}  // namespace ov::test

--- a/src/tests/functional/plugin/shared/include/subgraph_tests/selective_ssm.hpp
+++ b/src/tests/functional/plugin/shared/include/subgraph_tests/selective_ssm.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/subgraph/selective_ssm.hpp"
+
+namespace ov::test {
+
+TEST_P(SelectiveSSM, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    run();
+    auto runtime_model = compiledModel.get_runtime_model();
+    CheckNumberOfNodesWithType(runtime_model, {"SelectiveSSM"}, 1);
+    CheckNumberOfNodesWithType(runtime_model, {"Loop"}, 0);
+}
+
+}  // namespace ov::test

--- a/src/tests/functional/plugin/shared/src/single_op/paged_selective_ssm.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/paged_selective_ssm.cpp
@@ -52,6 +52,10 @@ void run_reference(const std::vector<T>& A,
     for (int32_t seq = 0; seq < num_sequences; seq++) {
         const int32_t token_begin = subsequence_begins[seq];
         const int32_t token_end = subsequence_begins[seq + 1];
+        if (token_begin == token_end) {
+            continue;
+        }
+
         const int32_t block_begin = block_indices_begins[seq];
         const int32_t block_end = block_indices_begins[seq + 1];
         const int32_t seq_blocks = std::max(block_end - block_begin, 0);
@@ -112,9 +116,27 @@ std::vector<T> tensor_to_vector(const ov::Tensor& tensor) {
     return std::vector<T>(ptr, ptr + tensor.get_size());
 }
 
-ov::Tensor make_i32_tensor(const std::vector<int32_t>& values) {
-    ov::Tensor tensor(ov::element::i32, ov::Shape{values.size()});
-    std::copy(values.begin(), values.end(), tensor.data<int32_t>());
+std::vector<int32_t> tensor_to_i32(const ov::Tensor& tensor) {
+    if (tensor.get_element_type() == ov::element::i32) {
+        return tensor_to_vector<int32_t>(tensor);
+    }
+    const auto values = tensor_to_vector<int64_t>(tensor);
+    std::vector<int32_t> result(values.size());
+    std::transform(values.begin(), values.end(), result.begin(), [](int64_t value) {
+        return static_cast<int32_t>(value);
+    });
+    return result;
+}
+
+ov::Tensor make_index_tensor(const std::vector<int32_t>& values, const ov::element::Type& index_type) {
+    ov::Tensor tensor(index_type, ov::Shape{values.size()});
+    if (index_type == ov::element::i32) {
+        std::copy(values.begin(), values.end(), tensor.data<int32_t>());
+    } else {
+        std::transform(values.begin(), values.end(), tensor.data<int64_t>(), [](int32_t value) {
+            return static_cast<int64_t>(value);
+        });
+    }
     return tensor;
 }
 
@@ -134,11 +156,11 @@ std::vector<ov::Tensor> calculate_typed_refs(const std::map<std::shared_ptr<ov::
     auto x = tensor_to_vector<T>(host_inputs.at(params[3]));
     auto C = tensor_to_vector<T>(host_inputs.at(params[4]));
     auto state = tensor_to_vector<T>(host_inputs.at(params[5]));
-    auto subsequence_begins = tensor_to_vector<int32_t>(host_inputs.at(params[6]));
-    auto block_indices = tensor_to_vector<int32_t>(host_inputs.at(params[7]));
-    auto block_indices_begins = tensor_to_vector<int32_t>(host_inputs.at(params[8]));
-    auto num_processed_tokens = tensor_to_vector<int32_t>(host_inputs.at(params[9]));
-    auto cache_interval = tensor_to_vector<int32_t>(host_inputs.at(params[10]));
+    auto subsequence_begins = tensor_to_i32(host_inputs.at(params[6]));
+    auto block_indices = tensor_to_i32(host_inputs.at(params[7]));
+    auto block_indices_begins = tensor_to_i32(host_inputs.at(params[8]));
+    auto num_processed_tokens = tensor_to_i32(host_inputs.at(params[9]));
+    auto cache_interval = tensor_to_i32(host_inputs.at(params[10]));
 
     std::vector<T> ref_output;
     run_reference(A,
@@ -178,8 +200,10 @@ std::string PagedSelectiveSSMLayerTest::getTestCaseName(
                  head_dim,
                  state_size,
                  seq_lengths,
+                 num_processed_tokens,
                  cache_intervals,
                  element_type,
+                 index_type,
                  target_device] = obj.param;
     std::ostringstream result;
     result << "Heads=" << num_heads;
@@ -192,24 +216,44 @@ std::string PagedSelectiveSSMLayerTest::getTestCaseName(
             result << "x";
         result << seq_lengths[i];
     }
+    result << "_Processed=";
+    for (size_t i = 0; i < num_processed_tokens.size(); i++) {
+        if (i > 0)
+            result << "x";
+        result << num_processed_tokens[i];
+    }
     result << "_Intervals=";
     for (size_t i = 0; i < cache_intervals.size(); i++) {
         if (i > 0)
             result << "x";
-        result << cache_intervals[i];
+        if (cache_intervals[i] < 0) {
+            result << "neg" << -cache_intervals[i];
+        } else {
+            result << cache_intervals[i];
+        }
     }
     result << "_Type=" << element_type;
+    result << "_IndexType=" << index_type;
     result << "_Target=" << target_device;
     return result.str();
 }
 
 void PagedSelectiveSSMLayerTest::SetUp() {
-    const auto& [num_heads, num_groups, head_dim, state_size, seq_lengths, cache_intervals, data_type, device] =
-        GetParam();
+    const auto& [num_heads,
+                 num_groups,
+                 head_dim,
+                 state_size,
+                 seq_lengths,
+                 num_processed_tokens,
+                 cache_intervals,
+                 data_type,
+                 index_type,
+                 device] = GetParam();
     targetDevice = device;
     this->data_type = data_type;
     configuration[ov::hint::inference_precision.name()] = data_type;
     OPENVINO_ASSERT(!seq_lengths.empty());
+    OPENVINO_ASSERT(seq_lengths.size() == num_processed_tokens.size());
     OPENVINO_ASSERT(seq_lengths.size() == cache_intervals.size());
 
     const int32_t tokens = std::accumulate(seq_lengths.begin(), seq_lengths.end(), 0);
@@ -217,12 +261,13 @@ void PagedSelectiveSSMLayerTest::SetUp() {
 
     int32_t num_blocks = 0;
     for (size_t i = 0; i < seq_lengths.size(); i++) {
-        OPENVINO_ASSERT(cache_intervals[i] >= 0);
-        const int32_t processed = 1 + static_cast<int32_t>(i % 3);
-        if (cache_intervals[i] == 0) {
+        if (seq_lengths[i] == 0) {
+            continue;
+        }
+        if (cache_intervals[i] <= 0) {
             num_blocks += 1;
         } else {
-            const int32_t prev_nums = processed % cache_intervals[i];
+            const int32_t prev_nums = num_processed_tokens[i] % cache_intervals[i];
             const int32_t write_blocks = (prev_nums + seq_lengths[i] + cache_intervals[i] - 1) / cache_intervals[i];
             num_blocks += 1 + write_blocks;
         }
@@ -238,18 +283,24 @@ void PagedSelectiveSSMLayerTest::SetUp() {
                                 static_cast<size_t>(num_heads),
                                 static_cast<size_t>(head_dim),
                                 static_cast<size_t>(state_size)};
-
-    init_input_shapes(static_shapes_to_test_representation({A_shape,
-                                                            dt_shape,
-                                                            BC_shape,
-                                                            x_shape,
-                                                            BC_shape,
-                                                            state_shape,
-                                                            ov::Shape{static_cast<size_t>(num_sequences + 1)},
-                                                            ov::Shape{static_cast<size_t>(num_blocks)},
-                                                            ov::Shape{static_cast<size_t>(num_sequences + 1)},
-                                                            ov::Shape{static_cast<size_t>(num_sequences)},
-                                                            ov::Shape{static_cast<size_t>(num_sequences)}}));
+    auto expanded_state_shape = state_shape;
+    expanded_state_shape[0] += 2;
+    const auto repeated = [](const ov::Shape& shape) {
+        return std::vector<ov::Shape>{shape, shape, shape};
+    };
+    init_input_shapes(
+        {InputShape{ov::PartialShape{num_heads}, repeated(A_shape)},
+         InputShape{ov::PartialShape{-1, num_heads}, repeated(dt_shape)},
+         InputShape{ov::PartialShape{-1, num_groups, state_size}, repeated(BC_shape)},
+         InputShape{ov::PartialShape{-1, num_heads, head_dim}, repeated(x_shape)},
+         InputShape{ov::PartialShape{-1, num_groups, state_size}, repeated(BC_shape)},
+         InputShape{ov::PartialShape{-1, num_heads, head_dim, state_size},
+                    {state_shape, expanded_state_shape, state_shape}},
+         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_sequences + 1)})},
+         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_blocks)})},
+         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_sequences + 1)})},
+         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_sequences)})},
+         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_sequences)})}});
 
     auto p_A = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{num_heads});
     auto p_dt = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_heads});
@@ -258,11 +309,11 @@ void PagedSelectiveSSMLayerTest::SetUp() {
     auto p_C = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_groups, state_size});
     auto p_state =
         std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_heads, head_dim, state_size});
-    auto p_subseq = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
-    auto p_blocks = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
-    auto p_block_begins = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
-    auto p_num_processed = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
-    auto p_cache_interval = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto p_subseq = std::make_shared<ov::op::v0::Parameter>(index_type, ov::PartialShape{-1});
+    auto p_blocks = std::make_shared<ov::op::v0::Parameter>(index_type, ov::PartialShape{-1});
+    auto p_block_begins = std::make_shared<ov::op::v0::Parameter>(index_type, ov::PartialShape{-1});
+    auto p_num_processed = std::make_shared<ov::op::v0::Parameter>(index_type, ov::PartialShape{-1});
+    auto p_cache_interval = std::make_shared<ov::op::v0::Parameter>(index_type, ov::PartialShape{-1});
     auto pssm = std::make_shared<ov::op::internal::PagedSelectiveSSM>(p_A,
                                                                       p_dt,
                                                                       p_B,
@@ -293,8 +344,16 @@ void PagedSelectiveSSMLayerTest::generate_inputs(const std::vector<ov::Shape>& t
     inputs.clear();
     host_inputs.clear();
 
-    const auto& [num_heads, num_groups, head_dim, state_size, seq_lengths, cache_intervals, element_type, device] =
-        GetParam();
+    const auto& [num_heads,
+                 num_groups,
+                 head_dim,
+                 state_size,
+                 seq_lengths,
+                 num_processed_tokens_param,
+                 cache_intervals,
+                 element_type,
+                 index_type,
+                 device] = GetParam();
     const auto num_sequences = static_cast<int32_t>(seq_lengths.size());
 
     std::vector<int32_t> subsequence_begins;
@@ -315,14 +374,16 @@ void PagedSelectiveSSMLayerTest::generate_inputs(const std::vector<ov::Shape>& t
     for (int32_t seq = 0; seq < num_sequences; seq++) {
         const int32_t seq_len = seq_lengths[seq];
         const int32_t seq_interval = cache_intervals[seq];
-        const int32_t processed = 1 + (seq % 3);
+        const int32_t processed = num_processed_tokens_param[seq];
 
         subsequence_begins.push_back(subsequence_begins.back() + seq_len);
         num_processed_tokens.push_back(processed);
         cache_interval.push_back(seq_interval);
 
         int32_t required_slots = 1;
-        if (seq_interval > 0) {
+        if (seq_len == 0) {
+            required_slots = 0;
+        } else if (seq_interval > 0) {
             const int32_t prev_nums = processed % seq_interval;
             const int32_t write_blocks = (prev_nums + seq_len + seq_interval - 1) / seq_interval;
             required_slots = 1 + write_blocks;
@@ -359,15 +420,15 @@ void PagedSelectiveSSMLayerTest::generate_inputs(const std::vector<ov::Shape>& t
                                                              shape,
                                                              ov::test::utils::InputGenerateData(-0.5f, 1.0f, 1000, 1));
         } else if (i == 6) {
-            tensor = make_i32_tensor(subsequence_begins);
+            tensor = make_index_tensor(subsequence_begins, index_type);
         } else if (i == 7) {
-            tensor = make_i32_tensor(block_indices);
+            tensor = make_index_tensor(block_indices, index_type);
         } else if (i == 8) {
-            tensor = make_i32_tensor(block_indices_begins);
+            tensor = make_index_tensor(block_indices_begins, index_type);
         } else if (i == 9) {
-            tensor = make_i32_tensor(num_processed_tokens);
+            tensor = make_index_tensor(num_processed_tokens, index_type);
         } else if (i == 10) {
-            tensor = make_i32_tensor(cache_interval);
+            tensor = make_index_tensor(cache_interval, index_type);
         }
 
         host_inputs[param] = tensor;
@@ -382,8 +443,16 @@ void PagedSelectiveSSMLayerTest::generate_inputs(const std::vector<ov::Shape>& t
 }
 
 std::vector<ov::Tensor> PagedSelectiveSSMLayerTest::calculate_refs() {
-    const auto& [num_heads, num_groups, head_dim, state_size, seq_lengths, cache_intervals, element_type, device] =
-        GetParam();
+    const auto& [num_heads,
+                 num_groups,
+                 head_dim,
+                 state_size,
+                 seq_lengths,
+                 num_processed_tokens,
+                 cache_intervals,
+                 element_type,
+                 index_type,
+                 device] = GetParam();
 
     if (element_type == ov::element::f16) {
         return calculate_typed_refs<ov::float16>(host_inputs,

--- a/src/tests/functional/plugin/shared/src/single_op/paged_selective_ssm.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/paged_selective_ssm.cpp
@@ -1,0 +1,444 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/single_op/paged_selective_ssm.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <numeric>
+#include <sstream>
+#include <vector>
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/core/type/bfloat16.hpp"
+#include "openvino/core/type/float16.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/runtime/remote_context.hpp"
+#include "openvino/runtime/remote_tensor.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace {
+
+template <typename T>
+void run_reference(const std::vector<T>& A,
+                   const std::vector<T>& dt,
+                   const std::vector<T>& B,
+                   const std::vector<T>& x,
+                   const std::vector<T>& C,
+                   std::vector<T>& recurrent_state_table,
+                   const std::vector<int32_t>& subsequence_begins,
+                   const std::vector<int32_t>& block_indices,
+                   const std::vector<int32_t>& block_indices_begins,
+                   const std::vector<int32_t>& num_processed_tokens,
+                   const std::vector<int32_t>& cache_interval,
+                   int32_t num_heads,
+                   int32_t num_groups,
+                   int32_t head_dim,
+                   int32_t state_size,
+                   std::vector<T>& output) {
+    const int32_t tokens = static_cast<int32_t>(x.size()) / (num_heads * head_dim);
+    const int32_t heads_per_group = num_heads / num_groups;
+    const int32_t num_sequences = static_cast<int32_t>(subsequence_begins.size()) - 1;
+    output.resize(static_cast<size_t>(tokens) * num_heads * head_dim);
+
+    const auto state_off = [=](int32_t block, int32_t h, int32_t p, int32_t n) {
+        return ((block * num_heads + h) * head_dim + p) * state_size + n;
+    };
+
+    for (int32_t seq = 0; seq < num_sequences; seq++) {
+        const int32_t token_begin = subsequence_begins[seq];
+        const int32_t token_end = subsequence_begins[seq + 1];
+        const int32_t block_begin = block_indices_begins[seq];
+        const int32_t block_end = block_indices_begins[seq + 1];
+        const int32_t seq_blocks = std::max(block_end - block_begin, 0);
+        const int32_t processed = num_processed_tokens[seq];
+        const int32_t interval = cache_interval[seq];
+        const int32_t prev_nums = interval > 0 ? (processed % interval) : 0;
+        const int32_t first_block = block_indices[block_begin];
+
+        for (int32_t h = 0; h < num_heads; h++) {
+            const int32_t g = h / heads_per_group;
+            std::vector<float> state(static_cast<size_t>(head_dim) * state_size, 0.f);
+            for (int32_t p = 0; p < head_dim; p++) {
+                for (int32_t n = 0; n < state_size; n++) {
+                    state[p * state_size + n] =
+                        static_cast<float>(recurrent_state_table[state_off(first_block, h, p, n)]);
+                }
+            }
+
+            for (int32_t token = token_begin; token < token_end; token++) {
+                const float dt_value = static_cast<float>(dt[token * num_heads + h]);
+                const float dA = std::exp(static_cast<float>(A[h]) * dt_value);
+                for (int32_t p = 0; p < head_dim; p++) {
+                    const float x_value = static_cast<float>(x[(token * num_heads + h) * head_dim + p]);
+                    float acc = 0.f;
+                    for (int32_t n = 0; n < state_size; n++) {
+                        float& s = state[p * state_size + n];
+                        s = s * dA +
+                            x_value * dt_value * static_cast<float>(B[(token * num_groups + g) * state_size + n]);
+                        acc += s * static_cast<float>(C[(token * num_groups + g) * state_size + n]);
+                    }
+                    output[(token * num_heads + h) * head_dim + p] = static_cast<T>(acc);
+                }
+
+                const int32_t processed_tokens = (token - token_begin) + 1;
+                const int32_t cached_tokens = prev_nums + processed_tokens;
+                const bool reached_interval_boundary = interval > 0 && ((cached_tokens % interval) == 0);
+                const bool reached_sequence_end = token == token_end - 1;
+                if (interval > 0 && (reached_interval_boundary || reached_sequence_end)) {
+                    const int32_t slot = 1 + (cached_tokens - 1) / interval;
+                    if (slot < seq_blocks) {
+                        const int32_t block_id = block_indices[block_begin + slot];
+                        for (int32_t p = 0; p < head_dim; p++) {
+                            for (int32_t n = 0; n < state_size; n++) {
+                                recurrent_state_table[state_off(block_id, h, p, n)] =
+                                    static_cast<T>(state[p * state_size + n]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+std::vector<T> tensor_to_vector(const ov::Tensor& tensor) {
+    const auto* ptr = tensor.data<const T>();
+    return std::vector<T>(ptr, ptr + tensor.get_size());
+}
+
+ov::Tensor make_i32_tensor(const std::vector<int32_t>& values) {
+    ov::Tensor tensor(ov::element::i32, ov::Shape{values.size()});
+    std::copy(values.begin(), values.end(), tensor.data<int32_t>());
+    return tensor;
+}
+
+template <typename T>
+std::vector<ov::Tensor> calculate_typed_refs(const std::map<std::shared_ptr<ov::Node>, ov::Tensor>& host_inputs,
+                                             const std::shared_ptr<ov::Model>& function,
+                                             int32_t num_heads,
+                                             int32_t num_groups,
+                                             int32_t head_dim,
+                                             int32_t state_size,
+                                             const ov::element::Type& data_type) {
+    const auto& params = function->get_parameters();
+
+    auto A = tensor_to_vector<T>(host_inputs.at(params[0]));
+    auto dt = tensor_to_vector<T>(host_inputs.at(params[1]));
+    auto B = tensor_to_vector<T>(host_inputs.at(params[2]));
+    auto x = tensor_to_vector<T>(host_inputs.at(params[3]));
+    auto C = tensor_to_vector<T>(host_inputs.at(params[4]));
+    auto state = tensor_to_vector<T>(host_inputs.at(params[5]));
+    auto subsequence_begins = tensor_to_vector<int32_t>(host_inputs.at(params[6]));
+    auto block_indices = tensor_to_vector<int32_t>(host_inputs.at(params[7]));
+    auto block_indices_begins = tensor_to_vector<int32_t>(host_inputs.at(params[8]));
+    auto num_processed_tokens = tensor_to_vector<int32_t>(host_inputs.at(params[9]));
+    auto cache_interval = tensor_to_vector<int32_t>(host_inputs.at(params[10]));
+
+    std::vector<T> ref_output;
+    run_reference(A,
+                  dt,
+                  B,
+                  x,
+                  C,
+                  state,
+                  subsequence_begins,
+                  block_indices,
+                  block_indices_begins,
+                  num_processed_tokens,
+                  cache_interval,
+                  num_heads,
+                  num_groups,
+                  head_dim,
+                  state_size,
+                  ref_output);
+
+    ov::Tensor output_tensor(data_type, host_inputs.at(params[3]).get_shape());
+    std::copy(ref_output.begin(), ref_output.end(), output_tensor.data<T>());
+
+    ov::Tensor state_tensor(data_type, host_inputs.at(params[5]).get_shape());
+    std::copy(state.begin(), state.end(), state_tensor.data<T>());
+
+    return {output_tensor, state_tensor};
+}
+
+}  // namespace
+
+namespace ov::test {
+
+std::string PagedSelectiveSSMLayerTest::getTestCaseName(
+    const testing::TestParamInfo<PagedSelectiveSSMLayerParams>& obj) {
+    const auto& [num_heads,
+                 num_groups,
+                 head_dim,
+                 state_size,
+                 seq_lengths,
+                 cache_intervals,
+                 element_type,
+                 target_device] = obj.param;
+    std::ostringstream result;
+    result << "Heads=" << num_heads;
+    result << "_Groups=" << num_groups;
+    result << "_HeadDim=" << head_dim;
+    result << "_StateSize=" << state_size;
+    result << "_SeqLens=";
+    for (size_t i = 0; i < seq_lengths.size(); i++) {
+        if (i > 0)
+            result << "x";
+        result << seq_lengths[i];
+    }
+    result << "_Intervals=";
+    for (size_t i = 0; i < cache_intervals.size(); i++) {
+        if (i > 0)
+            result << "x";
+        result << cache_intervals[i];
+    }
+    result << "_Type=" << element_type;
+    result << "_Target=" << target_device;
+    return result.str();
+}
+
+void PagedSelectiveSSMLayerTest::SetUp() {
+    const auto& [num_heads, num_groups, head_dim, state_size, seq_lengths, cache_intervals, data_type, device] =
+        GetParam();
+    targetDevice = device;
+    this->data_type = data_type;
+    configuration[ov::hint::inference_precision.name()] = data_type;
+    OPENVINO_ASSERT(!seq_lengths.empty());
+    OPENVINO_ASSERT(seq_lengths.size() == cache_intervals.size());
+
+    const int32_t tokens = std::accumulate(seq_lengths.begin(), seq_lengths.end(), 0);
+    const int32_t num_sequences = static_cast<int32_t>(seq_lengths.size());
+
+    int32_t num_blocks = 0;
+    for (size_t i = 0; i < seq_lengths.size(); i++) {
+        OPENVINO_ASSERT(cache_intervals[i] >= 0);
+        const int32_t processed = 1 + static_cast<int32_t>(i % 3);
+        if (cache_intervals[i] == 0) {
+            num_blocks += 1;
+        } else {
+            const int32_t prev_nums = processed % cache_intervals[i];
+            const int32_t write_blocks = (prev_nums + seq_lengths[i] + cache_intervals[i] - 1) / cache_intervals[i];
+            num_blocks += 1 + write_blocks;
+        }
+    }
+
+    const ov::Shape A_shape{static_cast<size_t>(num_heads)};
+    const ov::Shape dt_shape{static_cast<size_t>(tokens), static_cast<size_t>(num_heads)};
+    const ov::Shape BC_shape{static_cast<size_t>(tokens),
+                             static_cast<size_t>(num_groups),
+                             static_cast<size_t>(state_size)};
+    const ov::Shape x_shape{static_cast<size_t>(tokens), static_cast<size_t>(num_heads), static_cast<size_t>(head_dim)};
+    const ov::Shape state_shape{static_cast<size_t>(num_blocks),
+                                static_cast<size_t>(num_heads),
+                                static_cast<size_t>(head_dim),
+                                static_cast<size_t>(state_size)};
+
+    init_input_shapes(static_shapes_to_test_representation({A_shape,
+                                                            dt_shape,
+                                                            BC_shape,
+                                                            x_shape,
+                                                            BC_shape,
+                                                            state_shape,
+                                                            ov::Shape{static_cast<size_t>(num_sequences + 1)},
+                                                            ov::Shape{static_cast<size_t>(num_blocks)},
+                                                            ov::Shape{static_cast<size_t>(num_sequences + 1)},
+                                                            ov::Shape{static_cast<size_t>(num_sequences)},
+                                                            ov::Shape{static_cast<size_t>(num_sequences)}}));
+
+    auto p_A = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{num_heads});
+    auto p_dt = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_heads});
+    auto p_B = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_groups, state_size});
+    auto p_x = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_heads, head_dim});
+    auto p_C = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_groups, state_size});
+    auto p_state =
+        std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_heads, head_dim, state_size});
+    auto p_subseq = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto p_blocks = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto p_block_begins = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto p_num_processed = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto p_cache_interval = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+    auto pssm = std::make_shared<ov::op::internal::PagedSelectiveSSM>(p_A,
+                                                                      p_dt,
+                                                                      p_B,
+                                                                      p_x,
+                                                                      p_C,
+                                                                      p_state,
+                                                                      p_subseq,
+                                                                      p_blocks,
+                                                                      p_block_begins,
+                                                                      p_num_processed,
+                                                                      p_cache_interval);
+
+    function = std::make_shared<ov::Model>(ov::ResultVector{std::make_shared<ov::op::v0::Result>(pssm)},
+                                           ov::ParameterVector{p_A,
+                                                               p_dt,
+                                                               p_B,
+                                                               p_x,
+                                                               p_C,
+                                                               p_state,
+                                                               p_subseq,
+                                                               p_blocks,
+                                                               p_block_begins,
+                                                               p_num_processed,
+                                                               p_cache_interval});
+}
+
+void PagedSelectiveSSMLayerTest::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
+    inputs.clear();
+    host_inputs.clear();
+
+    const auto& [num_heads, num_groups, head_dim, state_size, seq_lengths, cache_intervals, element_type, device] =
+        GetParam();
+    const auto num_sequences = static_cast<int32_t>(seq_lengths.size());
+
+    std::vector<int32_t> subsequence_begins;
+    std::vector<int32_t> block_indices;
+    std::vector<int32_t> block_indices_begins;
+    std::vector<int32_t> num_processed_tokens;
+    std::vector<int32_t> cache_interval;
+
+    subsequence_begins.reserve(static_cast<size_t>(num_sequences + 1));
+    block_indices_begins.reserve(static_cast<size_t>(num_sequences + 1));
+    num_processed_tokens.reserve(static_cast<size_t>(num_sequences));
+    cache_interval.reserve(static_cast<size_t>(num_sequences));
+
+    subsequence_begins.push_back(0);
+    block_indices_begins.push_back(0);
+
+    int32_t total_blocks = 0;
+    for (int32_t seq = 0; seq < num_sequences; seq++) {
+        const int32_t seq_len = seq_lengths[seq];
+        const int32_t seq_interval = cache_intervals[seq];
+        const int32_t processed = 1 + (seq % 3);
+
+        subsequence_begins.push_back(subsequence_begins.back() + seq_len);
+        num_processed_tokens.push_back(processed);
+        cache_interval.push_back(seq_interval);
+
+        int32_t required_slots = 1;
+        if (seq_interval > 0) {
+            const int32_t prev_nums = processed % seq_interval;
+            const int32_t write_blocks = (prev_nums + seq_len + seq_interval - 1) / seq_interval;
+            required_slots = 1 + write_blocks;
+        }
+        for (int32_t i = 0; i < required_slots; i++) {
+            block_indices.push_back(total_blocks + i);
+        }
+        total_blocks += required_slots;
+        block_indices_begins.push_back(total_blocks);
+    }
+
+    const auto& params = function->get_parameters();
+    const bool use_remote_tensors = targetDevice == "GPU";
+    ov::RemoteContext remote_context;
+    if (use_remote_tensors) {
+        remote_context = compiledModel.get_context();
+    }
+
+    for (size_t i = 0; i < params.size(); i++) {
+        const auto& param = params[i];
+        const auto& shape = targetInputStaticShapes[i];
+        ov::Tensor tensor;
+
+        if (i == 0) {
+            tensor = ov::test::utils::create_and_fill_tensor(param->get_element_type(),
+                                                             shape,
+                                                             ov::test::utils::InputGenerateData(-0.5f, 0.7f, 1000, 1));
+        } else if (i == 1) {
+            tensor = ov::test::utils::create_and_fill_tensor(param->get_element_type(),
+                                                             shape,
+                                                             ov::test::utils::InputGenerateData(0.0f, 0.5f, 1000, 1));
+        } else if (i <= 5) {
+            tensor = ov::test::utils::create_and_fill_tensor(param->get_element_type(),
+                                                             shape,
+                                                             ov::test::utils::InputGenerateData(-0.5f, 1.0f, 1000, 1));
+        } else if (i == 6) {
+            tensor = make_i32_tensor(subsequence_begins);
+        } else if (i == 7) {
+            tensor = make_i32_tensor(block_indices);
+        } else if (i == 8) {
+            tensor = make_i32_tensor(block_indices_begins);
+        } else if (i == 9) {
+            tensor = make_i32_tensor(num_processed_tokens);
+        } else if (i == 10) {
+            tensor = make_i32_tensor(cache_interval);
+        }
+
+        host_inputs[param] = tensor;
+        if (use_remote_tensors && i <= 5) {
+            auto remote_tensor = remote_context.create_tensor(param->get_element_type(), shape);
+            remote_tensor.copy_from(tensor);
+            inputs[param] = remote_tensor;
+        } else {
+            inputs[param] = tensor;
+        }
+    }
+}
+
+std::vector<ov::Tensor> PagedSelectiveSSMLayerTest::calculate_refs() {
+    const auto& [num_heads, num_groups, head_dim, state_size, seq_lengths, cache_intervals, element_type, device] =
+        GetParam();
+
+    if (element_type == ov::element::f16) {
+        return calculate_typed_refs<ov::float16>(host_inputs,
+                                                 function,
+                                                 num_heads,
+                                                 num_groups,
+                                                 head_dim,
+                                                 state_size,
+                                                 element_type);
+    }
+    if (element_type == ov::element::bf16) {
+        return calculate_typed_refs<ov::bfloat16>(host_inputs,
+                                                  function,
+                                                  num_heads,
+                                                  num_groups,
+                                                  head_dim,
+                                                  state_size,
+                                                  element_type);
+    }
+    return calculate_typed_refs<float>(host_inputs,
+                                       function,
+                                       num_heads,
+                                       num_groups,
+                                       head_dim,
+                                       state_size,
+                                       element_type);
+}
+
+std::vector<ov::Tensor> PagedSelectiveSSMLayerTest::get_plugin_outputs() {
+    auto outputs = SubgraphBaseTest::get_plugin_outputs();
+
+    const auto& state_param = function->get_parameters().at(5);
+    const auto actual_state_tensor = inferRequest.get_tensor(state_param);
+    ov::Tensor host_state_tensor(actual_state_tensor.get_element_type(), actual_state_tensor.get_shape());
+    actual_state_tensor.copy_to(host_state_tensor);
+    outputs.push_back(host_state_tensor);
+
+    return outputs;
+}
+
+void PagedSelectiveSSMLayerTest::compare(const std::vector<ov::Tensor>& expected,
+                                         const std::vector<ov::Tensor>& actual) {
+    ASSERT_EQ(expected.size(), actual.size());
+    if (data_type == ov::element::bf16) {
+        abs_threshold = 1e-3f;
+        rel_threshold = 1e-2f;
+    } else if (data_type == ov::element::f16) {
+        abs_threshold = 5e-4f;
+        rel_threshold = 1e-5f;
+    } else {
+        abs_threshold = 2e-4f;
+        rel_threshold = 1e-5f;
+    }
+    ov::test::utils::compare(expected[0], actual[0], abs_threshold, rel_threshold);
+    ov::test::utils::compare(expected[1], actual[1], abs_threshold, rel_threshold);
+}
+
+}  // namespace ov::test

--- a/src/tests/functional/plugin/shared/src/single_op/paged_selective_ssm.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/paged_selective_ssm.cpp
@@ -23,84 +23,97 @@
 
 namespace {
 
-template <typename T>
+template <typename T, typename IndexT>
 void run_reference(const std::vector<T>& A,
                    const std::vector<T>& dt,
                    const std::vector<T>& B,
                    const std::vector<T>& x,
                    const std::vector<T>& C,
                    std::vector<T>& recurrent_state_table,
-                   const std::vector<int32_t>& subsequence_begins,
-                   const std::vector<int32_t>& block_indices,
-                   const std::vector<int32_t>& block_indices_begins,
-                   const std::vector<int32_t>& num_processed_tokens,
-                   const std::vector<int32_t>& cache_interval,
-                   int32_t num_heads,
-                   int32_t num_groups,
-                   int32_t head_dim,
-                   int32_t state_size,
+                   const std::vector<IndexT>& subsequence_begins,
+                   const std::vector<IndexT>& block_indices,
+                   const std::vector<IndexT>& block_indices_begins,
+                   const std::vector<IndexT>& num_processed_tokens,
+                   const std::vector<IndexT>& cache_interval,
+                   size_t num_heads,
+                   size_t num_groups,
+                   size_t head_dim,
+                   size_t state_size,
                    std::vector<T>& output) {
-    const int32_t tokens = static_cast<int32_t>(x.size()) / (num_heads * head_dim);
-    const int32_t heads_per_group = num_heads / num_groups;
-    const int32_t num_sequences = static_cast<int32_t>(subsequence_begins.size()) - 1;
-    output.resize(static_cast<size_t>(tokens) * num_heads * head_dim);
+    const size_t tokens = x.size() / (num_heads * head_dim);
+    const size_t heads_per_group = num_heads / num_groups;
+    const size_t num_sequences = subsequence_begins.size() - 1;
+    output.resize(tokens * num_heads * head_dim);
 
-    const auto state_off = [=](int32_t block, int32_t h, int32_t p, int32_t n) {
-        return ((block * num_heads + h) * head_dim + p) * state_size + n;
+    const auto state_off = [=](size_t block, size_t head, size_t position, size_t state) {
+        return ((block * num_heads + head) * head_dim + position) * state_size + state;
     };
 
-    for (int32_t seq = 0; seq < num_sequences; seq++) {
-        const int32_t token_begin = subsequence_begins[seq];
-        const int32_t token_end = subsequence_begins[seq + 1];
+    for (size_t sequence = 0; sequence < num_sequences; ++sequence) {
+        const auto token_begin = static_cast<size_t>(subsequence_begins[sequence]);
+        const auto token_end = static_cast<size_t>(subsequence_begins[sequence + 1]);
         if (token_begin == token_end) {
             continue;
         }
 
-        const int32_t block_begin = block_indices_begins[seq];
-        const int32_t block_end = block_indices_begins[seq + 1];
-        const int32_t seq_blocks = std::max(block_end - block_begin, 0);
-        const int32_t processed = num_processed_tokens[seq];
-        const int32_t interval = cache_interval[seq];
-        const int32_t prev_nums = interval > 0 ? (processed % interval) : 0;
-        const int32_t first_block = block_indices[block_begin];
+        const auto logical_block_begin = static_cast<size_t>(block_indices_begins[sequence]);
+        const auto logical_block_end = static_cast<size_t>(block_indices_begins[sequence + 1]);
+        const auto interval = cache_interval[sequence];
+        const auto read_block = static_cast<size_t>(block_indices[logical_block_begin]);
 
-        for (int32_t h = 0; h < num_heads; h++) {
-            const int32_t g = h / heads_per_group;
-            std::vector<float> state(static_cast<size_t>(head_dim) * state_size, 0.f);
-            for (int32_t p = 0; p < head_dim; p++) {
-                for (int32_t n = 0; n < state_size; n++) {
-                    state[p * state_size + n] =
-                        static_cast<float>(recurrent_state_table[state_off(first_block, h, p, n)]);
+        for (size_t head = 0; head < num_heads; ++head) {
+            const size_t group = head / heads_per_group;
+            std::vector<float> state(head_dim * state_size);
+            for (size_t position = 0; position < head_dim; ++position) {
+                for (size_t state_index = 0; state_index < state_size; ++state_index) {
+                    state[position * state_size + state_index] =
+                        static_cast<float>(recurrent_state_table[state_off(read_block, head, position, state_index)]);
                 }
             }
 
-            for (int32_t token = token_begin; token < token_end; token++) {
-                const float dt_value = static_cast<float>(dt[token * num_heads + h]);
-                const float dA = std::exp(static_cast<float>(A[h]) * dt_value);
-                for (int32_t p = 0; p < head_dim; p++) {
-                    const float x_value = static_cast<float>(x[(token * num_heads + h) * head_dim + p]);
-                    float acc = 0.f;
-                    for (int32_t n = 0; n < state_size; n++) {
-                        float& s = state[p * state_size + n];
-                        s = s * dA +
-                            x_value * dt_value * static_cast<float>(B[(token * num_groups + g) * state_size + n]);
-                        acc += s * static_cast<float>(C[(token * num_groups + g) * state_size + n]);
-                    }
-                    output[(token * num_heads + h) * head_dim + p] = static_cast<T>(acc);
+            for (size_t token = token_begin; token < token_end; ++token) {
+                const float delta = static_cast<float>(dt[token * num_heads + head]);
+                const float decay = std::exp(static_cast<float>(A[head]) * delta);
+                const auto projection_base = (token * num_groups + group) * state_size;
+                std::vector<float> input_projection(state_size);
+                for (size_t state_index = 0; state_index < state_size; ++state_index) {
+                    input_projection[state_index] =
+                        delta * static_cast<float>(B[projection_base + state_index]);
                 }
 
-                const int32_t processed_tokens = (token - token_begin) + 1;
-                const int32_t cached_tokens = prev_nums + processed_tokens;
-                const bool reached_interval_boundary = interval > 0 && ((cached_tokens % interval) == 0);
-                const bool reached_sequence_end = token == token_end - 1;
-                if (interval > 0 && (reached_interval_boundary || reached_sequence_end)) {
-                    const int32_t slot = 1 + (cached_tokens - 1) / interval;
-                    if (slot < seq_blocks) {
-                        const int32_t block_id = block_indices[block_begin + slot];
-                        for (int32_t p = 0; p < head_dim; p++) {
-                            for (int32_t n = 0; n < state_size; n++) {
-                                recurrent_state_table[state_off(block_id, h, p, n)] =
-                                    static_cast<T>(state[p * state_size + n]);
+                for (size_t position = 0; position < head_dim; ++position) {
+                    const auto state_base = position * state_size;
+                    const float input = static_cast<float>(x[(token * num_heads + head) * head_dim + position]);
+                    for (size_t state_index = 0; state_index < state_size; ++state_index) {
+                        auto& state_value = state[state_base + state_index];
+                        state_value = state_value * decay + input * input_projection[state_index];
+                    }
+
+                    double reduction = 0.0;
+                    for (size_t state_index = 0; state_index < state_size; ++state_index) {
+                        reduction += static_cast<double>(state[state_base + state_index]) *
+                                     static_cast<float>(C[projection_base + state_index]);
+                    }
+                    output[(token * num_heads + head) * head_dim + position] = static_cast<T>(reduction);
+                }
+
+                if (interval > 0) {
+                    const auto positive_interval = static_cast<uint64_t>(interval);
+                    const auto previous_offset =
+                        static_cast<uint64_t>(num_processed_tokens[sequence]) % positive_interval;
+                    const auto current_tokens = token - token_begin + 1;
+                    const auto cached_tokens = previous_offset + current_tokens;
+                    const bool is_boundary = cached_tokens % positive_interval == 0;
+                    const bool is_last = token + 1 == token_end;
+                    if (is_boundary || is_last) {
+                        const auto write_slot = 1 + (cached_tokens - 1) / positive_interval;
+                        OPENVINO_ASSERT(logical_block_begin + write_slot < logical_block_end);
+                        const auto write_block =
+                            static_cast<size_t>(block_indices[logical_block_begin + write_slot]);
+                        for (size_t position = 0; position < head_dim; ++position) {
+                            for (size_t state_index = 0; state_index < state_size; ++state_index) {
+                                recurrent_state_table[state_off(write_block, head, position, state_index)] =
+                                    static_cast<T>(state[position * state_size + state_index]);
                             }
                         }
                     }
@@ -116,18 +129,6 @@ std::vector<T> tensor_to_vector(const ov::Tensor& tensor) {
     return std::vector<T>(ptr, ptr + tensor.get_size());
 }
 
-std::vector<int32_t> tensor_to_i32(const ov::Tensor& tensor) {
-    if (tensor.get_element_type() == ov::element::i32) {
-        return tensor_to_vector<int32_t>(tensor);
-    }
-    const auto values = tensor_to_vector<int64_t>(tensor);
-    std::vector<int32_t> result(values.size());
-    std::transform(values.begin(), values.end(), result.begin(), [](int64_t value) {
-        return static_cast<int32_t>(value);
-    });
-    return result;
-}
-
 ov::Tensor make_index_tensor(const std::vector<int32_t>& values, const ov::element::Type& index_type) {
     ov::Tensor tensor(index_type, ov::Shape{values.size()});
     if (index_type == ov::element::i32) {
@@ -140,13 +141,13 @@ ov::Tensor make_index_tensor(const std::vector<int32_t>& values, const ov::eleme
     return tensor;
 }
 
-template <typename T>
+template <typename T, typename IndexT>
 std::vector<ov::Tensor> calculate_typed_refs(const std::map<std::shared_ptr<ov::Node>, ov::Tensor>& host_inputs,
                                              const std::shared_ptr<ov::Model>& function,
-                                             int32_t num_heads,
-                                             int32_t num_groups,
-                                             int32_t head_dim,
-                                             int32_t state_size,
+                                             size_t num_heads,
+                                             size_t num_groups,
+                                             size_t head_dim,
+                                             size_t state_size,
                                              const ov::element::Type& data_type) {
     const auto& params = function->get_parameters();
 
@@ -156,11 +157,11 @@ std::vector<ov::Tensor> calculate_typed_refs(const std::map<std::shared_ptr<ov::
     auto x = tensor_to_vector<T>(host_inputs.at(params[3]));
     auto C = tensor_to_vector<T>(host_inputs.at(params[4]));
     auto state = tensor_to_vector<T>(host_inputs.at(params[5]));
-    auto subsequence_begins = tensor_to_i32(host_inputs.at(params[6]));
-    auto block_indices = tensor_to_i32(host_inputs.at(params[7]));
-    auto block_indices_begins = tensor_to_i32(host_inputs.at(params[8]));
-    auto num_processed_tokens = tensor_to_i32(host_inputs.at(params[9]));
-    auto cache_interval = tensor_to_i32(host_inputs.at(params[10]));
+    auto subsequence_begins = tensor_to_vector<IndexT>(host_inputs.at(params[6]));
+    auto block_indices = tensor_to_vector<IndexT>(host_inputs.at(params[7]));
+    auto block_indices_begins = tensor_to_vector<IndexT>(host_inputs.at(params[8]));
+    auto num_processed_tokens = tensor_to_vector<IndexT>(host_inputs.at(params[9]));
+    auto cache_interval = tensor_to_vector<IndexT>(host_inputs.at(params[10]));
 
     std::vector<T> ref_output;
     run_reference(A,
@@ -189,6 +190,49 @@ std::vector<ov::Tensor> calculate_typed_refs(const std::map<std::shared_ptr<ov::
     return {output_tensor, state_tensor};
 }
 
+template <typename T>
+std::vector<ov::Tensor> calculate_data_typed_refs(
+    const std::map<std::shared_ptr<ov::Node>, ov::Tensor>& host_inputs,
+    const std::shared_ptr<ov::Model>& function,
+    size_t num_heads,
+    size_t num_groups,
+    size_t head_dim,
+    size_t state_size,
+    const ov::element::Type& data_type,
+    const ov::element::Type& index_type) {
+    if (index_type == ov::element::i64) {
+        return calculate_typed_refs<T, int64_t>(
+            host_inputs, function, num_heads, num_groups, head_dim, state_size, data_type);
+    }
+    return calculate_typed_refs<T, int32_t>(
+        host_inputs, function, num_heads, num_groups, head_dim, state_size, data_type);
+}
+
+int32_t count_logical_blocks(const std::vector<int32_t>& sequence_lengths,
+                             const std::vector<int32_t>& processed_tokens,
+                             const std::vector<int32_t>& cache_intervals) {
+    OPENVINO_ASSERT(sequence_lengths.size() == processed_tokens.size());
+    OPENVINO_ASSERT(sequence_lengths.size() == cache_intervals.size());
+
+    int32_t result = 0;
+    for (size_t sequence = 0; sequence < sequence_lengths.size(); ++sequence) {
+        const auto sequence_length = sequence_lengths[sequence];
+        if (sequence_length == 0) {
+            continue;
+        }
+
+        const auto interval = cache_intervals[sequence];
+        if (interval <= 0) {
+            ++result;
+            continue;
+        }
+
+        const auto previous_offset = processed_tokens[sequence] % interval;
+        const auto write_count = (previous_offset + sequence_length + interval - 1) / interval;
+        result += 1 + write_count;
+    }
+    return result;
+}
 }  // namespace
 
 namespace ov::test {
@@ -256,51 +300,74 @@ void PagedSelectiveSSMLayerTest::SetUp() {
     OPENVINO_ASSERT(seq_lengths.size() == num_processed_tokens.size());
     OPENVINO_ASSERT(seq_lengths.size() == cache_intervals.size());
 
-    const int32_t tokens = std::accumulate(seq_lengths.begin(), seq_lengths.end(), 0);
-    const int32_t num_sequences = static_cast<int32_t>(seq_lengths.size());
+    auto alternate_seq_lengths = seq_lengths;
+    auto alternate_processed_tokens = num_processed_tokens;
+    auto alternate_cache_intervals = cache_intervals;
+    alternate_seq_lengths.push_back(1);
+    alternate_processed_tokens.push_back(0);
+    alternate_cache_intervals.push_back(2);
 
-    int32_t num_blocks = 0;
-    for (size_t i = 0; i < seq_lengths.size(); i++) {
-        if (seq_lengths[i] == 0) {
-            continue;
-        }
-        if (cache_intervals[i] <= 0) {
-            num_blocks += 1;
-        } else {
-            const int32_t prev_nums = num_processed_tokens[i] % cache_intervals[i];
-            const int32_t write_blocks = (prev_nums + seq_lengths[i] + cache_intervals[i] - 1) / cache_intervals[i];
-            num_blocks += 1 + write_blocks;
-        }
-    }
+    const auto tokens = std::accumulate(seq_lengths.begin(), seq_lengths.end(), int32_t{0});
+    const auto alternate_tokens =
+        std::accumulate(alternate_seq_lengths.begin(), alternate_seq_lengths.end(), int32_t{0});
+    const auto num_sequences = static_cast<int32_t>(seq_lengths.size());
+    const auto alternate_num_sequences = static_cast<int32_t>(alternate_seq_lengths.size());
+    const auto num_blocks = count_logical_blocks(seq_lengths, num_processed_tokens, cache_intervals);
+    const auto alternate_num_blocks =
+        count_logical_blocks(alternate_seq_lengths, alternate_processed_tokens, alternate_cache_intervals);
 
     const ov::Shape A_shape{static_cast<size_t>(num_heads)};
     const ov::Shape dt_shape{static_cast<size_t>(tokens), static_cast<size_t>(num_heads)};
+    const ov::Shape alternate_dt_shape{static_cast<size_t>(alternate_tokens), static_cast<size_t>(num_heads)};
     const ov::Shape BC_shape{static_cast<size_t>(tokens),
                              static_cast<size_t>(num_groups),
                              static_cast<size_t>(state_size)};
+    const ov::Shape alternate_BC_shape{static_cast<size_t>(alternate_tokens),
+                                       static_cast<size_t>(num_groups),
+                                       static_cast<size_t>(state_size)};
     const ov::Shape x_shape{static_cast<size_t>(tokens), static_cast<size_t>(num_heads), static_cast<size_t>(head_dim)};
+    const ov::Shape alternate_x_shape{static_cast<size_t>(alternate_tokens),
+                                      static_cast<size_t>(num_heads),
+                                      static_cast<size_t>(head_dim)};
     const ov::Shape state_shape{static_cast<size_t>(num_blocks),
                                 static_cast<size_t>(num_heads),
                                 static_cast<size_t>(head_dim),
                                 static_cast<size_t>(state_size)};
-    auto expanded_state_shape = state_shape;
-    expanded_state_shape[0] += 2;
+    const ov::Shape alternate_state_shape{static_cast<size_t>(alternate_num_blocks + 2),
+                                          static_cast<size_t>(num_heads),
+                                          static_cast<size_t>(head_dim),
+                                          static_cast<size_t>(state_size)};
     const auto repeated = [](const ov::Shape& shape) {
         return std::vector<ov::Shape>{shape, shape, shape};
     };
     init_input_shapes(
         {InputShape{ov::PartialShape{num_heads}, repeated(A_shape)},
-         InputShape{ov::PartialShape{-1, num_heads}, repeated(dt_shape)},
-         InputShape{ov::PartialShape{-1, num_groups, state_size}, repeated(BC_shape)},
-         InputShape{ov::PartialShape{-1, num_heads, head_dim}, repeated(x_shape)},
-         InputShape{ov::PartialShape{-1, num_groups, state_size}, repeated(BC_shape)},
+         InputShape{ov::PartialShape{-1, num_heads}, {dt_shape, alternate_dt_shape, dt_shape}},
+         InputShape{ov::PartialShape{-1, num_groups, state_size}, {BC_shape, alternate_BC_shape, BC_shape}},
+         InputShape{ov::PartialShape{-1, num_heads, head_dim}, {x_shape, alternate_x_shape, x_shape}},
+         InputShape{ov::PartialShape{-1, num_groups, state_size}, {BC_shape, alternate_BC_shape, BC_shape}},
          InputShape{ov::PartialShape{-1, num_heads, head_dim, state_size},
-                    {state_shape, expanded_state_shape, state_shape}},
-         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_sequences + 1)})},
-         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_blocks)})},
-         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_sequences + 1)})},
-         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_sequences)})},
-         InputShape{ov::PartialShape::dynamic(1), repeated(ov::Shape{static_cast<size_t>(num_sequences)})}});
+                    {state_shape, alternate_state_shape, state_shape}},
+         InputShape{ov::PartialShape::dynamic(1),
+                    {ov::Shape{static_cast<size_t>(num_sequences + 1)},
+                     ov::Shape{static_cast<size_t>(alternate_num_sequences + 1)},
+                     ov::Shape{static_cast<size_t>(num_sequences + 1)}}},
+         InputShape{ov::PartialShape::dynamic(1),
+                    {ov::Shape{static_cast<size_t>(num_blocks)},
+                     ov::Shape{static_cast<size_t>(alternate_num_blocks)},
+                     ov::Shape{static_cast<size_t>(num_blocks)}}},
+         InputShape{ov::PartialShape::dynamic(1),
+                    {ov::Shape{static_cast<size_t>(num_sequences + 1)},
+                     ov::Shape{static_cast<size_t>(alternate_num_sequences + 1)},
+                     ov::Shape{static_cast<size_t>(num_sequences + 1)}}},
+         InputShape{ov::PartialShape::dynamic(1),
+                    {ov::Shape{static_cast<size_t>(num_sequences)},
+                     ov::Shape{static_cast<size_t>(alternate_num_sequences)},
+                     ov::Shape{static_cast<size_t>(num_sequences)}}},
+         InputShape{ov::PartialShape::dynamic(1),
+                    {ov::Shape{static_cast<size_t>(num_sequences)},
+                     ov::Shape{static_cast<size_t>(alternate_num_sequences)},
+                     ov::Shape{static_cast<size_t>(num_sequences)}}}});
 
     auto p_A = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{num_heads});
     auto p_dt = std::make_shared<ov::op::v0::Parameter>(data_type, ov::PartialShape{-1, num_heads});
@@ -354,7 +421,20 @@ void PagedSelectiveSSMLayerTest::generate_inputs(const std::vector<ov::Shape>& t
                  element_type,
                  index_type,
                  device] = GetParam();
-    const auto num_sequences = static_cast<int32_t>(seq_lengths.size());
+    const auto num_sequences = static_cast<int32_t>(targetInputStaticShapes[9][0]);
+    OPENVINO_ASSERT(targetInputStaticShapes[6][0] == static_cast<size_t>(num_sequences + 1));
+    OPENVINO_ASSERT(targetInputStaticShapes[8][0] == static_cast<size_t>(num_sequences + 1));
+    OPENVINO_ASSERT(targetInputStaticShapes[10][0] == static_cast<size_t>(num_sequences));
+    const bool use_alternate_metadata = static_cast<size_t>(num_sequences) != seq_lengths.size();
+    auto active_seq_lengths = seq_lengths;
+    auto active_processed_tokens = num_processed_tokens_param;
+    auto active_cache_intervals = cache_intervals;
+    if (use_alternate_metadata) {
+        active_seq_lengths.push_back(1);
+        active_processed_tokens.push_back(0);
+        active_cache_intervals.push_back(2);
+    }
+    OPENVINO_ASSERT(static_cast<size_t>(num_sequences) == active_seq_lengths.size());
 
     std::vector<int32_t> subsequence_begins;
     std::vector<int32_t> block_indices;
@@ -372,9 +452,9 @@ void PagedSelectiveSSMLayerTest::generate_inputs(const std::vector<ov::Shape>& t
 
     int32_t total_blocks = 0;
     for (int32_t seq = 0; seq < num_sequences; seq++) {
-        const int32_t seq_len = seq_lengths[seq];
-        const int32_t seq_interval = cache_intervals[seq];
-        const int32_t processed = num_processed_tokens_param[seq];
+        const int32_t seq_len = active_seq_lengths[seq];
+        const int32_t seq_interval = active_cache_intervals[seq];
+        const int32_t processed = active_processed_tokens[seq];
 
         subsequence_begins.push_back(subsequence_begins.back() + seq_len);
         num_processed_tokens.push_back(processed);
@@ -455,30 +535,15 @@ std::vector<ov::Tensor> PagedSelectiveSSMLayerTest::calculate_refs() {
                  device] = GetParam();
 
     if (element_type == ov::element::f16) {
-        return calculate_typed_refs<ov::float16>(host_inputs,
-                                                 function,
-                                                 num_heads,
-                                                 num_groups,
-                                                 head_dim,
-                                                 state_size,
-                                                 element_type);
+        return calculate_data_typed_refs<ov::float16>(
+            host_inputs, function, num_heads, num_groups, head_dim, state_size, element_type, index_type);
     }
     if (element_type == ov::element::bf16) {
-        return calculate_typed_refs<ov::bfloat16>(host_inputs,
-                                                  function,
-                                                  num_heads,
-                                                  num_groups,
-                                                  head_dim,
-                                                  state_size,
-                                                  element_type);
+        return calculate_data_typed_refs<ov::bfloat16>(
+            host_inputs, function, num_heads, num_groups, head_dim, state_size, element_type, index_type);
     }
-    return calculate_typed_refs<float>(host_inputs,
-                                       function,
-                                       num_heads,
-                                       num_groups,
-                                       head_dim,
-                                       state_size,
-                                       element_type);
+    return calculate_data_typed_refs<float>(
+        host_inputs, function, num_heads, num_groups, head_dim, state_size, element_type, index_type);
 }
 
 std::vector<ov::Tensor> PagedSelectiveSSMLayerTest::get_plugin_outputs() {

--- a/src/tests/functional/plugin/shared/src/subgraph/selective_ssm.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/selective_ssm.cpp
@@ -50,29 +50,56 @@ std::vector<ov::Tensor> calculate_selective_ssm_refs(const std::map<std::shared_
         return static_cast<float>(value);
     });
 
-    ov::Tensor output_tensor(x_tensor.get_element_type(), x_shape);
-    auto* output = output_tensor.data<T>();
-    const auto state_batch_stride = num_heads * head_dim * state_size;
-    const auto state_head_stride = head_dim * state_size;
+    // Deliberately materialize the small discretized terms in the oracle. The production kernel does not use this
+    // decomposition, so this catches indexing/grouping mistakes independently of its fused update-reduction loop.
+    const auto token_heads = batch_size * sequence_length * num_heads;
+    std::vector<float> decay(token_heads);
+    std::vector<float> discretized_B(token_heads * state_size);
     for (size_t batch = 0; batch < batch_size; ++batch) {
         for (size_t token = 0; token < sequence_length; ++token) {
             for (size_t head = 0; head < num_heads; ++head) {
                 const auto token_head = (batch * sequence_length + token) * num_heads + head;
                 const auto group = head / heads_per_group;
-                const auto projection_base = ((batch * sequence_length + token) * num_groups + group) * state_size;
-                const auto state_base = batch * state_batch_stride + head * state_head_stride;
-                const auto x_base = token_head * head_dim;
+                const auto grouped_projection =
+                    ((batch * sequence_length + token) * num_groups + group) * state_size;
                 const float delta = static_cast<float>(dt[token_head]);
-                const float decay = std::exp(static_cast<float>(A[head]) * delta);
-                for (size_t p = 0; p < head_dim; ++p) {
-                    float value = 0.F;
-                    for (size_t n = 0; n < state_size; ++n) {
-                        auto& state_value = state[state_base + p * state_size + n];
-                        state_value = state_value * decay + static_cast<float>(x[x_base + p]) * delta *
-                                                                static_cast<float>(B[projection_base + n]);
-                        value += state_value * static_cast<float>(C[projection_base + n]);
+                decay[token_head] = std::exp(static_cast<float>(A[head]) * delta);
+                for (size_t state_index = 0; state_index < state_size; ++state_index) {
+                    discretized_B[token_head * state_size + state_index] =
+                        delta * static_cast<float>(B[grouped_projection + state_index]);
+                }
+            }
+        }
+    }
+
+    ov::Tensor output_tensor(x_tensor.get_element_type(), x_shape);
+    auto* output = output_tensor.data<T>();
+    const auto state_batch_stride = num_heads * head_dim * state_size;
+    const auto state_head_stride = head_dim * state_size;
+    for (size_t batch = 0; batch < batch_size; ++batch) {
+        for (size_t head = 0; head < num_heads; ++head) {
+            const auto group = head / heads_per_group;
+            for (size_t position = 0; position < head_dim; ++position) {
+                const auto state_base =
+                    batch * state_batch_stride + head * state_head_stride + position * state_size;
+                for (size_t token = 0; token < sequence_length; ++token) {
+                    const auto token_head = (batch * sequence_length + token) * num_heads + head;
+                    const auto projection_base =
+                        ((batch * sequence_length + token) * num_groups + group) * state_size;
+                    const auto x_index = token_head * head_dim + position;
+                    const float input = static_cast<float>(x[x_index]);
+                    for (size_t state_index = 0; state_index < state_size; ++state_index) {
+                        auto& state_value = state[state_base + state_index];
+                        state_value = state_value * decay[token_head] +
+                                      input * discretized_B[token_head * state_size + state_index];
                     }
-                    output[x_base + p] = static_cast<T>(value);
+
+                    double reduction = 0.0;
+                    for (size_t state_index = 0; state_index < state_size; ++state_index) {
+                        reduction += static_cast<double>(state[state_base + state_index]) *
+                                     static_cast<float>(C[projection_base + state_index]);
+                    }
+                    output[x_index] = static_cast<T>(reduction);
                 }
             }
         }
@@ -84,7 +111,6 @@ std::vector<ov::Tensor> calculate_selective_ssm_refs(const std::map<std::shared_
     });
     return {output_tensor, state_tensor};
 }
-
 }  // namespace
 
 namespace ov::test {

--- a/src/tests/functional/plugin/shared/src/subgraph/selective_ssm.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/selective_ssm.cpp
@@ -1,0 +1,188 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/subgraph/selective_ssm.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <sstream>
+#include <vector>
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/core/type/bfloat16.hpp"
+#include "openvino/core/type/float16.hpp"
+#include "openvino/op/selective_ssm.hpp"
+#include "openvino/runtime/properties.hpp"
+
+namespace {
+
+template <typename T>
+std::vector<ov::Tensor> calculate_selective_ssm_refs(const std::map<std::shared_ptr<ov::Node>, ov::Tensor>& inputs,
+                                                     const std::shared_ptr<ov::Model>& function) {
+    const auto& params = function->get_parameters();
+    const auto& A_tensor = inputs.at(params[0]);
+    const auto& dt_tensor = inputs.at(params[1]);
+    const auto& B_tensor = inputs.at(params[2]);
+    const auto& x_tensor = inputs.at(params[3]);
+    const auto& C_tensor = inputs.at(params[4]);
+    const auto& initial_state_tensor = inputs.at(params[5]);
+    const auto& x_shape = x_tensor.get_shape();
+    const auto& B_shape = B_tensor.get_shape();
+    const auto& state_shape = initial_state_tensor.get_shape();
+    const auto batch_size = x_shape[0];
+    const auto sequence_length = x_shape[1];
+    const auto num_heads = x_shape[2];
+    const auto head_dim = x_shape[3];
+    const auto num_groups = B_shape[2];
+    const auto state_size = B_shape[3];
+    const auto heads_per_group = num_heads / num_groups;
+
+    const auto* A = A_tensor.data<const T>();
+    const auto* dt = dt_tensor.data<const T>();
+    const auto* B = B_tensor.data<const T>();
+    const auto* x = x_tensor.data<const T>();
+    const auto* C = C_tensor.data<const T>();
+    const auto* initial_state = initial_state_tensor.data<const T>();
+    std::vector<float> state(initial_state_tensor.get_size());
+    std::transform(initial_state, initial_state + state.size(), state.begin(), [](T value) {
+        return static_cast<float>(value);
+    });
+
+    ov::Tensor output_tensor(x_tensor.get_element_type(), x_shape);
+    auto* output = output_tensor.data<T>();
+    const auto state_batch_stride = num_heads * head_dim * state_size;
+    const auto state_head_stride = head_dim * state_size;
+    for (size_t batch = 0; batch < batch_size; ++batch) {
+        for (size_t token = 0; token < sequence_length; ++token) {
+            for (size_t head = 0; head < num_heads; ++head) {
+                const auto token_head = (batch * sequence_length + token) * num_heads + head;
+                const auto group = head / heads_per_group;
+                const auto projection_base = ((batch * sequence_length + token) * num_groups + group) * state_size;
+                const auto state_base = batch * state_batch_stride + head * state_head_stride;
+                const auto x_base = token_head * head_dim;
+                const float delta = static_cast<float>(dt[token_head]);
+                const float decay = std::exp(static_cast<float>(A[head]) * delta);
+                for (size_t p = 0; p < head_dim; ++p) {
+                    float value = 0.F;
+                    for (size_t n = 0; n < state_size; ++n) {
+                        auto& state_value = state[state_base + p * state_size + n];
+                        state_value = state_value * decay + static_cast<float>(x[x_base + p]) * delta *
+                                                                static_cast<float>(B[projection_base + n]);
+                        value += state_value * static_cast<float>(C[projection_base + n]);
+                    }
+                    output[x_base + p] = static_cast<T>(value);
+                }
+            }
+        }
+    }
+
+    ov::Tensor state_tensor(initial_state_tensor.get_element_type(), state_shape);
+    std::transform(state.begin(), state.end(), state_tensor.data<T>(), [](float value) {
+        return static_cast<T>(value);
+    });
+    return {output_tensor, state_tensor};
+}
+
+}  // namespace
+
+namespace ov::test {
+
+std::string SelectiveSSM::getTestCaseName(const testing::TestParamInfo<selective_ssm_params>& obj) {
+    const auto& [batch, seq_len, num_heads, num_groups, head_dim, state_size, prec, device] = obj.param;
+    std::ostringstream result;
+    result << "batch=" << batch;
+    result << ",seq_len=" << seq_len;
+    result << ",num_heads=" << num_heads;
+    result << ",num_groups=" << num_groups;
+    result << ",head_dim=" << head_dim;
+    result << ",state_size=" << state_size;
+    result << ",prec=" << prec;
+    result << ",device=" << device;
+    return result.str();
+}
+
+void SelectiveSSM::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
+    inputs.clear();
+    const auto& params = function->get_parameters();
+    for (size_t i = 0; i < params.size(); ++i) {
+        const auto& param = params[i];
+        const auto& shape = targetInputStaticShapes[i];
+        if (i == 0) {
+            inputs[param] =
+                ov::test::utils::create_and_fill_tensor(param->get_element_type(),
+                                                        shape,
+                                                        ov::test::utils::InputGenerateData(-0.5f, 0.7f, 1000, 1));
+        } else if (i == 1) {
+            inputs[param] =
+                ov::test::utils::create_and_fill_tensor(param->get_element_type(),
+                                                        shape,
+                                                        ov::test::utils::InputGenerateData(0.0f, 0.5f, 1000, 1));
+        } else {
+            inputs[param] =
+                ov::test::utils::create_and_fill_tensor(param->get_element_type(),
+                                                        shape,
+                                                        ov::test::utils::InputGenerateData(-0.5f, 1.0f, 1000, 1));
+        }
+    }
+}
+
+std::vector<ov::Tensor> SelectiveSSM::calculate_refs() {
+    const auto& precision = std::get<6>(GetParam());
+    if (precision == ov::element::f16) {
+        return calculate_selective_ssm_refs<ov::float16>(inputs, function);
+    }
+    if (precision == ov::element::bf16) {
+        return calculate_selective_ssm_refs<ov::bfloat16>(inputs, function);
+    }
+    return calculate_selective_ssm_refs<float>(inputs, function);
+}
+
+void SelectiveSSM::compare(const std::vector<ov::Tensor>& expected, const std::vector<ov::Tensor>& actual) {
+    ASSERT_EQ(expected.size(), actual.size());
+    ov::test::utils::compare(expected[0], actual[0], abs_threshold, rel_threshold);
+    ov::test::utils::compare(expected[1], actual[1], abs_threshold, rel_threshold);
+}
+
+void SelectiveSSM::SetUp() {
+    const auto& [batch, seq_len, num_heads, num_groups, head_dim, state_size, prec, device] = GetParam();
+
+    targetDevice = device;
+    inType = prec;
+    configuration[ov::hint::inference_precision.name()] = prec;
+
+    abs_threshold = prec == ov::element::f32 ? 1e-6f : 1e-3f;
+    rel_threshold = 1e-5f;
+
+    const ov::Shape A_shape{static_cast<size_t>(num_heads)};
+    const ov::Shape dt_shape{static_cast<size_t>(batch), static_cast<size_t>(seq_len), static_cast<size_t>(num_heads)};
+    const ov::Shape B_shape{static_cast<size_t>(batch),
+                            static_cast<size_t>(seq_len),
+                            static_cast<size_t>(num_groups),
+                            static_cast<size_t>(state_size)};
+    const ov::Shape x_shape{static_cast<size_t>(batch),
+                            static_cast<size_t>(seq_len),
+                            static_cast<size_t>(num_heads),
+                            static_cast<size_t>(head_dim)};
+    const ov::Shape state_shape{static_cast<size_t>(batch),
+                                static_cast<size_t>(num_heads),
+                                static_cast<size_t>(head_dim),
+                                static_cast<size_t>(state_size)};
+
+    init_input_shapes(
+        static_shapes_to_test_representation({A_shape, dt_shape, B_shape, x_shape, B_shape, state_shape}));
+
+    auto A = std::make_shared<ov::op::v0::Parameter>(prec, ov::PartialShape{num_heads});
+    auto dt = std::make_shared<ov::op::v0::Parameter>(prec, ov::PartialShape{-1, -1, num_heads});
+    auto B = std::make_shared<ov::op::v0::Parameter>(prec, ov::PartialShape{-1, -1, num_groups, state_size});
+    auto x = std::make_shared<ov::op::v0::Parameter>(prec, ov::PartialShape{-1, -1, num_heads, head_dim});
+    auto C = std::make_shared<ov::op::v0::Parameter>(prec, ov::PartialShape{-1, -1, num_groups, state_size});
+    auto state = std::make_shared<ov::op::v0::Parameter>(prec, ov::PartialShape{-1, num_heads, head_dim, state_size});
+    auto selective_ssm = std::make_shared<ov::op::internal::SelectiveSSM>(A, dt, B, x, C, state);
+    function = std::make_shared<ov::Model>(selective_ssm->outputs(),
+                                           ov::ParameterVector{A, dt, B, x, C, state},
+                                           "SelectiveSSM");
+}
+
+}  // namespace ov::test

--- a/src/tests/functional/plugin/shared/src/subgraph/selective_ssm.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/selective_ssm.cpp
@@ -157,6 +157,9 @@ void SelectiveSSM::SetUp() {
 
     const ov::Shape A_shape{static_cast<size_t>(num_heads)};
     const ov::Shape dt_shape{static_cast<size_t>(batch), static_cast<size_t>(seq_len), static_cast<size_t>(num_heads)};
+    const ov::Shape alternate_dt_shape{static_cast<size_t>(batch == 1 ? 2 : 1),
+                                       static_cast<size_t>(seq_len + 2),
+                                       static_cast<size_t>(num_heads)};
     const ov::Shape B_shape{static_cast<size_t>(batch),
                             static_cast<size_t>(seq_len),
                             static_cast<size_t>(num_groups),
@@ -165,13 +168,31 @@ void SelectiveSSM::SetUp() {
                             static_cast<size_t>(seq_len),
                             static_cast<size_t>(num_heads),
                             static_cast<size_t>(head_dim)};
+    const ov::Shape alternate_B_shape{alternate_dt_shape[0],
+                                      alternate_dt_shape[1],
+                                      static_cast<size_t>(num_groups),
+                                      static_cast<size_t>(state_size)};
+    const ov::Shape alternate_x_shape{alternate_dt_shape[0],
+                                      alternate_dt_shape[1],
+                                      static_cast<size_t>(num_heads),
+                                      static_cast<size_t>(head_dim)};
     const ov::Shape state_shape{static_cast<size_t>(batch),
                                 static_cast<size_t>(num_heads),
                                 static_cast<size_t>(head_dim),
                                 static_cast<size_t>(state_size)};
+    const ov::Shape alternate_state_shape{alternate_dt_shape[0],
+                                          static_cast<size_t>(num_heads),
+                                          static_cast<size_t>(head_dim),
+                                          static_cast<size_t>(state_size)};
 
     init_input_shapes(
-        static_shapes_to_test_representation({A_shape, dt_shape, B_shape, x_shape, B_shape, state_shape}));
+        {InputShape{ov::PartialShape{num_heads}, {A_shape, A_shape, A_shape}},
+         InputShape{ov::PartialShape{-1, -1, num_heads}, {dt_shape, alternate_dt_shape, dt_shape}},
+         InputShape{ov::PartialShape{-1, -1, num_groups, state_size}, {B_shape, alternate_B_shape, B_shape}},
+         InputShape{ov::PartialShape{-1, -1, num_heads, head_dim}, {x_shape, alternate_x_shape, x_shape}},
+         InputShape{ov::PartialShape{-1, -1, num_groups, state_size}, {B_shape, alternate_B_shape, B_shape}},
+         InputShape{ov::PartialShape{-1, num_heads, head_dim, state_size},
+                    {state_shape, alternate_state_shape, state_shape}}});
 
     auto A = std::make_shared<ov::op::v0::Parameter>(prec, ov::PartialShape{num_heads});
     auto dt = std::make_shared<ov::op::v0::Parameter>(prec, ov::PartialShape{-1, -1, num_heads});


### PR DESCRIPTION
## Implementation details

- Implements `SelectiveSSM` and `PagedSelectiveSSM` in the Intel CPU plugin with a portable C++17 common executor and x64 JIT executors selected through `ExecutorFactory`.
- Supports `f32`, `f16`, and `bf16` data and `i32` or `i64` paged metadata while preserving FP32 recurrent-state accumulation.
- Shares recurrence, precision-conversion, cache-boundary, and paged-state handling between both operations.
- Uses paired head-dimension slices, four independent reduction chains, cache-bounded tiling, `CpuParallel`, and non-overlapping `DnnlScratchPad` storage.
- Preconverts low-precision B/C projections once per invocation, writes decode state directly, initializes paged prefill state from the first token, and removes dead state stores for cache-disabled single-token execution.
- Validates shape products, metadata ranges, cache capacity, block ownership, aliasing, and dynamic-shape changes before indexing or parallel execution.
- Adds independent-reference coverage for dynamic shapes, decode and prefill, cache modes, state aliasing, supported data and index types, overflow, empty dimensions, and fusion pipelines.
