### PR TITLE
[Core] Add non-zero guards for Col2Im shape_infer divisors (CWE-369)

### DIFF
--- a/src/core/shape_inference/include/col2im_shape_inference.hpp
+++ b/src/core/shape_inference/include/col2im_shape_inference.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
 
 #include "openvino/op/col2im.hpp"
 #include "utils.hpp"
@@ -65,16 +66,27 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
         //                   ^
         const size_t C_idx = is_batched ? 1 : 0;
         const auto kernel_val = ov::op::get_input_const_data_as<TRShape, int64_t>(op, 2, tensor_accessor);
-        if (kernel_val && data_shape.rank().is_static() && data_shape[C_idx].is_static()) {
-            const auto& dividend = data_shape[C_idx].get_length();
-            const auto divisor = ((*kernel_val)[0] * (*kernel_val)[1]);
-            output_shape[idx] = dividend / divisor;
-
+        if (kernel_val) {
             NODE_SHAPE_INFER_CHECK(op,
                                    input_shapes,
-                                   dividend % divisor == 0,
-                                   "First non-batch dimension is not evenly divisible by Product(kernel_shape). Got: ",
-                                   data_shape[C_idx].get_length());
+                                   (*kernel_val)[0] > 0 && (*kernel_val)[1] > 0,
+                                   "kernel_size elements must be positive non-zero values.");
+            NODE_SHAPE_INFER_CHECK(op,
+                                   input_shapes,
+                                   (*kernel_val)[0] <= std::numeric_limits<int64_t>::max() / (*kernel_val)[1],
+                                   "kernel_size product overflows int64.");
+            if (data_shape[C_idx].is_static()) {
+                const auto& dividend = data_shape[C_idx].get_length();
+                const auto divisor = (*kernel_val)[0] * (*kernel_val)[1];
+                output_shape[idx] = dividend / divisor;
+
+                NODE_SHAPE_INFER_CHECK(
+                    op,
+                    input_shapes,
+                    dividend % divisor == 0,
+                    "First non-batch dimension is not evenly divisible by Product(kernel_shape). Got: ",
+                    data_shape[C_idx].get_length());
+            }
         }
 
         // output_shape: (N, C, H, W)
@@ -98,6 +110,11 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
                     using TVal = typename TShape::value_type::value_type;
                     TVal L_calculated = 1;
                     for (size_t d = 0; d < spatial_dims; ++d) {
+                        NODE_SHAPE_INFER_CHECK(op,
+                                               input_shapes,
+                                               strides[d] != 0,
+                                               "strides must be non-zero at dimension ",
+                                               d);
                         L_calculated *= (((*output_size_val)[d].get_length() + pads_begin[d] + pads_end[d] -
                                           dilations[d] * ((*kernel_val)[d] - 1) - 1) /
                                          strides[d]) +

--- a/src/core/shape_inference/include/col2im_shape_inference.hpp
+++ b/src/core/shape_inference/include/col2im_shape_inference.hpp
@@ -5,9 +5,10 @@
 #pragma once
 
 #include <cmath>
-#include <limits>
 
+#include "dimension_util.hpp"
 #include "openvino/op/col2im.hpp"
+#include "openvino/util/math_util.hpp"
 #include "utils.hpp"
 
 namespace ov {
@@ -66,27 +67,25 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
         //                   ^
         const size_t C_idx = is_batched ? 1 : 0;
         const auto kernel_val = ov::op::get_input_const_data_as<TRShape, int64_t>(op, 2, tensor_accessor);
-        if (kernel_val) {
+        if (kernel_val && data_shape[C_idx].is_static()) {
+            int64_t divisor;
             NODE_SHAPE_INFER_CHECK(op,
                                    input_shapes,
-                                   (*kernel_val)[0] > 0 && (*kernel_val)[1] > 0,
-                                   "kernel_size elements must be positive non-zero values.");
-            NODE_SHAPE_INFER_CHECK(op,
-                                   input_shapes,
-                                   (*kernel_val)[0] <= std::numeric_limits<int64_t>::max() / (*kernel_val)[1],
+                                   !ov::util::mul_overflow<int64_t>((*kernel_val)[0], (*kernel_val)[1], divisor),
                                    "kernel_size product overflows int64.");
-            if (data_shape[C_idx].is_static()) {
-                const auto& dividend = data_shape[C_idx].get_length();
-                const auto divisor = (*kernel_val)[0] * (*kernel_val)[1];
-                output_shape[idx] = dividend / divisor;
+            NODE_SHAPE_INFER_CHECK(op,
+                                   input_shapes,
+                                   divisor > 0,
+                                   "kernel_size elements must be positive non-zero values.");
+            // Dimension division yields an empty dimension when it is not evenly divisible.
+            output_shape[idx] = data_shape[C_idx] / static_cast<typename TShape::value_type::value_type>(divisor);
 
-                NODE_SHAPE_INFER_CHECK(
-                    op,
-                    input_shapes,
-                    dividend % divisor == 0,
-                    "First non-batch dimension is not evenly divisible by Product(kernel_shape). Got: ",
-                    data_shape[C_idx].get_length());
-            }
+            NODE_SHAPE_INFER_CHECK(
+                op,
+                input_shapes,
+                !ov::util::dim::is_empty(output_shape[idx]),
+                "First non-batch dimension is not evenly divisible by Product(kernel_shape). Got: ",
+                data_shape[C_idx]);
         }
 
         // output_shape: (N, C, H, W)
@@ -110,11 +109,7 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
                     using TVal = typename TShape::value_type::value_type;
                     TVal L_calculated = 1;
                     for (size_t d = 0; d < spatial_dims; ++d) {
-                        NODE_SHAPE_INFER_CHECK(op,
-                                               input_shapes,
-                                               strides[d] != 0,
-                                               "strides must be non-zero at dimension ",
-                                               d);
+                        NODE_SHAPE_INFER_CHECK(op, input_shapes, strides[d] != 0, "strides must be non-zero.");
                         L_calculated *= (((*output_size_val)[d].get_length() + pads_begin[d] + pads_end[d] -
                                           dilations[d] * ((*kernel_val)[d] - 1) - 1) /
                                          strides[d]) +

--- a/src/core/shape_inference/include/col2im_shape_inference.hpp
+++ b/src/core/shape_inference/include/col2im_shape_inference.hpp
@@ -80,12 +80,11 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
             // Dimension division yields an empty dimension when it is not evenly divisible.
             output_shape[idx] = data_shape[C_idx] / static_cast<typename TShape::value_type::value_type>(divisor);
 
-            NODE_SHAPE_INFER_CHECK(
-                op,
-                input_shapes,
-                !ov::util::dim::is_empty(output_shape[idx]),
-                "First non-batch dimension is not evenly divisible by Product(kernel_shape). Got: ",
-                data_shape[C_idx]);
+            NODE_SHAPE_INFER_CHECK(op,
+                                   input_shapes,
+                                   !ov::util::dim::is_empty(output_shape[idx]),
+                                   "First non-batch dimension is not evenly divisible by Product(kernel_shape). Got: ",
+                                   data_shape[C_idx]);
         }
 
         // output_shape: (N, C, H, W)

--- a/src/core/tests/type_prop/col2im.cpp
+++ b/src/core/tests/type_prop/col2im.cpp
@@ -452,8 +452,7 @@ TEST_F(TypePropCol2ImTest, kernel_size_overflow_product) {
     const auto data = std::make_shared<Parameter>(element::i64, PartialShape{1, 12, 81});
     const auto output_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{16, 16});
     const int64_t large = std::numeric_limits<int64_t>::max() / 2 + 1;
-    const auto kernel_size =
-        std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{large, 2});
+    const auto kernel_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{large, 2});
 
     OV_EXPECT_THROW(
         std::ignore = make_op(data, output_size, kernel_size, Strides{1, 1}, Strides{1, 1}, Shape{0, 0}, Shape{0, 0}),

--- a/src/core/tests/type_prop/col2im.cpp
+++ b/src/core/tests/type_prop/col2im.cpp
@@ -461,5 +461,19 @@ TEST_F(TypePropCol2ImTest, kernel_size_overflow_product) {
         HasSubstr("kernel_size product overflows"));
 }
 
+TEST_F(TypePropCol2ImTest, kernel_size_product_wraps_to_zero) {
+    const auto data = std::make_shared<Parameter>(element::i64, PartialShape{1, 12, 81});
+    const auto output_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{16, 16});
+    // Both elements are positive, but their product wraps around to exactly 0 without the overflow guard.
+    constexpr int64_t two_pow_32 = int64_t{1} << 32;
+    const auto kernel_size =
+        std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{two_pow_32, two_pow_32});
+
+    OV_EXPECT_THROW(
+        std::ignore = make_op(data, output_size, kernel_size, Strides{1, 1}, Strides{1, 1}, Shape{0, 0}, Shape{0, 0}),
+        ov::NodeValidationFailure,
+        HasSubstr("kernel_size product overflows"));
+}
+
 }  // namespace test
 }  // namespace ov

--- a/src/core/tests/type_prop/col2im.cpp
+++ b/src/core/tests/type_prop/col2im.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "common_test_utils/test_assertions.hpp"
 #include "common_test_utils/type_prop.hpp"
 #include "openvino/op/constant.hpp"
@@ -400,6 +402,63 @@ TEST_F(TypePropCol2ImTest, interval_inputs_from_shapeof) {
     EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{{4, 5}, Dimension::dynamic(), {5, 16}, {5, 16}}));
     EXPECT_THAT(get_shape_symbols(op->get_output_partial_shape(0)),
                 testing::ElementsAre(data_symbols[0], nullptr, output_size_symbols[0], output_size_symbols[1]));
+}
+
+TEST_F(TypePropCol2ImTest, kernel_size_zero_both_dims) {
+    const auto data = std::make_shared<Parameter>(element::i64, PartialShape{3, 12, 81});
+    const auto output_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{16, 16});
+    const auto kernel_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{0, 0});
+
+    OV_EXPECT_THROW(
+        std::ignore = make_op(data, output_size, kernel_size, Strides{2, 2}, Strides{2, 2}, Shape{2, 2}, Shape{2, 2}),
+        ov::NodeValidationFailure,
+        HasSubstr("kernel"));
+}
+
+TEST_F(TypePropCol2ImTest, kernel_size_zero_one_dim) {
+    const auto data = std::make_shared<Parameter>(element::i64, PartialShape{3, 12, 81});
+    const auto output_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{16, 16});
+    const auto kernel_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{0, 3});
+
+    OV_EXPECT_THROW(
+        std::ignore = make_op(data, output_size, kernel_size, Strides{2, 2}, Strides{2, 2}, Shape{2, 2}, Shape{2, 2}),
+        ov::NodeValidationFailure,
+        HasSubstr("kernel"));
+}
+
+TEST_F(TypePropCol2ImTest, zero_strides_both_dims) {
+    const auto data = std::make_shared<Parameter>(element::i64, Shape{12, 324});
+    const auto output_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int32_t>{32, 32});
+    const auto kernel_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int32_t>{2, 2});
+
+    OV_EXPECT_THROW(
+        std::ignore = make_op(data, output_size, kernel_size, Strides{0, 0}, Strides{1, 1}, Shape{0, 0}, Shape{0, 0}),
+        ov::NodeValidationFailure,
+        HasSubstr("strides"));
+}
+
+TEST_F(TypePropCol2ImTest, zero_strides_one_dim) {
+    const auto data = std::make_shared<Parameter>(element::i64, Shape{12, 324});
+    const auto output_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int32_t>{32, 32});
+    const auto kernel_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int32_t>{2, 2});
+
+    OV_EXPECT_THROW(
+        std::ignore = make_op(data, output_size, kernel_size, Strides{1, 0}, Strides{1, 1}, Shape{0, 0}, Shape{0, 0}),
+        ov::NodeValidationFailure,
+        HasSubstr("strides"));
+}
+
+TEST_F(TypePropCol2ImTest, kernel_size_overflow_product) {
+    const auto data = std::make_shared<Parameter>(element::i64, PartialShape{1, 12, 81});
+    const auto output_size = std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{16, 16});
+    const int64_t large = std::numeric_limits<int64_t>::max() / 2 + 1;
+    const auto kernel_size =
+        std::make_shared<Constant>(element::i64, Shape{2}, std::vector<int64_t>{large, 2});
+
+    OV_EXPECT_THROW(
+        std::ignore = make_op(data, output_size, kernel_size, Strides{1, 1}, Strides{1, 1}, Shape{0, 0}, Shape{0, 0}),
+        ov::NodeValidationFailure,
+        HasSubstr("kernel_size product overflows"));
 }
 
 }  // namespace test


### PR DESCRIPTION
### Details:
Add NODE_SHAPE_INFER_CHECK guards before division operations in col2im_shape_inference.hpp to reject zero kernel_size product and zero strides, preventing SIGFPE/DoS on crafted ONNX models.

Two divide-by-zero paths are fixed:

- `divisor = (*kernel_val)[0] * (*kernel_val)[1]` used at line 71 without non-zero check
- `strides[d]` used as divisor in the spatial_dims loop at line 103 without non-zero check

### Tickets:
- *CVS-192534*

### AI Assistance:
- *AI assistance used: yes*
- *Bug root cause was found by AI.*