### PR TITLE
[OV JS] Skip e2e test for js api

### DIFF
--- a/.github/workflows/job_openvino_js.yml
+++ b/.github/workflows/job_openvino_js.yml
@@ -86,6 +86,6 @@ jobs:
         run: Xvfb "$DISPLAY" &
 
       - name: E2E of openvino-node package
-        if: fromJSON(inputs.nodejs-version) >= 22
+        if: ${{ 'false' }} # Skipping E2E tests for now due to CVS-192563
         working-directory: ${{ env.OPENVINO_JS_DIR }}
         run: npm run test:e2e --loglevel=silly

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -259,12 +259,12 @@ jobs:
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
       - name: E2E of openvino-node package
-        if: fromJSON(env.NODE_VERSION) >= 22
+        if: ${{ 'false' }} # Skipping E2E tests for now due to CVS-192563
         working-directory: ${{ env.OPENVINO_JS_DIR }}
         run: npm run test:e2e
 
       - name: E2E of openvino-node package (cmd)
-        if: fromJSON(env.NODE_VERSION) >= 22
+        if: ${{ 'false' }} # Skipping E2E tests for now due to CVS-192563
         shell: cmd
         working-directory: ${{ env.OPENVINO_JS_DIR }}
         run: call npm run test:e2e


### PR DESCRIPTION
Signed-off-by: Kirill Suvorov <kirill.suvorov@intel.com>

### Details:
 - Skipping E2E tests for now due to CVS-192563

### AI Assistance:
 - *AI assistance used: no*
