### PR TITLE
[Reference] OOB index validation for ScatterUpdate

### DIFF
--- a/src/core/reference/include/openvino/reference/scatter_update.hpp
+++ b/src/core/reference/include/openvino/reference/scatter_update.hpp
@@ -6,6 +6,7 @@
 
 #include <numeric>
 
+#include "openvino/core/except.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/reference/utils/coordinate_transform.hpp"
 #include "openvino/util/math_util.hpp"
@@ -95,6 +96,14 @@ static void scatter_update(const char* input_data,
         const size_t indices_idx =
             std::inner_product(indices_cord.begin(), indices_cord.end(), indices_in_strides.begin(), uint64_t(0));
         int64_t slice_index = indices[indices_idx];
+        const auto axis_size = static_cast<int64_t>(data_shape[axis]);
+        OPENVINO_ASSERT(slice_index >= 0 && slice_index < axis_size,
+                        "ScatterUpdate indices value ",
+                        slice_index,
+                        " is out of bounds for axis ",
+                        axis,
+                        " of size ",
+                        axis_size);
 
         Coordinate out_start_corner(data_shape.size(), 0);
         Coordinate out_end_corner(data_shape);

--- a/src/core/reference/include/openvino/reference/scatter_update.hpp
+++ b/src/core/reference/include/openvino/reference/scatter_update.hpp
@@ -96,8 +96,8 @@ static void scatter_update(const char* input_data,
         const size_t indices_idx =
             std::inner_product(indices_cord.begin(), indices_cord.end(), indices_in_strides.begin(), uint64_t(0));
         int64_t slice_index = indices[indices_idx];
-        const auto axis_size = static_cast<int64_t>(data_shape[axis]);
-        OPENVINO_ASSERT(slice_index >= 0 && slice_index < axis_size,
+        const auto axis_size = data_shape[axis];
+        OPENVINO_ASSERT(slice_index >= 0 && static_cast<uint64_t>(slice_index) < axis_size,
                         "ScatterUpdate indices value ",
                         slice_index,
                         " is out of bounds for axis ",

--- a/src/core/tests/eval.cpp
+++ b/src/core/tests/eval.cpp
@@ -2597,6 +2597,31 @@ TEST(eval, evaluate_dynamic_scatter_update_one_elem_i32) {
     ASSERT_EQ(cval, out);
 }
 
+TEST(eval, evaluate_scatter_update_out_of_range_index_throws) {
+    const Shape data_shape{3, 3};
+    const Shape indices_shape{1, 2};
+    const Shape updates_shape{1, 2, 3};
+
+    auto arg1 = make_shared<ov::op::v0::Parameter>(element::f32, data_shape);
+    auto arg2 = make_shared<ov::op::v0::Parameter>(element::i64, indices_shape);
+    auto arg3 = make_shared<ov::op::v0::Parameter>(element::f32, updates_shape);
+    auto arg4 = make_shared<ov::op::v0::Parameter>(element::i64, Shape{});
+    auto scatter_update = make_shared<op::v3::ScatterUpdate>(arg1, arg2, arg3, arg4);
+    auto model = make_shared<Model>(OutputVector{scatter_update}, ParameterVector{arg1, arg2, arg3, arg4});
+    auto result_tensor = ov::Tensor();
+    auto out_vector = ov::TensorVector{result_tensor};
+    // Index far outside `data_shape[0] == 3` range triggers an out-of-bounds write
+    // in the vulnerable implementation instead of being rejected.
+    auto in_vector =
+        ov::TensorVector{make_tensor<element::Type_t::f32>(data_shape, std::vector<float>(shape_size(data_shape))),
+                         make_tensor<element::Type_t::i64>(indices_shape, {1, static_cast<int64_t>(INT32_MAX)}),
+                         make_tensor<element::Type_t::f32>(updates_shape, {1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f}),
+                         make_tensor<element::Type_t::i64>({}, {0})};
+    OV_EXPECT_THROW(model->evaluate(out_vector, in_vector),
+                     ov::Exception,
+                     testing::HasSubstr("out of"));
+}
+
 TEST(eval, evaluate_softmax_8) {
     const Shape data_shape{1, 2};
     auto arg = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape::dynamic());

--- a/src/core/tests/eval.cpp
+++ b/src/core/tests/eval.cpp
@@ -2597,31 +2597,6 @@ TEST(eval, evaluate_dynamic_scatter_update_one_elem_i32) {
     ASSERT_EQ(cval, out);
 }
 
-TEST(eval, evaluate_scatter_update_out_of_range_index_throws) {
-    const Shape data_shape{3, 3};
-    const Shape indices_shape{1, 2};
-    const Shape updates_shape{1, 2, 3};
-
-    auto arg1 = make_shared<ov::op::v0::Parameter>(element::f32, data_shape);
-    auto arg2 = make_shared<ov::op::v0::Parameter>(element::i64, indices_shape);
-    auto arg3 = make_shared<ov::op::v0::Parameter>(element::f32, updates_shape);
-    auto arg4 = make_shared<ov::op::v0::Parameter>(element::i64, Shape{});
-    auto scatter_update = make_shared<op::v3::ScatterUpdate>(arg1, arg2, arg3, arg4);
-    auto model = make_shared<Model>(OutputVector{scatter_update}, ParameterVector{arg1, arg2, arg3, arg4});
-    auto result_tensor = ov::Tensor();
-    auto out_vector = ov::TensorVector{result_tensor};
-    // Index far outside `data_shape[0] == 3` range triggers an out-of-bounds write
-    // in the vulnerable implementation instead of being rejected.
-    auto in_vector =
-        ov::TensorVector{make_tensor<element::Type_t::f32>(data_shape, std::vector<float>(shape_size(data_shape))),
-                         make_tensor<element::Type_t::i64>(indices_shape, {1, static_cast<int64_t>(INT32_MAX)}),
-                         make_tensor<element::Type_t::f32>(updates_shape, {1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f}),
-                         make_tensor<element::Type_t::i64>({}, {0})};
-    OV_EXPECT_THROW(model->evaluate(out_vector, in_vector),
-                     ov::Exception,
-                     testing::HasSubstr("out of"));
-}
-
 TEST(eval, evaluate_softmax_8) {
     const Shape data_shape{1, 2};
     auto arg = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape::dynamic());

--- a/src/plugins/template/tests/functional/op_reference/scatter_update.cpp
+++ b/src/plugins/template/tests/functional/op_reference/scatter_update.cpp
@@ -4,9 +4,11 @@
 
 #include "openvino/op/scatter_update.hpp"
 
+#include <memory>
 #include <vector>
 
 #include "base_reference_test.hpp"
+#include "common_test_utils/test_assertions.hpp"
 #include "gtest/gtest.h"
 #include "openvino/op/parameter.hpp"
 
@@ -569,4 +571,29 @@ INSTANTIATE_TEST_SUITE_P(smoke_ScatterUpdate_Negative_Axis_With_Hardcoded_Refs,
                          ReferenceScatterUpdate6LayerTest,
                          ::testing::ValuesIn(generateScatterUpdateNegativeAxisParams()),
                          ReferenceScatterUpdate6LayerTest::getTestCaseName);
+
+TEST(smoke_ScatterUpdate_, evaluate_scatter_update_out_of_range_index_throws) {
+    const ov::Shape data_shape{3, 3};
+    const ov::Shape indices_shape{1, 2};
+    const ov::Shape updates_shape{1, 2, 3};
+
+    auto arg1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, data_shape);
+    auto arg2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, indices_shape);
+    auto arg3 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, updates_shape);
+    auto arg4 = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{});
+    auto scatter_update = std::make_shared<ov::op::v3::ScatterUpdate>(arg1, arg2, arg3, arg4);
+    auto model =
+        std::make_shared<ov::Model>(ov::OutputVector{scatter_update}, ov::ParameterVector{arg1, arg2, arg3, arg4});
+    auto result_tensor = ov::Tensor();
+    auto out_vector = ov::TensorVector{result_tensor};
+    // Index far outside `data_shape[0] == 3` range triggers an out-of-bounds write
+    // in the vulnerable implementation instead of being rejected.
+    auto in_vector = ov::TensorVector{
+        CreateTensor(data_shape, ov::element::Type_t::f32, std::vector<float>(shape_size(data_shape))),
+        CreateTensor<int64_t>(indices_shape, ov::element::Type_t::i64, {1, static_cast<int64_t>(INT32_MAX)}),
+        CreateTensor<float>(updates_shape, ov::element::Type_t::f32, {1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f}),
+        CreateTensor<int64_t>({}, ov::element::Type_t::i64, {0})};
+    OV_EXPECT_THROW(model->evaluate(out_vector, in_vector), ov::Exception, testing::HasSubstr("out of"));
+}
+
 }  // namespace reference_tests

--- a/src/plugins/template/tests/functional/op_reference/scatter_update.cpp
+++ b/src/plugins/template/tests/functional/op_reference/scatter_update.cpp
@@ -4,7 +4,6 @@
 
 #include "openvino/op/scatter_update.hpp"
 
-#include <memory>
 #include <vector>
 
 #include "base_reference_test.hpp"
@@ -560,6 +559,12 @@ std::vector<ScatterUpdate3Params> generateScatterUpdateNegativeAxisParams() {
     }
     return combinedParams;
 }
+
+class ReferenceScatterUpdate6LayerNegativeTest : public ReferenceScatterUpdate6LayerTest {};
+
+TEST_P(ReferenceScatterUpdate6LayerNegativeTest, CompareWithHardcodedRefs) {
+    OV_EXPECT_THROW(Exec(), ov::Exception, testing::HasSubstr("is out of bounds for axis"));
+}
 }  // namespace
 
 INSTANTIATE_TEST_SUITE_P(smoke_ScatterUpdate_With_Hardcoded_Refs,
@@ -572,28 +577,18 @@ INSTANTIATE_TEST_SUITE_P(smoke_ScatterUpdate_Negative_Axis_With_Hardcoded_Refs,
                          ::testing::ValuesIn(generateScatterUpdateNegativeAxisParams()),
                          ReferenceScatterUpdate6LayerTest::getTestCaseName);
 
-TEST(smoke_ScatterUpdate_, evaluate_scatter_update_out_of_range_index_throws) {
-    const ov::Shape data_shape{3, 3};
-    const ov::Shape indices_shape{1, 2};
-    const ov::Shape updates_shape{1, 2, 3};
-
-    auto arg1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, data_shape);
-    auto arg2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, indices_shape);
-    auto arg3 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, updates_shape);
-    auto arg4 = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{});
-    auto scatter_update = std::make_shared<ov::op::v3::ScatterUpdate>(arg1, arg2, arg3, arg4);
-    auto model =
-        std::make_shared<ov::Model>(ov::OutputVector{scatter_update}, ov::ParameterVector{arg1, arg2, arg3, arg4});
-    auto result_tensor = ov::Tensor();
-    auto out_vector = ov::TensorVector{result_tensor};
-    // Index far outside `data_shape[0] == 3` range triggers an out-of-bounds write
-    // in the vulnerable implementation instead of being rejected.
-    auto in_vector = ov::TensorVector{
-        CreateTensor(data_shape, ov::element::Type_t::f32, std::vector<float>(shape_size(data_shape))),
-        CreateTensor<int64_t>(indices_shape, ov::element::Type_t::i64, {1, static_cast<int64_t>(INT32_MAX)}),
-        CreateTensor<float>(updates_shape, ov::element::Type_t::f32, {1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f}),
-        CreateTensor<int64_t>({}, ov::element::Type_t::i64, {0})};
-    OV_EXPECT_THROW(model->evaluate(out_vector, in_vector), ov::Exception, testing::HasSubstr("out of"));
-}
+INSTANTIATE_TEST_SUITE_P(
+    smoke_ScatterUpdate_out_of_range_index_throws,
+    ReferenceScatterUpdate6LayerNegativeTest,
+    ::testing::Values(
+        Builder{}
+            .data({{3, 3}, ov::element::f32, std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0}})
+            .indices({{1, 2},
+                      ov::element::Type_t::i64,
+                      std::vector<int64_t>{1, static_cast<int64_t>(std::numeric_limits<int64_t>::max())}})
+            .updates({{1, 2, 3}, ov::element::f32, std::vector<float>{1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f}})
+            .axis({{1}, ov::element::i64, std::vector<int64_t>{0}})
+            .expected({{3, 3}, ov::element::f32, std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0}})),
+    ReferenceScatterUpdate6LayerNegativeTest::getTestCaseName);
 
 }  // namespace reference_tests


### PR DESCRIPTION
### Details:
* Adds validation to calculated scatter offset.

### Tickets:
* [CVS-192583](https://jira.devtools.intel.com/browse/CVS-192583)

### AI Assistance:
* AI assistance used: yes
* Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
