### PR TITLE
[GPU][Coverity] harden SDPA size handling

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1457,8 +1457,7 @@ DispatchDataFunc SDPAMicroGenerator::get_dispatch_data_func() const {
             }
 
             auto to_int32 = [](size_t value) {
-                OPENVINO_ASSERT(value <= static_cast<size_t>(std::numeric_limits<int32_t>::max()),
-                                "[GPU] SDPA micro scalar value exceeds int32 range");
+                OPENVINO_ASSERT(value <= static_cast<size_t>(std::numeric_limits<int32_t>::max()), "[GPU] SDPA micro scalar value exceeds int32 range");
                 return static_cast<int32_t>(value);
             };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -140,7 +140,7 @@ inline size_t micro_get_num_heads(const kernel_impl_params& params, size_t qkv_i
             OPENVINO_THROW("Invalid qkv index for scaled dot product attention");
         }
     }
-    return -1;
+    OPENVINO_THROW("[GPU] Invalid qkv index in micro_get_num_heads");
 }
 
 inline size_t micro_get_head_size(const kernel_impl_params& params, size_t qkv_idx) {
@@ -169,7 +169,7 @@ inline size_t micro_get_head_size(const kernel_impl_params& params, size_t qkv_i
             OPENVINO_THROW("Invalid qkv index for scaled dot product attention");
         }
     }
-    return -1;
+    OPENVINO_THROW("[GPU] Invalid qkv index in micro_get_head_size");
 }
 
 inline ov::Dimension micro_get_seq_length(const kernel_impl_params& params, int32_t qkv_idx) {
@@ -1457,9 +1457,8 @@ DispatchDataFunc SDPAMicroGenerator::get_dispatch_data_func() const {
             }
 
             auto to_int32 = [](size_t value) {
-                if (value > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
-                    return static_cast<int32_t>(-1);
-                }
+                OPENVINO_ASSERT(value <= static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+                                "[GPU] SDPA micro scalar value exceeds int32 range");
                 return static_cast<int32_t>(value);
             };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
@@ -35,7 +35,7 @@ JitConstants SDPAOptGeneratorBase::get_jit_constants_base(const kernel_impl_para
     jit.make("SUBGROUP_SIZE", subgroup_size);
 
     auto [broadcast_axis, group_size] = get_gqa_params(params);
-    int64_t v_head_size = -1, k_head_size = -1;
+    int64_t v_head_size = 0, k_head_size = 0;
 
     if (is_paged_attention) {
         auto desc = params.typed_desc<paged_attention>();
@@ -129,6 +129,9 @@ JitConstants SDPAOptGeneratorBase::get_jit_constants_base(const kernel_impl_para
             }
         }
     }
+
+    OPENVINO_ASSERT(k_head_size > 0 && v_head_size > 0,
+                    "SDPA: invalid head sizes for JIT constants generation");
 
     if (unaligned_head_size(k_head_size, v_head_size, subgroup_size)) {
         jit.make("K_HEAD_SIZE_LEFTOVER", k_head_size % subgroup_size);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
@@ -130,8 +130,7 @@ JitConstants SDPAOptGeneratorBase::get_jit_constants_base(const kernel_impl_para
         }
     }
 
-    OPENVINO_ASSERT(k_head_size > 0 && v_head_size > 0,
-                    "SDPA: invalid head sizes for JIT constants generation");
+    OPENVINO_ASSERT(k_head_size > 0 && v_head_size > 0, "SDPA: invalid head sizes for JIT constants generation");
 
     if (unaligned_head_size(k_head_size, v_head_size, subgroup_size)) {
         jit.make("K_HEAD_SIZE_LEFTOVER", k_head_size % subgroup_size);


### PR DESCRIPTION
### Summary
removing unsafe negative sentinel propagation and tightening size validation checks, while keeping dynamic-shape sentinel behavior unchanged to minimize side effects.

### Changes
- replace -1 sentinel conversion in SDPA micro dispatch with range assert
- remove unsigned -1 fallback returns in qkv helper functions
- validate positive head sizes in SDPA opt JIT setup

### Why
Coverity flagged improper negative-value usage in size-related paths.
These updates prevent invalid negative sentinels from being treated as valid size values, fail fast on invalid ranges, and keep runtime behavior for normal inputs unchanged.

### Tickets:
 - 192433

### AI Assistance:
 - AI assistance used: yes
 - AI: fix
 - Human: review
