### PR TITLE
[Snippets] Preserve shape inference factory when cloning LinearIR

### DIFF
--- a/src/common/snippets/src/lowered/linear_ir_builder.cpp
+++ b/src/common/snippets/src/lowered/linear_ir_builder.cpp
@@ -90,6 +90,7 @@ void LinearIRBuilder::clone(const LinearIR* src, LinearIR* dst, ExpressionMap& e
     dst->m_loop_manager = src->m_loop_manager->clone_with_new_expr(expression_map);
     // It's Ok to share shapeInfer factory ptr, since the factory doesn't depend on LIR in any way
     dst->m_shape_infer_factory = src->m_shape_infer_factory;
+    dst->m_expression_factory = std::make_shared<ExpressionFactory>(dst->m_shape_infer_factory);
     dst->m_shape_infer = std::make_shared<LinearIR::LIRShapeInfer>(dst->m_expressions,
                                                                    dst->m_parameter_expressions,
                                                                    dst->m_result_expressions);

--- a/src/common/snippets/tests/src/lowered/linear_ir.cpp
+++ b/src/common/snippets/tests/src/lowered/linear_ir.cpp
@@ -12,7 +12,9 @@
 #include "openvino/op/parameter.hpp"
 
 #include "snippets/lowered/linear_ir.hpp"
+#include "snippets/lowered/linear_ir_builder.hpp"
 #include "snippets/lowered/port_descriptor.hpp"
+#include "snippets/op/broadcastmove.hpp"
 
 #include "lir_test_utils.hpp"
 
@@ -58,6 +60,19 @@ TEST(LinearIRReplaceWithNode, PreservesPerOutputDescriptors) {
     EXPECT_EQ(new_desc_1->get_subtensor(), expected_desc_1->get_subtensor());
     EXPECT_EQ(new_desc_0->get_layout(), expected_desc_0->get_layout());
     EXPECT_EQ(new_desc_1->get_layout(), expected_desc_1->get_layout());
+    auto cloned_ir = ov::snippets::lowered::LinearIRBuilder().clone(linear_ir);
+    const auto& cloned_param = cloned_ir.front();
+    const auto broadcast = std::make_shared<ov::snippets::op::BroadcastMove>(cloned_param->get_node()->output(0), 16);
+    const auto broadcast_expr = *cloned_ir.insert_node(broadcast,
+                                                        std::vector<ov::snippets::lowered::PortConnectorPtr>{
+                                                            cloned_param->get_output_port_connector(0)},
+                                                        {},
+                                                        false,
+                                                        cloned_ir.end());
+
+    broadcast_expr->updateShapes();
+
+    EXPECT_EQ(broadcast_expr->get_output_port_descriptor(0)->get_shape(), (VectorDims{1, 16}));
 }
 
 }  // namespace snippets


### PR DESCRIPTION
### Details:
Rebuild the expression factory after cloning the shape inference factory so expressions inserted into cloned dynamic LIR can infer descriptors

Fix clone semantic of `LinearIRBuilder` that is violated on `m_expression_factory` field

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
 - Implementation is assisted and after that manually tested and reviewed
