### PR TITLE
[GPU][COVERITY] fix UNCAUGHT_EXCEPT Coverity issues

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -93,12 +93,11 @@ struct stages_helper {
         return {};
     }
 
-    size_t get_index(kv_stage stage) const noexcept {
+    size_t get_index(kv_stage stage) const {
         const auto idx = try_get_index(stage);
         OPENVINO_ASSERT(idx.has_value(), "expect stage ", static_cast<uint8_t>(stage), " exist");
         return *idx;
     }
-
 };
 
 struct kv_cache_impl : multi_stage_primitive<kv_cache> {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.cpp
@@ -175,7 +175,7 @@ static micro::Type convert_type(ov::element::Type t) {
 
 std::mutex MoE3GemmMicroGenerator::mtx;
 std::unordered_map<MoE3GemmMicroGenerator::GemmCacheKey, micro::Package, MoE3GemmMicroGenerator::GemmCacheKeyHash> MoE3GemmMicroGenerator::s_gemm_cache;
-void MoE3GemmMicroGenerator::init_microkernels(const kernel_impl_params& params, micro::Package& gemm_moe, MoE3GemmMicroKernelType type) noexcept {
+void MoE3GemmMicroGenerator::init_microkernels(const kernel_impl_params& params, micro::Package& gemm_moe, MoE3GemmMicroKernelType type) {
     std::lock_guard<std::mutex> l(mtx);
 
     int wei_idx, scale_idx, zp_idx;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/moe/moe_3gemm_gen_micro.hpp
@@ -71,7 +71,7 @@ public:
         return cfg;
     }
 
-    static void init_microkernels(const kernel_impl_params& params, micro::Package& gemm_moe, MoE3GemmMicroKernelType type) noexcept;
+    static void init_microkernels(const kernel_impl_params& params, micro::Package& gemm_moe, MoE3GemmMicroKernelType type);
     MoE3GemmMicroKernelType m_type;
     int m_wei_idx;
     int m_scale_idx;
@@ -96,7 +96,7 @@ public:
     };
 
     struct GemmCacheKeyHash {
-        size_t operator()(const GemmCacheKey& k) const noexcept {
+        size_t operator()(const GemmCacheKey& k) const {
             size_t h = 0;
 
             auto hash_combine = [](size_t& seed, size_t v) {

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -853,10 +853,11 @@ ov::intel_gpu::OutputMemoryBlock* network::get_output_memory_block(const primiti
 }
 
 void network::clear_output_memory_blocks() {
-    for (auto& [prim_id, block_ptr] : _output_memory_blocks) {
+    // Move map out first so _output_memory_blocks is empty even if invalidation throws.
+    auto blocks = std::move(_output_memory_blocks);
+    for (auto& [prim_id, block_ptr] : blocks) {
         invalidate_ext_block_compute_nodes(prim_id);
     }
-    _output_memory_blocks.clear();
 }
 
 void network::add_to_exec_order(const primitive_id& id) {

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -133,14 +133,20 @@ SyncInferRequest::SyncInferRequest(const std::shared_ptr<const CompiledModel>& c
 }
 
 SyncInferRequest::~SyncInferRequest() {
-    // Clear the network's non-owning pointers to our OutputMemoryBlocks
-    // before they are destroyed, to prevent dangling pointers.
-    if (!m_output_memory_blocks.empty()) {
-        std::lock_guard<std::mutex> lk(m_graph->get_mutex());
-        auto network = m_graph->get_network();
-        if (network) {
-            network->clear_output_memory_blocks();
+    try {
+        // Clear the network's non-owning pointers to our OutputMemoryBlocks
+        // before they are destroyed, to prevent dangling pointers.
+        if (!m_output_memory_blocks.empty()) {
+            std::lock_guard<std::mutex> lk(m_graph->get_mutex());
+            auto network = m_graph->get_network();
+            if (network) {
+                network->clear_output_memory_blocks();
+            }
         }
+    } catch (const std::exception& ex) {
+        GPU_DEBUG_LOG << "[GPU] ~SyncInferRequest: failed to clear output memory blocks: " << ex.what() << std::endl;
+    } catch (...) {
+        GPU_DEBUG_LOG << "[GPU] ~SyncInferRequest: failed to clear output memory blocks: unknown exception" << std::endl;
     }
 }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -221,8 +221,14 @@ dnnl::memory gpu_buffer::get_onednn_grouped_memory(dnnl::memory::desc desc, cons
 #endif
 
 gpu_buffer_from_handle::~gpu_buffer_from_handle() {
-    const auto* cl_engine = downcast<const ocl_engine>(_engine);
-    cl_engine->release_external_memory(static_cast<cl_mem>(_buffer.get()));
+    try {
+        const auto* cl_engine = downcast<const ocl_engine>(_engine);
+        cl_engine->release_external_memory(static_cast<cl_mem>(_buffer.get()));
+    } catch (const std::exception& ex) {
+        GPU_DEBUG_LOG << "[GPU] ~gpu_buffer_from_handle: release_external_memory failed: " << ex.what() << std::endl;
+    } catch (...) {
+        GPU_DEBUG_LOG << "[GPU] ~gpu_buffer_from_handle: release_external_memory failed: unknown exception" << std::endl;
+    }
 }
 
 gpu_image2d::gpu_image2d(ocl_engine* engine, const layout& layout)


### PR DESCRIPTION
### changes
- Remove noexcept from get_index() in kv_cache.cpp (OPENVINO_ASSERT can throw)
- Remove noexcept from init_microkernels() in moe_3gemm_gen_micro.{cpp,hpp} (multiple OPENVINO_THROW paths; callers already wrap with try-catch)
- Remove noexcept from GemmCacheKeyHash::operator() (to_string() can throw)
- Wrap ~SyncInferRequest() body in try-catch to prevent exception from dtor
- Fix clear_output_memory_blocks() to move map before iteration so _output_memory_blocks is empty even if invalidation throws (no dangling ptr)
- Wrap ~gpu_buffer_from_handle() body in try-catch to prevent exception from dtor

### Tickets:
 - 192434

### AI Assistance:
 - AI assistance used: yes
 - AI: fix
 - Human: review
