### PR TITLE
[GPU][COVERITY] guard zero fsv divisors in reorder kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fsv.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_fsv.cpp
@@ -95,6 +95,7 @@ CommonDispatchData ReorderKernel_fsv::SetDefault(const reorder_params& params) c
 
     const auto& input = params.inputs[0];
     const size_t out_fsv = GetFsv(params.outputs[0].GetLayout());
+    OPENVINO_ASSERT(out_fsv != 0, "[GPU] reorder_kernel_fsv: output layout is not FSV-blocked");
 
     // GWS[0] = x
     // GWS[1] = y * z
@@ -116,6 +117,7 @@ JitConstants ReorderKernel_fsv::GetJitConstants(const reorder_params& params) co
 
     const size_t in_fsv = GetFsv(params.inputs[0].GetLayout());
     const size_t out_fsv = GetFsv(params.outputs[0].GetLayout());
+    OPENVINO_ASSERT(in_fsv != 0 && out_fsv != 0, "[GPU] reorder_kernel_fsv: input/output layout is not FSV-blocked");
     const size_t ndims = params.inputs[0].GetDims().size();
 
     jit.AddConstant(MakeJitConstant("IN_FSV", in_fsv));


### PR DESCRIPTION
### Summary
Fix Coverity DIVIDE_BY_ZERO issues in GPU reorder FSV kernel by guarding zero FSV divisors before CeilDiv/JIT slice calculations.

### Changes
- Add non-zero guard for output FSV in SetDefault
- Add non-zero guard for input/output FSV in GetJitConstants
- Keep behavior unchanged for valid FSV layouts and fail fast on invalid paths

### Tickets:
 - 192445

### AI Assistance:
 - AI assistance used: yes
 - AI: fix
 - Human: review
