### PR TITLE
[HETERO][CI] Enable macOS ARM64 PR validation

### DIFF
--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -20,14 +20,14 @@ on:
    branches:
      - 'master'
      - 'releases/**'
-  # pull_request:
-  #  paths-ignore:
-  #    - '**/docs/**'
-  #    - 'docs/**'
-  #    - '**/**.md'
-  #    - '**.md'
-  #    - '**/layer_tests_summary/**'
-  #    - '**/conformance/**'
+  pull_request:
+   paths-ignore:
+     - '**/docs/**'
+     - 'docs/**'
+     - '**/**.md'
+     - '**.md'
+     - '**/layer_tests_summary/**'
+     - '**/conformance/**'
 
 concurrency:
   # github.ref is not unique in post-commit

--- a/src/plugins/hetero/tests/functional/skip_tests_config.cpp
+++ b/src/plugins/hetero/tests/functional/skip_tests_config.cpp
@@ -22,6 +22,11 @@ const std::vector<std::regex>& disabled_test_patterns() {
         std::regex(R"(.*OVCompiledModelBaseTest.*compile_from_.*_blob.*targetDevice=(HETERO.NPU).*)"),
         std::regex(R"(.*OVCompiledModelBaseTest.*compile_from_cached_weightless_blob.*targetDevice=(HETERO.NPU).*)"),
         std::regex(R"(.*OVCompiledModelBaseTest.*use_blob_hint_.*targetDevice=CPU.*)"),
+#if defined(__APPLE__) && defined(OPENVINO_ARCH_ARM64)
+        // CVS-182864: accuracy mismatch in multi-core HETERO/TEMPLATE compile_model threading test
+        std::regex(
+            R"(.*CoreThreadingTestsWithIter\.smoke_CompileModel_Accuracy_MultipleCores.*targetDevice=HETERO_config=MULTI_DEVICE_PRIORITIES=TEMPLATE_numThreads=4_numIter=50.*)"),
+#endif
         // model import is not supported
         std::regex(R"(.*OVCompiledModelBaseTest.import_from_.*)"),
     };


### PR DESCRIPTION
## Summary
- Carries over the macOS ARM64-only HETERO test skip from #37293.
- Enables the `pull_request` trigger in `.github/workflows/mac_arm64.yml` so this validation can run for PRs.

## Details
The HETERO test skip is guarded by `__APPLE__` and `OPENVINO_ARCH_ARM64`, so Linux ARM64 and macOS x86_64 remain covered.

The workflow trigger retains the existing documentation/conformance `paths-ignore` rules.

## Test plan
- [x] Verified the HETERO source change matches the exact head of #37293.
- [x] Parsed `.github/workflows/mac_arm64.yml` successfully.
- [x] Ran `git diff --check`.
- [ ] GitHub Actions macOS ARM64 workflow runs for this PR.

Related: #37293
