### PR TITLE
[GPU] Fix out-of-bounds read in `Gather`

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -104,7 +104,8 @@ void CreateGatherOpBase(ProgramBuilder& p, const std::shared_ptr<T>& op, const i
     bool is_indices_constant = (indices_constant) ? true : false;
 
     if (is_static && axis == 0 && input_rank > 1 && indices.get_partial_shape().rank().get_length() == 0 &&
-        std::equal(input_shape.begin()+1, input_shape.end(), out_shape.begin()+1) && is_indices_constant) {
+        out_shape_original.size() + 1 == input_shape.size() &&
+        std::equal(input_shape.begin()+1, input_shape.end(), out_shape_original.begin()) && is_indices_constant) {
         // Gather -> Crop
         // this Gather simply divides an input tensor along Batch axis
         auto get_crop_layer_name = [&](std::string name, size_t idx)->std::string {

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/gather.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/gather.cpp
@@ -114,6 +114,31 @@ protected:
         ov::ResultVector results{std::make_shared<ov::op::v0::Result>(gatherNode)};
         function = std::make_shared<ov::Model>(results, params, "Gather");
     }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        // constrain "indices" to a valid range while leaving every other input to the default generator
+        const auto axis = std::get<0>(this->GetParam()).axis;
+        const auto& funcInputs = function->inputs();
+        inputs.clear();
+        for (size_t i = 0; i < funcInputs.size(); ++i) {
+            const auto& funcInput = funcInputs[i];
+            ov::Tensor tensor;
+            if (funcInput.get_node()->get_friendly_name() == "indices") {
+                const auto dataRank = static_cast<int>(targetInputStaticShapes[0].size());
+                const auto axisNorm = axis < 0 ? axis + dataRank : axis;
+                ov::test::utils::InputGenerateData in_data;
+                in_data.start_from = 0;
+                in_data.range = static_cast<uint32_t>(targetInputStaticShapes[0][axisNorm]);
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[i],
+                                                                 in_data);
+            } else {
+                tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(),
+                                                                 targetInputStaticShapes[i]);
+            }
+            inputs.insert({funcInput.get_node_shared_ptr(), tensor});
+        }
+    }
 };
 
 TEST_P(GatherGPUTest, Inference) {
@@ -186,5 +211,21 @@ INSTANTIATE_TEST_SUITE_P(smoke_dynamic_input_shapes_const_target_shapes, GatherG
                     ::testing::ValuesIn(model_types),                          // network precision
                     ::testing::Values(true),                                   // is const indices
                     ::testing::Values(true)),                                  // is const axis
+                GatherGPUTest::getTestCaseName);
+
+const std::vector<GatherShapeParams> dynamicAxisStaticOutputScalarIndices = {
+    {
+        ov::test::InputShape(ov::PartialShape({-1, 300}), {{271, 300}}),
+        ov::test::InputShape(ov::PartialShape({}), {{}}),
+        0, 0
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_dynamic_axis0_scalar_indices_static_output, GatherGPUTest,
+                ::testing::Combine(
+                    ::testing::ValuesIn(dynamicAxisStaticOutputScalarIndices),  // input shapes
+                    ::testing::Values(ov::element::f32),                        // network precision
+                    ::testing::Values(false),                                   // is const indices
+                    ::testing::Values(true)),                                   // is const axis
                 GatherGPUTest::getTestCaseName);
 } // namespace


### PR DESCRIPTION
### Details:
`CreateGatherOpBase()` in the GPU plugin decides whether to lower a `Gather` to a `Crop` primitive. That decision compared the input shape against the output shape with:
```
std::equal(input_shape.begin()+1, input_shape.end(), out_shape.begin()+1)
```
This assumes `out_shape` has `input_rank` elements. That only holds on the legacy shape-infer path, where `out_shape` is explicitly padded back up to `input_rank`. When the new shape-infer path is active, the padding never happens, so for a scalar-index gather along axis 0 (which removes that axis) `out_shape` has rank `input_rank - 1`. The `begin()+1` offset then walks `out_shape`'s iterator one past its end: an out-of-bounds read.

### Fix:
Compare against `out_shape_original` - the true, unpadded output shape that is always available regardless of the shape-infer path - and add an explicit rank guard:
```
  out_shape_original.size() + 1 == input_shape.size() &&
  std::equal(input_shape.begin()+1, input_shape.end(), out_shape_original.begin())
```
This is semantically equivalent in the old-shape-infer case and correct (and in-bounds) in the new-shape-infer case. `out_shape`, which is used later to build the Crop/Gather primitive's physical tensor shape, is left untouched - only the decision to take the Gather->Crop optimization was buggy.

### Tickets:
 - CVS-190953