### PR TITLE
[NPU] Add support for NPU6010

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
@@ -16,6 +16,7 @@ constexpr std::string_view NPU3720 = "3720";             // NPU3720
 constexpr std::string_view NPU4000 = "4000";             // NPU4000
 constexpr std::string_view NPU5010 = "5010";             // NPU5010
 constexpr std::string_view NPU5020 = "5020";             // NPU5020
+constexpr std::string_view NPU6010 = "6010";             // NPU6010
 
 /**
  * @brief Converts the given platform value to the standard one.

--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -74,6 +74,7 @@ std::string ZeroDevice::getName() const {
 #define NPU_4000_DEVICE_ID   0x643E
 #define NPU_5010_DEVICE_ID   0xB03E
 #define NPU_5020_DEVICE_ID   0xFD3E
+#define NPU_6010_DEVICE_ID   0xD71D
 
     std::string name;
     switch (_device_properties.deviceId) {
@@ -89,6 +90,9 @@ std::string ZeroDevice::getName() const {
         break;
     case NPU_5020_DEVICE_ID:
         name = ov::intel_npu::Platform::NPU5020;
+        break;
+    case NPU_6010_DEVICE_ID:
+        name = ov::intel_npu::Platform::NPU6010;
         break;
     case LEGACY_NPU_3000_DEVICE_ID:
         OPENVINO_THROW("[LEGACY] NPU device ID 0x", std::hex, _device_properties.deviceId, " is not supported!");

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_adapter_factory.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_adapter_factory.cpp
@@ -13,7 +13,7 @@ namespace intel_npu {
 ov::intel_npu::CompilerType CompilerAdapterFactory::determineAppropriateCompilerTypeBasedOnPlatform(
     std::string_view platform) const {
     if (platform == ov::intel_npu::Platform::NPU4000 || platform == ov::intel_npu::Platform::NPU5010 ||
-        platform == ov::intel_npu::Platform::NPU5020) {
+        platform == ov::intel_npu::Platform::NPU5020 || platform == ov::intel_npu::Platform::NPU6010) {
         return ov::intel_npu::CompilerType::PLUGIN;
     }
 

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.hpp
@@ -301,7 +301,7 @@ using CheckCompilerTypeProperty = ClassExecutableNetworkGetPropertiesTestNPU;
 
 TEST_P(CheckCompilerTypeProperty, CheckCompilerTypePropertyFromCompiledModel) {
     std::string platform = ov::test::utils::getTestsPlatformFromEnvironmentOr(deviceName);
-    const std::vector<std::string> plugin_compiler_platforms = {"4000", "5010", "5020"};
+    const std::vector<std::string> plugin_compiler_platforms = {"4000", "5010", "5020", "6010"};
     bool is_plugin_compiler_platform = false;
     for (const auto& p : plugin_compiler_platforms) {
         if (platform.find(p) != std::string::npos) {
@@ -339,7 +339,7 @@ TEST_P(CheckCompilerTypeProperty, CheckCompilerTypePropertyFromCompiledModel) {
 
 TEST_P(CheckCompilerTypeProperty, CheckCompilerTypePropertyAfterSettingExtraConfigToGetProperty) {
     std::string platform = ov::test::utils::getTestsPlatformFromEnvironmentOr(deviceName);
-    const std::vector<std::string> plugin_compiler_platforms = {"4000", "5010", "5020"};
+    const std::vector<std::string> plugin_compiler_platforms = {"4000", "5010", "5020", "6010"};
     bool is_plugin_compiler_platform = false;
     for (const auto& p : plugin_compiler_platforms) {
         if (platform.find(p) != std::string::npos) {

--- a/src/plugins/intel_npu/tests/functional/behavior/plugin_compiler_compile.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/plugin_compiler_compile.cpp
@@ -13,7 +13,8 @@ namespace {
 const std::vector<ov::AnyMap> configs = {
     {{"NPU_COMPILER_TYPE", "PLUGIN"}, {"NPU_PLATFORM", "NPU4000"}, {"NPU_CREATE_EXECUTOR", "0"}},
     {{"NPU_COMPILER_TYPE", "PLUGIN"}, {"NPU_PLATFORM", "NPU5010"}, {"NPU_CREATE_EXECUTOR", "0"}},
-    {{"NPU_COMPILER_TYPE", "PLUGIN"}, {"NPU_PLATFORM", "NPU5020"}, {"NPU_CREATE_EXECUTOR", "0"}}};
+    {{"NPU_COMPILER_TYPE", "PLUGIN"}, {"NPU_PLATFORM", "NPU5020"}, {"NPU_CREATE_EXECUTOR", "0"}},
+    {{"NPU_COMPILER_TYPE", "PLUGIN"}, {"NPU_PLATFORM", "NPU6010"}, {"NPU_CREATE_EXECUTOR", "0"}}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          TestPluginCompilerCompilationNPU,


### PR DESCRIPTION
### Details:
 - *Add support for NPU6010 and set default `PLUGIN` compiler when using prefer-plugin logic.*
 - *Update the plugin-compiler platform list for functional behavior tests.*

### Tickets:
 - *CVS-188208*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
