### PR TITLE
[GPU] fix to embedding_bag_ref kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/embedding_bag_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/embedding_bag_ref.cl
@@ -53,10 +53,10 @@ KERNEL(embedding_bag_ref)(
     const uint emb_dim3 = (uint)get_global_id(2) % OUTPUT_SIZE_X;
 
     uint offsets_ind = INPUT2_OFFSET + batch;
-    uint start_indices = INPUT1_OFFSET + offsets[offsets_ind];
+    uint start_indices = offsets[offsets_ind];
     offsets_ind = INPUT2_OFFSET + batch + 1;
     uint end_indices = (batch < OUTPUT_BATCH_NUM - 1) ?
-                            INPUT1_OFFSET + offsets[offsets_ind] :
+                            offsets[offsets_ind] :
                             INPUT1_LENGTH;
 
     OUTPUT_TYPE res = OUTPUT_VAL_ZERO;
@@ -119,7 +119,7 @@ KERNEL(embedding_bag_ref)(
             OUTPUT_TYPE val = emb_table[emb_index];
 #ifdef INPUT4_TYPE
             {
-                uint weight_index = INPUT3_OFFSET + i;
+                uint weight_index = INPUT4_OFFSET + i;
                 val *= weights[weight_index];
             }
 #endif

--- a/src/plugins/intel_gpu/tests/unit/test_cases/embedding_bag_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/embedding_bag_gpu_test.cpp
@@ -10,6 +10,7 @@
 #include <intel_gpu/primitives/input_layout.hpp>
 
 #include <cstddef>
+#include <iostream>
 
 using namespace cldnn;
 using namespace ::tests;
@@ -428,12 +429,13 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_basic) {
 }
 
 TEST(embedding_bag_fp16_gpu, offsets_sum_indices_with_non_zero_physical_offset) {
-    // Same logical values as offsets_sum_basic, but indices are provided via a cropped view.
-    // This forces non-zero INPUT1_OFFSET and catches regressions in indices addressing.
+        // Same logical values as offsets_sum_basic, but indices memory has explicit lower padding.
+        // This guarantees non-zero INPUT1_OFFSET and catches regressions in indices addressing.
     auto& engine = get_test_engine();
 
     auto emb_table = engine.allocate_memory({ data_types::f16, format::bfyx, { 5, 2, 1, 1 } });
-    auto indices_full = engine.allocate_memory({ data_types::i32, format::bfyx, { 5, 1, 1, 1 } });
+        auto indices_layout = layout{ data_types::i32, format::bfyx, { 4, 1, 1, 1 }, padding({ 1, 0, 0, 0 }, { 0, 0, 0, 0 }) };
+        auto indices = engine.allocate_memory(indices_layout);
     auto offsets = engine.allocate_memory({ data_types::i32, format::bfyx, { 3, 1, 1, 1 } });
     auto per_sample_weights = engine.allocate_memory({ data_types::f16, format::bfyx, { 4, 1, 1, 1 } });
     tensor output_shape = {3, 2, 1, 1};
@@ -445,10 +447,14 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_indices_with_non_zero_physical_offset) 
             ov::float16(-1.0f), ov::float16(1.5f),
             ov::float16(0.8f), ov::float16(-0.7f)
     });
-    // Crop with offset {1, 0, 0, 0} produces logical indices {0, 2, 3, 4}.
-    set_values<int32_t>(indices_full, {
-            4, 0, 2, 3, 4
-    });
+    {
+        cldnn::mem_lock<int32_t, mem_lock_type::write> indices_ptr(indices, get_test_stream());
+        auto indices_l = indices->get_layout();
+        indices_ptr[indices_l.get_linear_offset(tensor(batch(0), feature(0), spatial(0, 0, 0, 0)))] = 0;
+        indices_ptr[indices_l.get_linear_offset(tensor(batch(1), feature(0), spatial(0, 0, 0, 0)))] = 2;
+        indices_ptr[indices_l.get_linear_offset(tensor(batch(2), feature(0), spatial(0, 0, 0, 0)))] = 3;
+        indices_ptr[indices_l.get_linear_offset(tensor(batch(3), feature(0), spatial(0, 0, 0, 0)))] = 4;
+    }
     set_values<int32_t>(offsets, {
             0, 2, 2
     });
@@ -459,8 +465,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_indices_with_non_zero_physical_offset) 
     auto type = embedding_bag::offsets_sum;
     topology topology;
     topology.add(input_layout("Input0", emb_table->get_layout()));
-    topology.add(input_layout("Input1_full", indices_full->get_layout()));
-    topology.add(crop("Input1", input_info("Input1_full"), { 4, 1, 1, 1 }, { 1, 0, 0, 0 }));
+    topology.add(input_layout("Input1", indices->get_layout()));
     topology.add(input_layout("Input2", offsets->get_layout()));
     topology.add(data("Input3", per_sample_weights));
     topology.add(
@@ -469,7 +474,7 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_indices_with_non_zero_physical_offset) 
     network network(engine, topology, get_test_default_config(engine));
 
     network.set_input_data("Input0", emb_table);
-    network.set_input_data("Input1_full", indices_full);
+    network.set_input_data("Input1", indices);
     network.set_input_data("Input2", offsets);
 
     auto outputs = network.execute();
@@ -894,7 +899,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_basic) {
 
 TEST(embedding_bag_fp16_gpu, segments_sum_weighted_with_non_zero_weights_physical_offset) {
     // Keep Input3 (segments_num) dense while giving Input4 (weights) a non-zero physical offset.
-
+    // This catches regressions where INPUT3_OFFSET is accidentally used for weights access.
     auto& engine = get_test_engine();
 
     auto emb_table = engine.allocate_memory({ data_types::f16, format::bfyx, { 5, 2, 1, 1 } });

--- a/src/plugins/intel_gpu/tests/unit/test_cases/embedding_bag_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/embedding_bag_gpu_test.cpp
@@ -4,7 +4,6 @@
 
 #include "test_utils.h"
 
-#include <intel_gpu/primitives/crop.hpp>
 #include <intel_gpu/primitives/data.hpp>
 #include <intel_gpu/primitives/embedding_bag.hpp>
 #include <intel_gpu/primitives/input_layout.hpp>
@@ -906,7 +905,8 @@ TEST(embedding_bag_fp16_gpu, segments_sum_weighted_with_non_zero_weights_physica
     auto indices = engine.allocate_memory({ data_types::i32, format::bfyx, { 4, 1, 1, 1 } });
     auto segment_ids = engine.allocate_memory({ data_types::i32, format::bfyx, { 4, 1, 1, 1 } });
     auto segments_num = engine.allocate_memory({ data_types::i32, format::bfyx, { 1, 1, 1, 1 } });
-    auto per_sample_weights_full = engine.allocate_memory({ data_types::f16, format::bfyx, { 5, 1, 1, 1 } });
+    auto weights_layout = layout{ data_types::f16, format::bfyx, { 4, 1, 1, 1 }, padding({ 1, 0, 0, 0 }, { 0, 0, 0, 0 }) };
+    auto per_sample_weights = engine.allocate_memory(weights_layout);
     tensor output_shape = {3, 2, 1, 1};
 
     set_values(emb_table, {
@@ -923,11 +923,15 @@ TEST(embedding_bag_fp16_gpu, segments_sum_weighted_with_non_zero_weights_physica
             0, 0, 2, 2
     });
     set_values<int32_t>(segments_num, { 4 });
-    // Crop with offset {1, 0, 0, 0} produces logical weights {0.5, 0.5, 0.5, 0.5}.
-    // A wrong offset source would consume the leading 10.0 value and change the result.
-    set_values(per_sample_weights_full, {
-            ov::float16(10.0f), ov::float16(0.5f), ov::float16(0.5f), ov::float16(0.5f), ov::float16(0.5f)
-    });
+    {
+        cldnn::mem_lock<ov::float16, mem_lock_type::write> weights_ptr(per_sample_weights, get_test_stream());
+        std::fill(weights_ptr.begin(), weights_ptr.end(), ov::float16(10.0f));
+        auto weights_l = per_sample_weights->get_layout();
+        weights_ptr[weights_l.get_linear_offset(tensor(batch(0), feature(0), spatial(0, 0, 0, 0)))] = ov::float16(0.5f);
+        weights_ptr[weights_l.get_linear_offset(tensor(batch(1), feature(0), spatial(0, 0, 0, 0)))] = ov::float16(0.5f);
+        weights_ptr[weights_l.get_linear_offset(tensor(batch(2), feature(0), spatial(0, 0, 0, 0)))] = ov::float16(0.5f);
+        weights_ptr[weights_l.get_linear_offset(tensor(batch(3), feature(0), spatial(0, 0, 0, 0)))] = ov::float16(0.5f);
+    }
 
     auto type = embedding_bag::segments_sum;
     topology topology;
@@ -935,8 +939,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_weighted_with_non_zero_weights_physica
     topology.add(input_layout("Input1", indices->get_layout()));
     topology.add(input_layout("Input2", segment_ids->get_layout()));
     topology.add(input_layout("Input3", segments_num->get_layout()));
-    topology.add(input_layout("Input4_full", per_sample_weights_full->get_layout()));
-    topology.add(crop("Input4", input_info("Input4_full"), { 4, 1, 1, 1 }, { 1, 0, 0, 0 }));
+    topology.add(input_layout("Input4", per_sample_weights->get_layout()));
     topology.add(
             embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3"), input_info("Input4") }, type, output_shape, 0)
     );
@@ -947,7 +950,7 @@ TEST(embedding_bag_fp16_gpu, segments_sum_weighted_with_non_zero_weights_physica
     network.set_input_data("Input1", indices);
     network.set_input_data("Input2", segment_ids);
     network.set_input_data("Input3", segments_num);
-    network.set_input_data("Input4_full", per_sample_weights_full);
+    network.set_input_data("Input4", per_sample_weights);
 
     auto outputs = network.execute();
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/embedding_bag_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/embedding_bag_gpu_test.cpp
@@ -9,7 +9,6 @@
 #include <intel_gpu/primitives/input_layout.hpp>
 
 #include <cstddef>
-#include <iostream>
 
 using namespace cldnn;
 using namespace ::tests;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/embedding_bag_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/embedding_bag_gpu_test.cpp
@@ -4,6 +4,7 @@
 
 #include "test_utils.h"
 
+#include <intel_gpu/primitives/crop.hpp>
 #include <intel_gpu/primitives/data.hpp>
 #include <intel_gpu/primitives/embedding_bag.hpp>
 #include <intel_gpu/primitives/input_layout.hpp>
@@ -426,6 +427,67 @@ TEST(embedding_bag_fp16_gpu, offsets_sum_basic) {
     }
 }
 
+TEST(embedding_bag_fp16_gpu, offsets_sum_indices_with_non_zero_physical_offset) {
+    // Same logical values as offsets_sum_basic, but indices are provided via a cropped view.
+    // This forces non-zero INPUT1_OFFSET and catches regressions in indices addressing.
+    auto& engine = get_test_engine();
+
+    auto emb_table = engine.allocate_memory({ data_types::f16, format::bfyx, { 5, 2, 1, 1 } });
+    auto indices_full = engine.allocate_memory({ data_types::i32, format::bfyx, { 5, 1, 1, 1 } });
+    auto offsets = engine.allocate_memory({ data_types::i32, format::bfyx, { 3, 1, 1, 1 } });
+    auto per_sample_weights = engine.allocate_memory({ data_types::f16, format::bfyx, { 4, 1, 1, 1 } });
+    tensor output_shape = {3, 2, 1, 1};
+
+    set_values(emb_table, {
+            ov::float16(-0.2f), ov::float16(-0.6f),
+            ov::float16(-0.1f), ov::float16(-0.4f),
+            ov::float16(-1.9f), ov::float16(-1.8f),
+            ov::float16(-1.0f), ov::float16(1.5f),
+            ov::float16(0.8f), ov::float16(-0.7f)
+    });
+    // Crop with offset {1, 0, 0, 0} produces logical indices {0, 2, 3, 4}.
+    set_values<int32_t>(indices_full, {
+            4, 0, 2, 3, 4
+    });
+    set_values<int32_t>(offsets, {
+            0, 2, 2
+    });
+    set_values(per_sample_weights, {
+            ov::float16(0.5f), ov::float16(0.5f), ov::float16(0.5f), ov::float16(0.5f)
+    });
+
+    auto type = embedding_bag::offsets_sum;
+    topology topology;
+    topology.add(input_layout("Input0", emb_table->get_layout()));
+    topology.add(input_layout("Input1_full", indices_full->get_layout()));
+    topology.add(crop("Input1", input_info("Input1_full"), { 4, 1, 1, 1 }, { 1, 0, 0, 0 }));
+    topology.add(input_layout("Input2", offsets->get_layout()));
+    topology.add(data("Input3", per_sample_weights));
+    topology.add(
+            embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3") }, type, output_shape, 0)
+    );
+    network network(engine, topology, get_test_default_config(engine));
+
+    network.set_input_data("Input0", emb_table);
+    network.set_input_data("Input1_full", indices_full);
+    network.set_input_data("Input2", offsets);
+
+    auto outputs = network.execute();
+
+    auto output = outputs.at("embedding_bag").get_memory();
+    cldnn::mem_lock<uint16_t, mem_lock_type::read> output_ptr(output, get_test_stream());
+
+    std::vector<float> expected_results = {
+            -1.05f, -1.2f,
+            -0.2f, -0.6f,
+            -0.1f, 0.4f
+    };
+
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+    }
+}
+
 TEST(embedding_bag_fp16_gpu, offsets_sum_basic_first_empty) {
     //  emb_table : 5x2
     //  indices : 4x1
@@ -813,6 +875,74 @@ TEST(embedding_bag_fp16_gpu, segments_sum_basic) {
     network.set_input_data("Input1", indices);
     network.set_input_data("Input2", segment_ids);
     network.set_input_data("Input3", segments_num);
+
+    auto outputs = network.execute();
+
+    auto output = outputs.at("embedding_bag").get_memory();
+    cldnn::mem_lock<uint16_t, mem_lock_type::read> output_ptr(output, get_test_stream());
+
+    std::vector<float> expected_results = {
+            -1.05f, -1.2f,
+            -0.2f, -0.6f,
+            -0.1f, 0.4f
+    };
+
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_TRUE(are_equal(expected_results[i], half_to_float(output_ptr[i]))) << i;
+    }
+}
+
+TEST(embedding_bag_fp16_gpu, segments_sum_weighted_with_non_zero_weights_physical_offset) {
+    // Keep Input3 (segments_num) dense while giving Input4 (weights) a non-zero physical offset.
+
+    auto& engine = get_test_engine();
+
+    auto emb_table = engine.allocate_memory({ data_types::f16, format::bfyx, { 5, 2, 1, 1 } });
+    auto indices = engine.allocate_memory({ data_types::i32, format::bfyx, { 4, 1, 1, 1 } });
+    auto segment_ids = engine.allocate_memory({ data_types::i32, format::bfyx, { 4, 1, 1, 1 } });
+    auto segments_num = engine.allocate_memory({ data_types::i32, format::bfyx, { 1, 1, 1, 1 } });
+    auto per_sample_weights_full = engine.allocate_memory({ data_types::f16, format::bfyx, { 5, 1, 1, 1 } });
+    tensor output_shape = {3, 2, 1, 1};
+
+    set_values(emb_table, {
+            ov::float16(-0.2f), ov::float16(-0.6f),
+            ov::float16(-0.1f), ov::float16(-0.4f),
+            ov::float16(-1.9f), ov::float16(-1.8f),
+            ov::float16(-1.0f), ov::float16(1.5f),
+            ov::float16(0.8f), ov::float16(-0.7f)
+    });
+    set_values<int32_t>(indices, {
+            0, 2, 3, 4
+    });
+    set_values<int32_t>(segment_ids, {
+            0, 0, 2, 2
+    });
+    set_values<int32_t>(segments_num, { 4 });
+    // Crop with offset {1, 0, 0, 0} produces logical weights {0.5, 0.5, 0.5, 0.5}.
+    // A wrong offset source would consume the leading 10.0 value and change the result.
+    set_values(per_sample_weights_full, {
+            ov::float16(10.0f), ov::float16(0.5f), ov::float16(0.5f), ov::float16(0.5f), ov::float16(0.5f)
+    });
+
+    auto type = embedding_bag::segments_sum;
+    topology topology;
+    topology.add(input_layout("Input0", emb_table->get_layout()));
+    topology.add(input_layout("Input1", indices->get_layout()));
+    topology.add(input_layout("Input2", segment_ids->get_layout()));
+    topology.add(input_layout("Input3", segments_num->get_layout()));
+    topology.add(input_layout("Input4_full", per_sample_weights_full->get_layout()));
+    topology.add(crop("Input4", input_info("Input4_full"), { 4, 1, 1, 1 }, { 1, 0, 0, 0 }));
+    topology.add(
+            embedding_bag("embedding_bag", { input_info("Input0"), input_info("Input1"), input_info("Input2"), input_info("Input3"), input_info("Input4") }, type, output_shape, 0)
+    );
+
+    network network(engine, topology, get_test_default_config(engine));
+
+    network.set_input_data("Input0", emb_table);
+    network.set_input_data("Input1", indices);
+    network.set_input_data("Input2", segment_ids);
+    network.set_input_data("Input3", segments_num);
+    network.set_input_data("Input4_full", per_sample_weights_full);
 
     auto outputs = network.execute();
 


### PR DESCRIPTION
### Details:
 - ```INPUT1_OFFSET``` was added twice. First, to ```start_indices``` and to ```end_indices```, which are the range of the for loop and later to ```i``` in the same for loop. So finally ```indices_index``` was equal ```2*INPUT1_OFFSET+offsets[offsets_ind]```
 - in line 122 ```INPUT3_OFFSET``` was used to calculate ```weight_index``` while ```INPUT4_OFFSET``` represents the offset for weights. Setting ```INPUT3``` is not required, and the check is set only to checking if ```INPUT4``` is set, so it even might result in some crashes (```INPUT3_OFFSET``` not declared). 

### Tickets:
 - CVS-192572

### AI
 - AI was used to speed up writing unit tests.
