### PR TITLE
Ov weight sharing

### DIFF
--- a/src/core/src/weight_sharing_util.cpp
+++ b/src/core/src/weight_sharing_util.cpp
@@ -84,14 +84,24 @@ DataID Extension::get_constant_id(const ov::op::v0::Constant& constant) {
 }
 
 std::optional<WeightOriginMetaData> Extension::get_constant_origin(const ov::op::v0::Constant& constant) {
+    // 1) Preferred: weight-sharing identity carried by the buffer descriptor. The
+    //    descriptor's id is the weight source id and its offset is the bin offset;
+    //    the size and precision come from the Constant itself. This is self-describing
+    //    and needs no external Context, so it works for the compile-from-model flow.
+    if (const auto desc = constant.m_data ? constant.m_data->get_descriptor() : nullptr) {
+        return std::make_optional(WeightOriginMetaData{desc->get_id(),
+                                                       desc->get_offset(),
+                                                       constant.get_byte_size(),
+                                                       constant.get_element_type()});
+    }
+    // 2) Transitional fallback: the deprecated WeightlessCacheAttribute rt_info.
     if (auto wl_attr = constant.get_rt_info().find(ov::WeightlessCacheAttribute::get_type_info_static());
         wl_attr != constant.get_rt_info().end()) {
         const auto& wl = wl_attr->second.as<ov::WeightlessCacheAttribute>();
         return std::make_optional(
             WeightOriginMetaData{get_constant_source_id(constant), wl.bin_offset, wl.original_size, wl.original_dtype});
-    } else {
-        return std::nullopt;
     }
+    return std::nullopt;
 }
 
 std::shared_ptr<ov::AlignedBuffer> Extension::get_constant_source_buffer(const ov::op::v0::Constant& constant) {

--- a/src/core/tests/weight_sharing_util_test.cpp
+++ b/src/core/tests/weight_sharing_util_test.cpp
@@ -167,6 +167,47 @@ TEST_F(WeightShareExtensionTest, get_constant_origin_desc_no_wl_set) {
     ASSERT_FALSE(weight_sharing::Extension::get_constant_origin(c).has_value());
 }
 
+TEST_F(WeightShareExtensionTest, get_constant_origin_from_descriptor) {
+    // A Constant whose buffer carries a descriptor resolves its origin from the
+    // descriptor alone (source id + offset), with no WeightlessCacheAttribute.
+    auto buffer = std::make_shared<ov::AlignedBuffer>(4000);
+    auto wt_buffer = std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(
+        buffer->get_ptr<char>() + 100,
+        buffer->size() - 100,
+        buffer,
+        ov::create_base_descriptor(7, 0, buffer));
+    auto c = Constant(element::f32, Shape{975}, wt_buffer);
+
+    const auto origin = weight_sharing::Extension::get_constant_origin(c);
+    ASSERT_TRUE(origin.has_value());
+    EXPECT_EQ(origin->m_id, 7);                  // descriptor id == weight source id
+    EXPECT_EQ(origin->m_offset, 100);            // descriptor offset (ptr arithmetic)
+    EXPECT_EQ(origin->m_size, 4000 - 100);       // size from the Constant
+    EXPECT_EQ(origin->m_type, element::f32);     // dtype from the Constant
+}
+
+TEST_F(WeightShareExtensionTest, get_constant_origin_descriptor_precedes_wl) {
+    // When both a descriptor and a WeightlessCacheAttribute are present, the
+    // descriptor identity wins (the WLCA is only a transitional fallback).
+    auto buffer = std::make_shared<ov::AlignedBuffer>(4000);
+    auto wt_buffer = std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::AlignedBuffer>>>(
+        buffer->get_ptr<char>() + 100,
+        buffer->size() - 100,
+        buffer,
+        ov::create_base_descriptor(7, 0, buffer));
+    auto c = Constant(element::f32, Shape{975}, wt_buffer);
+    // Deliberately-divergent WLCA offset to prove the descriptor path is taken.
+    c.get_rt_info()[ov::WeightlessCacheAttribute::get_type_info_static()] =
+        ov::WeightlessCacheAttribute{32, 999, element::f64};
+
+    const auto origin = weight_sharing::Extension::get_constant_origin(c);
+    ASSERT_TRUE(origin.has_value());
+    EXPECT_EQ(origin->m_id, 7);
+    EXPECT_EQ(origin->m_offset, 100);  // descriptor offset, not the WLCA's 999
+    EXPECT_EQ(origin->m_size, 4000 - 100);
+    EXPECT_EQ(origin->m_type, element::f32);
+}
+
 TEST_F(WeightShareExtensionTest, set_mapped_weight_buffer) {
     const auto weights_path = test_dir / "weights.bin";
     create_test_weights_file(weights_path);

--- a/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/decoder.hpp
+++ b/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/decoder.hpp
@@ -22,6 +22,14 @@ struct TENSORFLOW_LITE_FRONTEND_API TensorMetaInfo {
     const uint8_t* m_tensor_data;
     size_t m_tensor_data_size = 0;
     std::string m_tensor_name;
+    // Optional weight-sharing identity. When m_source_id != 0 the frontend
+    // builds the resulting ov::op::v0::Constant with an IBufferDescriptor
+    // carrying (m_source_id, m_bin_offset), so downstream consumers (e.g.
+    // ov::weight_sharing / NPUW) can identify shared weights via
+    // Constant->m_data->get_descriptor(). m_bin_offset is used verbatim as the
+    // offset of this weight within its (caller-chosen) source id.
+    std::size_t m_source_id = 0;
+    std::size_t m_bin_offset = 0;
 };
 
 class TENSORFLOW_LITE_FRONTEND_API DecoderBase : public ov::frontend::DecoderBase {

--- a/src/frontends/tensorflow_lite/src/input_model.cpp
+++ b/src/frontends/tensorflow_lite/src/input_model.cpp
@@ -10,6 +10,8 @@
 #include "openvino/core/memory_util.hpp"
 #include "openvino/frontend/exception.hpp"
 #include "openvino/opsets/opset10.hpp"
+#include "openvino/runtime/aligned_buffer.hpp"
+#include "openvino/runtime/shared_buffer.hpp"
 #include "openvino/util/log.hpp"
 #include "tensor_lite_place.hpp"
 #include "utils.hpp"
@@ -28,9 +30,40 @@ std::shared_ptr<ov::frontend::tensorflow_lite::TensorLitePlace> decode_tensor_pl
         tensor_meta_info.m_quantization_info,
         tensor_meta_info.m_sparsity_info,
         tensor_meta_info.m_tensor_data,
-        tensor_meta_info.m_tensor_data_size);
+        tensor_meta_info.m_tensor_data_size,
+        tensor_meta_info.m_source_id,
+        tensor_meta_info.m_bin_offset);
     return tensor_place;
 }
+
+// AlignedBuffer subclass that owns a pre-built IBufferDescriptor with a
+// caller-chosen (source_id, offset). Used when the frontend needs to publish
+// a weight-identity descriptor without physically nesting the bytes inside
+// a source buffer (SharedBufferBase would recompute the offset via ptr
+// arithmetic and assert data-in-range, which is incompatible with
+// synthesized offsets like LiteRT BufferId-derived bin offsets).
+class IdentifiedBuffer : public ov::AlignedBuffer {
+public:
+    IdentifiedBuffer(const void* data, std::size_t byte_size, std::shared_ptr<ov::IBufferDescriptor> descriptor)
+        : m_descriptor(std::move(descriptor)) {
+        m_aligned_buffer = const_cast<char*>(static_cast<const char*>(data));
+        m_byte_size = byte_size;
+    }
+    ~IdentifiedBuffer() override {
+        // We do not own m_aligned_buffer — the bytes belong to the caller (e.g.
+        // a LiteRT flatbuffer arena mmap). Null it out so ~AlignedBuffer does
+        // not aligned_free() a pointer it did not allocate. Mirrors the pattern
+        // used by SharedBufferBase.
+        m_aligned_buffer = nullptr;
+        m_byte_size = 0;
+    }
+    std::shared_ptr<ov::IBufferDescriptor> get_descriptor() const override {
+        return m_descriptor;
+    }
+
+private:
+    std::shared_ptr<ov::IBufferDescriptor> m_descriptor;
+};
 
 std::shared_ptr<ov::frontend::tensorflow_lite::TensorLitePlace> decode_input_tensor(
     const std::shared_ptr<ov::frontend::tensorflow_lite::DecoderBaseOperation>& decoder,
@@ -165,9 +198,28 @@ void InputModel::InputModelTFLiteImpl::load_model() {
                                                 required_size_opt.value(),
                                                 " bytes). The model file may be corrupted.");
                     }
-                    auto constant = ov::op::v0::Constant::create(place->get_element_type(),
-                                                                 place->get_partial_shape().to_shape(),
-                                                                 data);
+                    std::shared_ptr<ov::op::v0::Constant> constant;
+                    if (place->get_source_id() != 0) {
+                        // Weight identity supplied by the iterator: build a
+                        // descriptor-backed Constant so downstream consumers
+                        // (ov::weight_sharing / NPUW) can look the weight up via
+                        // Constant->m_data->get_descriptor(). The identity is the
+                        // (source_id, bin_offset) pair chosen by the iterator; the
+                        // bytes are not owned here so an IdentifiedBuffer wraps them
+                        // together with the pre-built descriptor.
+                        const auto shape = place->get_partial_shape().to_shape();
+                        const auto byte_size =
+                            ov::util::get_memory_size(place->get_element_type(), ov::shape_size(shape));
+                        auto buffer = std::make_shared<IdentifiedBuffer>(
+                            data,
+                            byte_size,
+                            ov::create_base_descriptor(place->get_source_id(), place->get_bin_offset(), nullptr));
+                        constant = std::make_shared<ov::op::v0::Constant>(place->get_element_type(), shape, buffer);
+                    } else {
+                        constant = ov::op::v0::Constant::create(place->get_element_type(),
+                                                                place->get_partial_shape().to_shape(),
+                                                                data);
+                    }
                     constant->set_friendly_name(name);
                     m_tensor_values[name] = constant;
                 } else if (place->get_partial_shape() == PartialShape{0}) {  // empty constant

--- a/src/frontends/tensorflow_lite/src/tensor_lite_place.hpp
+++ b/src/frontends/tensorflow_lite/src/tensor_lite_place.hpp
@@ -25,12 +25,16 @@ public:
                     std::shared_ptr<ov::frontend::tensorflow_lite::QuantizationInfo> quantization,
                     std::shared_ptr<ov::frontend::tensorflow_lite::SparsityInfo> sparsity,
                     const void* data,
-                    size_t data_size = 0)
+                    size_t data_size = 0,
+                    std::size_t source_id = 0,
+                    std::size_t bin_offset = 0)
         : ov::frontend::tensorflow::TensorPlace(input_model, pshape, type, names),
           m_quantization(quantization),
           m_sparsity(sparsity),
           m_data(m_sparsity == nullptr || m_sparsity->is_disabled() ? data : m_sparsity->dense_data()),
-          m_data_size(m_sparsity == nullptr || m_sparsity->is_disabled() ? data_size : 0) {};
+          m_data_size(m_sparsity == nullptr || m_sparsity->is_disabled() ? data_size : 0),
+          m_source_id(source_id),
+          m_bin_offset(bin_offset) {};
 
     void translate(ov::Output<ov::Node>& output, bool convert_tensor_attrs_to_nodes = false);
 
@@ -63,12 +67,21 @@ public:
         return m_data_size;
     }
 
+    std::size_t get_source_id() const {
+        return m_source_id;
+    }
+    std::size_t get_bin_offset() const {
+        return m_bin_offset;
+    }
+
 protected:
     std::shared_ptr<ov::frontend::tensorflow_lite::QuantizationInfo> m_quantization;
     std::shared_ptr<ov::frontend::tensorflow_lite::SparsityInfo> m_sparsity;
     int64_t m_input_idx = -1, m_output_idx = -1;
     const void* m_data;
     size_t m_data_size = 0;
+    std::size_t m_source_id = 0;
+    std::size_t m_bin_offset = 0;
 };
 
 }  // namespace tensorflow_lite

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
@@ -22,6 +22,17 @@ namespace ov::intel_npu::npuw {
 
 inline constexpr ov::Property<ov::FileHandleProvider> weights_handle_provider{"NPUW_WEIGHTS_HANDLE_PROVIDER"};
 
+// Sub-region of the handle returned by NPUW_WEIGHTS_HANDLE_PROVIDER that holds
+// the weights pool. When the size is non-zero, NPUW maps only
+// [offset, offset+size) out of the handle instead of the whole file, so the
+// mapped base coincides with the pool start and per-constant descriptor offsets
+// (which are pool-relative) resolve as mapped->data() + offset. See fd-backed
+// weight sharing (Option B): the pool is a region embedded inside a larger
+// model file. Two scalar properties (rather than a struct) so callers outside
+// this plugin can set them without depending on a private type.
+inline constexpr ov::Property<std::size_t> weights_handle_region_offset{"NPUW_WEIGHTS_HANDLE_REGION_OFFSET"};
+inline constexpr ov::Property<std::size_t> weights_handle_region_size{"NPUW_WEIGHTS_HANDLE_REGION_SIZE"};
+
 namespace llm {
 
 // Read-only compiled-model capability: continuous prefill is active for this

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -14,6 +14,7 @@
 #include "gqa_compiled_model.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 #include "just_sync_infer_request.hpp"
+#include "lazy_tensor.hpp"
 #include "logging.hpp"
 #include "moe/moe_subgraph.hpp"
 #include "openvino/core/parallel.hpp"
@@ -46,6 +47,7 @@
 #include "openvino/util/file_util.hpp"
 #include "partitioning/patterns/sdpa.hpp"
 #include "transformations/convert_precision.hpp"
+#include "wsh_lookup.hpp"
 
 namespace {
 std::string canonical_device_name(const std::string& device_name) {
@@ -147,14 +149,11 @@ ov::npuw::s11n::WeightsContext make_import_weights_ctx(const ov::AnyMap& propert
                     continue;
                 }
                 const auto& c = std::static_pointer_cast<ov::op::v0::Constant>(node);
-                auto rt_info = c->get_rt_info();
-                auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
-                if (weightless_cache_attr == rt_info.end()) {
+                auto origin = ov::npuw::wsh::resolve_origin(*c);
+                if (!origin) {
                     continue;
                 }
-                std::size_t offset = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>().bin_offset;
-                std::size_t size = c->get_byte_size();
-                consts_cache[{offset, size}] = node;
+                consts_cache[{origin->offset, c->get_byte_size()}] = node;
             }
         } else if (!handle_provider) {
             NPUW_ASSERT(false && "Blob is weightless but no WEIGHTS_PATH nor MODEL_PTR property is provided!");
@@ -1517,20 +1516,19 @@ void ov::npuw::CompiledModel::finalize_weights_bank() {
 
 void ov::npuw::CompiledModel::store_const_offsets(const std::shared_ptr<ov::Model>& model) {
     for (auto&& node_ptr : model->get_ordered_ops()) {
-        if (ov::op::util::is_constant(node_ptr)) {
-            const auto& c = std::static_pointer_cast<ov::op::v0::Constant>(node_ptr);
-            auto rt_info = c->get_rt_info();
-            auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
-            if (weightless_cache_attr == rt_info.end()) {
-                continue;
-            }
-            std::size_t offset = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>().bin_offset;
-            auto data_ptr = c->get_data_ptr();
-            auto inserted = m_const_to_offset.insert({data_ptr, offset});
-            if (!inserted.second) {
-                NPUW_ASSERT(inserted.first->second == offset &&
-                            "Model contains two constants with same pointer and different offset!");
-            }
+        if (!ov::op::util::is_constant(node_ptr)) {
+            continue;
+        }
+        const auto& c = std::static_pointer_cast<ov::op::v0::Constant>(node_ptr);
+        auto origin = ov::npuw::wsh::resolve_origin(*c);
+        if (!origin) {
+            continue;
+        }
+        auto data_ptr = c->get_data_ptr();
+        auto inserted = m_const_to_offset.insert({data_ptr, origin->offset});
+        if (!inserted.second) {
+            NPUW_ASSERT(inserted.first->second == origin->offset &&
+                        "Model contains two constants with same pointer and different offset!");
         }
     }
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -122,6 +122,10 @@ ov::npuw::s11n::WeightsContext make_import_weights_ctx(const ov::AnyMap& propert
     std::string weights_path;
     WeightsContext::ConstsCache consts_cache;
     ov::FileHandleProvider handle_provider = nullptr;
+    // Optional sub-region of the handle to map (Option B, fd-backed sharing).
+    // size 0 keeps the legacy whole-handle mapping at offset 0.
+    std::size_t handle_region_offset = 0;
+    std::size_t handle_region_size = 0;
     if (is_weightless) {
         if (const auto handle_it = properties.find(ov::intel_npu::npuw::weights_handle_provider.name());
             handle_it != properties.end()) {
@@ -130,6 +134,16 @@ ov::npuw::s11n::WeightsContext make_import_weights_ctx(const ov::AnyMap& propert
             } else {
                 LOG_WARN("WEIGHTS_HANDLE_PROVIDER property is present but is not a FileHandleProvider; falling back to "
                          "other weightless import sources");
+            }
+        }
+        if (handle_provider) {
+            if (const auto it = properties.find(ov::intel_npu::npuw::weights_handle_region_size.name());
+                it != properties.end()) {
+                handle_region_size = it->second.as<std::size_t>();
+            }
+            if (const auto it = properties.find(ov::intel_npu::npuw::weights_handle_region_offset.name());
+                it != properties.end()) {
+                handle_region_offset = it->second.as<std::size_t>();
             }
         }
         if (!handle_provider && properties.find(ov::weights_path.name()) != properties.end()) {
@@ -165,7 +179,11 @@ ov::npuw::s11n::WeightsContext make_import_weights_ctx(const ov::AnyMap& propert
         std::shared_ptr<ov::MappedMemory> mapped_memory;
         if (handle_provider) {
             ov::FileHandle handle = handle_provider();
-            mapped_memory = ov::load_mmap_object(handle);
+            if (handle_region_size != 0) {
+                mapped_memory = ov::load_mmap_object(handle, handle_region_offset, handle_region_size);
+            } else {
+                mapped_memory = ov::load_mmap_object(handle);
+            }
         } else if (!weights_path.empty()) {
             mapped_memory = ov::load_mmap_object(ov::util::make_path(weights_path));
         }
@@ -174,7 +192,13 @@ ov::npuw::s11n::WeightsContext make_import_weights_ctx(const ov::AnyMap& propert
         }
     }
 
-    return WeightsContext(weights, weights_path, consts_cache, bf16_consts, handle_provider);
+    return WeightsContext(weights,
+                          weights_path,
+                          consts_cache,
+                          bf16_consts,
+                          handle_provider,
+                          handle_region_offset,
+                          handle_region_size);
 }
 
 std::function<std::string(const std::string&)> get_encrypt_callback(const ov::AnyMap& properties) {

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -69,7 +69,13 @@ ov::Tensor Const::eval() const {
         // Use handle_provider if available, otherwise use default mmap
         if (m_handle_provider) {
             ov::FileHandle handle = m_handle_provider();
-            mapped_memory = ov::load_mmap_object(handle);
+            if (m_handle_region_size != 0) {
+                // Map only the weights pool sub-region so m_mmaped_weights->get_ptr(m_offset)
+                // resolves the pool-relative descriptor offset (fd-backed sharing, Option B).
+                mapped_memory = ov::load_mmap_object(handle, m_handle_region_offset, m_handle_region_size);
+            } else {
+                mapped_memory = ov::load_mmap_object(handle);
+            }
         } else {
             mapped_memory = ov::load_mmap_object(ov::util::make_path(m_weights_path));
         }
@@ -128,6 +134,9 @@ void Const::read_weight(const ov::npuw::s11n::WeightsContext& ctx) {
             m_weights_path = ctx.weights_path;
             // Also save handle_provider if available
             m_handle_provider = ctx.handle_provider;
+            // Carry the pool sub-region so eval() maps the same window.
+            m_handle_region_offset = ctx.handle_region_offset;
+            m_handle_region_size = ctx.handle_region_size;
         }
     } else {
         auto it = ctx.consts_cache.find({m_offset, m_byte_size});

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -9,7 +9,6 @@
 #include <variant>
 
 #include "logging.hpp"
-#include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/reference/convert.hpp"
 #include "openvino/runtime/make_tensor.hpp"
@@ -18,12 +17,14 @@
 #include "openvino/util/mmap_object.hpp"
 #include "orc.hpp"
 #include "util.hpp"
+#include "wsh_lookup.hpp"
 
 using ov::npuw::weights::LazyTensor;
 
 namespace ov {
 namespace npuw {
 namespace weights {
+
 namespace op {
 Const::Const(const std::shared_ptr<ov::op::v0::Constant>& n) : m_node(n) {
     m_cached_type = m_node->get_element_type();
@@ -31,10 +32,8 @@ Const::Const(const std::shared_ptr<ov::op::v0::Constant>& n) : m_node(n) {
     m_cached_ptr = m_node->get_data_ptr();
     m_byte_size = m_node->get_byte_size();
 
-    auto rt_info = m_node->get_rt_info();
-    auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
-    if (weightless_cache_attr != rt_info.end()) {
-        m_offset = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>().bin_offset;
+    if (auto origin = ov::npuw::wsh::resolve_origin(*m_node)) {
+        m_offset = origin->offset;
     } else {
         // See the comment in serialize() for more details
         LOG_WARN("Some pattern introduced a new Constant node not present in the original weights file. We need to "

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.hpp
@@ -112,6 +112,10 @@ private:
     ov::Tensor m_read_from_bin;
     std::string m_weights_path;
     ov::FileHandleProvider m_handle_provider = nullptr;
+    // Sub-region of the handle to map in eval() (size 0 => whole handle). Keeps
+    // descriptor offsets pool-relative for fd-backed weight sharing (Option B).
+    std::size_t m_handle_region_offset = 0;
+    std::size_t m_handle_region_size = 0;
     mutable ov::npuw::s11n::WeightsPtr m_mmaped_weights = nullptr;
     // FIXME: special case when a new Constant was added into the model,
     // then made into LazyTensor during folding. We need to keep a copy of it,

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -887,7 +887,7 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
 
     LOG_DEBUG("   ...also convert BF16 to FP16");
     // Note: we need to identify original bf16 constants for potential weightless deserialization later
-    // And only then do bf16 to f16 transformation
+    // And only then do bf16 to f16 transformation.
     m_bf16_consts = ov::npuw::s11n::get_bf16_consts(model);
     ov::pass::ConvertPrecision(ov::element::bf16, ov::element::f16).run_on_model(kvcache_model);
 

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
@@ -33,12 +33,16 @@ ov::npuw::s11n::WeightsContext::WeightsContext(const ov::npuw::s11n::WeightsPtr&
                                                const std::string& _weights_path,
                                                const s11n::WeightsContext::ConstsCache& _consts_cache,
                                                const BF16Cache& _bf16_consts,
-                                               const ov::FileHandleProvider& _handle_provider)
+                                               const ov::FileHandleProvider& _handle_provider,
+                                               std::size_t _handle_region_offset,
+                                               std::size_t _handle_region_size)
     : weights(_weights),
       weights_path(_weights_path),
       consts_cache(_consts_cache),
       bf16_consts(_bf16_consts),
-      handle_provider(_handle_provider) {
+      handle_provider(_handle_provider),
+      handle_region_offset(_handle_region_offset),
+      handle_region_size(_handle_region_size) {
     is_weightless = _weights || !_consts_cache.empty();
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
@@ -20,6 +20,7 @@
 #include "pyramid_attention.hpp"
 #include "spatial.hpp"
 #include "util.hpp"
+#include "wsh_lookup.hpp"
 
 // NOTE: This constructor should only be used when exporting blobs.
 ov::npuw::s11n::WeightsContext::WeightsContext(bool _is_weightless,
@@ -48,13 +49,9 @@ ov::npuw::s11n::BF16Cache ov::npuw::s11n::get_bf16_consts(const std::shared_ptr<
             if (c->get_element_type() != ov::element::bf16) {
                 continue;
             }
-            auto rt_info = c->get_rt_info();
-            auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
-            if (weightless_cache_attr == rt_info.end()) {
-                continue;
+            if (auto origin = ov::npuw::wsh::resolve_origin(*c)) {
+                bf16_cache.insert({origin->offset, c->get_byte_size()});
             }
-            std::size_t offset = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>().bin_offset;
-            bf16_cache.insert({offset, c->get_byte_size()});
         }
     }
     return bf16_cache;

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -152,11 +152,16 @@ struct WeightsContext {
 
     // NOTE: This constructor is used on blob import to carry the resolved weight source
     // (embedded weights, mmap'ed weights file, or model-backed constants cache).
+    // _handle_region_offset/_handle_region_size (when the latter is non-zero)
+    // restrict the mmap to a sub-region of the provided handle so descriptor
+    // offsets remain pool-relative (fd-backed weight sharing, Option B).
     WeightsContext(const ov::npuw::s11n::WeightsPtr& _weights,
                    const std::string& _weights_path,
                    const ConstsCache& _consts_cache,
                    const BF16Cache& _bf16_consts,
-                   const ov::FileHandleProvider& _handle_provider = nullptr);
+                   const ov::FileHandleProvider& _handle_provider = nullptr,
+                   std::size_t _handle_region_offset = 0,
+                   std::size_t _handle_region_size = 0);
 
     WeightsContext& operator=(const WeightsContext& other) = default;
 
@@ -172,6 +177,11 @@ struct WeightsContext {
     ConstsCache consts_cache;
     BF16Cache bf16_consts;
     ov::FileHandleProvider handle_provider = nullptr;
+    // Sub-region of the handle to map (size 0 => whole handle). Used so that
+    // mapped->data() points at the weights pool start and descriptor offsets
+    // resolve pool-relative (fd-backed weight sharing, Option B).
+    std::size_t handle_region_offset = 0;
+    std::size_t handle_region_size = 0;
 };
 
 // Context for deserializing submodels with dynamic attention mechanisms

--- a/src/plugins/intel_npu/src/plugin/npuw/wsh_lookup.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/wsh_lookup.hpp
@@ -1,0 +1,56 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <optional>
+
+#include "openvino/core/model.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/core/weight_sharing_util.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/util/op_types.hpp"
+
+namespace ov {
+namespace npuw {
+namespace wsh {
+
+struct Origin {
+    std::size_t offset;
+    std::size_t size;
+    ov::element::Type dtype;
+};
+
+// Resolve a Constant's origin metadata (offset in the source bin, byte size,
+// original dtype). Delegates to ov::weight_sharing, which resolves in this
+// order:
+//   1) The weight-sharing identity carried by the Constant's buffer descriptor
+//      (source id + offset). Self-describing, needs no external Context.
+//   2) The deprecated ov::WeightlessCacheAttribute rt_info as a transitional
+//      fallback.
+// Returns std::nullopt when neither source has an entry for this Constant.
+inline std::optional<Origin> resolve_origin(const ov::op::v0::Constant& c) {
+    if (auto origin = ov::weight_sharing::Extension::get_constant_origin(c)) {
+        return Origin{origin->m_offset, origin->m_size, origin->m_type};
+    }
+    return std::nullopt;
+}
+
+// True iff at least one Constant in the model has a resolvable origin.
+inline bool any_origin_available(const ov::Model& model) {
+    for (const auto& n : model.get_ordered_ops()) {
+        if (!ov::op::util::is_constant(n)) {
+            continue;
+        }
+        const auto& c = *std::static_pointer_cast<ov::op::v0::Constant>(n);
+        if (resolve_origin(c).has_value()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace wsh
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -22,6 +22,7 @@
 #include "npuw/llm_compiled_model.hpp"
 #include "npuw/orc/schema_npuw.hpp"
 #include "npuw/serialization.hpp"
+#include "npuw/wsh_lookup.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/runtime/intel_npu/properties.hpp"
@@ -40,27 +41,21 @@ constexpr std::string_view NO_BACKEND_MESSAGE = "No backend registered during mo
 constexpr std::string_view NPUW_MODEL_IMPORTED_MESSAGE = "Finished importing the NPUW compiled model";
 
 /**
- * @brief Just checks if there is any "WeightlessCacheAttribute" present in the model. In the negative case, an error is
- * thrown. The weights separation flow in its current state cannot work without this attribuite.
+ * @brief Checks that every Constant's origin (bin offset / size / dtype) can be resolved, either through the
+ * weight-sharing identity carried by the Constant's buffer descriptor (ov::weight_sharing) or through the legacy
+ * "WeightlessCacheAttribute" rt_info. Throws if neither source produces an entry for the model's Constants — the
+ * weights separation flow cannot proceed without it.
  */
 void check_weightless_cache_attribute_occurrence(const std::shared_ptr<const ov::Model>& model) {
     if (!model) {
         return;
     }
-
-    for (const auto& ov_node : model->get_ordered_ops()) {
-        if (!ov::is_type<ov::op::v0::Constant>(ov_node)) {
-            continue;
-        }
-
-        if (auto it = ov_node->get_rt_info().find(ov::WeightlessCacheAttribute::get_type_info_static());
-            it != ov_node->get_rt_info().end()) {
-            return;
-        }
+    if (ov::npuw::wsh::any_origin_available(*model)) {
+        return;
     }
-
-    OPENVINO_THROW("No \"WeightlessCacheAttribute\" has been found in any of the model's Constant nodes. This "
-                   "attribute is required for running the \"weights separation\" flow.");
+    OPENVINO_THROW("No weight-sharing buffer descriptor and no \"WeightlessCacheAttribute\" rt_info has been "
+                   "found for any of the model's Constant nodes. One of these origin sources is required for running "
+                   "the \"weights separation\" flow.");
 }
 
 std::shared_ptr<ov::ICompiledModel> import_model_npuw(std::istream& stream,


### PR DESCRIPTION
### Details:
 - *OV Core* : Extension::get_constant_origin() - Introduces a descriptor check for constructing WeightOriginMetaData
 - *TFLite FE* : Introduces Optional (m_source_id, m_bin_offset) weight identity in TensorMetaInfo
 - *NPUW* : New wsh_lookup.hpp: a thin wrapper over ov::weight_sharing::Extension to fetch Origin
 - *NPUW* : Sub-region mapping : new private props NPUW_WEIGHTS_HANDLE_REGION_OFFSET / REGION_SIZE

### Tickets:
 - *CVS-184522*

### AI Assistance:
 - *AI assistance used: yes*
  - *Copilot/Claude was used to help with code generation*
  - *Manually reviewed the changes, and verified the test cases by running the tests*
