### PR TITLE
[GPU] Fix PagedAttention mixed-cache boundary and sliding-window tail handling

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -659,7 +659,7 @@ KERNEL(pa_sdpa_opt)(
 #endif
 
 #if SWA_BLOCK_SKIP_ENABLED && !MULTI_TOKENS_PROCESSING
-        const uint effective_seq_len = min(effective_blocks_num * PAGED_ATTENTION_BLOCK_SIZE, seq_len);
+        const uint effective_seq_len = seq_len - swa_start_token;
 #else
         const uint effective_seq_len = seq_len;
 #endif

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -919,7 +919,7 @@ KERNEL(pa_sdpa_opt)(
 #endif
 
 #ifdef USE_DUAL_NIBBLE_V_OPT
-        if (seq_len > SEQ_LEN_PARTITION_SIZE && total_partitions_num > 1) {
+        if (effective_seq_len > SEQ_LEN_PARTITION_SIZE && total_partitions_num > 1) {
             unroll_for (uint q_idx = 0; q_idx < HEADS_PER_WI; q_idx++) {
 #if HEADS_LEFTOVERS_NUM > 0
                 if (q_idx >= iter_heads_num)
@@ -946,7 +946,7 @@ KERNEL(pa_sdpa_opt)(
             }
         }
 #else  // !USE_DUAL_NIBBLE_V_OPT
-        if (seq_len > SEQ_LEN_PARTITION_SIZE && total_partitions_num > 1) {
+        if (effective_seq_len > SEQ_LEN_PARTITION_SIZE && total_partitions_num > 1) {
             unroll_for (uint q_idx = 0; q_idx < HEADS_PER_WI; q_idx++) {
 #if HEADS_LEFTOVERS_NUM > 0
                 if (q_idx >= iter_heads_num)
@@ -1028,7 +1028,13 @@ KERNEL(pa_sdpa_finalization_stage)(
     const uint seq_len = past_lens[seq_idx] + 1;
 #endif
 
-    const uint num_of_partitions = min((uint)CEIL_DIV(seq_len, SEQ_LEN_PARTITION_SIZE), total_partitions_num);
+#if SWA_BLOCK_SKIP_ENABLED && !MULTI_TOKENS_PROCESSING
+    const uint swa_start_block = (seq_len > SLIDING_WINDOW_SIZE) ? ((seq_len - SLIDING_WINDOW_SIZE) / PAGED_ATTENTION_BLOCK_SIZE) : 0;
+    const uint effective_seq_len = seq_len - swa_start_block * PAGED_ATTENTION_BLOCK_SIZE;
+#else
+    const uint effective_seq_len = seq_len;
+#endif
+    const uint num_of_partitions = min((uint)CEIL_DIV(effective_seq_len, SEQ_LEN_PARTITION_SIZE), total_partitions_num);
 
     if (num_of_partitions <= 1) {
         /* Short path, no need any actions for currently processing sequence */

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -1213,7 +1213,8 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
     auto Q_num_heads_dim = micro_get_num_heads(params, 0);
     auto K_num_heads_dim = micro_get_num_heads(params, 1);
 
-    jit.make("REMAINDER_K", !k_full);
+    const bool may_have_mixed_k_boundary = config.is_paged_attention && !m_is_prefill && !m_is_gqa_single_token;
+    jit.make("REMAINDER_K", !k_full || may_have_mixed_k_boundary);
     jit.make("KV_GROUP_SIZE", Q_num_heads_dim / K_num_heads_dim);
 
     if (d_full) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
@@ -576,14 +576,18 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     barrier(CLK_LOCAL_MEM_FENCE);
 
     /* Main loop over k blocks */
-    for (int k0 = window_k0_begin; k0 < causal_k; k0 += ugemm_kq_wg_tile_m) {
+    for (int k0 = window_k0_begin; k0 < causal_k;) {
         bool first = (k0 == window_k0_begin);
-        bool last = (k0 + ugemm_kq_wg_tile_m >= causal_k);
+
+        int k_chunk = min(causal_k - k0, ugemm_kq_wg_tile_m);
+#if IS_PAGED_ATTENTION && !IS_PREFILL && !IS_GQA_SINGLE_TOKEN
+        if (k0 < past_len && k0 + k_chunk > past_len)
+            k_chunk = past_len - k0;
+#endif
+        bool last = (k0 + k_chunk >= causal_k);
 
         uint sg_i0_kq = sg_i_kq * ugemm_kq_sg_tile_m;
         uint sg_j0_kq = sg_j_kq * ugemm_kq_sg_tile_n;
-
-        int k_chunk = min(causal_k - k0, ugemm_kq_wg_tile_m);
 
 #if WITH_ATTN_MASK
         /* Load mask. No remainder handling needed assuming k block size is a power of 2. */
@@ -602,12 +606,10 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         /* Prepare k mask: NaN in bounds, -inf out of bounds */
         mask_tile_type_float k_mask;
 #pragma unroll
-        for (int ii = 0; ii < ugemm_kq_sg_tile_m / SUBGROUP_SIZE; ii++)
-            k_mask.x[0][ii] = (k0 + sg_i0_kq + ii * SUBGROUP_SIZE
-                                              + get_sub_group_local_id()
-                                      < causal_k)
-                    ? nan(0u)
-                    : -INFINITY;
+        for (int ii = 0; ii < ugemm_kq_sg_tile_m / SUBGROUP_SIZE; ii++) {
+            const int key_idx = k0 + sg_i0_kq + ii * SUBGROUP_SIZE + get_sub_group_local_id();
+            k_mask.x[0][ii] = key_idx < k0 + k_chunk ? nan(0u) : -INFINITY;
+        }
 #endif
 
         /* Calculate S = (K^T) * Q */
@@ -1147,6 +1149,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #else
         tile_binary(A_tile, A_tile1, binary_add);
 #endif
+    k0 += k_chunk;
     }
 
     /* Wait for column sums to be ready */

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -66,6 +66,42 @@ INSTANTIATE_TEST_SUITE_P(
         paged_attention_test_params{{{25, 128}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
 #endif
 
+class paged_attention_u4_swa_tail_test : public PagedAttentionTest<paged_attention_test_params> {};
+
+TEST_P(paged_attention_u4_swa_tail_test, ignores_invalid_value_cache_rows) {
+    auto p = GetParam();
+    ASSERT_TRUE(this->pam.has_value());
+    auto& pam = *this->pam;
+
+    auto result = run_gpu_inference(pam, p);
+
+    const size_t valid_tokens_in_last_block = (p.subsequences[0].past_len + 1) % p.block_size;
+    const size_t packed_head_size = p.v_head_size / 2;
+    const size_t adjusted_head_size = packed_head_size + 2 * sizeof(ov::float16);
+    const size_t physical_block = pam.block_indices.back();
+    const ov::float16 nan = std::numeric_limits<ov::float16>::quiet_NaN();
+    {
+        cldnn::mem_lock<uint8_t, cldnn::mem_lock_type::write> cache(result.value_cache_mem, tests::get_test_stream());
+        for (int head = 0; head < p.num_kv_heads; ++head) {
+            const size_t block_head_offset = (physical_block * p.num_kv_heads + head) * p.block_size * adjusted_head_size;
+            for (size_t token = valid_tokens_in_last_block; token < static_cast<size_t>(p.block_size); ++token) {
+                const size_t scale_offset = block_head_offset + token * adjusted_head_size + packed_head_size;
+                std::memcpy(cache.data() + scale_offset, &nan, sizeof(nan));
+            }
+        }
+    }
+
+    result.outputs = result.network->execute();
+    this->tolerance = 0.1f;
+    const auto reference = PagedAttentionReference(pam).get_reference(result.key_cache_mem);
+    compare(result.outputs.at("output_data").get_memory(), nullptr, nullptr, reference);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    regression_paged_attention_u4_swa_tail,
+    paged_attention_u4_swa_tail_test,
+    ::testing::Values(paged_attention_test_params{{{1, 35}}, 8, 2, 128, 128, 16, 16, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
+
 class xattention_test : public PagedAttentionTest<paged_attention_test_params> {};
 TEST_P(xattention_test, basic) {
     auto p = GetParam();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -102,6 +102,18 @@ INSTANTIATE_TEST_SUITE_P(
     paged_attention_u4_swa_tail_test,
     ::testing::Values(paged_attention_test_params{{{1, 35}}, 8, 2, 128, 128, 16, 16, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
 
+class paged_attention_swa_partition_finalization_test : public PagedAttentionTest<paged_attention_test_params> {};
+
+TEST_P(paged_attention_swa_partition_finalization_test, ignores_inactive_partition) {
+    auto p = GetParam();
+    execute(p, true);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    regression_paged_attention_swa_partition_finalization,
+    paged_attention_swa_partition_finalization_test,
+    ::testing::Values(paged_attention_test_params{{{1, 511}, {1, 512}}, 8, 2, 128, 128, 16, 256, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false}));
+
 class xattention_test : public PagedAttentionTest<paged_attention_test_params> {};
 TEST_P(xattention_test, basic) {
     auto p = GetParam();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -11,6 +11,61 @@ TEST_P(paged_attention_test, basic) {
     execute(p, p.run_reference);
 }
 
+#ifdef ENABLE_ONEDNN_FOR_GPU
+class paged_attention_u4_mixed_micro_test : public PagedAttentionTest<paged_attention_test_params> {};
+
+TEST_P(paged_attention_u4_mixed_micro_test, matches_cpu_reference) {
+    if (!tests::get_test_engine().get_device_info().supports_immad)
+        GTEST_SKIP() << "Micro SDPA requires DPAS/XMX support";
+
+    auto p = GetParam();
+    ASSERT_TRUE(this->pam.has_value());
+    auto& pam = *this->pam;
+
+    for (size_t sequence = 0; sequence < pam.subsequence_descs.size(); ++sequence) {
+        std::fill(pam.query_data[sequence].begin(), pam.query_data[sequence].end(), ov::float16{8.0f});
+        std::fill(pam.key_data[sequence].begin(), pam.key_data[sequence].end(), ov::float16{-1.0f});
+        std::fill(pam.value_data[sequence].begin(), pam.value_data[sequence].end(), ov::float16{0.0f});
+
+        const int past_len = pam.subsequence_descs[sequence].past_len;
+        const int num_tokens = pam.subsequence_descs[sequence].num_tokens;
+        for (int token = 0; token < num_tokens; ++token) {
+            const float key_value = -0.2f + 0.4f * static_cast<float>(token % p.block_size) /
+                                                     static_cast<float>(p.block_size - 1);
+            const ov::float16 value = token % 2 == 0 ? ov::float16{-1.0f} : ov::float16{1.0f};
+            for (int head = 0; head < p.num_kv_heads; ++head) {
+                const size_t key_offset = (static_cast<size_t>(past_len + token) * p.num_kv_heads + head) *
+                                          p.k_head_size;
+                const size_t value_offset = (static_cast<size_t>(past_len + token) * p.num_kv_heads + head) *
+                                            p.v_head_size;
+                std::fill_n(pam.key_data[sequence].begin() + key_offset, p.k_head_size, ov::float16{key_value});
+                std::fill_n(pam.value_data[sequence].begin() + value_offset, p.v_head_size, value);
+            }
+        }
+    }
+
+    auto result = run_gpu_inference(pam, p);
+    auto pa_inst = result.network->get_primitive("paged_attention");
+    ASSERT_NE(pa_inst, nullptr);
+    auto* impl = pa_inst->get_impl();
+    ASSERT_NE(impl, nullptr);
+    const auto dump_info = impl->get_kernels_dump_info(*pa_inst->get_impl_params());
+    ASSERT_NE(dump_info.get_entries().find("sdpa_micro"), std::string::npos)
+        << "Regression must exercise micro SDPA: " << dump_info.get_entries();
+
+    this->tolerance = 1e-2f;
+    const auto reference = PagedAttentionReference(pam).get_reference(result.key_cache_mem);
+    compare(result.outputs.at("output_data").get_memory(), nullptr, nullptr, reference);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    regression_paged_attention_u4_mixed_micro,
+    paged_attention_u4_mixed_micro_test,
+    ::testing::Values(
+        paged_attention_test_params{{{25, 34}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4},
+        paged_attention_test_params{{{25, 128}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
+#endif
+
 class xattention_test : public PagedAttentionTest<paged_attention_test_params> {};
 TEST_P(xattention_test, basic) {
     auto p = GetParam();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.h
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.h
@@ -1829,6 +1829,7 @@ public:
     struct gpu_outputs {
         std::map<cldnn::primitive_id, cldnn::network_output> outputs;
         cldnn::memory::ptr key_cache_mem;
+        cldnn::memory::ptr value_cache_mem;
         cldnn::network::ptr network;
     };
 
@@ -1938,7 +1939,7 @@ public:
         } else {
             result.key_cache_mem = pam.get_key_cache_memory();
         }
-        auto value_cache_mem = pam.get_value_cache_memory();
+        result.value_cache_mem = pam.get_value_cache_memory();
 
         auto past_lens_mem = pam.get_past_lens_memory();
         auto subsequence_begins_mem = pam.get_subsequence_begins_memory();
@@ -1974,7 +1975,7 @@ public:
         auto key_layout = key_mem->get_layout();
         auto value_layout = value_mem->get_layout();
         auto key_cache_layout = result.key_cache_mem->get_layout();
-        auto value_cache_layout = value_cache_mem->get_layout();
+        auto value_cache_layout = result.value_cache_mem->get_layout();
         auto past_lens_layout = past_lens_mem->get_layout();
         auto subsequence_begins_layout = subsequence_begins_mem->get_layout();
         auto block_indices_layout = block_indices_mem->get_layout();
@@ -2181,7 +2182,7 @@ public:
         network->set_input_data("key", key_mem);
         network->set_input_data("value", value_mem);
         network->set_input_data("key_cache", result.key_cache_mem);
-        network->set_input_data("value_cache", value_cache_mem);
+        network->set_input_data("value_cache", result.value_cache_mem);
         network->set_input_data("past_lens", past_lens_mem);
         network->set_input_data("subsequence_begins", subsequence_begins_mem);
         network->set_input_data("block_indices", block_indices_mem);


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
This PR fixes two independent PagedAttention issues exposed by compressed U4 KV-cache execution:
1. **Mixed micro-SDPA cache boundary handling**
   - U4 micro-SDPA produced incorrect results when a KQ tile crossed the boundary between the compressed prefix cache and the uncompressed current K/V tensors.
   - The source was selected using only the tile start position, causing the current-token portion of a boundary tile to be read from the compressed cache.
   - Split boundary tiles at `past_len`, advance by the actual chunk size, and mask the unused tail of shortened chunks.
   - Added independent CPU-reference coverage for aligned and unaligned cache boundaries.
2. **Sliding-window partial-block handling**
   - The single-token sliding-window QK*V path used block-aligned cache capacity as the effective sequence length.
   - When the final cache block was only partially filled, this included unused rows beyond the logical sequence length.
   - Compressed value-cache metadata in those rows may be invalid. Even with a zero softmax weight, `0 * NaN` propagates NaN to the output.
   - Compute the effective sequence length from the exact retained token range, `seq_len - swa_start_token`, instead of block capacity.
   - Added a deterministic U4 regression that injects NaN scales into unused value-cache rows and verifies that they are not consumed.
3. **Sliding-window inactive partition handling**
   - The partitioned single-token path used the full sequence length when deciding whether to write a direct result or partition intermediates, and when selecting partitions for finalization.
   - After sliding-window block skipping, the retained sequence may require fewer partitions than the full history. Inactive partition buffers can still contain stale intermediate values from earlier execution.
   - Finalization could therefore merge stale inactive partitions into the current attention result, producing corrupted output during long prefix-cached generation.
   - Use the retained sliding-window sequence length, `effective_seq_len`, consistently for both stage-0 output routing and finalization partition counting.

#### The code and line that caused this issue (if it is not changed directly)
 - Fixed directly in `src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl`, in the KQ tile loop of the micro-SDPA kernel.
 - Fixed the sliding-window tail handling directly in `src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl`, in the QK*V sequence-length calculation.
 
#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - Run the synthetic GPU unit regression:
   ```bash
   ./bin/intel64/Debug/ov_gpu_unit_tests \
     --gtest_filter='*paged_attention_u4_mixed_micro_test.matches_cpu_reference*'
   ```
   - Without the fix, the unaligned boundary case differs from the CPU reference by up to `0.1630859375`.
   - With the fix, both the unaligned boundary and aligned control cases pass with tolerance `0.01`.

#### Problematic graph
 - PagedAttention with a U4 compressed KV cache in the `MIXED` stage, where a micro-SDPA KQ tile crosses `past_len`.
 - Single-token PagedAttention generation with sliding-window block skipping enabled and a partially filled final cache block.
 - The first issue reads part of a boundary tile from the wrong source.
 - The second issue reads unused value-cache rows beyond the logical retained sequence length

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - Reviewed the existing PagedAttention cache-reuse coverage in `paged_attention_gpu_test.cpp`. It compares GPU paths that can share the same defect, so an independent CPU-reference regression was added.
   - Reviewed the existing compressed-cache and #37095 zero-range coverage. Those tests validate cache metadata generation but do not exercise sliding-window QK*V reads from a partially filled final block, so a dedicated invalid-tail regression was added.
