### PR TITLE
[GPU] Prevent stale VA-surface cache collisions

### DIFF
--- a/src/plugins/intel_gpu/include/va/va.h
+++ b/src/plugins/intel_gpu/include/va/va.h
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#ifdef OV_GPU_USE_SYSTEM_LIBVA_HEADERS
+# include <va.h>
+#else
 using VASurfaceID = cl_uint;
 using VADisplay = void *;
 using VAImageFormat = void *;
+#endif

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -458,7 +458,11 @@ bool RemoteTensorImpl::is_shared() const noexcept {
 }
 
 bool RemoteTensorImpl::supports_caching() const {
+#ifdef _WIN32
+    return is_shared();
+#else
     return is_shared() && m_mem_type != TensorType::BT_SURF_SHARED;
+#endif
 }
 
 void RemoteTensorImpl::update_hash() {

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -458,7 +458,7 @@ bool RemoteTensorImpl::is_shared() const noexcept {
 }
 
 bool RemoteTensorImpl::supports_caching() const {
-    return is_shared() && !is_surface();
+    return is_shared() && m_mem_type != TensorType::BT_SURF_SHARED;
 }
 
 void RemoteTensorImpl::update_hash() {

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -458,7 +458,7 @@ bool RemoteTensorImpl::is_shared() const noexcept {
 }
 
 bool RemoteTensorImpl::supports_caching() const {
-    return is_shared();
+    return is_shared() && !is_surface();
 }
 
 void RemoteTensorImpl::update_hash() {

--- a/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
@@ -52,6 +52,15 @@ endif()
 if(libva_FOUND)
     target_compile_definitions(${TARGET_NAME} PRIVATE ENABLE_LIBVA)
     target_link_libraries(${TARGET_NAME} PRIVATE PkgConfig::libva)
+
+    # VA surface interop tests need a VADisplay of their own. The DRM backend is the only one
+    # which works headless, so these tests are enabled only when libva-drm is available.
+    pkg_search_module(libva_drm QUIET IMPORTED_TARGET libva-drm)
+    if(libva_drm_FOUND AND EXISTS "${libva_INCLUDEDIR}/va/va.h")
+        target_include_directories(${TARGET_NAME} PRIVATE "${libva_INCLUDEDIR}/va")
+        target_compile_definitions(${TARGET_NAME} PRIVATE ENABLE_LIBVA_DRM OV_GPU_USE_SYSTEM_LIBVA_HEADERS)
+        target_link_libraries(${TARGET_NAME} PRIVATE PkgConfig::libva_drm)
+    endif()
 endif()
 
 if(WIN32)

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/dx11_remote_ctx_test.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/dx11_remote_ctx_test.cpp
@@ -236,20 +236,6 @@ TEST_F(DX11CachedTexture_Test, smoke_make_shared_nv12_tensor_cached) {
     }
 }
 
-TEST_F(DX11CachedTexture_Test, smoke_make_shared_nv12_tensor_reimports_surface) {
-#if defined(ANDROID)
-    GTEST_SKIP();
-#endif
-    ov::Core core;
-    ov::intel_gpu::ocl::D3DContext context(core, device_ptr);
-
-    auto tensor_first = context.create_tensor_nv12(texture_description.Height, texture_description.Width, dx11_textures[0]);
-    auto tensor_second = context.create_tensor_nv12(texture_description.Height, texture_description.Width, dx11_textures[0]);
-
-    EXPECT_NE(tensor_first.first.get(), tensor_second.first.get());
-    EXPECT_NE(tensor_first.second.get(), tensor_second.second.get());
-}
-
 TEST_F(DX11CachedTexture_Test, _make_shared_nv12_tensor_cached_inference) {
     this->run_make_shared_nv12_tensor_cached_inference(false);
 }

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/dx11_remote_ctx_test.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/dx11_remote_ctx_test.cpp
@@ -236,6 +236,20 @@ TEST_F(DX11CachedTexture_Test, smoke_make_shared_nv12_tensor_cached) {
     }
 }
 
+TEST_F(DX11CachedTexture_Test, smoke_make_shared_nv12_tensor_reimports_surface) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+    ov::Core core;
+    ov::intel_gpu::ocl::D3DContext context(core, device_ptr);
+
+    auto tensor_first = context.create_tensor_nv12(texture_description.Height, texture_description.Width, dx11_textures[0]);
+    auto tensor_second = context.create_tensor_nv12(texture_description.Height, texture_description.Width, dx11_textures[0]);
+
+    EXPECT_NE(tensor_first.first.get(), tensor_second.first.get());
+    EXPECT_NE(tensor_first.second.get(), tensor_second.second.get());
+}
+
 TEST_F(DX11CachedTexture_Test, _make_shared_nv12_tensor_cached_inference) {
     this->run_make_shared_nv12_tensor_cached_inference(false);
 }

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/helpers.hpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/helpers.hpp
@@ -15,6 +15,11 @@
 # include "openvino/runtime/intel_gpu/ocl/dx.hpp"
 #elif defined ENABLE_LIBVA
 # include "openvino/runtime/intel_gpu/ocl/va.hpp"
+# ifdef ENABLE_LIBVA_DRM
+#  include <fcntl.h>
+#  include <unistd.h>
+#  include <va/va_drm.h>
+# endif
 #endif
 #include "openvino/core/model.hpp"
 #include "openvino/op/add.hpp"
@@ -191,6 +196,83 @@ struct OpenCL {
         return ret_val;
     }
 };
+
+#if !defined(_WIN32) && defined(ENABLE_LIBVA) && defined(ENABLE_LIBVA_DRM)
+// Minimal VA-API environment for GPU interop tests: opens a DRM render node and initializes a
+// VADisplay on top of it
+struct VADevice {
+    VADevice() {
+        for (int node_index = 128; node_index < 136; node_index++) {
+            const auto node = "/dev/dri/renderD" + std::to_string(node_index);
+            _drm_fd = open(node.c_str(), O_RDWR);
+            if (_drm_fd < 0)
+                continue;
+
+            VADisplay display = vaGetDisplayDRM(_drm_fd);
+            int major_version = 0;
+            int minor_version = 0;
+            if (display != nullptr && vaInitialize(display, &major_version, &minor_version) == VA_STATUS_SUCCESS) {
+                _display = display;
+                break;
+            }
+
+            close(_drm_fd);
+            _drm_fd = -1;
+        }
+    }
+
+    VADevice(const VADevice&) = delete;
+    VADevice& operator=(const VADevice&) = delete;
+
+    ~VADevice() {
+        if (_display != nullptr)
+            vaTerminate(_display);
+        if (_drm_fd >= 0)
+            close(_drm_fd);
+    }
+
+    bool is_valid() const {
+        return _display != nullptr;
+    }
+
+    VADisplay get() const {
+        return _display;
+    }
+
+    // Allocates an NV12 surface
+    VASurfaceID create_nv12_surface(size_t width, size_t height) const {
+        VASurfaceAttrib attrib{};
+        attrib.type = VASurfaceAttribPixelFormat;
+        attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
+        attrib.value.type = VAGenericValueTypeInteger;
+        attrib.value.value.i = VA_FOURCC_NV12;
+
+        VASurfaceID surface = VA_INVALID_SURFACE;
+        const auto status = vaCreateSurfaces(_display,
+                                             VA_RT_FORMAT_YUV420,
+                                             static_cast<unsigned int>(width),
+                                             static_cast<unsigned int>(height),
+                                             &surface,
+                                             1,
+                                             &attrib,
+                                             1);
+        return status == VA_STATUS_SUCCESS ? surface : VA_INVALID_SURFACE;
+    }
+
+    // Releases the surface and invalidates the passed id
+    void destroy_surface(VASurfaceID& surface) const {
+        if (surface == VA_INVALID_SURFACE)
+            return;
+
+        vaDestroySurfaces(_display, &surface, 1);
+        surface = VA_INVALID_SURFACE;
+    }
+
+private:
+    int _drm_fd = -1;
+    VADisplay _display = nullptr;
+};
+#endif  // !_WIN32 && ENABLE_LIBVA && ENABLE_LIBVA_DRM
 
 inline std::shared_ptr<ov::Model> make_copy_model(const ov::Shape& shape) {
     auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/va_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/va_remote_tensor_tests.cpp
@@ -1,0 +1,215 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if defined(OV_GPU_WITH_OCL_RT) && !defined(_WIN32) && defined(ENABLE_LIBVA) && defined(ENABLE_LIBVA_DRM)
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
+#include "common_test_utils/test_assertions.hpp"
+#include "common_test_utils/test_common.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "openvino/core/preprocess/pre_post_process.hpp"
+#include "openvino/runtime/core.hpp"
+#include "openvino/runtime/intel_gpu/properties.hpp"
+#include "openvino/runtime/intel_gpu/remote_properties.hpp"
+
+#include "remote_tensor_tests/helpers.hpp"
+
+using namespace ::testing;
+
+namespace {
+constexpr size_t surface_width = 320;
+constexpr size_t surface_height = 240;
+
+bool has_gpu_device() {
+    ov::Core core;
+    const auto devices = core.get_available_devices();
+    return std::any_of(devices.begin(), devices.end(), [](const std::string& device) {
+        return device.find(ov::test::utils::DEVICE_GPU) != std::string::npos;
+    });
+}
+}  // namespace
+
+class OVRemoteTensorVA_Test : public ov::test::TestsCommon {
+protected:
+    VADevice va_device;
+    VASurfaceID surface = VA_INVALID_SURFACE;
+
+    void SetUp() override {
+        if (!va_device.is_valid())
+            GTEST_SKIP() << "VA-API display is not available on this host";
+
+        if (!has_gpu_device())
+            GTEST_SKIP() << "GPU plugin has no available device";
+
+        surface = va_device.create_nv12_surface(surface_width, surface_height);
+        if (surface == VA_INVALID_SURFACE)
+            GTEST_SKIP() << "VA-API driver can't allocate an NV12 surface";
+    }
+
+    void TearDown() override {
+        va_device.destroy_surface(surface);
+    }
+};
+
+TEST_F(OVRemoteTensorVA_Test, smoke_va_context_from_display) {
+    ov::Core core;
+    ov::intel_gpu::ocl::VAContext context(core, va_device.get());
+
+    OV_ASSERT_NO_THROW(ov::intel_gpu::ocl::VAContext::type_check(context));
+    ASSERT_EQ(static_cast<VADisplay>(context), va_device.get());
+    // The shared context is expected to expose the OpenCL context created on top of the VA display
+    ASSERT_NE(context.get(), nullptr);
+    ASSERT_EQ(context.get_device_name().find(ov::test::utils::DEVICE_GPU), 0);
+}
+
+TEST_F(OVRemoteTensorVA_Test, smoke_create_tensor_nv12) {
+    ov::Core core;
+    ov::intel_gpu::ocl::VAContext context(core, va_device.get());
+
+    auto nv12 = context.create_tensor_nv12(surface_height, surface_width, surface);
+    auto& tensor_y = nv12.first;
+    auto& tensor_uv = nv12.second;
+
+    OV_ASSERT_NO_THROW(ov::intel_gpu::ocl::VASurfaceTensor::type_check(tensor_y));
+    OV_ASSERT_NO_THROW(ov::intel_gpu::ocl::VASurfaceTensor::type_check(tensor_uv));
+
+    ASSERT_EQ(tensor_y.get_element_type(), ov::element::u8);
+    ASSERT_EQ(tensor_uv.get_element_type(), ov::element::u8);
+    ASSERT_EQ(tensor_y.get_shape(), ov::Shape({1, surface_height, surface_width, 1}));
+    ASSERT_EQ(tensor_uv.get_shape(), ov::Shape({1, surface_height / 2, surface_width / 2, 2}));
+
+    // Both planes refer to the same surface, but to different memory objects
+    ASSERT_EQ(static_cast<VASurfaceID>(tensor_y), surface);
+    ASSERT_EQ(static_cast<VASurfaceID>(tensor_uv), surface);
+    ASSERT_EQ(tensor_y.plane(), 0);
+    ASSERT_EQ(tensor_uv.plane(), 1);
+    ASSERT_NE(tensor_y.get(), nullptr);
+    ASSERT_NE(tensor_uv.get(), nullptr);
+    ASSERT_NE(tensor_y.get(), tensor_uv.get());
+}
+
+TEST_F(OVRemoteTensorVA_Test, smoke_distinct_surfaces_get_distinct_memory) {
+    ov::Core core;
+    ov::intel_gpu::ocl::VAContext context(core, va_device.get());
+
+    VASurfaceID other_surface = va_device.create_nv12_surface(surface_width, surface_height);
+    ASSERT_NE(other_surface, VA_INVALID_SURFACE);
+    ASSERT_NE(other_surface, surface);
+
+    {
+        auto nv12 = context.create_tensor_nv12(surface_height, surface_width, surface);
+        auto other_nv12 = context.create_tensor_nv12(surface_height, surface_width, other_surface);
+
+        ASSERT_EQ(static_cast<VASurfaceID>(other_nv12.first), other_surface);
+        ASSERT_NE(nv12.first.get(), other_nv12.first.get());
+        ASSERT_NE(nv12.second.get(), other_nv12.second.get());
+    }
+
+    va_device.destroy_surface(other_surface);
+}
+
+TEST_F(OVRemoteTensorVA_Test, smoke_repeated_import_of_the_same_surface) {
+    ov::Core core;
+    ov::intel_gpu::ocl::VAContext context(core, va_device.get());
+
+    // Every iteration releases the previously imported memory while the surface stays alive
+    const size_t total_run_number = 4;
+    for (size_t i = 0; i < total_run_number; i++) {
+        auto nv12 = context.create_tensor_nv12(surface_height, surface_width, surface);
+        ASSERT_NE(nv12.first.get(), nullptr);
+        ASSERT_NE(nv12.second.get(), nullptr);
+        ASSERT_EQ(static_cast<VASurfaceID>(nv12.first), surface);
+    }
+}
+
+// Surface imports are excluded from the remote context memory cache
+// so every import creates a new cl_mem for the surface.
+TEST_F(OVRemoteTensorVA_Test, smoke_surface_import_is_not_cached) {
+    ov::Core core;
+    ov::intel_gpu::ocl::VAContext context(core, va_device.get());
+
+    auto first = context.create_tensor_nv12(surface_height, surface_width, surface);
+    auto second = context.create_tensor_nv12(surface_height, surface_width, surface);
+
+    ASSERT_NE(first.first.get(), second.first.get());
+    ASSERT_NE(first.second.get(), second.second.get());
+
+    // Both imports still describe the very same surface
+    ASSERT_EQ(static_cast<VASurfaceID>(second.first), static_cast<VASurfaceID>(first.first));
+    ASSERT_EQ(second.first.get_shape(), first.first.get_shape());
+}
+
+TEST_F(OVRemoteTensorVA_Test, smoke_nv12_surface_inference) {
+    auto model = ov::test::utils::make_conv_pool_relu({1, 3, surface_height, surface_width});
+
+    using namespace ov::preprocess;
+    auto p = PrePostProcessor(model);
+    p.input().tensor().set_element_type(ov::element::u8)
+                      .set_color_format(ColorFormat::NV12_TWO_PLANES, {"y", "uv"})
+                      .set_memory_type(ov::intel_gpu::memory_type::surface);
+    p.input().preprocess().convert_color(ColorFormat::BGR);
+    p.input().model().set_layout("NCHW");
+    model = p.build();
+
+    auto param_input_y = model->get_parameters().at(0);
+    auto param_input_uv = model->get_parameters().at(1);
+
+    ov::Core core;
+    ov::intel_gpu::ocl::VAContext context(core, va_device.get());
+    auto compiled_model = core.compile_model(model, context);
+    auto request = compiled_model.create_infer_request();
+
+    const size_t iteration_count = 4;
+    for (size_t i = 0; i < iteration_count; i++) {
+        auto nv12 = context.create_tensor_nv12(surface_height, surface_width, surface);
+        request.set_tensor(param_input_y, nv12.first);
+        request.set_tensor(param_input_uv, nv12.second);
+
+        OV_ASSERT_NO_THROW(request.infer());
+
+        auto output_tensor = request.get_tensor(model->get_results().at(0));
+        ASSERT_EQ(output_tensor.get_shape(), model->get_results().at(0)->get_shape());
+    }
+}
+
+// Regression test for VA surface cache collisions.
+TEST_F(OVRemoteTensorVA_Test, smoke_recycled_surface_id_is_reimported) {
+    ov::Core core;
+    ov::intel_gpu::ocl::VAContext context(core, va_device.get());
+
+    const VASurfaceID original_id = surface;
+    // The original import is kept alive, so the driver can't reuse its cl_mem for the new import
+    auto original = context.create_tensor_nv12(surface_height, surface_width, surface);
+    const auto original_mem_y = original.first.get();
+    const auto original_mem_uv = original.second.get();
+
+    // Emulate decoder teardown and recreation until VA-API reassigns the released id
+    bool is_recycled = false;
+    const size_t max_attempts = 8;
+    for (size_t attempt = 0; attempt < max_attempts && !is_recycled; attempt++) {
+        va_device.destroy_surface(surface);
+        surface = va_device.create_nv12_surface(surface_width, surface_height);
+        ASSERT_NE(surface, VA_INVALID_SURFACE);
+        is_recycled = surface == original_id;
+    }
+
+    if (!is_recycled)
+        GTEST_SKIP() << "VA-API did not reassign the released surface id, cache aliasing can't be exercised";
+
+    auto reimported = context.create_tensor_nv12(surface_height, surface_width, surface);
+
+    // The new surface produces the same cache key as the destroyed one
+    ASSERT_EQ(static_cast<VASurfaceID>(reimported.first), original_id);
+    ASSERT_EQ(reimported.first.get_shape(), original.first.get_shape());
+    ASSERT_EQ(reimported.second.get_shape(), original.second.get_shape());
+    // it must be imported from scratch instead of being served from the cache
+    ASSERT_NE(reimported.first.get(), original_mem_y);
+    ASSERT_NE(reimported.second.get(), original_mem_uv);
+}
+
+#endif  // OV_GPU_WITH_OCL_RT && !_WIN32 && ENABLE_LIBVA && ENABLE_LIBVA_DRM


### PR DESCRIPTION
### Details:
 - The plugin caches imported surface memory `cl_mem` in an LRU cache `RemoteContextImpl::m_memory_cache` keyed by a hash of `{surface_handle, plane, shape, element_type}`. For VA surfaces the handle component is the numeric `VASurfaceID` (`m_surf`, uint32_t).
 - When an application destroys a decoder `vaDestroySurfaces` and creates a new one, VA-API is free to reassign a previously released `VASurfaceID` to a brand-new surface instance. On the next `create_tensor_nv12()`, `RemoteTensorImpl::allocate()` computes the same hash, hits the stale cache entry, and takes an early return handing back the `cl_mem` bound to the already-destroyed surface, instead of importing the new one. No OpenVINO or OpenCL error is raised; inference silently runs on the old surface's data.

### Root cause:
 - A cached import is only safe when the cache key uniquely and stably identifies the underlying object for the entry's lifetime, and the cached `cldnn::memory::ptr` pins that object alive. Surfaces satisfy neither:
   - Key is a recyclable small integer. `update_hash()` builds the key from `m_surf` for surfaces, i.e. from the raw `VASurfaceID`.
   - The cache does not pin the surface. The import `clCreateFromVA_APIMediaSurfaceINTEL` creates a `cl_mem` that owns its own image; `gpu_media_buffer` stores only `{device, surface_id, plane}` and holds no reference to the VA surface itself. VA-API can therefore destroy and reissue the id freely while the cached entry lives on.
 - By contrast, buffer/USM/DX-buffer imports are keyed on a full pointer/handle and (for buffer/image/DX) retained via `clRetainMemObject`, so their keys stably+uniquely name a pinned object: no aliasing window. These remain cached.

### The fix:
The fix excludes surface import from the remote-context memory cache so they are always re-imported.
`BT_SURF_SHARED` covers two different kinds of object. On Linux it is a VA surface, keyed on `m_surf`. On Windows `D3DContext::create_tensor_nv12()` reuses `SharedMemType::VA_SURFACE` for an `ID3D11Texture2D*`, so a D3D11 texture lands in the same tensor type but is keyed on `m_mem`.

### Tickets:
 - CVS-191539