### PR TITLE
[AUTO] Add GPUUtilization fallback for iGPU telemetry key

### DIFF
--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -64,11 +64,17 @@ public:
                 LOG_WARNING_TAG("TelemetryClient: JSON missing 'Performance' section");
                 return std::nullopt;
             }
-            if (!parsed["Performance"].contains(metric_key)) {
+            const auto& performance = parsed["Performance"];
+            auto metric_it = performance.find(metric_key);
+            // IGPU may be reported under either IGPUUtilization or GPUUtilization; fall back to the latter.
+            if (metric_it == performance.end() && metric_key_view == k_igpu_utilization_metric) {
+                metric_it = performance.find(std::string{k_gpu_utilization_metric});
+            }
+            if (metric_it == performance.end()) {
                 LOG_WARNING_TAG("TelemetryClient: Performance section missing key: %s", metric_key.c_str());
                 return std::nullopt;
             }
-            float value = parsed["Performance"][metric_key].get<float>();
+            float value = metric_it->get<float>();
             const std::string value_as_string = std::to_string(value);
             LOG_DEBUG_TAG("TelemetryClient: parsed utilization=%s for device=%s",
                           value_as_string.c_str(),

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -69,8 +69,7 @@ public:
             // IGPU may be reported under either IGPUUtilization or GPUUtilization; fall back to the latter.
             const bool igpu_fallback_attempted = metric_it == performance.end() && metric_key_view == k_igpu_utilization_metric;
             if (igpu_fallback_attempted) {
-                static const std::string igpu_fallback_key{k_igpu_utilization_fallback_metric};
-                metric_it = performance.find(igpu_fallback_key);
+                metric_it = performance.find(std::string{k_igpu_utilization_fallback_metric});
             }
             if (metric_it == performance.end()) {
                 if (igpu_fallback_attempted) {
@@ -84,7 +83,8 @@ public:
                 return std::nullopt;
             }
             if (!metric_it->is_number()) {
-                LOG_WARNING_TAG("TelemetryClient: Performance value for key %s is not a number", metric_key.c_str());
+                const auto& resolved_metric_key = metric_it.key();
+                LOG_WARNING_TAG("TelemetryClient: Performance value for key %s is not a number", resolved_metric_key.c_str());
                 return std::nullopt;
             }
             float value = metric_it->get<float>();

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -21,6 +21,62 @@ inline std::string get_log_tag() {
     return "[IPF]";
 }
 
+namespace {
+
+std::optional<float> parse_utilization_from_aiselector_json_impl(const std::string& json_str,
+                                                                 const std::string& metric_key,
+                                                                 std::string_view metric_key_view,
+                                                                 const std::string& device_name) {
+    try {
+        LOG_DEBUG_TAG("TelemetryClient: raw IPF response: %s", json_str.c_str());
+        const auto parsed = nlohmann::json::parse(json_str);
+        if (!parsed.contains("Performance")) {
+            LOG_WARNING_TAG("TelemetryClient: JSON missing 'Performance' section");
+            return std::nullopt;
+        }
+        const auto& performance = parsed["Performance"];
+        auto metric_it = performance.find(metric_key);
+        // IGPU may be reported under either IGPUUtilization or GPUUtilization; fall back to the latter.
+        const bool igpu_fallback_attempted = metric_it == performance.end() && metric_key_view == k_igpu_utilization_metric;
+        if (igpu_fallback_attempted) {
+            static const std::string igpu_fallback_key{k_igpu_utilization_fallback_metric};
+            metric_it = performance.find(igpu_fallback_key);
+        }
+        if (metric_it == performance.end()) {
+            if (igpu_fallback_attempted) {
+                LOG_WARNING_TAG("TelemetryClient: Performance section missing keys: %s and fallback %.*s",
+                                metric_key.c_str(),
+                                static_cast<int>(k_igpu_utilization_fallback_metric.size()),
+                                k_igpu_utilization_fallback_metric.data());
+            } else {
+                LOG_WARNING_TAG("TelemetryClient: Performance section missing key: %s", metric_key.c_str());
+            }
+            return std::nullopt;
+        }
+        if (!metric_it->is_number()) {
+            const auto& resolved_metric_key = metric_it.key();
+            LOG_WARNING_TAG("TelemetryClient: Performance value for key %s is not a number", resolved_metric_key.c_str());
+            return std::nullopt;
+        }
+        float value = metric_it->get<float>();
+        const std::string value_as_string = std::to_string(value);
+        LOG_DEBUG_TAG("TelemetryClient: parsed utilization=%s for device=%s", value_as_string.c_str(), device_name.c_str());
+        if (!std::isfinite(value) || value < 0.0f || value > 100.0f) {
+            LOG_WARNING_TAG("TelemetryClient: utilization value out of supported range [0,100], value=%s for device=%s",
+                            value_as_string.c_str(),
+                            device_name.c_str());
+            return std::nullopt;
+        }
+
+        return value;
+    } catch (const nlohmann::json::exception& e) {
+        LOG_DEBUG_TAG("TelemetryClient: JSON parsing exception: %s", e.what());
+        return std::nullopt;
+    }
+}
+
+}  // namespace
+
 // Calls into ClientApi.dll through the plain-C ABI (ClientApiC.h).
 class TelemetryClient::Impl {
 public:
@@ -57,53 +113,7 @@ public:
         if (json_str.empty()) {
             return std::nullopt;
         }
-        try {
-            LOG_DEBUG_TAG("TelemetryClient: raw IPF response: %s", json_str.c_str());
-            const auto parsed = nlohmann::json::parse(json_str);
-            if (!parsed.contains("Performance")) {
-                LOG_WARNING_TAG("TelemetryClient: JSON missing 'Performance' section");
-                return std::nullopt;
-            }
-            const auto& performance = parsed["Performance"];
-            auto metric_it = performance.find(metric_key);
-            // IGPU may be reported under either IGPUUtilization or GPUUtilization; fall back to the latter.
-            const bool igpu_fallback_attempted = metric_it == performance.end() && metric_key_view == k_igpu_utilization_metric;
-            if (igpu_fallback_attempted) {
-                metric_it = performance.find(std::string{k_igpu_utilization_fallback_metric});
-            }
-            if (metric_it == performance.end()) {
-                if (igpu_fallback_attempted) {
-                    LOG_WARNING_TAG("TelemetryClient: Performance section missing keys: %s and fallback %.*s",
-                                    metric_key.c_str(),
-                                    static_cast<int>(k_igpu_utilization_fallback_metric.size()),
-                                    k_igpu_utilization_fallback_metric.data());
-                } else {
-                    LOG_WARNING_TAG("TelemetryClient: Performance section missing key: %s", metric_key.c_str());
-                }
-                return std::nullopt;
-            }
-            if (!metric_it->is_number()) {
-                const auto& resolved_metric_key = metric_it.key();
-                LOG_WARNING_TAG("TelemetryClient: Performance value for key %s is not a number", resolved_metric_key.c_str());
-                return std::nullopt;
-            }
-            float value = metric_it->get<float>();
-            const std::string value_as_string = std::to_string(value);
-            LOG_DEBUG_TAG("TelemetryClient: parsed utilization=%s for device=%s",
-                          value_as_string.c_str(),
-                          device_name.c_str());
-            if (!std::isfinite(value) || value < 0.0f || value > 100.0f) {
-                LOG_WARNING_TAG("TelemetryClient: utilization value out of supported range [0,100], value=%s for device=%s",
-                              value_as_string.c_str(),
-                              device_name.c_str());
-                return std::nullopt;
-            }
-
-            return value;
-        } catch (const nlohmann::json::exception& e) {
-            LOG_DEBUG_TAG("TelemetryClient: JSON parsing exception: %s", e.what());
-            return std::nullopt;
-        }
+        return parse_utilization_from_aiselector_json_impl(json_str, metric_key, metric_key_view, device_name);
     }
 
 private:
@@ -138,6 +148,21 @@ TelemetryClient::~TelemetryClient() = default;
 std::optional<float> TelemetryClient::utilization(const std::string& device_name, const std::string& device_type) {
     return m_impl->utilization(device_name, device_type);
 }
+
+#ifdef MULTIUNITTEST
+std::optional<float> parse_utilization_from_aiselector_json_for_test(const std::string& json_str,
+                                                                     const std::string& device_name,
+                                                                     const std::string& device_type) {
+    const auto metric_key_view = device_to_metric_key(device_name, device_type);
+    if (metric_key_view.empty()) {
+        return std::nullopt;
+    }
+    return parse_utilization_from_aiselector_json_impl(json_str,
+                                                       std::string{metric_key_view},
+                                                       metric_key_view,
+                                                       device_name);
+}
+#endif
 
 }  // namespace device_monitor
 }  // namespace auto_plugin

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -67,11 +67,24 @@ public:
             const auto& performance = parsed["Performance"];
             auto metric_it = performance.find(metric_key);
             // IGPU may be reported under either IGPUUtilization or GPUUtilization; fall back to the latter.
-            if (metric_it == performance.end() && metric_key_view == k_igpu_utilization_metric) {
-                metric_it = performance.find(std::string{k_gpu_utilization_metric});
+            const bool igpu_fallback_attempted = metric_it == performance.end() && metric_key_view == k_igpu_utilization_metric;
+            if (igpu_fallback_attempted) {
+                static const std::string igpu_fallback_key{k_igpu_utilization_fallback_metric};
+                metric_it = performance.find(igpu_fallback_key);
             }
             if (metric_it == performance.end()) {
-                LOG_WARNING_TAG("TelemetryClient: Performance section missing key: %s", metric_key.c_str());
+                if (igpu_fallback_attempted) {
+                    LOG_WARNING_TAG("TelemetryClient: Performance section missing keys: %s and fallback %.*s",
+                                    metric_key.c_str(),
+                                    static_cast<int>(k_igpu_utilization_fallback_metric.size()),
+                                    k_igpu_utilization_fallback_metric.data());
+                } else {
+                    LOG_WARNING_TAG("TelemetryClient: Performance section missing key: %s", metric_key.c_str());
+                }
+                return std::nullopt;
+            }
+            if (!metric_it->is_number()) {
+                LOG_WARNING_TAG("TelemetryClient: Performance value for key %s is not a number", metric_key.c_str());
                 return std::nullopt;
             }
             float value = metric_it->get<float>();

--- a/src/plugins/auto/src/utils/device_telemetry.hpp
+++ b/src/plugins/auto/src/utils/device_telemetry.hpp
@@ -29,6 +29,8 @@ private:
 
 inline constexpr std::string_view k_cpu_utilization_metric = "CPUUtilization";
 inline constexpr std::string_view k_igpu_utilization_metric = "IGPUUtilization";
+// Fallback key: some platforms report integrated GPU utilization as "GPUUtilization".
+inline constexpr std::string_view k_gpu_utilization_metric = "GPUUtilization";
 inline constexpr std::string_view k_dgpu_utilization_metric = "DGPUUtilization";
 inline constexpr std::string_view k_npu_utilization_metric = "NPUUtilization";
 

--- a/src/plugins/auto/src/utils/device_telemetry.hpp
+++ b/src/plugins/auto/src/utils/device_telemetry.hpp
@@ -30,7 +30,7 @@ private:
 inline constexpr std::string_view k_cpu_utilization_metric = "CPUUtilization";
 inline constexpr std::string_view k_igpu_utilization_metric = "IGPUUtilization";
 // Fallback key: some platforms report integrated GPU utilization as "GPUUtilization".
-inline constexpr std::string_view k_gpu_utilization_metric = "GPUUtilization";
+inline constexpr std::string_view k_igpu_utilization_fallback_metric = "GPUUtilization";
 inline constexpr std::string_view k_dgpu_utilization_metric = "DGPUUtilization";
 inline constexpr std::string_view k_npu_utilization_metric = "NPUUtilization";
 

--- a/src/plugins/auto/src/utils/device_telemetry.hpp
+++ b/src/plugins/auto/src/utils/device_telemetry.hpp
@@ -56,6 +56,12 @@ inline constexpr std::string_view device_to_metric_key(std::string_view device_n
     return metric_key;
 }
 
+#if defined(MULTIUNITTEST) && defined(OV_AUTO_ENABLE_IPF)
+std::optional<float> parse_utilization_from_aiselector_json_for_test(const std::string& json_str,
+                                                                     const std::string& device_name,
+                                                                     const std::string& device_type = "");
+#endif
+
 }  // namespace device_monitor
 }  // namespace auto_plugin
 }  // namespace ov

--- a/src/plugins/auto/tests/unit/CMakeLists.txt
+++ b/src/plugins/auto/tests/unit/CMakeLists.txt
@@ -28,4 +28,11 @@ ov_add_test_target(
 
 ov_add_version_defines(${OpenVINO_SOURCE_DIR}/src/plugins/auto/src/plugin.cpp ${TARGET_NAME})
 
+if(TARGET openvino::ipf_client_api)
+    target_compile_definitions(${TARGET_NAME} PRIVATE OV_AUTO_ENABLE_IPF ClientApi_IMPORTS)
+    target_link_libraries(${TARGET_NAME} PRIVATE openvino::ipf_client_api)
+    target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
+        $<TARGET_PROPERTY:nlohmann_json::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+endif()
+
 ov_set_threading_interface_for(${TARGET_NAME})

--- a/src/plugins/auto/tests/unit/device_telemetry_test.cpp
+++ b/src/plugins/auto/tests/unit/device_telemetry_test.cpp
@@ -75,3 +75,34 @@ TEST(DeviceMonitorTest, telemetry_client_unknown_device_returns_nullopt) {
     ASSERT_NO_THROW(utilization = client.utilization("UNKNOWN_DEVICE"));
     EXPECT_FALSE(utilization.has_value());
 }
+
+#ifdef OV_AUTO_ENABLE_IPF
+TEST(DeviceMonitorTest, parse_utilization_uses_gpu_fallback_for_igpu) {
+    const std::string aiselector_json = R"({
+        "Performance": {
+            "GPUUtilization": 4.63
+        },
+        "Status": "Online"
+    })";
+
+    const auto utilization = device_monitor::parse_utilization_from_aiselector_json_for_test(aiselector_json,
+                                                                                              "GPU",
+                                                                                              "integrated");
+    ASSERT_TRUE(utilization.has_value());
+    EXPECT_FLOAT_EQ(utilization.value(), 4.63f);
+}
+
+TEST(DeviceMonitorTest, parse_utilization_returns_nullopt_when_igpu_keys_missing) {
+    const std::string aiselector_json = R"({
+        "Performance": {
+            "CPUUtilization": 20.83
+        },
+        "Status": "Online"
+    })";
+
+    const auto utilization = device_monitor::parse_utilization_from_aiselector_json_for_test(aiselector_json,
+                                                                                              "GPU",
+                                                                                              "integrated");
+    EXPECT_FALSE(utilization.has_value());
+}
+#endif


### PR DESCRIPTION
### Details:
- The integrated GPU utilization may be reported under either "IGPUUtilization" or "GPUUtilization" depending on the platform.Fall back to "GPUUtilization" when "IGPUUtilization" is absent, so iGPU utilization is not silently dropped.
- Add regression tests for:
  1) iGPU request succeeds when only GPUUtilization is present.
  2) iGPU request returns nullopt when both IGPUUtilization and GPUUtilization are missing.
