### PR TITLE
Fix CPU division by 0 by rejecting zero step in v4::Range

### DIFF
--- a/src/core/shape_inference/include/range_shape_inference.hpp
+++ b/src/core/shape_inference/include/range_shape_inference.hpp
@@ -40,7 +40,6 @@ template <class T, class TRShape = result_shape_t<T>>
 std::vector<TRShape> range_shape_infer(const Node* op,
                                        const std::vector<T>& input_shapes,
                                        bool output_is_integral,
-                                       bool step_allows_zero,
                                        const ITensorAccessor& tensor_accessor) {
     NODE_VALIDATION_CHECK(op, (input_shapes.size() == 3));
 
@@ -77,12 +76,9 @@ std::vector<TRShape> range_shape_infer(const Node* op,
     if (step_val) {
         NODE_VALIDATION_CHECK(op, step_val->size() == 1);
         step = (*step_val)[0];
-        if (step_allows_zero)
-            NODE_VALIDATION_CHECK(op, std::isfinite(step) && !std::isnan(step), "'step' cannot be nan or infinite.");
-        else
-            NODE_VALIDATION_CHECK(op,
-                                  std::isfinite(step) && !std::isnan(step) && step != 0,
-                                  "'step' cannot be zero, nan, or infinite.");
+        NODE_VALIDATION_CHECK(op,
+                              std::isfinite(step) && !std::isnan(step) && step != 0,
+                              "'step' cannot be zero, nan, or infinite.");
         if (output_is_integral)
             // all inputs must be casted to output_type before the rounding for casting values are done towards zero
             step = std::trunc(step);
@@ -116,7 +112,6 @@ std::vector<TRShape> shape_infer(const Range* op,
     return ShapeInferRange::range_shape_infer(op,
                                               input_shapes,
                                               op->get_input_element_type(0).is_integral_number(),
-                                              false,
                                               tensor_accessor);
 }
 }  // namespace v0
@@ -129,7 +124,6 @@ std::vector<TRShape> shape_infer(const Range* op,
     return ShapeInferRange::range_shape_infer(op,
                                               input_shapes,
                                               op->get_output_type().is_integral_number(),
-                                              true,
                                               tensor_accessor);
 }
 }  // namespace v4

--- a/src/core/tests/type_prop/range.cpp
+++ b/src/core/tests/type_prop/range.cpp
@@ -618,7 +618,7 @@ TEST(type_prop, range_v4_invalid_inputs_plus_inf) {
         auto range = make_shared<op::v4::Range>(start, stop, step, element::f32);
         FAIL() << "+Infinity step not detected";
     } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), "'step' cannot be nan or infinite.");
+        EXPECT_HAS_SUBSTRING(error.what(), "'step' cannot be zero, nan, or infinite.");
     } catch (const ov::Exception& error) {
         EXPECT_HAS_SUBSTRING(error.what(), "Check 'std::numeric_limits<OUT_T>::max() >= c");
     } catch (...) {
@@ -675,7 +675,7 @@ TEST(type_prop, range_v4_invalid_inputs_minus_inf) {
         auto range = make_shared<op::v4::Range>(start, stop, step, element::f32);
         FAIL() << "-Infinity step not detected";
     } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), "'step' cannot be nan or infinite.");
+        EXPECT_HAS_SUBSTRING(error.what(), "'step' cannot be zero, nan, or infinite.");
     } catch (const ov::Exception& error) {
         EXPECT_HAS_SUBSTRING(
             error.what(),
@@ -728,11 +728,41 @@ TEST(type_prop, range_v4_invalid_inputs_nan) {
         auto range = make_shared<op::v4::Range>(start, stop, step, element::f32);
         FAIL() << "NaN step not detected";
     } catch (const NodeValidationFailure& error) {
-        EXPECT_HAS_SUBSTRING(error.what(), "'step' cannot be nan or infinite.");
+        EXPECT_HAS_SUBSTRING(error.what(), "'step' cannot be zero, nan, or infinite.");
     } catch (const ov::Exception& error) {
         EXPECT_HAS_SUBSTRING(
             error.what(),
             "Check '!std::numeric_limits<IN_T>::is_signed || std::numeric_limits<OUT_T>::lowest() <= c");
+    } catch (...) {
+        FAIL() << "Test failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, range_v4_some_const_zero_step_fails) {
+    auto start = make_shared<ov::op::v0::Constant>(element::i32, Shape{}, std::vector<int32_t>{3});
+    auto stop = make_shared<ov::op::v0::Parameter>(element::i32, Shape{});
+    auto step = make_shared<ov::op::v0::Constant>(element::i32, Shape{}, std::vector<int32_t>{0});
+
+    try {
+        auto range = make_shared<op::v4::Range>(start, stop, step, element::i32);
+        FAIL() << "Zero step not detected";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), "'step' cannot be zero");
+    } catch (...) {
+        FAIL() << "Test failed for unexpected reason";
+    }
+}
+
+TEST(type_prop, range_v4_all_const_zero_step_fails) {
+    auto start = make_shared<ov::op::v0::Constant>(element::i32, Shape{}, std::vector<int32_t>{3});
+    auto stop = make_shared<ov::op::v0::Constant>(element::i32, Shape{}, std::vector<int32_t>{5});
+    auto step = make_shared<ov::op::v0::Constant>(element::i32, Shape{}, std::vector<int32_t>{0});
+
+    try {
+        auto range = make_shared<op::v4::Range>(start, stop, step, element::i32);
+        FAIL() << "Zero step not detected";
+    } catch (const NodeValidationFailure& error) {
+        EXPECT_HAS_SUBSTRING(error.what(), "'step' cannot be zero");
     } catch (...) {
         FAIL() << "Test failed for unexpected reason";
     }

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/range_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/range_shape_inference_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gmock/gmock.h>
 
+#include "common_test_utils/test_assertions.hpp"
 #include "range_shape_inference.hpp"
 #include "utils.hpp"
 
@@ -11,6 +12,7 @@ using namespace ov;
 using namespace ov::intel_cpu;
 using std::make_shared;
 using testing::ElementsAre;
+using testing::HasSubstr;
 
 TEST(StaticShapeInferenceTest, Rangev4_i32) {
     auto start = make_shared<op::v0::Parameter>(element::i32, ov::PartialShape{});
@@ -64,4 +66,62 @@ TEST(StaticShapeInferenceTest, Rangev4_f32) {
     stop_v = .875f;
     output_shapes = shape_inference(range.get(), StaticShapeVector{{}, {}, {}}, const_data);
     EXPECT_THAT(output_shapes, ElementsAre(StaticShape{8}));
+}
+
+TEST(StaticShapeInferenceTest, Rangev4_i32_zero_step_from_tensor_accessor) {
+    auto start = make_shared<op::v0::Parameter>(element::i32, ov::PartialShape{});
+    auto stop = make_shared<op::v0::Parameter>(element::i32, ov::PartialShape{});
+    auto step = make_shared<op::v0::Parameter>(element::i32, ov::PartialShape{});
+    auto range = make_shared<op::v4::Range>(start, stop, step, element::i32);
+
+    int32_t start_v = 0, stop_v = 10, step_v = 0;
+    const auto const_data = std::unordered_map<size_t, ov::Tensor>{{0, {element::i32, ov::Shape{}, &start_v}},
+                                                                   {1, {element::i32, ov::Shape{}, &stop_v}},
+                                                                   {2, {element::i32, ov::Shape{}, &step_v}}};
+
+    OV_EXPECT_THROW(shape_inference(range.get(), StaticShapeVector{{}, {}, {}}, const_data),
+                    NodeValidationFailure,
+                    HasSubstr("'step' cannot be zero, nan, or infinite."));
+}
+
+TEST(StaticShapeInferenceTest, Rangev4_f32_zero_step_from_tensor_accessor) {
+    auto start = make_shared<op::v0::Parameter>(element::f32, ov::PartialShape{});
+    auto stop = make_shared<op::v0::Parameter>(element::f32, ov::PartialShape{});
+    auto step = make_shared<op::v0::Parameter>(element::f32, ov::PartialShape{});
+    auto range = make_shared<op::v4::Range>(start, stop, step, element::f32);
+
+    float start_v = 0.f, stop_v = 1.f, step_v = 0.f;
+    const auto const_data = std::unordered_map<size_t, ov::Tensor>{{0, {element::f32, ov::Shape{}, &start_v}},
+                                                                   {1, {element::f32, ov::Shape{}, &stop_v}},
+                                                                   {2, {element::f32, ov::Shape{}, &step_v}}};
+
+    OV_EXPECT_THROW(shape_inference(range.get(), StaticShapeVector{{}, {}, {}}, const_data),
+                    NodeValidationFailure,
+                    HasSubstr("'step' cannot be zero, nan, or infinite."));
+}
+
+TEST(StaticShapeInferenceTest, Rangev4_f32_inf_nan_step_from_tensor_accessor) {
+    auto start = make_shared<op::v0::Parameter>(element::f32, ov::PartialShape{});
+    auto stop = make_shared<op::v0::Parameter>(element::f32, ov::PartialShape{});
+    auto step = make_shared<op::v0::Parameter>(element::f32, ov::PartialShape{});
+    auto range = make_shared<op::v4::Range>(start, stop, step, element::f32);
+
+    float start_v = 0.f, stop_v = 1.f, step_v = std::numeric_limits<float>::infinity();
+    const auto const_data = std::unordered_map<size_t, ov::Tensor>{{0, {element::f32, ov::Shape{}, &start_v}},
+                                                                   {1, {element::f32, ov::Shape{}, &stop_v}},
+                                                                   {2, {element::f32, ov::Shape{}, &step_v}}};
+
+    OV_EXPECT_THROW(shape_inference(range.get(), StaticShapeVector{{}, {}, {}}, const_data),
+                    NodeValidationFailure,
+                    HasSubstr("'step' cannot be zero, nan, or infinite."));
+
+    step_v = -std::numeric_limits<float>::infinity();
+    OV_EXPECT_THROW(shape_inference(range.get(), StaticShapeVector{{}, {}, {}}, const_data),
+                    NodeValidationFailure,
+                    HasSubstr("'step' cannot be zero, nan, or infinite."));
+
+    step_v = std::nanf("");
+    OV_EXPECT_THROW(shape_inference(range.get(), StaticShapeVector{{}, {}, {}}, const_data),
+                    NodeValidationFailure,
+                    HasSubstr("'step' cannot be zero, nan, or infinite."));
 }


### PR DESCRIPTION
### Details:
 - ONNX Range maps to OV `v4::Range`, which allows a zero step, leading to a division-by-zero crash in CPU Plugin. ONNXRuntime rejects zero/inf/NaN delta, OV did not for v4.
 - Steps of size 0/NaN/inf are always rejected after this change.
 - Added tests

### Notes:
 - I couldn't find why `bool step_allows_zero` existed in the first place, there had to have been a behavior it enabled, but I'm not sure what it was. I see no regressions in tests, so I'm opening the change for review.

### Tickets:
 - CVS-192344
