### PR TITLE
[C API] Fix C API import for blobs larger than 2 GB

### DIFF
--- a/src/bindings/c/src/common.h
+++ b/src/bindings/c/src/common.h
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <iterator>
 #include <map>
-#include <streambuf>
 #include <string>
 
 #include "openvino/c/ov_common.h"
@@ -199,50 +198,6 @@ struct ov_preprocess_preprocess_steps {
  */
 struct ov_remote_context {
     std::shared_ptr<ov::RemoteContext> object;
-};
-
-/**
- * @struct mem_stringbuf
- * @brief This struct puts memory buffer to stringbuf.
- */
-struct mem_stringbuf : std::streambuf {
-    mem_stringbuf(const char* buffer, size_t sz) {
-        char* bptr(const_cast<char*>(buffer));
-        setg(bptr, bptr, bptr + sz);
-    }
-
-    pos_type seekoff(off_type off,
-                     std::ios_base::seekdir dir,
-                     std::ios_base::openmode which = std::ios_base::in) override {
-        switch (dir) {
-        case std::ios_base::beg:
-            setg(eback(), eback() + off, egptr());
-            break;
-        case std::ios_base::end:
-            setg(eback(), egptr() + off, egptr());
-            break;
-        case std::ios_base::cur:
-            setg(eback(), gptr() + off, egptr());
-            break;
-        default:
-            return pos_type(off_type(-1));
-        }
-        return (gptr() < eback() || gptr() > egptr()) ? pos_type(off_type(-1)) : pos_type(gptr() - eback());
-    }
-
-    pos_type seekpos(pos_type pos, std::ios_base::openmode which) override {
-        return seekoff(pos, std::ios_base::beg, which);
-    }
-};
-
-/**
- * @struct mem_istream
- * @brief This struct puts stringbuf buffer to istream.
- */
-struct mem_istream : virtual mem_stringbuf, std::istream {
-    mem_istream(const char* buffer, size_t sz)
-        : mem_stringbuf(buffer, sz),
-          std::istream(static_cast<std::streambuf*>(this)) {}
 };
 
 char* str_to_char_array(const std::string& str);

--- a/src/bindings/c/src/ov_core.cpp
+++ b/src/bindings/c/src/ov_core.cpp
@@ -297,9 +297,9 @@ ov_status_e ov_core_import_model(const ov_core_t* core,
         return ov_status_e::INVALID_C_PARAM;
     }
     try {
-        mem_istream model_stream(content, content_size);
+        const ov::Tensor model_blob(ov::element::u8, ov::Shape{content_size}, content);
         std::unique_ptr<ov_compiled_model_t> _compiled_model(new ov_compiled_model_t);
-        auto object = core->object->import_model(model_stream, device_name);
+        auto object = core->object->import_model(model_blob, device_name);
         _compiled_model->object = std::make_shared<ov::CompiledModel>(std::move(object));
         *compiled_model = _compiled_model.release();
     }


### PR DESCRIPTION
### Details:
`ov_core_import_model` wraps the caller-provided compiled model buffer in a
custom `std::istream`. On Windows, stream operations fail when importing
compiled model blobs larger than 2 GB.

Use a read-only `ov::Tensor` backed by the caller-provided buffer and invoke
the tensor-based `ov::Core::import_model` overload instead.

This avoids the Windows stream-size limitation without copying the compiled
model data.

### Tickets:
 - [*CVS-192146*](https://jira.devtools.intel.com/browse/CVS-192146)

### AI Assistance:
 - *AI assistance used:  yes
- Built the `openvino_c` Release target successfully.
- Built and ran the complete `ov_capi_test` suite successfully.
- Verified existing C API import paths.
- Tested with the supplied unet reproduction:
  - Compiled blob size: (3.20 GiB)
  - `ov_core_import_model` status: `0` (`OK`)
