### PR TITLE
[GPU] Fix duplicate copy for remote tensors in convert_and_copy

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/common_utils.cpp
+++ b/src/plugins/intel_gpu/src/plugin/common_utils.cpp
@@ -236,8 +236,8 @@ void convert_and_copy(const ov::ITensor* src, cldnn::memory::ptr dst, cldnn::str
             dst->copy_from(stream, *mem, blocking);
         } else {
             dst->copy_from(stream, src->data(), blocking);
-            return;
         }
+        return;
     }
 
     size_t size = ov::shape_size(src->get_shape());

--- a/src/plugins/intel_gpu/tests/unit/module_tests/convert_and_copy_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/convert_and_copy_test.cpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include "intel_gpu/plugin/common_utils.hpp"
+#include "intel_gpu/plugin/remote_context.hpp"
+#include "intel_gpu/plugin/remote_tensor.hpp"
+
+using namespace cldnn;
+using namespace ov::intel_gpu;
+using namespace ::tests;
+
+// IRemoteTensor::data() always throws, so if the fast-path `return` is ever dropped again and
+// execution falls through to the fallback path, this call throws instead of silently passing.
+TEST(convert_and_copy_test, remote_tensor_fast_path_does_not_fall_through) {
+    auto& engine = get_test_engine();
+    auto& stream = get_test_stream();
+
+    auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
+
+    const ov::Shape shape{1, 2, 2, 2};
+    const ov::element::Type et = ov::element::f32;
+
+    auto src_remote = std::make_shared<RemoteTensorImpl>(context, shape, et);
+    auto src_mem = src_remote->get_original_memory();
+    std::vector<float> src_values{1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f};
+    set_values(src_mem, src_values);
+
+    layout dst_layout{shape, et, format::bfyx};
+    auto dst_mem = engine.allocate_memory(dst_layout);
+
+    OV_ASSERT_NO_THROW(convert_and_copy(src_remote.get(), dst_mem, stream, dst_layout, false));
+
+    cldnn::mem_lock<float, mem_lock_type::read> dst_ptr(dst_mem, stream);
+    for (size_t i = 0; i < src_values.size(); ++i) {
+        ASSERT_EQ(dst_ptr[i], src_values[i]);
+    }
+}


### PR DESCRIPTION
## Details
**Problem:** In `convert_and_copy()`, a remote tensor was copied with `memory::copy_from()` and then incorrectly fell through to the conversion path, causing a second copy (CPU .

**Fix:** Moved the `return` after the remote/host tensor branch to exit once `copy_from()` has handled the copy request, preventing fall-through into a second copy path..

## Tickets
- CVS-187607
## AI Assistance
- AI assistance used: yes
- AI was used for code analysis and PR description drafting. The change was manually reviewed and validated.
