### PR TITLE
[CPU] Fix Windows link error: align segfault_detector() declaration guard to its definition

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/x64/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/subgraph.hpp
@@ -29,7 +29,7 @@ public:
                      const BufferScratchpadAllocator& allocator,
                      const ov::intel_cpu::MultiCacheWeakPtr& kernel_cache);
 
-#ifdef SNIPPETS_DEBUG_CAPS
+#if defined(SNIPPETS_DEBUG_CAPS) && (defined(__linux__) || defined(__APPLE__))
 protected:
     void segfault_detector() const override;
 


### PR DESCRIPTION
### Details:
 - *Fixes a Windows Release link failure (`LNK2001/LNK1120: unresolved external symbol SubgraphExecutor::segfault_detector`) when `SNIPPETS_DEBUG_CAPS` is enabled.*

### Tickets:
 - *CVS-192685*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
