### PR TITLE
[NPU][IE-MDK] Update Latest driver to WW33

### DIFF
--- a/src/plugins/intel_npu/tests/driver_version.json
+++ b/src/plugins/intel_npu/tests/driver_version.json
@@ -1,15 +1,15 @@
 {
     "windows10": {
-        "MTL": "windows/unified/integration/ci_tag_driver_rc_config1_20260723_1903/npu-driver-ci-master-13131-RelWithDebInfo.zip",
-        "LNL": "windows/unified/integration/ci_tag_driver_rc_config1_20260723_1903/npu-driver-ci-master-13131-RelWithDebInfo.zip",
-        "PTL": "windows/unified/integration/ci_tag_driver_rc_config1_20260723_1903/npu-driver-ci-master-13131-RelWithDebInfo.zip",
+        "MTL": "windows/unified/integration/ci_tag_driver_rc_config1_20260810_1903/npu-driver-ci-master-13416-RelWithDebInfo.zip",
+        "LNL": "windows/unified/integration/ci_tag_driver_rc_config1_20260810_1903/npu-driver-ci-master-13416-RelWithDebInfo.zip",
+        "PTL": "windows/unified/integration/ci_tag_driver_rc_config1_20260810_1903/npu-driver-ci-master-13416-RelWithDebInfo.zip",
         "MTL_release": "windows/unified/UD202628/ci_tag_driver_rc_ud202628_20260731_1901/npu-driver-ci-releases_26ww25-ci-master-12471-647-RelWithDebInfo.zip",
         "LNL_release": "windows/unified/UD202628/ci_tag_driver_rc_ud202628_20260731_1901/npu-driver-ci-releases_26ww25-ci-master-12471-647-RelWithDebInfo.zip",
         "PTL_release": "windows/unified/UD202628/ci_tag_driver_rc_ud202628_20260731_1901/npu-driver-ci-releases_26ww25-ci-master-12471-647-RelWithDebInfo.zip",
         "MTL_PV": "windows/MTL/PV2/ci_tag_mtl_pv2_driver_rc_20231031_2101/npu_win_31.0.100.1688.zip"
     },
     "ubuntu24": {
-        "MTL": "ubuntu24/unified/integration/npu-linux-driver-ci-1.37.0.20260723-30021051329/npu-linux-driver-ci-1.37.0.20260723-30021051329-ubuntu2404-release.tar.gz",
+        "MTL": "ubuntu24/unified/integration/npu-linux-driver-ci-1.39.0.20260810-31423273404/npu-linux-driver-ci-1.39.0.20260810-31423273404-ubuntu2404-release.tar.gz",
         "MTL_release": "ubuntu24/unified/1.35.0/npu-linux-driver-ci-1.35.0.20260722-29947505341/npu-linux-driver-ci-1.35.0.20260722-29947505341-ubuntu2404-opensource.tar.gz",
         "PTL_release": "ubuntu24/unified/1.35.0/npu-linux-driver-ci-1.35.0.20260722-29947505341/npu-linux-driver-ci-1.35.0.20260722-29947505341-ubuntu2404-opensource.tar.gz"
     }


### PR DESCRIPTION
### Details:
Updating NPU drivers used in OV Integration under LATEST tag
Picking latest drivers for Windows and Linux used by NPU Compiler

### Tickets:
 - E 230229

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
