### PR TITLE
[CPU] Fix x64 cache detection in oneDNN utilities

### DIFF
--- a/src/plugins/intel_cpu/src/onednn/dnnl.cpp
+++ b/src/plugins/intel_cpu/src/onednn/dnnl.cpp
@@ -4,6 +4,8 @@
 
 #include "dnnl.h"
 
+#include "openvino/core/visibility.hpp"
+
 #include <oneapi/dnnl/dnnl_debug.h>
 #include <oneapi/dnnl/dnnl_types.h>
 

--- a/src/plugins/intel_cpu/src/onednn/dnnl.cpp
+++ b/src/plugins/intel_cpu/src/onednn/dnnl.cpp
@@ -4,8 +4,6 @@
 
 #include "dnnl.h"
 
-#include "openvino/core/visibility.hpp"
-
 #include <oneapi/dnnl/dnnl_debug.h>
 #include <oneapi/dnnl/dnnl_types.h>
 
@@ -13,6 +11,8 @@
 #include <cpu/platform.hpp>
 #include <cstring>
 #include <oneapi/dnnl/dnnl.hpp>
+
+#include "openvino/core/visibility.hpp"
 
 #if defined(OPENVINO_ARCH_X86_64)
 #    include "cpu/x64/cpu_isa_traits.hpp"


### PR DESCRIPTION
### Details:
 - Include `openvino/core/visibility.hpp` before checking `OPENVINO_ARCH_X86_64` in the CPU plugin oneDNN utilities.
 - Without this header, x64 builds take the non-x64 fallback in `get_cache_size()` and return per-core L3 cache size instead of total L3 cache size.
 - The underestimated cache size changes the convolution fusion heuristic and can introduce unnecessary reorders, causing MobileNet-v2 latency regressions on affected platforms.
 - Restoring the correct x64 branch recovers the original primitive selection and performance.

### Tickets:
 - CVS-192672