### PR TITLE
[GPU][COVERITY] guard SDPA dimension values before size_t conversion

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
@@ -72,11 +72,6 @@ size_t get_beam_table_id(const std::shared_ptr<const scaled_dot_product_attentio
     return primitive->input_size() - 1;
 }
 
-inline size_t ensure_positive_dim(int64_t value, const char* dim_name) {
-    OPENVINO_ASSERT(value > 0, "SDPA: invalid non-positive ", dim_name, " for JIT constants generation");
-    return static_cast<size_t>(value);
-}
-
 }  // namespace
 
 // 4-bit KV-cache packs two u4 values into one i8 byte, halving the physical
@@ -311,11 +306,26 @@ JitConstants SDPABase::get_jit_constants(const kernel_impl_params& params) const
         LayoutJitter k_jitter(updated_params.input_layouts[1], in_offsets_map.at(1));
         jit.make("SOURCE_SEQ_LEN", k_jitter.dim(get_transposed_channel(ChannelName::Y, extended_input_k_transpose_order)));
 
-        const auto q_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(0), extended_input_q_transpose_order), "q_head_size");
-        const auto q_num_head = ensure_positive_dim(get_num_heads(params.get_input_layout(0), extended_input_q_transpose_order), "q_num_head");
-        auto k_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(1), extended_input_k_transpose_order), "k_head_size");
-        const auto k_num_head = ensure_positive_dim(get_num_heads(params.get_input_layout(1), extended_input_k_transpose_order), "k_num_head");
-        auto v_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(2), extended_input_v_transpose_order), "v_head_size");
+        const auto q_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(0), extended_input_q_transpose_order),
+                                                     "q_head_size",
+                                                     "SDPA: invalid non-positive ",
+                                                     " for JIT constants generation");
+        const auto q_num_head = ensure_positive_dim(get_num_heads(params.get_input_layout(0), extended_input_q_transpose_order),
+                                                    "q_num_head",
+                                                    "SDPA: invalid non-positive ",
+                                                    " for JIT constants generation");
+        auto k_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(1), extended_input_k_transpose_order),
+                                               "k_head_size",
+                                               "SDPA: invalid non-positive ",
+                                               " for JIT constants generation");
+        const auto k_num_head = ensure_positive_dim(get_num_heads(params.get_input_layout(1), extended_input_k_transpose_order),
+                                                    "k_num_head",
+                                                    "SDPA: invalid non-positive ",
+                                                    " for JIT constants generation");
+        auto v_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(2), extended_input_v_transpose_order),
+                                               "v_head_size",
+                                               "SDPA: invalid non-positive ",
+                                               " for JIT constants generation");
 
         // 4-bit KV-cache: K/V layouts have head_size/2 due to u4→i8 packing.
         // Override with logical head size from query (which is not packed).

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
@@ -72,6 +72,11 @@ size_t get_beam_table_id(const std::shared_ptr<const scaled_dot_product_attentio
     return primitive->input_size() - 1;
 }
 
+inline size_t ensure_positive_dim(int64_t value, const char* dim_name) {
+    OPENVINO_ASSERT(value > 0, "SDPA: invalid non-positive ", dim_name, " for JIT constants generation");
+    return static_cast<size_t>(value);
+}
+
 }  // namespace
 
 // 4-bit KV-cache packs two u4 values into one i8 byte, halving the physical
@@ -306,11 +311,11 @@ JitConstants SDPABase::get_jit_constants(const kernel_impl_params& params) const
         LayoutJitter k_jitter(updated_params.input_layouts[1], in_offsets_map.at(1));
         jit.make("SOURCE_SEQ_LEN", k_jitter.dim(get_transposed_channel(ChannelName::Y, extended_input_k_transpose_order)));
 
-        const auto q_head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
-        const auto q_num_head = get_num_heads(params.get_input_layout(0), extended_input_q_transpose_order);
-        auto k_head_size = get_head_size(params.get_input_layout(1), extended_input_k_transpose_order);
-        const auto k_num_head = get_num_heads(params.get_input_layout(1), extended_input_k_transpose_order);
-        auto v_head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
+        const auto q_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(0), extended_input_q_transpose_order), "q_head_size");
+        const auto q_num_head = ensure_positive_dim(get_num_heads(params.get_input_layout(0), extended_input_q_transpose_order), "q_num_head");
+        auto k_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(1), extended_input_k_transpose_order), "k_head_size");
+        const auto k_num_head = ensure_positive_dim(get_num_heads(params.get_input_layout(1), extended_input_k_transpose_order), "k_num_head");
+        auto v_head_size = ensure_positive_dim(get_head_size(params.get_input_layout(2), extended_input_v_transpose_order), "v_head_size");
 
         // 4-bit KV-cache: K/V layouts have head_size/2 due to u4→i8 packing.
         // Override with logical head size from query (which is not packed).

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -43,6 +43,11 @@ inline size_t get_d_max(size_t head_size) {
     return head_size;
 }
 
+inline size_t ensure_positive_dim(int64_t value, const char* dim_name) {
+    OPENVINO_ASSERT(value > 0, "[GPU] Invalid non-positive ", dim_name);
+    return static_cast<size_t>(value);
+}
+
 micro::Type convert_type(ov::element::Type t) {
     switch (t) {
     case ov::element::f32:
@@ -130,12 +135,18 @@ inline size_t micro_get_num_heads(const kernel_impl_params& params, size_t qkv_i
     } else {
         const auto desc = params.typed_desc<scaled_dot_product_attention>();
         switch (qkv_idx) {
-        case 0:
-            return get_num_heads(params.input_layouts[0], extend_order_in_num_heads_dim(desc->input_q_transpose_order));
-        case 1:
-            return get_num_heads(params.input_layouts[1], extend_order_in_num_heads_dim(desc->input_k_transpose_order));
-        case 2:
-            return get_num_heads(params.input_layouts[2], extend_order_in_num_heads_dim(desc->input_v_transpose_order));
+        case 0: {
+            const auto num_heads = get_num_heads(params.input_layouts[0], extend_order_in_num_heads_dim(desc->input_q_transpose_order));
+            return ensure_positive_dim(num_heads, "number of heads for Q");
+        }
+        case 1: {
+            const auto num_heads = get_num_heads(params.input_layouts[1], extend_order_in_num_heads_dim(desc->input_k_transpose_order));
+            return ensure_positive_dim(num_heads, "number of heads for K");
+        }
+        case 2: {
+            const auto num_heads = get_num_heads(params.input_layouts[2], extend_order_in_num_heads_dim(desc->input_v_transpose_order));
+            return ensure_positive_dim(num_heads, "number of heads for V");
+        }
         default:
             OPENVINO_THROW("Invalid qkv index for scaled dot product attention");
         }
@@ -159,12 +170,18 @@ inline size_t micro_get_head_size(const kernel_impl_params& params, size_t qkv_i
     } else {
         const auto desc = params.typed_desc<scaled_dot_product_attention>();
         switch (qkv_idx) {
-        case 0:
-            return get_head_size(params.input_layouts[0], extend_order_in_num_heads_dim(desc->input_q_transpose_order));
-        case 1:
-            return get_head_size(params.input_layouts[1], extend_order_in_num_heads_dim(desc->input_k_transpose_order));
-        case 2:
-            return get_head_size(params.input_layouts[2], extend_order_in_num_heads_dim(desc->input_v_transpose_order));
+        case 0: {
+            const auto head_size = get_head_size(params.input_layouts[0], extend_order_in_num_heads_dim(desc->input_q_transpose_order));
+            return ensure_positive_dim(head_size, "head size for Q");
+        }
+        case 1: {
+            const auto head_size = get_head_size(params.input_layouts[1], extend_order_in_num_heads_dim(desc->input_k_transpose_order));
+            return ensure_positive_dim(head_size, "head size for K");
+        }
+        case 2: {
+            const auto head_size = get_head_size(params.input_layouts[2], extend_order_in_num_heads_dim(desc->input_v_transpose_order));
+            return ensure_positive_dim(head_size, "head size for V");
+        }
         default:
             OPENVINO_THROW("Invalid qkv index for scaled dot product attention");
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -43,11 +43,6 @@ inline size_t get_d_max(size_t head_size) {
     return head_size;
 }
 
-inline size_t ensure_positive_dim(int64_t value, const char* dim_name) {
-    OPENVINO_ASSERT(value > 0, "[GPU] Invalid non-positive ", dim_name);
-    return static_cast<size_t>(value);
-}
-
 micro::Type convert_type(ov::element::Type t) {
     switch (t) {
     case ov::element::f32:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
@@ -16,11 +16,6 @@
 
 namespace ov::intel_gpu::ocl {
 
-inline size_t ensure_positive_dim(int64_t value, const char* dim_name) {
-    OPENVINO_ASSERT(value > 0, "SDPA: invalid non-positive ", dim_name, " in static dispatch");
-    return static_cast<size_t>(value);
-}
-
 static bool unaligned_head_size(const size_t k_head_size, const size_t v_head_size, const size_t subgroup_size) {
     return (k_head_size % subgroup_size != 0) || (v_head_size % subgroup_size != 0);
 }
@@ -227,8 +222,14 @@ DispatchDataFunc SDPAOptGeneratorSingleToken::get_dispatch_data_func() const {
             auto extended_output_transpose_order = extend_order_in_num_heads_dim(desc->output_transpose_order);
 
             const size_t batch_size = get_batch_size(params.get_output_layout(0), extended_output_transpose_order);
-            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order), "target_seq_len");
-            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order), "heads_num");
+            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order),
+                                                              "target_seq_len",
+                                                              "SDPA: invalid non-positive ",
+                                                              " in static dispatch");
+            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order),
+                                                         "heads_num",
+                                                         "SDPA: invalid non-positive ",
+                                                         " in static dispatch");
             const size_t num_of_partitions = get_partitions_num(params, SDPAStage::SINGLE_TOKEN);
             auto head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
 
@@ -238,7 +239,7 @@ DispatchDataFunc SDPAOptGeneratorSingleToken::get_dispatch_data_func() const {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
 
-            const size_t head_size_u = ensure_positive_dim(head_size, "head_size");
+            const size_t head_size_u = ensure_positive_dim(head_size, "head_size", "SDPA: invalid non-positive ", " in static dispatch");
 
             const size_t sg_num_scale = get_sg_number_scale_factor(params.get_device_info(), head_size_u, SDPAStage::SINGLE_TOKEN);
             GPU_DEBUG_TRACE_DETAIL << "batch_size = " << batch_size << ", target_seq_len = " << target_seq_len << ", heads_num = " << heads_num << "\n";
@@ -275,8 +276,14 @@ DispatchDataFunc SDPAOptGeneratorMultiToken::get_dispatch_data_func() const {
             auto extended_output_transpose_order = extend_order_in_num_heads_dim(desc->output_transpose_order);
 
             const size_t batch_size = get_batch_size(params.get_output_layout(0), extended_output_transpose_order);
-            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order), "target_seq_len");
-            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order), "heads_num");
+            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order),
+                                                              "target_seq_len",
+                                                              "SDPA: invalid non-positive ",
+                                                              " in static dispatch");
+            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order),
+                                                         "heads_num",
+                                                         "SDPA: invalid non-positive ",
+                                                         " in static dispatch");
             const size_t target_seq_len_block_size = get_target_seq_len_block_size();
             auto head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
 
@@ -286,7 +293,7 @@ DispatchDataFunc SDPAOptGeneratorMultiToken::get_dispatch_data_func() const {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
 
-            const size_t head_size_u = ensure_positive_dim(head_size, "head_size");
+            const size_t head_size_u = ensure_positive_dim(head_size, "head_size", "SDPA: invalid non-positive ", " in static dispatch");
 
             const size_t sg_num_scale = get_sg_number_scale_factor(params.get_device_info(), head_size_u, SDPAStage::MULTI_TOKENS);
 
@@ -327,8 +334,14 @@ DispatchDataFunc SDPAOptGeneratorFinalization::get_dispatch_data_func() const {
             auto extended_input_v_transpose_order = extend_order_in_num_heads_dim(desc->input_v_transpose_order);
             auto extended_output_transpose_order = extend_order_in_num_heads_dim(desc->output_transpose_order);
             const size_t batch_size = get_batch_size(params.get_output_layout(0), extended_output_transpose_order);
-            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order), "target_seq_len");
-            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order), "heads_num");
+            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order),
+                                                              "target_seq_len",
+                                                              "SDPA: invalid non-positive ",
+                                                              " in static dispatch");
+            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order),
+                                                         "heads_num",
+                                                         "SDPA: invalid non-positive ",
+                                                         " in static dispatch");
             const size_t num_of_partitions = get_partitions_num(params, SDPAStage::FINALIZATION);
             auto head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
 
@@ -338,7 +351,7 @@ DispatchDataFunc SDPAOptGeneratorFinalization::get_dispatch_data_func() const {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
 
-            const size_t head_size_u = ensure_positive_dim(head_size, "head_size");
+            const size_t head_size_u = ensure_positive_dim(head_size, "head_size", "SDPA: invalid non-positive ", " in static dispatch");
 
             GPU_DEBUG_TRACE_DETAIL << "batch_size = " << batch_size << ", target_seq_len = " << target_seq_len << ", heads_num = " << heads_num << "\n";
             GPU_DEBUG_TRACE_DETAIL << "head_size = " << head_size_u << ", num_of_partitions = " << num_of_partitions << "\n";

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
@@ -16,6 +16,11 @@
 
 namespace ov::intel_gpu::ocl {
 
+inline size_t ensure_positive_dim(int64_t value, const char* dim_name) {
+    OPENVINO_ASSERT(value > 0, "SDPA: invalid non-positive ", dim_name, " in static dispatch");
+    return static_cast<size_t>(value);
+}
+
 static bool unaligned_head_size(const size_t k_head_size, const size_t v_head_size, const size_t subgroup_size) {
     return (k_head_size % subgroup_size != 0) || (v_head_size % subgroup_size != 0);
 }
@@ -222,8 +227,8 @@ DispatchDataFunc SDPAOptGeneratorSingleToken::get_dispatch_data_func() const {
             auto extended_output_transpose_order = extend_order_in_num_heads_dim(desc->output_transpose_order);
 
             const size_t batch_size = get_batch_size(params.get_output_layout(0), extended_output_transpose_order);
-            const size_t target_seq_len = get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order);
-            const size_t heads_num = get_num_heads(params.get_output_layout(0), extended_output_transpose_order);
+            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order), "target_seq_len");
+            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order), "heads_num");
             const size_t num_of_partitions = get_partitions_num(params, SDPAStage::SINGLE_TOKEN);
             auto head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
 
@@ -233,13 +238,15 @@ DispatchDataFunc SDPAOptGeneratorSingleToken::get_dispatch_data_func() const {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
 
-            const size_t sg_num_scale = get_sg_number_scale_factor(params.get_device_info(), head_size, SDPAStage::SINGLE_TOKEN);
+            const size_t head_size_u = ensure_positive_dim(head_size, "head_size");
+
+            const size_t sg_num_scale = get_sg_number_scale_factor(params.get_device_info(), head_size_u, SDPAStage::SINGLE_TOKEN);
             GPU_DEBUG_TRACE_DETAIL << "batch_size = " << batch_size << ", target_seq_len = " << target_seq_len << ", heads_num = " << heads_num << "\n";
-            GPU_DEBUG_TRACE_DETAIL << "head_size = " << head_size << ", num_of_partitions = " << num_of_partitions << "\n";
+            GPU_DEBUG_TRACE_DETAIL << "head_size = " << head_size_u << ", num_of_partitions = " << num_of_partitions << "\n";
             GPU_DEBUG_TRACE_DETAIL << "sg_num_scale = " << sg_num_scale << "\n";
 
-            wgs.global = {batch_size * heads_num, target_seq_len, head_size * num_of_partitions * sg_num_scale};
-            wgs.local = {1, 1, head_size * sg_num_scale};
+            wgs.global = {batch_size * heads_num, target_seq_len, head_size_u * num_of_partitions * sg_num_scale};
+            wgs.local = {1, 1, head_size_u * sg_num_scale};
         }
     }};
 }
@@ -268,8 +275,8 @@ DispatchDataFunc SDPAOptGeneratorMultiToken::get_dispatch_data_func() const {
             auto extended_output_transpose_order = extend_order_in_num_heads_dim(desc->output_transpose_order);
 
             const size_t batch_size = get_batch_size(params.get_output_layout(0), extended_output_transpose_order);
-            const size_t target_seq_len = get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order);
-            const size_t heads_num = get_num_heads(params.get_output_layout(0), extended_output_transpose_order);
+            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order), "target_seq_len");
+            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order), "heads_num");
             const size_t target_seq_len_block_size = get_target_seq_len_block_size();
             auto head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
 
@@ -279,14 +286,16 @@ DispatchDataFunc SDPAOptGeneratorMultiToken::get_dispatch_data_func() const {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
 
-            const size_t sg_num_scale = get_sg_number_scale_factor(params.get_device_info(), head_size, SDPAStage::MULTI_TOKENS);
+            const size_t head_size_u = ensure_positive_dim(head_size, "head_size");
+
+            const size_t sg_num_scale = get_sg_number_scale_factor(params.get_device_info(), head_size_u, SDPAStage::MULTI_TOKENS);
 
             GPU_DEBUG_TRACE_DETAIL << "batch_size = " << batch_size << ", target_seq_len = " << target_seq_len << ", heads_num = " << heads_num << "\n";
-            GPU_DEBUG_TRACE_DETAIL << "head_size = " << head_size << ", sg_num_scale = " << sg_num_scale << "\n";
+            GPU_DEBUG_TRACE_DETAIL << "head_size = " << head_size_u << ", sg_num_scale = " << sg_num_scale << "\n";
 
             const size_t subgroup_size = 16;
-            wgs.global = {batch_size * heads_num, ceil_div(target_seq_len, target_seq_len_block_size), align_to(head_size * sg_num_scale, subgroup_size)};
-            wgs.local = {1, 1, align_to(head_size * sg_num_scale, subgroup_size)};
+            wgs.global = {batch_size * heads_num, ceil_div(target_seq_len, target_seq_len_block_size), align_to(head_size_u * sg_num_scale, subgroup_size)};
+            wgs.local = {1, 1, align_to(head_size_u * sg_num_scale, subgroup_size)};
         }
     }};
 }
@@ -318,8 +327,8 @@ DispatchDataFunc SDPAOptGeneratorFinalization::get_dispatch_data_func() const {
             auto extended_input_v_transpose_order = extend_order_in_num_heads_dim(desc->input_v_transpose_order);
             auto extended_output_transpose_order = extend_order_in_num_heads_dim(desc->output_transpose_order);
             const size_t batch_size = get_batch_size(params.get_output_layout(0), extended_output_transpose_order);
-            const size_t target_seq_len = get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order);
-            const size_t heads_num = get_num_heads(params.get_output_layout(0), extended_output_transpose_order);
+            const size_t target_seq_len = ensure_positive_dim(get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order), "target_seq_len");
+            const size_t heads_num = ensure_positive_dim(get_num_heads(params.get_output_layout(0), extended_output_transpose_order), "heads_num");
             const size_t num_of_partitions = get_partitions_num(params, SDPAStage::FINALIZATION);
             auto head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
 
@@ -329,11 +338,13 @@ DispatchDataFunc SDPAOptGeneratorFinalization::get_dispatch_data_func() const {
                 head_size = get_head_size(params.get_input_layout(0), extended_input_q_transpose_order);
             }
 
-            GPU_DEBUG_TRACE_DETAIL << "batch_size = " << batch_size << ", target_seq_len = " << target_seq_len << ", heads_num = " << heads_num << "\n";
-            GPU_DEBUG_TRACE_DETAIL << "head_size = " << head_size << ", num_of_partitions = " << num_of_partitions << "\n";
+            const size_t head_size_u = ensure_positive_dim(head_size, "head_size");
 
-            wgs.global = {batch_size * heads_num, target_seq_len, static_cast<size_t>(head_size)};
-            wgs.local = {1, 1, static_cast<size_t>(head_size)};
+            GPU_DEBUG_TRACE_DETAIL << "batch_size = " << batch_size << ", target_seq_len = " << target_seq_len << ", heads_num = " << heads_num << "\n";
+            GPU_DEBUG_TRACE_DETAIL << "head_size = " << head_size_u << ", num_of_partitions = " << num_of_partitions << "\n";
+
+            wgs.global = {batch_size * heads_num, target_seq_len, head_size_u};
+            wgs.local = {1, 1, head_size_u};
             num_of_partitions_scalar.v.u32 = static_cast<uint32_t>(num_of_partitions);
             scalars.push_back(num_of_partitions_scalar);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
@@ -49,6 +49,14 @@ inline bool sdpa_has_runtime_attn_mask_input(const cldnn::kernel_impl_params& pa
     return !attn_mask_pshape.rank().is_static() || attn_mask_pshape.rank().get_length() > 1;
 }
 
+inline size_t ensure_positive_dim(int64_t value,
+                                  const char* dim_name,
+                                  const char* error_prefix = "SDPA: invalid non-positive ",
+                                  const char* error_suffix = "") {
+    OPENVINO_ASSERT(value > 0, error_prefix, dim_name, error_suffix);
+    return static_cast<size_t>(value);
+}
+
 inline size_t get_key_cache_id(const cldnn::scaled_dot_product_attention& desc) {
     size_t key_cache_id = desc.input_size();
 


### PR DESCRIPTION
### Background
SDPA helper functions (get_num_heads, get_head_size, get_seq_length, and get_batch_size) use -1 as a sentinel for dynamic dimensions.
In several paths, these values were consumed by size/dispatch logic that expects positive values, which can lead to incorrect unsigned conversions (for example, -1 to size_t) and trigger Coverity NEGATIVE_RETURNS findings.

### Behavior Impact
For valid static-shape inputs, behavior is unchanged.
For invalid non-positive dimension values, execution now fails early with explicit assertions instead of allowing unsafe propagation into unsigned size calculations or dispatch parameters.

### Tickets:
 - 192433

### AI Assistance:
 - AI assistance used: yes
 - AI: fix
 - User: review
