### PR TITLE
[NPU] Make sure that the zero_mem_pool is cleared when context is destroyed

### DIFF
--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem_pool.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem_pool.hpp
@@ -10,6 +10,8 @@
 #include <mutex>
 #include <unordered_map>
 
+#include "openvino/core/except.hpp"
+
 namespace intel_npu {
 
 class ZeroInitStructsHolder;
@@ -23,6 +25,14 @@ class ZeroMem;
  * allocation/import/look-up is intentionally mediated by zero_mem helper APIs.
  */
 struct ZeroMemPool {
+    void clear() {
+        std::scoped_lock lock(mem_pool_mutex, mem_pool_deleter_mutex);
+        if (!notify_mem_pool.empty()) {
+            OPENVINO_THROW("Zero memory notification pool is not empty during pool cleanup");
+        }
+        mem_pool.clear();
+    }
+
     // Tracks Level Zero allocations and imported memory by allocation ID without extending their lifetime.
     std::unordered_map<uint64_t, std::weak_ptr<ZeroMem>> mem_pool;
     // Signals completion of asynchronous pool entry removal before a standard allocation is imported again.

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -517,6 +517,8 @@ void ZeroInitStructsHolder::setContextOptions(const uint32_t options) {
 }
 
 void ZeroInitStructsHolder::destroyContextLocked() {
+    _zero_mem_pool.clear();
+
     if (!_context.load()) {
         return;
     }

--- a/src/plugins/intel_npu/tests/functional/common/zero_init_mock.cpp
+++ b/src/plugins/intel_npu/tests/functional/common/zero_init_mock.cpp
@@ -397,6 +397,8 @@ void ZeroInitStructsMock::destroyContextForInstance(std::shared_ptr<ZeroInitStru
 }
 
 void ZeroInitStructsMock::destroyContextLocked() {
+    _zero_mem_pool.clear();
+
     if (!_context.load()) {
         return;
     }

--- a/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_mem_pool_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/utils/zero/zero_mem_pool_tests.cpp
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <array>
-#include <cstddef>
-#include <exception>
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <exception>
 #include <memory>
 #include <random>
 #include <thread>
@@ -433,12 +434,37 @@ TEST_P(ZeroMemPoolTests, DontDestroyZeroMemoryWhenZeroContextIsDestroyed) {
     ASSERT_EQ(logs.find("L0 zeMemFree result:"), std::string::npos);
 }
 
+TEST_P(ZeroMemPoolTests, PoolIsEmptiedAfterContextIsDestroyed) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    auto zero_init_mock = std::make_shared<::intel_npu::ZeroInitStructsMock>();
+    std::shared_ptr<::intel_npu::ZeroInitStructsHolder> zero_init_struct =
+        std::reinterpret_pointer_cast<::intel_npu::ZeroInitStructsHolder>(zero_init_mock);
+
+    // Keep the ZeroMem objects alive on purpose: the pool must be cleared regardless of whether the
+    // tracked instances are still referenced elsewhere.
+    auto mem0 = ::intel_npu::zero_mem::allocate_memory(zero_init_struct, 4096, 4096);
+    auto mem1 = ::intel_npu::zero_mem::allocate_memory(zero_init_struct, 4096, 4096);
+    ASSERT_EQ(zero_init_mock->getZeroMemPool().mem_pool.size(), 2u);
+
+    ::intel_npu::ZeroInitStructsMock::destroyContextForInstance(zero_init_mock);
+
+    ASSERT_EQ(zero_init_mock->getZeroMemPool().mem_pool.size(), 0u);
+    ASSERT_EQ(zero_init_mock->getZeroMemPool().notify_mem_pool.size(), 0u);
+
+    // Destroying an already-destroyed context must be a no-op and must not crash.
+    OV_ASSERT_NO_THROW(::intel_npu::ZeroInitStructsMock::destroyContextForInstance(zero_init_mock));
+    ASSERT_EQ(zero_init_mock->getZeroMemPool().mem_pool.size(), 0u);
+
+    mem0 = {};
+    mem1 = {};
+}
+
 }  // namespace behavior
 }  // namespace test
 }  // namespace ov
 
 using namespace ov::test::behavior;
-
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
                          ZeroMemPoolTests,


### PR DESCRIPTION
### Details:
 - *In case DEVICE_IS_LOST and we need to re-initialize everything, we need to make sure that the mem pool is also cleared*

### Tickets:
 - *E#206742*

### AI Assistance:
 - *AI assistance used: yes*
 - *Tests and review*
