### PR TITLE
[GPU] Prevent unsafe in-place crop optimization for 2D-to-1D bbox splits

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -79,6 +79,7 @@ public:
                 axis == 1 &&
                 !input_pshape[1].is_dynamic() &&
                 input_pshape[1].get_length() == 1 &&
+                prim->output_partial_shape.size() >= 2 &&
                 prim->output_partial_shape.size() + 1 == input_pshape.size();
             if (!is_axis1_size1_squeeze)
                 return false;
@@ -134,8 +135,15 @@ public:
         // shape tensor (not a compile-time constant) for the Reshape second input,
         // leaving output_pattern empty — requiring it would incorrectly block this
         // case even though conditions 1–3 are fully sufficient.
+        // Only the TransposeSplitMatcher pattern is safe: crop [batch, 1, H, S] → reshape
+        // drops the size-1 dim → [batch, H, S].  The output must stay ≥ 2D so that the
+        // downstream CM/OCL kernel still has at least one inner stride to carry the offset.
+        // A 2D → 1D squeeze (e.g. NMS bbox-coord split [-1, 4] → [-1, 1] → [-1]) does NOT
+        // meet this condition and must not be optimized — its downstream arithmetic kernels
+        // are compiled without dynamic-padding support.
         if (axis == 1 && !input_pshape[1].is_dynamic() && input_pshape[1].get_length() == 1) {
-            if (prim->output_partial_shape.size() + 1 == input_pshape.size()) {
+            if (prim->output_partial_shape.size() >= 2 &&
+                prim->output_partial_shape.size() + 1 == input_pshape.size()) {
                 return true;
             }
         }

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
@@ -586,8 +586,8 @@ TransposeSplitMatcher::TransposeSplitMatcher() {
         // This produces 3 outputs of shape [-1, 1, H, S] instead of [1, -1, H, S]
         auto new_split_axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
         auto new_split = std::make_shared<ov::op::v1::Split>(input_node, new_split_axis, split->get_num_splits());
-         ov::copy_runtime_info(m.get_matched_nodes(), new_split);
-         ov::replace_node(split, new_split);
+        ov::copy_runtime_info(m.get_matched_nodes(), new_split);
+        ov::replace_node(split, new_split);
         return true;
     };
 

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -1014,6 +1014,52 @@ TEST(prepare_buffer_fusing, do_runtime_in_place_crop_skips_non_propagatable_resh
     ASSERT_FALSE(crop_inst->can_be_optimized());
 }
 
+TEST(prepare_buffer_fusing, in_place_crop_axis1_rank_reducing_to_1d_not_optimized) {
+    auto& engine = get_test_engine();
+
+    constexpr int64_t rows = 8;
+    const auto input_layout_dynamic = layout{ov::PartialShape{-1, 4}, data_types::f32, format::bfyx};
+    auto input_memory = engine.allocate_memory({{rows, 4}, data_types::f32, format::bfyx});
+    auto axis_memory = engine.allocate_memory({{}, data_types::i64, format::bfyx});
+    auto split_lengths_memory = engine.allocate_memory({{4}, data_types::i64, format::bfyx});
+    auto scale_memory = engine.allocate_memory({{1}, data_types::f32, format::bfyx});
+
+    set_values<float>(input_memory, std::vector<float>(rows * 4, 1.0f));
+    set_values<int64_t>(axis_memory, {1});
+    set_values<int64_t>(split_lengths_memory, {1, 1, 1, 1});
+    set_values<float>(scale_memory, {1.0f});
+
+    topology topology(
+        input_layout("input", input_layout_dynamic),
+        data("axis", axis_memory),
+        data("split_lengths", split_lengths_memory),
+        data("scale", scale_memory),
+        crop("bbox_coordinate", {input_info("input"), input_info("axis"), input_info("split_lengths")},
+             tensor(1),
+             tensor(0),
+             crop_ngraph_op_mode::variadic_split,
+             0,
+             1),
+        reshape("bbox_coordinate_1d",
+                input_info("bbox_coordinate"),
+                false,
+                {-1},
+                ov::PartialShape{-1},
+                reshape::reshape_mode::base),
+        eltwise("bbox_coordinate_scale", {input_info("bbox_coordinate_1d"), input_info("scale")}, eltwise_mode::prod),
+        reorder("output", input_info("bbox_coordinate_scale"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    network network(engine, topology, config);
+    network.set_input_data("input", input_memory);
+    network.execute();
+
+    ASSERT_FALSE(network.get_primitive("bbox_coordinate")->can_be_optimized());
+}
+
 TEST(prepare_buffer_fusing, in_place_crop_dynamic_reshape_unsqueeze) {
     auto& engine = get_test_engine();
 


### PR DESCRIPTION
### Details:
- Prevent unsafe runtime in-place crop optimization for 2D-to-1D rank-reducing reshape patterns.
- Add a regression unit test for the Faster RCNN / SSD bbox-coordinate pattern.

### Description of the issue (symptom, root cause, and resolution)

  - **Symptom**:
After commit `3f24992895e41aa669b3743c8b6a7f499f3d789a`, several GPU object-detection models produced incorrect detection results. The original reproducer was:
    - `TF_V2_Faster_RCNN_Inception_ResNet_v2_atrous_coco`
    - Expected detections: 5
    - GPU inference detections: 25
    - Failing output layer: `tf_detections`

    The same regression pattern was also observed for:
    - `TF_V2_Faster_RCNN_ResNet50_v1_atrous_coco`
    - `TF_V2_Mask_RCNN_ResNetv2_atrous_coco`
    - `ONNX_Runtime_ssd_mobilenet_V1_coco_mlperf_opset10`

  - **Root Cause**
    Commit `3f24992895e41aa669b3743c8b6a7f499f3d789a` enabled runtime padding propagation for the TransposeSplitMatcher QKV pattern. The new condition in `reshape_node::is_runtime_propagatable_padding()` accepted any axis-1 crop with a size-1 dimension followed by a rank-reducing reshape:
    ```cpp
    axis == 1 && input_pshape[1] == 1 && output_rank + 1 == input_rank
    ```
    This condition was intended for the QWen-VL pattern:
    ```text
    [-1, 3, H, S] -> [-1, 1, H, S] -> [-1, H, S]
             4D           4D              3D
    ```
    However, it also accepted the object-detection bbox-coordinate pattern:
    ```text
    [N, 4] -> [N, 1] -> [N]
       2D       2D      1D
    ```
    The latter is not safe for runtime padding propagation. In the affected models, `Split([N, 4])` produces four coordinate crops `[N, 1]`, which are squeezed to one-dimensional vectors `[N]` and consumed by bbox decode arithmetic. The in-place crop optimization exposed a strided/padded view to downstream kernels that expected a contiguous one-dimensional vector. This corrupted decoded box coordinates and caused NMS to return an incorrect number of detections.
    The existing unit tests added by commit `3f24992895e` covered the valid QKV/TransposeSplitMatcher path and other padding propagation cases, but did not cover the invalid 2D-to-1D bbox-coordinate boundary case.

  - **Resolution**:
    Restrict the axis-1 rank-reducing padding propagation rule to outputs with rank at least 2:
    ```cpp
    if (prim->output_partial_shape.size() >= 2 &&
        prim->output_partial_shape.size() + 1 == input_pshape.size()) {
        return true;
    }
    ```
    The same guard is applied in the `vl_sdpa` path so both build-time and runtime decisions use the same safety contract.
    This preserves the intended QWen-VL optimization (`4D -> 3D`) while rejecting the unsafe bbox-coordinate case (`2D -> 1D`). The change is generic and is not tied to a specific model.

#### Performance and compatibility
 - The fix only disables the newly introduced padding optimization for unsafe 2D-to-1D rank reduction. This path was not optimized before commit `3f24992895e`, so the change restores the previous behavior for these models and avoids an accuracy regression. The valid QWen-VL 4D-to-3D optimization remains enabled.

#### The code and line that caused this issue (if it is not changed directly)
https://github.com/openvinotoolkit/openvino/blob/187288961b4d60989f49a3ecbaff5ea572eab676/src/plugins/intel_gpu/src/graph/include/reshape_inst.h#L137-L141

#### Reproduction step
```
python -m pytest test_skip_ir_generation.py \
    --tb=native \
    --env_conf=.automation/env_config.yml \
    --test_conf=.automation/test_configs/desktop_test_config.yml \
    -m "not launch_only_if_manually_specified " \
    --pregen_irs=irs_mapping.csv \
    --tf_models_version=2 \
    --modules pipelines/production/tf_2x/heavy \
    -k "TF_V2_Faster_RCNN_Inception_ResNet_v2_atrous_coco_batch_1_device_GPU_precision_FP32" \
    --dynamism_type=None \
    --skip_ir_generation \
    --log-cli-level INFO 
```

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
  - *CVS-192143*, *CVS-192144*, *CVS-192235*
