### PR TITLE
[NPUW] Support GQA sliding-window and smooth-softmax in DecomposeGQA

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
@@ -241,12 +241,12 @@ public:
         // this with its sink input: a [1, num_heads, 1, 1] tensor included in the softmax then sliced out.
         // head_sink provides a per-head value; plain smooth_softmax uses 0.
         ov::Output<ov::Node> sink;
-        const bool has_head_sink = node->get_input_size() > 11 && !is_null(node->input_value(11));
+        const bool has_head_sink = has_input(ov::op::internal::GroupQueryAttentionInputs::HEAD_SINK);
         if (has_head_sink || smooth_softmax) {
             const auto sink_shape =
                 register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, -1, 1, 1}));
             if (has_head_sink) {
-                auto head_sink = node->input_value(11);
+                auto head_sink = get_input(ov::op::internal::GroupQueryAttentionInputs::HEAD_SINK);
                 if (head_sink.get_element_type() != T) {
                     head_sink = register_new_node<v0::Convert>(head_sink, T);
                 }

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
@@ -56,6 +56,10 @@ public:
         const auto scale = node->get_scale();
         const auto do_rotary = node->get_do_rotary();
         const auto rotary_interleaved = node->get_rotary_interleaved();
+        const auto local_window_size = node->get_local_window_size();
+        // A sliding window is active for local_window_size >= 1; -1 disables it. sliding_window_cache (the
+        // physical rolling KV buffer) is intentionally NOT honored here: NPUW manages the KV cache statically
+        // on the host, so the window is applied as a mask over the full cache (same attention result).
         // TODO: add softcap support
 
         const auto has_input = [&](ov::op::internal::GroupQueryAttentionInputs input_pos) {
@@ -175,12 +179,61 @@ public:
             const auto padding_mask_vert = register_new_node<v3::Broadcast>(padding_len, padding_mask_vert_shape);
             const auto padding_mask = register_new_node<v1::GreaterEqual>(hori_range, padding_mask_vert);
             mask = register_new_node<v1::Select>(padding_mask, mask, minus_inf);
+            if (local_window_size >= 1) {
+                // Sliding window: prefill packs past+current in one right-aligned frame, so (vert - hori) is
+                // the true query-key distance. Mask keys older than the window: (q - k) >= local_window_size.
+                const auto window =
+                    register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{}, {local_window_size}));
+                const auto distance = register_new_node<v1::Subtract>(vert_range, hori_range);
+                const auto too_old = register_new_node<v1::GreaterEqual>(distance, window);
+                mask = register_new_node<v1::Select>(too_old, minus_inf, mask);
+            }
         } else {
-            // kv cache model
-            const auto left_mask = register_new_node<v1::Less>(hori_range, seqlens_elemi64);     // first N
-            const auto righ_mask = register_new_node<v1::GreaterEqual>(hori_range, vert_range);  // last 1
-            const auto atte_mask = register_new_node<v1::LogicalOr>(left_mask, righ_mask);       // [1,1,1,..., 0,0,0,1]
+            // kv cache model. Valid keys are the resident past plus the current block: past occupies the
+            // real prefix [0, past_seqlen) (past_seqlen = seqlens_k + 1 - curr; the slots [past_seqlen,
+            // capacity) hold stale/garbage KV and must be masked), and the current tokens occupy the block
+            // [capacity, capacity + curr). Using seqlens_k / a single diagonal here is only correct for
+            // single-token decode (curr == 1); for a multi-token (speculative) step it would keep curr-1
+            // garbage past slots and drop earlier current tokens. Gate on past_seqlen and the whole current
+            // block; the causal triu above provides intra-current-block causality.
+            const auto left_mask = register_new_node<v1::Less>(hori_range, past_seqlen);              // resident past
+            const auto righ_mask = register_new_node<v1::GreaterEqual>(hori_range, past_k_node_len);  // current block
+            const auto atte_mask = register_new_node<v1::LogicalOr>(left_mask, righ_mask);
             mask = register_new_node<v1::Select>(atte_mask, mask, minus_inf);
+            if (local_window_size >= 1) {
+                // Sliding window (generate). The mask coordinates here are NOT the true absolute positions:
+                // past keys are left-aligned at slots [0, seqlens_k) (slot h holds absolute key h), the
+                // current tokens sit at the fixed capacity slots [C, C+curr) (slot h holds absolute key
+                // total-curr + (h-C)), and vert = C + i is the capacity slot, not the query position. So the
+                // window must be expressed in true absolute positions, computed per query row (correct for
+                // curr > 1 speculative decode, not just single-token decode):
+                //   q_abs(i)  = (total - curr) + i          , total = seqlens_k + 1
+                //   k_abs(h)  = h                            if h < seqlens_k   (past, left-aligned)
+                //             = (total - curr) + (h - C)     if h >= C          (current block)
+                //   mask (too old) iff q_abs - k_abs >= local_window_size
+                const auto total_len = register_new_node<v1::Add>(seqlens_elemi64, one);                // seqlens_k + 1
+                const auto past_base = register_new_node<v1::Subtract>(total_len, curr_seqlen_scalar);  // total - curr
+                // Per-row query absolute positions [curr, 1]: (total - curr) + [0, curr).
+                std::shared_ptr<ov::Node> q_abs = register_new_node<v4::Range>(zero_without_shape,
+                                                                               curr_seqlen_scalar,
+                                                                               one_without_shape,
+                                                                               ov::element::i64);
+                q_abs = register_new_node<v0::Unsqueeze>(q_abs, one);
+                q_abs = register_new_node<v1::Add>(q_abs, past_base);
+                // Per-slot key absolute positions [1, kv]: a past slot h (h < capacity C) holds abs key h;
+                // a current-block slot h (h >= C) holds abs key (total - curr) + (h - C). The past/current
+                // boundary is the capacity C (past_k_node_len), NOT seqlens_k: when the past overflows the
+                // capacity (seqlens_k >= C) a seqlens_k boundary would misclassify current-block slots as past.
+                const auto cur_kabs =
+                    register_new_node<v1::Add>(register_new_node<v1::Subtract>(hori_range, past_k_node_len), past_base);
+                const auto is_past = register_new_node<v1::Less>(hori_range, past_k_node_len);
+                const auto k_abs = register_new_node<v1::Select>(is_past, hori_range, cur_kabs);
+                const auto window =
+                    register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{}, {local_window_size}));
+                const auto distance = register_new_node<v1::Subtract>(q_abs, k_abs);
+                const auto too_old = register_new_node<v1::GreaterEqual>(distance, window);
+                mask = register_new_node<v1::Select>(too_old, minus_inf, mask);
+            }
         }
 
         std::shared_ptr<ov::Node> qga_output;

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/decompose_gqa.cpp
@@ -57,6 +57,7 @@ public:
         const auto do_rotary = node->get_do_rotary();
         const auto rotary_interleaved = node->get_rotary_interleaved();
         const auto local_window_size = node->get_local_window_size();
+        const auto smooth_softmax = node->get_smooth_softmax();
         // A sliding window is active for local_window_size >= 1; -1 disables it. sliding_window_cache (the
         // physical rolling KV buffer) is intentionally NOT honored here: NPUW manages the KV cache statically
         // on the host, so the window is applied as a mask over the full cache (same attention result).
@@ -236,8 +237,42 @@ public:
             }
         }
 
+        // head_sink (input 11) or smooth_softmax add an extra logit to the softmax denominator. SDPA models
+        // this with its sink input: a [1, num_heads, 1, 1] tensor included in the softmax then sliced out.
+        // head_sink provides a per-head value; plain smooth_softmax uses 0.
+        ov::Output<ov::Node> sink;
+        const bool has_head_sink = node->get_input_size() > 11 && !is_null(node->input_value(11));
+        if (has_head_sink || smooth_softmax) {
+            const auto sink_shape =
+                register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, -1, 1, 1}));
+            if (has_head_sink) {
+                auto head_sink = node->input_value(11);
+                if (head_sink.get_element_type() != T) {
+                    head_sink = register_new_node<v0::Convert>(head_sink, T);
+                }
+                sink = register_new_node<v1::Reshape>(head_sink, sink_shape, false);
+            } else {
+                const auto num_heads_1d =
+                    register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {num_heads}));
+                sink = register_new_node<v3::Broadcast>(
+                    register_new_node(v0::Constant::create(T, ov::Shape{}, {0})),
+                    register_new_node<v0::Concat>(ov::NodeVector{one, num_heads_1d, one, one}, 0));
+            }
+        }
+
         std::shared_ptr<ov::Node> qga_output;
-        if (scale != 0.0f) {
+        if (sink.get_node_shared_ptr()) {
+            // SDPA's 6-input form requires an explicit scale; use the op scale or the default 1/sqrt(head_size).
+            ov::Output<ov::Node> scale_node;
+            if (scale != 0.0f) {
+                scale_node = register_new_node(v0::Constant::create(T, Shape{}, {scale}));
+            } else {
+                const auto head_size_t = register_new_node<v0::Convert>(head_size_node, T);
+                const auto neg_half = register_new_node(v0::Constant::create(T, Shape{}, {-0.5f}));
+                scale_node = register_new_node<v0::Squeeze>(register_new_node<v1::Power>(head_size_t, neg_half));
+            }
+            qga_output = register_new_node<v13::ScaledDotProductAttention>(Q, K, V, mask, scale_node, sink, false);
+        } else if (scale != 0.0f) {
             auto scale_node = register_new_node(v0::Constant::create(T, Shape{}, {scale}));
             qga_output = register_new_node<v13::ScaledDotProductAttention>(Q, K, V, mask, scale_node, false);
         } else {

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -160,6 +160,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_compiled_model_graph_options_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/flux2_compiled_model_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_decompose_gqa_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_continuation_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/stored_tokens_state_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_infer_request_variant_switch_test.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/npuw_decompose_gqa_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/npuw_decompose_gqa_test.cpp
@@ -1,0 +1,185 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "npuw_transformations/decompose_gqa.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/group_query_attention.hpp"
+#include "openvino/op/op.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/scaled_dot_product_attention.hpp"
+#include "openvino/pass/manager.hpp"
+
+// Structural coverage for NPUW's DecomposeGQA (decompose_gqa.cpp): the internal GroupQueryAttention op must
+// lower to a ScaledDotProductAttention-based subgraph in both the prefill and generate branches, with the
+// sliding-window (local_window_size) band and the smooth_softmax / head_sink sink wired in. Numerical parity
+// of the windowing coordinates is covered off-tree against a NumPy port of the ORT windowed attention; these
+// tests guard that the pass keeps firing and emitting the expected structure after refactors / rebases.
+
+namespace {
+
+using ov::op::internal::GroupQueryAttention;
+using SDPA = ov::op::v13::ScaledDotProductAttention;
+
+constexpr int64_t NUM_HEADS = 4;
+constexpr int64_t KV_NUM_HEADS = 2;
+constexpr int64_t HEAD_SIZE = 16;
+constexpr int64_t CAPACITY = 8;
+
+// Stand-in for an absent optional input: the ONNX frontend forwards trailing optional inputs verbatim and the
+// decomposition detects a missing one by node description ("NullNode"). Declared without OPENVINO_OP so no
+// RTTI/visibility attributes are applied (rejected under -Werror on some toolchains).
+class NullNode : public ov::op::Op {
+public:
+    static const ov::DiscreteTypeInfo& get_type_info_static() {
+        static const ov::DiscreteTypeInfo info{"NullNode", "test"};
+        return info;
+    }
+    const ov::DiscreteTypeInfo& get_type_info() const override {
+        return get_type_info_static();
+    }
+    std::string description() const override {
+        return "NullNode";
+    }
+    NullNode() {
+        set_output_size(1);
+    }
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector&) const override {
+        return std::make_shared<NullNode>();
+    }
+};
+
+template <typename T>
+size_t count_of(const std::shared_ptr<ov::Model>& model) {
+    size_t n = 0;
+    for (const auto& op : model->get_ops()) {
+        if (ov::is_type<T>(op)) {
+            ++n;
+        }
+    }
+    return n;
+}
+
+std::shared_ptr<SDPA> first_sdpa(const std::shared_ptr<ov::Model>& model) {
+    for (const auto& op : model->get_ops()) {
+        if (auto sdpa = ov::as_type_ptr<SDPA>(op)) {
+            return sdpa;
+        }
+    }
+    return nullptr;
+}
+
+// Builds a single-GroupQueryAttention model. seq_len selects decode (1) vs multi-token; local_window_size < 0
+// disables the window. head_sink adds the per-head sink input (index 11); smooth_softmax is an attribute.
+std::shared_ptr<ov::Model> make_gqa_model(int64_t seq_len,
+                                          int64_t local_window_size,
+                                          bool smooth_softmax,
+                                          bool head_sink) {
+    const auto f32 = ov::element::f32;
+    auto query = std::make_shared<ov::op::v0::Parameter>(f32, ov::Shape{1, NUM_HEADS, size_t(seq_len), HEAD_SIZE});
+    auto key = std::make_shared<ov::op::v0::Parameter>(f32, ov::Shape{1, KV_NUM_HEADS, size_t(seq_len), HEAD_SIZE});
+    auto value = std::make_shared<ov::op::v0::Parameter>(f32, ov::Shape{1, KV_NUM_HEADS, size_t(seq_len), HEAD_SIZE});
+    auto past_key = std::make_shared<ov::op::v0::Parameter>(f32, ov::Shape{1, KV_NUM_HEADS, CAPACITY, HEAD_SIZE});
+    auto past_value = std::make_shared<ov::op::v0::Parameter>(f32, ov::Shape{1, KV_NUM_HEADS, CAPACITY, HEAD_SIZE});
+    auto seqlens_k = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
+    auto total_sequence_length = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{1});
+
+    ov::ParameterVector params{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
+    ov::OutputVector args{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
+    // cos_cache (7) / sin_cache (8): absent (do_rotary = false).
+    args.push_back(std::make_shared<NullNode>());
+    args.push_back(std::make_shared<NullNode>());
+    if (head_sink) {
+        // position_ids (9) / attention_bias (10): absent; head_sink is input 11.
+        args.push_back(std::make_shared<NullNode>());
+        args.push_back(std::make_shared<NullNode>());
+        auto sink = std::make_shared<ov::op::v0::Parameter>(f32, ov::Shape{size_t(NUM_HEADS)});
+        params.push_back(sink);
+        args.push_back(sink);
+    }
+
+    auto gqa = std::make_shared<GroupQueryAttention>(args,
+                                                     NUM_HEADS,
+                                                     KV_NUM_HEADS,
+                                                     /*scale*/ 0.0f,
+                                                     /*do_rotary*/ false,
+                                                     /*rotary_interleaved*/ false,
+                                                     /*kv_cache_bit_width*/ 0,
+                                                     /*k_quant_type*/ "NONE",
+                                                     /*v_quant_type*/ "NONE",
+                                                     local_window_size,
+                                                     /*sliding_window_cache*/ false,
+                                                     smooth_softmax);
+    ov::ResultVector results;
+    for (size_t i = 0; i < gqa->get_output_size(); ++i) {
+        results.push_back(std::make_shared<ov::op::v0::Result>(gqa->output(i)));
+    }
+    return std::make_shared<ov::Model>(results, params, "npuw_gqa");
+}
+
+void run_decompose(const std::shared_ptr<ov::Model>& model, bool is_prefill) {
+    ov::pass::Manager manager;
+    manager.register_pass<ov::npuw::DecomposeGQA>(is_prefill);
+    manager.run_passes(model);
+}
+
+}  // namespace
+
+// The generate branch (single-token decode) lowers to exactly one SDPA and removes the GQA op.
+TEST(NpuwDecomposeGQA, GenerateDecomposesToSdpa) {
+    auto model = make_gqa_model(/*seq_len*/ 1, /*window*/ -1, /*smooth*/ false, /*head_sink*/ false);
+    run_decompose(model, /*is_prefill*/ false);
+    EXPECT_EQ(count_of<GroupQueryAttention>(model), 0u);
+    EXPECT_EQ(count_of<SDPA>(model), 1u);
+}
+
+// The prefill branch (multi-token) lowers the same way.
+TEST(NpuwDecomposeGQA, PrefillDecomposesToSdpa) {
+    auto model = make_gqa_model(/*seq_len*/ 4, /*window*/ -1, /*smooth*/ false, /*head_sink*/ false);
+    run_decompose(model, /*is_prefill*/ true);
+    EXPECT_EQ(count_of<GroupQueryAttention>(model), 0u);
+    EXPECT_EQ(count_of<SDPA>(model), 1u);
+}
+
+// A sliding window (local_window_size >= 1) exercises the extra window-band masking in the generate branch;
+// the op must still fully decompose.
+TEST(NpuwDecomposeGQA, GenerateSlidingWindowDecomposes) {
+    auto model = make_gqa_model(/*seq_len*/ 1, /*window*/ 2, /*smooth*/ false, /*head_sink*/ false);
+    run_decompose(model, /*is_prefill*/ false);
+    EXPECT_EQ(count_of<GroupQueryAttention>(model), 0u);
+    EXPECT_EQ(count_of<SDPA>(model), 1u);
+}
+
+// Sliding window on the prefill branch (right-aligned frame path).
+TEST(NpuwDecomposeGQA, PrefillSlidingWindowDecomposes) {
+    auto model = make_gqa_model(/*seq_len*/ 4, /*window*/ 2, /*smooth*/ false, /*head_sink*/ false);
+    run_decompose(model, /*is_prefill*/ true);
+    EXPECT_EQ(count_of<GroupQueryAttention>(model), 0u);
+    EXPECT_EQ(count_of<SDPA>(model), 1u);
+}
+
+// smooth_softmax wires an explicit sink into SDPA, selecting the 6-input form (Q, K, V, mask, scale, sink).
+TEST(NpuwDecomposeGQA, GenerateSmoothSoftmaxWiresSdpaSink) {
+    auto model = make_gqa_model(/*seq_len*/ 1, /*window*/ -1, /*smooth*/ true, /*head_sink*/ false);
+    run_decompose(model, /*is_prefill*/ false);
+    ASSERT_EQ(count_of<GroupQueryAttention>(model), 0u);
+    auto sdpa = first_sdpa(model);
+    ASSERT_NE(sdpa, nullptr);
+    EXPECT_EQ(sdpa->get_input_size(), 6u);
+}
+
+// head_sink (input 11) is wired as the SDPA sink the same way.
+TEST(NpuwDecomposeGQA, GenerateHeadSinkWiresSdpaSink) {
+    auto model = make_gqa_model(/*seq_len*/ 1, /*window*/ -1, /*smooth*/ false, /*head_sink*/ true);
+    run_decompose(model, /*is_prefill*/ false);
+    ASSERT_EQ(count_of<GroupQueryAttention>(model), 0u);
+    auto sdpa = first_sdpa(model);
+    ASSERT_NE(sdpa, nullptr);
+    EXPECT_EQ(sdpa->get_input_size(), 6u);
+}

--- a/src/plugins/intel_npu/tests/unit/npuw/npuw_decompose_gqa_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/npuw_decompose_gqa_test.cpp
@@ -9,6 +9,7 @@
 
 #include "npuw_transformations/decompose_gqa.hpp"
 #include "openvino/core/model.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/group_query_attention.hpp"
 #include "openvino/op/op.hpp"
 #include "openvino/op/parameter.hpp"
@@ -25,6 +26,7 @@
 namespace {
 
 using ov::op::internal::GroupQueryAttention;
+using ov::op::internal::GroupQueryAttentionQuantType;
 using SDPA = ov::op::v13::ScaledDotProductAttention;
 
 constexpr int64_t NUM_HEADS = 4;
@@ -32,28 +34,11 @@ constexpr int64_t KV_NUM_HEADS = 2;
 constexpr int64_t HEAD_SIZE = 16;
 constexpr int64_t CAPACITY = 8;
 
-// Stand-in for an absent optional input: the ONNX frontend forwards trailing optional inputs verbatim and the
-// decomposition detects a missing one by node description ("NullNode"). Declared without OPENVINO_OP so no
-// RTTI/visibility attributes are applied (rejected under -Werror on some toolchains).
-class NullNode : public ov::op::Op {
-public:
-    static const ov::DiscreteTypeInfo& get_type_info_static() {
-        static const ov::DiscreteTypeInfo info{"NullNode", "test"};
-        return info;
-    }
-    const ov::DiscreteTypeInfo& get_type_info() const override {
-        return get_type_info_static();
-    }
-    std::string description() const override {
-        return "NullNode";
-    }
-    NullNode() {
-        set_output_size(1);
-    }
-    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector&) const override {
-        return std::make_shared<NullNode>();
-    }
-};
+// Absent optional input: per #36842 the ONNX frontend now inserts an empty Constant (shape {0}) in place of
+// a missing optional input; the decomposition detects it via ov::util::is_empty_constant_tensor.
+auto make_absent_input(ov::element::Type t = ov::element::f32) {
+    return ov::op::v0::Constant::create(t, ov::Shape{0}, {});
+}
 
 template <typename T>
 size_t count_of(const std::shared_ptr<ov::Model>& model) {
@@ -93,12 +78,12 @@ std::shared_ptr<ov::Model> make_gqa_model(int64_t seq_len,
     ov::ParameterVector params{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
     ov::OutputVector args{query, key, value, past_key, past_value, seqlens_k, total_sequence_length};
     // cos_cache (7) / sin_cache (8): absent (do_rotary = false).
-    args.push_back(std::make_shared<NullNode>());
-    args.push_back(std::make_shared<NullNode>());
+    args.push_back(make_absent_input());
+    args.push_back(make_absent_input());
     if (head_sink) {
         // position_ids (9) / attention_bias (10): absent; head_sink is input 11.
-        args.push_back(std::make_shared<NullNode>());
-        args.push_back(std::make_shared<NullNode>());
+        args.push_back(make_absent_input());
+        args.push_back(make_absent_input());
         auto sink = std::make_shared<ov::op::v0::Parameter>(f32, ov::Shape{size_t(NUM_HEADS)});
         params.push_back(sink);
         args.push_back(sink);
@@ -111,8 +96,8 @@ std::shared_ptr<ov::Model> make_gqa_model(int64_t seq_len,
                                                      /*do_rotary*/ false,
                                                      /*rotary_interleaved*/ false,
                                                      /*kv_cache_bit_width*/ 0,
-                                                     /*k_quant_type*/ "NONE",
-                                                     /*v_quant_type*/ "NONE",
+                                                     /*k_quant_type*/ GroupQueryAttentionQuantType::NONE,
+                                                     /*v_quant_type*/ GroupQueryAttentionQuantType::NONE,
                                                      local_window_size,
                                                      /*sliding_window_cache*/ false,
                                                      smooth_softmax);


### PR DESCRIPTION
## Details

Extends NPUW's `DecomposeGQA` (`decompose_gqa.cpp`) to honor two `com.microsoft.GroupQueryAttention`
features that were previously ignored on the NPU LLM path, matching the common
`GroupQueryAttentionDecomposition` behavior:

- **`local_window_size` (sliding-window attention)** — previously a windowed model was lowered as plain
  causal attention (silently wrong output).
- **`smooth_softmax` / `head_sink`** — previously lowered with a plain softmax (silently wrong denominator).

Two feature commits + one test commit. Touches only `decompose_gqa.cpp` and adds a unit test.

## What changed

### Sliding window (`local_window_size`)
Applied as an additive mask band over NPUW's static, host-managed KV cache. The band is branch-specific
because NPUW's mask coordinates are not the true absolute positions:

- **Prefill:** past and current share one right-aligned frame, so `vert - hori` is the true query-key
  distance; mask keys with `vert - hori >= local_window_size`.
- **Generate:** past keys are left-aligned in `[0, past_seqlen)` and the current block sits at the fixed
  capacity slots `[C, C+curr)`, so the mask coordinate is not the query/key position. The window is computed
  in true absolute positions per query row — `q_abs(i) = (total - curr) + i`, `k_abs(h) = h` for a past slot
  (`h < C`) or `(total - curr) + (h - C)` for a current-block slot — masking when
  `q_abs - k_abs >= local_window_size`. The past/current boundary is the **capacity `C`, not `seqlens_k`**
  (`seqlens_k` is wrong once the past overflows the buffer, `seqlens_k >= C`). The generate base KV-cache mask
  was also generalized from single-token-only to gate on `past_seqlen` and the whole current block, so it is
  correct for multi-token (speculative) decode.

`sliding_window_cache` (the physical rolling KV buffer) is **intentionally not honored**: NPUW manages the KV
cache statically on the host, so applying the window as a mask over the full cache yields the same attention
result and fits NPUW's static-shape design. The frontend guarantees `local_window_size >= 1` whenever
`sliding_window_cache = 1`, so the masking path fully covers the windowed-cache semantics.

### smooth_softmax / head_sink
Wired onto SDPA's sink input, mirroring the common decomposition: a `[1, num_heads, 1, 1]` sink tensor (the
`head_sink` input reshaped per-head, or a zero broadcast for plain `smooth_softmax`) passed as the 6th input
of `ScaledDotProductAttention` with an explicit scale. The extra logit participates in the softmax denominator
and is sliced out. When neither is set, the original 4-/5-input SDPA path is unchanged.

`batch > 1` is  rejected at the internal-op level, so NPUW inherits that guard; quantized KV (i8/i4/f8) is out of scope here — proper VPUX-native support is tracked separately.


## Testing

Added `npuw_decompose_gqa_test.cpp` (`ov_npu_unit_tests`, 6 cases): the internal op fully decomposes to a
single SDPA in both prefill and generate branches, the `local_window_size` band decomposes on both, and
`smooth_softmax` / `head_sink` select the 6-input SDPA (sink) form. All pass.

Numerical parity of the windowing coordinates was verified off-tree against a NumPy port of the ORT windowed
attention on the decomposed graph (run on CPU), across generate and prefill, `curr = 1 / 2 / 3`,
`local_window_size = -1 / 1 / 3 / large`, and past-overflow (`seqlens_k >= capacity`): the window masks
exactly the correct keys (plain-causal at a large window, self-only at window 1), stale buffer slots are fully
masked, and single-token decode is unchanged; smooth_softmax (zero sink) and per-head head_sink match to
~1e-7. A committable numerical oracle test (replacing the off-tree check) is a tracked follow-up — the
committed structural tests guard against the pass silently not firing or dropping the window/sink wiring.

## Notes / scope

- SWC is not modeled by design (see above), not an omission.
- The mask math is verified at graph level against synthetic buffers; end-to-end interaction with NPUW's live
  host-side KV management (`num_stored_tokens` / `make_tensor_slice`) during a real window-crossing
  speculative step is not covered by an automated test.

### Tickets:
 - *ticket-id*

### AI Assistance
Yes — used for mapping the ONNX Runtime windowed-attention semantics onto NPUW's capacity-relative mask
coordinate system, adversarial correctness review of the generate-branch coordinates, and generating the
NumPy reference tensors.


