### PR TITLE
[CPU] Guard Subgraph segfault_detector override to match its POSIX-only definition

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/aarch64/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/aarch64/subgraph.hpp
@@ -29,7 +29,7 @@ public:
                      const BufferScratchpadAllocator& allocator,
                      const ov::intel_cpu::MultiCacheWeakPtr& kernel_cache);
 
-#ifdef SNIPPETS_DEBUG_CAPS
+#if defined(SNIPPETS_DEBUG_CAPS) && (defined(__linux__) || defined(__APPLE__))
 protected:
     void segfault_detector() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/executors/riscv64/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/riscv64/subgraph.hpp
@@ -25,7 +25,7 @@ public:
                      const BufferScratchpadAllocator& allocator,
                      const ov::intel_cpu::MultiCacheWeakPtr& kernel_cache);
 
-#ifdef SNIPPETS_DEBUG_CAPS
+#if defined(__linux__) && defined(SNIPPETS_DEBUG_CAPS)
 protected:
     bool enabled_segfault_detector = false;
     inline void segfault_detector() const;

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/subgraph.hpp
@@ -29,7 +29,7 @@ public:
                      const BufferScratchpadAllocator& allocator,
                      const ov::intel_cpu::MultiCacheWeakPtr& kernel_cache);
 
-#ifdef SNIPPETS_DEBUG_CAPS
+#if defined(SNIPPETS_DEBUG_CAPS) && (defined(__linux__) || defined(__APPLE__))
 protected:
     void segfault_detector() const override;
 


### PR DESCRIPTION
## Details

The snippets **segfault detector** is a POSIX-only debug feature — it installs a `SIGSEGV`
`sigaction` handler — so `SubgraphExecutor::segfault_detector()` is *defined* only under a
POSIX-gated guard in every executor's `.cpp`:

- `x64/subgraph.cpp`, `aarch64/subgraph.cpp`: `#if defined(SNIPPETS_DEBUG_CAPS) && (defined(__linux__) || defined(__APPLE__))`
- `riscv64/subgraph.cpp`: `#if defined(__linux__) && defined(SNIPPETS_DEBUG_CAPS)`

However, the virtual **override was declared** in the corresponding headers under a bare
`#ifdef SNIPPETS_DEBUG_CAPS`. On a non-POSIX build with debug caps enabled (e.g. **Windows x64
with `-DENABLE_DEBUG_CAPS=ON`**, which defines `SNIPPETS_DEBUG_CAPS`), the class then declares an
override that no translation unit defines — an undefined vtable entry — and the CPU plugin fails to
link.

## Error witnessed

Building `openvino_intel_cpu_plugin` on Windows x64 with `ENABLE_DEBUG_CAPS=ON`:

\`\`\`
subgraph.cpp.obj : error LNK2001: unresolved external symbol
  "protected: virtual void __cdecl ov::intel_cpu::SubgraphExecutor::segfault_detector(void)const "
  (?segfault_detector@SubgraphExecutor@intel_cpu@ov@@MEBAXXZ)
D:\...\openvino_intel_cpu_plugin.dll : fatal error LNK1120: 1 unresolved externals
\`\`\`

## Fix

Align each header's override-declaration guard with its own `.cpp` definition guard. This is a
guard-consistency fix, not a behavioral change:

- On POSIX (the platforms where the definition exists), the guard evaluates identically → **behavior
  unchanged**.
- On non-POSIX, the phantom override declaration is dropped and the base class's empty
  `segfault_detector()` virtual is used — which is exactly what the (already POSIX-gated, i.e.
  compiled-out) call site expects.

Applied to `x64`, `aarch64`, and `riscv64` since all three carried the identical mismatch.

## Testing

`openvino_intel_cpu_plugin` links cleanly on **Windows x64 with `ENABLE_DEBUG_CAPS=ON`** after the
change; Linux x64 behavior is unchanged (guard evaluates the same). The `aarch64`/`riscv64` edits are
the identical one-line guard alignment (definition already POSIX/Linux-only), safe by construction on
their normal Linux targets.

## Tickets
- CVS-192765

### AI Assistance
Yes — used to root-cause the unresolved-symbol/vtable guard mismatch and confirm the definition vs.
declaration guard divergence across the three executors.