### PR TITLE
[SKILLS] Fix invalid YAML frontmatter in ov-update-pytorch-version skill

### DIFF
--- a/.claude/skills/ov-update-pytorch-version/SKILL.md
+++ b/.claude/skills/ov-update-pytorch-version/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: ov-update-pytorch-version
-description: Upgrade the PyTorch version used by OpenVINO tests (torch / torchvision / torchaudio) and resolve fallout — missing operator translators, new functionalized `*_copy` aten ops, decomposition changes, FX-only tests failing in TorchScript mode, and accuracy regressions caused by stricter typing. Use when the user asks to "bump torch", "update pytorch to X.Y", "upgrade torch tests", or when pytorch_tests / model_hub pytorch tests fail after a torch version change. Do not use for: enabling a single new PyTorch operator unrelated to a version bump, GenAI / Optimum upgrades, or plugin-level numerical bugs unrelated to the frontend.
+description: >
+  Upgrade the PyTorch version used by OpenVINO tests (torch / torchvision / torchaudio) and
+  resolve fallout — missing operator translators, new functionalized `*_copy` aten ops,
+  decomposition changes, FX-only tests failing in TorchScript mode, and accuracy regressions
+  caused by stricter typing. Use when the user asks to "bump torch", "update pytorch to X.Y",
+  "upgrade torch tests", or when pytorch_tests / model_hub pytorch tests fail after a torch
+  version change. Do not use for: enabling a single new PyTorch operator unrelated to a version
+  bump, GenAI / Optimum upgrades, or plugin-level numerical bugs unrelated to the frontend.
 ---
 
 # Update PyTorch Version in OpenVINO


### PR DESCRIPTION
### Details

The `description` field in `.claude/skills/ov-update-pytorch-version/SKILL.md` is a plain (unquoted) YAML scalar that contains:

> ... **Do not use for:** enabling a single new PyTorch operator ...

A `": "` sequence inside a plain scalar is invalid YAML. Parsing the frontmatter therefore fails with `mapping values are not allowed here`, and the skill is silently skipped during skill discovery — it is currently never loaded, so it provides no benefit.

Reproducer on current `master`:

```console
$ python3 -c "
import yaml, glob
for f in sorted(glob.glob('.claude/skills/*/SKILL.md')):
    fm = open(f).read().split('---')[1]
    try:
        yaml.safe_load(fm); print('OK  ', f)
    except yaml.YAMLError as e:
        print('FAIL', f, '-', str(e).splitlines()[0])
"
OK   .claude/skills/ov-agentic-workflows/SKILL.md
OK   .claude/skills/ov-debug-matcher-pass/SKILL.md
OK   .claude/skills/ov-debug/SKILL.md
OK   .claude/skills/ov-ensure-coding-style/SKILL.md
OK   .claude/skills/ov-transformation-tests/SKILL.md
FAIL .claude/skills/ov-update-pytorch-version/SKILL.md - mapping values are not allowed here
```

The failure was found while auditing skill frontmatter; it also matches the observed behaviour that this skill never appears in the available-skills list while the other five do.

### Fix

Switch `description` to a folded block scalar (`>`), where the colon is literal text. This style is already used by `ov-debug-matcher-pass` and `ov-transformation-tests`, so it matches existing convention in this directory.

**The description wording is unchanged** — verified byte-identical after parsing:

```console
description identical: True
```

After the change all six skills parse:

```console
OK   ov-agentic-workflows
OK   ov-debug-matcher-pass
OK   ov-debug
OK   ov-ensure-coding-style
OK   ov-transformation-tests
OK   ov-update-pytorch-version
```

### Tickets:
 - N/A