### PR TITLE
[GHA] Fix missing certifi in job_npu_tests for certain Smart CI configs

### DIFF
--- a/.github/workflows/job_npu_tests.yml
+++ b/.github/workflows/job_npu_tests.yml
@@ -98,13 +98,13 @@ jobs:
           wheels-dir-path: ${{ env.INSTALL_WHEELS_DIR }}
           wheels-to-install: 'openvino'
 
+      - name: Install certifi and set SSL_CERT_FILE for model downloading
+        run: python3 -m pip install certifi && echo SSL_CERT_FILE=$(python3 -m certifi) >> $env:GITHUB_ENV
+
       # --- TensorFlow ---------------------------------------------------------
       - name: Install TF Models tests requirements
         if: fromJSON(inputs.affected-components).TF_FE.test
         run: python3 -m pip install -r ${{ env.INSTALL_TEST_DIR }}\requirements_tensorflow
-
-      - name: Set SSL_CERT_FILE for model downloading
-        run: echo SSL_CERT_FILE=$(python3 -m certifi) >> $env:GITHUB_ENV
 
       - name: TensorFlow Models Tests - NPU compile-only (convert_model)
         if: fromJSON(inputs.affected-components).TF_FE.test


### PR DESCRIPTION
### Details:
When TF FE dependency installation step is filtered out by Smart CI rules, certifi is not getting installed at all; need to install it explicitly