### PR TITLE
[NPUW][Security] Validate Spatial import and harden view bounds

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -940,6 +940,22 @@ void ov::npuw::CompiledModel::CompiledModelDesc::serialize(ov::npuw::s11n::Strea
         host_gather.idx_idx & quant_unpack_gather.dst_idx & quant_unpack_gather.src_w_idx &
         quant_unpack_gather.src_z_idx & quant_unpack_gather.src_s_idx & quant_unpack_gather.idx_idx & spatial;
 
+    if (stream.input() && spatial && compiled_model) {
+        std::vector<ov::Shape> input_shapes;
+        input_shapes.reserve(compiled_model->inputs().size());
+        for (const auto& input : compiled_model->inputs()) {
+            input_shapes.push_back(input.get_shape());
+        }
+
+        std::vector<ov::Shape> output_shapes;
+        output_shapes.reserve(compiled_model->outputs().size());
+        for (const auto& output : compiled_model->outputs()) {
+            output_shapes.push_back(output.get_shape());
+        }
+
+        ov::npuw::orc::validate_spatial(*spatial, input_shapes, output_shapes, param_base);
+    }
+
     // Function calls share pipeline.context with their function body at runtime.
     // There is no need to serialize the compiled moe/attn state for each call –
     // doing so would re-import NPU blobs for every repeated layer (one per call),

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
@@ -138,6 +138,7 @@ private:
     friend class IBaseInferRequest;
     friend class JustInferRequest;
     friend class UnfoldInferRequest;
+    friend class CompiledModelDescAccess;
     friend class MemAccessSim;
     friend class FuncMemMgr;
     friend class LLMCompiledModel;

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
@@ -98,8 +98,8 @@ void ov::npuw::orc::validate_spatial(const ov::npuw::compiled::Spatial& spatial,
             OPENVINO_THROW("Invalid NPUW spatial metadata: out_dim is out of range for output ", out_idx);
         }
 
-        if (output_shape[spatial.out_dim] < spatial.range) {
-            OPENVINO_THROW("Invalid NPUW spatial metadata: range exceeds output ", out_idx, " shape");
+        if (output_shape[spatial.out_dim] < spatial.nway) {
+            OPENVINO_THROW("Invalid NPUW spatial metadata: nway exceeds output ", out_idx, " shape");
         }
     }
 
@@ -117,8 +117,8 @@ void ov::npuw::orc::validate_spatial(const ov::npuw::compiled::Spatial& spatial,
             OPENVINO_THROW("Invalid NPUW spatial metadata: param dim is out of range");
         }
 
-        if (input_shape[param.dim] < spatial.range) {
-            OPENVINO_THROW("Invalid NPUW spatial metadata: range exceeds input shape");
+        if (input_shape[param.dim] < spatial.nway) {
+            OPENVINO_THROW("Invalid NPUW spatial metadata: nway exceeds input shape");
         }
     }
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
@@ -72,6 +72,57 @@ void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::Spatial::Param
     stream & var.idx & var.dim;
 }
 
+void ov::npuw::orc::validate_spatial(const ov::npuw::compiled::Spatial& spatial,
+                                     const std::vector<ov::Shape>& input_shapes,
+                                     const std::vector<ov::Shape>& output_shapes,
+                                     std::size_t param_base) {
+    if (spatial.nway == 0u) {
+        OPENVINO_THROW("Invalid NPUW spatial metadata: nway must be non-zero");
+    }
+
+    if (spatial.nway_iters != spatial.range / spatial.nway || spatial.tail_size != spatial.range % spatial.nway) {
+        OPENVINO_THROW("Invalid NPUW spatial metadata: inconsistent range, nway, nway_iters, and tail_size");
+    }
+
+    if (input_shapes.size() < param_base) {
+        OPENVINO_THROW("Invalid NPUW spatial metadata: param_base exceeds available inputs");
+    }
+
+    if (output_shapes.empty()) {
+        OPENVINO_THROW("Invalid NPUW spatial metadata: compiled model has no outputs");
+    }
+
+    for (std::size_t out_idx = 0u; out_idx < output_shapes.size(); ++out_idx) {
+        const auto& output_shape = output_shapes[out_idx];
+        if (spatial.out_dim >= output_shape.size()) {
+            OPENVINO_THROW("Invalid NPUW spatial metadata: out_dim is out of range for output ", out_idx);
+        }
+
+        if (output_shape[spatial.out_dim] < spatial.range) {
+            OPENVINO_THROW("Invalid NPUW spatial metadata: range exceeds output ", out_idx, " shape");
+        }
+    }
+
+    for (const auto& param : spatial.params) {
+        if (param.idx >= param_base) {
+            OPENVINO_THROW("Invalid NPUW spatial metadata: parameter index is out of range");
+        }
+
+        if (param.idx >= input_shapes.size()) {
+            OPENVINO_THROW("Invalid NPUW spatial metadata: parameter index exceeds available inputs");
+        }
+
+        const auto& input_shape = input_shapes[param.idx];
+        if (param.dim >= input_shape.size()) {
+            OPENVINO_THROW("Invalid NPUW spatial metadata: param dim is out of range");
+        }
+
+        if (input_shape[param.dim] < spatial.range) {
+            OPENVINO_THROW("Invalid NPUW spatial metadata: range exceeds input shape");
+        }
+    }
+}
+
 void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::Attention& var) {
     stream & var.query_size & var.context_size & var.params & var.mask_idx & var.attend_all;
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -258,6 +258,12 @@ void serialize(Stream& stream, ov::npuw::compiled::Attention::Param& var);
 void serialize(Stream& stream, ov::npuw::compiled::PyramidAttention& var);
 void serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionContiguous& var);
 void serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionBlock& var);
+
+// Validates imported spatial metadata against the concrete model shapes before runtime use.
+void validate_spatial(const ov::npuw::compiled::Spatial& spatial,
+                      const std::vector<ov::Shape>& input_shapes,
+                      const std::vector<ov::Shape>& output_shapes,
+                      std::size_t param_base);
 void serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionContiguousInfo& var);
 void serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionContiguousInfo::Param& var);
 void serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionBlockInfo& var);

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -468,7 +468,9 @@ ov::SoPtr<ov::ITensor> ov::npuw::util::view(const ov::SoPtr<ov::ITensor>& src,
                                             const ov::npuw::util::View& from,
                                             const ov::npuw::util::View& to) {
     const auto type = src->get_element_type();
+    const auto& shape = src->get_shape();
     NPUW_ASSERT(from.size() == to.size());
+    NPUW_ASSERT(from.size() == shape.size());
 
     // Sub-byte views are not supported here
     NPUW_ASSERT(type != ov::element::u4 && type != ov::element::i4);
@@ -476,6 +478,8 @@ ov::SoPtr<ov::ITensor> ov::npuw::util::view(const ov::SoPtr<ov::ITensor>& src,
     const auto num_dims = from.size();
     ov::Shape view_shape;
     for (auto d = 0u; d < num_dims; d++) {
+        NPUW_ASSERT(from[d] <= to[d]);
+        NPUW_ASSERT(to[d] <= shape[d]);
         view_shape.push_back(to[d] - from[d]);
     }
 
@@ -497,6 +501,8 @@ ov::SoPtr<ov::ITensor> ov::npuw::util::view(const ov::SoPtr<ov::ITensor>& src,
                                             std::size_t len) {
     const auto& shape = src->get_shape();
     NPUW_ASSERT(dim < shape.size());
+    NPUW_ASSERT(offset <= shape[dim]);
+    NPUW_ASSERT(len <= shape[dim] - offset);
     View view_start = View(shape.size(), 0u);
     View view_end = shape;
     view_start[dim] = offset;

--- a/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
@@ -400,6 +400,57 @@ TEST(SerializationTest, CompiledModelDescImportRejectsInvalidSpatialMetadata) {
     EXPECT_THROW(target_desc.serialize(reader, weights_context, std::nullopt, &submodel_ctx), ov::Exception);
 }
 
+TEST(SerializationTest, CompiledModelDescImportAcceptsSpatialPortsReshapedToNway) {
+    auto parameter = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{4, 8});
+    auto result = std::make_shared<ov::op::v0::Result>(parameter);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{parameter}, "spatial");
+
+    auto plugin = std::make_shared<ov::test::npuw::NullPlugin>();
+    auto core = std::make_shared<testing::NiceMock<ov::MockICore>>();
+    plugin->set_core(core);
+
+    auto compiled_model = std::make_shared<ov::test::npuw::MockSubCompiledModel>(model, plugin, ov::AnyMap{});
+    ON_CALL(
+        *core,
+        import_model(testing::A<std::istream&>(), testing::A<const std::string&>(), testing::A<const ov::AnyMap&>()))
+        .WillByDefault([compiled_model](std::istream&, const std::string&, const ov::AnyMap&) {
+            return compiled_model;
+        });
+
+    ov::npuw::CompiledModelDescAccess::Desc source_desc;
+    source_desc.compiled_model = compiled_model;
+    source_desc.param_base = 1u;
+    source_desc.spatial.emplace();
+    source_desc.spatial->params = {{0u, 0u}};
+    source_desc.spatial->range = 8u;
+    source_desc.spatial->nway = 4u;
+    source_desc.spatial->out_dim = 0u;
+    source_desc.spatial->nway_iters = 2u;
+    source_desc.spatial->tail_size = 0u;
+
+    std::stringstream buffer(std::ios::in | std::ios::out | std::ios::binary);
+    auto writer = ov::npuw::s11n::Stream::writer(buffer);
+    ov::npuw::s11n::WeightsContext weights_context;
+    source_desc.serialize(writer, weights_context, 0u);
+
+    buffer.seekg(0);
+
+    ov::npuw::CompiledModelDescAccess::Desc target_desc;
+    target_desc.compiled_model = compiled_model;
+    ov::npuw::s11n::SubmodelDeserializeCtx submodel_ctx(
+        plugin,
+        target_desc.compiled_model,
+        [](std::size_t) {
+            return std::string("CPU");
+        },
+        [](const std::string&) {
+            return ov::AnyMap{};
+        });
+
+    auto reader = ov::npuw::s11n::Stream::reader(buffer);
+    EXPECT_NO_THROW(target_desc.serialize(reader, weights_context, std::nullopt, &submodel_ctx));
+}
+
 TEST(SerializationTest, UtilViewRejectsOffsetLenBeyondExtent) {
     auto src = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{128}));
     EXPECT_THROW(ov::npuw::util::view(src, 0u, 100u, 64u), ov::Exception);

--- a/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
@@ -18,6 +18,7 @@
 #include "intel_npu/config/config.hpp"
 #include "intel_npu/config/npuw.hpp"
 #include "lazy_tensor.hpp"
+#include "llm_test_helpers.hpp"
 #include "model_builder.hpp"
 #include "moe_transformations/moe_transformation.hpp"
 #include "openvino/core/parallel.hpp"
@@ -28,9 +29,22 @@
 #include "openvino/util/mmap_object.hpp"
 #include "pyramid_attention.hpp"
 #include "spatial.hpp"
+#include "unit_test_utils/mocks/openvino/runtime/mock_icore.hpp"
+#include "util.hpp"
 #include "weights_bank.hpp"
 
 using ov::test::npuw::ModelBuilder;
+
+namespace ov {
+namespace npuw {
+
+class CompiledModelDescAccess {
+public:
+    using Desc = ov::npuw::CompiledModel::CompiledModelDesc;
+};
+
+}  // namespace npuw
+}  // namespace ov
 
 namespace {
 
@@ -292,6 +306,108 @@ TEST(SerializationTest, OVTypes_Spatial) {
     EXPECT_EQ(var.out_dim, res.out_dim);
     EXPECT_EQ(var.nway_iters, res.nway_iters);
     EXPECT_EQ(var.tail_size, res.tail_size);
+}
+
+TEST(SerializationTest, ValidateSpatialRejectsInvalidImportedMetadata) {
+    ov::npuw::compiled::Spatial spatial;
+    spatial.params = {{3, 1}};
+    spatial.range = 8;
+    spatial.nway = 4;
+    spatial.out_dim = 2;
+    spatial.nway_iters = 2;
+    spatial.tail_size = 0;
+
+    const std::vector<ov::Shape> input_shapes{ov::Shape{8, 8}};
+    const std::vector<ov::Shape> output_shapes{ov::Shape{8, 8}};
+
+    try {
+        ov::npuw::orc::validate_spatial(spatial, input_shapes, output_shapes, 1u);
+        FAIL() << "Expected invalid spatial metadata to be rejected";
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(std::string(ex.what()).find("Invalid NPUW spatial metadata"), std::string::npos) << ex.what();
+    }
+}
+
+TEST(SerializationTest, ValidateSpatialRejectsInconsistentIterationLayout) {
+    ov::npuw::compiled::Spatial spatial;
+    spatial.params = {{0, 0}};
+    spatial.range = 9;
+    spatial.nway = 4;
+    spatial.out_dim = 1;
+    spatial.nway_iters = 2;
+    spatial.tail_size = 2;
+
+    const std::vector<ov::Shape> input_shapes{ov::Shape{9, 9}};
+    const std::vector<ov::Shape> output_shapes{ov::Shape{9, 9}};
+
+    try {
+        ov::npuw::orc::validate_spatial(spatial, input_shapes, output_shapes, 1u);
+        FAIL() << "Expected invalid spatial iteration layout to be rejected";
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(std::string(ex.what()).find("inconsistent range, nway, nway_iters, and tail_size"), std::string::npos)
+            << ex.what();
+    }
+}
+
+TEST(SerializationTest, CompiledModelDescImportRejectsInvalidSpatialMetadata) {
+    auto parameter = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{8, 8});
+    auto result = std::make_shared<ov::op::v0::Result>(parameter);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{parameter}, "spatial");
+
+    auto plugin = std::make_shared<ov::test::npuw::NullPlugin>();
+    auto core = std::make_shared<testing::NiceMock<ov::MockICore>>();
+    plugin->set_core(core);
+
+    auto compiled_model = std::make_shared<ov::test::npuw::MockSubCompiledModel>(model, plugin, ov::AnyMap{});
+    ON_CALL(
+        *core,
+        import_model(testing::A<std::istream&>(), testing::A<const std::string&>(), testing::A<const ov::AnyMap&>()))
+        .WillByDefault([compiled_model](std::istream&, const std::string&, const ov::AnyMap&) {
+            return compiled_model;
+        });
+
+    ov::npuw::CompiledModelDescAccess::Desc source_desc;
+    source_desc.compiled_model = compiled_model;
+    source_desc.param_base = 1u;
+    source_desc.spatial.emplace();
+    source_desc.spatial->params = {{3u, 1u}};
+    source_desc.spatial->range = 8u;
+    source_desc.spatial->nway = 4u;
+    source_desc.spatial->out_dim = 2u;
+    source_desc.spatial->nway_iters = 2u;
+    source_desc.spatial->tail_size = 0u;
+
+    std::stringstream buffer(std::ios::in | std::ios::out | std::ios::binary);
+    auto writer = ov::npuw::s11n::Stream::writer(buffer);
+    ov::npuw::s11n::WeightsContext weights_context;
+    source_desc.serialize(writer, weights_context, 0u);
+
+    buffer.seekg(0);
+
+    ov::npuw::CompiledModelDescAccess::Desc target_desc;
+    target_desc.compiled_model = compiled_model;
+    ov::npuw::s11n::SubmodelDeserializeCtx submodel_ctx(
+        plugin,
+        target_desc.compiled_model,
+        [](std::size_t) {
+            return std::string("CPU");
+        },
+        [](const std::string&) {
+            return ov::AnyMap{};
+        });
+
+    auto reader = ov::npuw::s11n::Stream::reader(buffer);
+    EXPECT_THROW(target_desc.serialize(reader, weights_context, std::nullopt, &submodel_ctx), ov::Exception);
+}
+
+TEST(SerializationTest, UtilViewRejectsOffsetLenBeyondExtent) {
+    auto src = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{128}));
+    EXPECT_THROW(ov::npuw::util::view(src, 0u, 100u, 64u), ov::Exception);
+}
+
+TEST(SerializationTest, UtilViewAllowsInBoundsOffsetLen) {
+    auto src = ov::get_tensor_impl(ov::Tensor(ov::element::f32, ov::Shape{128}));
+    EXPECT_NO_THROW(ov::npuw::util::view(src, 0u, 64u, 64u));
 }
 
 TEST(SerializationTest, OVTypes_Config) {


### PR DESCRIPTION
### Tickets:
- [CVS-192829](https://jira.devtools.intel.com/browse/CVS-192829)

### Details:
- Validate deserialized Spatial metadata during ORC import before runtime use.
- Enforce invariants for nway, nway_iters, tail_size, and range.
- Validate out_dim against output rank and params indices/dims against input ranks.
- Re-enable import-path validation in CompiledModelDesc deserialization.
- Harden util::view with explicit bounds checks for offset and length.
- Add regression tests for malformed Spatial import rejection and util::view bounds behavior.

### AI Assistance:
- AI assistance used: yes
- AI helped draft validation checks and regression tests; changes were reviewed and validated with local builds.
