### PR TITLE
[Core] Fix out-of-bounds writes on negative Tile repeats

### DIFF
--- a/src/core/reference/src/op/tile.cpp
+++ b/src/core/reference/src/op/tile.cpp
@@ -27,7 +27,7 @@ void tile(const char* arg,
           const size_t elem_size,
           const std::vector<int64_t>& repeats) {
     if (std::any_of(repeats.begin(), repeats.end(), [](int64_t repeat) {
-            return repeat == 0;
+            return repeat <= 0;
         })) {
         return;
     }

--- a/src/core/reference/src/op/tile.cpp
+++ b/src/core/reference/src/op/tile.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <cstdio>
 
+#include "openvino/core/except.hpp"
+
 namespace ov {
 namespace reference {
 
@@ -29,6 +31,8 @@ void tile(const char* arg,
     if (std::any_of(repeats.begin(), repeats.end(), [](int64_t repeat) {
             return repeat <= 0;
         })) {
+        OPENVINO_ASSERT(shape_size(out_shape) == 0,
+                        "Tile with non-positive repeats must produce an empty output shape.");
         return;
     }
 

--- a/src/core/src/op/tile.cpp
+++ b/src/core/src/op/tile.cpp
@@ -52,14 +52,14 @@ bool Tile::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     const auto& d = inputs[0];
     const auto& r = inputs[1];
     auto repeats = get_tensor_data_as<int64_t>(r);
+    std::transform(repeats.begin(), repeats.end(), repeats.begin(), [](int64_t repeat) {
+        return std::max<int64_t>(0, repeat);
+    });
 
     const std::vector<ov::PartialShape> input_shapes{d.get_shape(), r.get_shape()};
     const auto output_shape = shape_infer(this, input_shapes, make_tensor_accessor(inputs)).front().to_shape();
     outputs[0].set_shape(output_shape);
     repeats.insert(repeats.begin(), output_shape.size() - repeats.size(), 1);
-    std::transform(repeats.begin(), repeats.end(), repeats.begin(), [](int64_t repeat) {
-        return std::max<int64_t>(0, repeat);
-    });
     reference::tile(static_cast<const char*>(d.data()),
                     static_cast<char*>(outputs[0].data()),
                     d.get_shape(),

--- a/src/core/src/op/tile.cpp
+++ b/src/core/src/op/tile.cpp
@@ -4,6 +4,8 @@
 
 #include "openvino/op/tile.hpp"
 
+#include <algorithm>
+
 #include "bound_evaluate.hpp"
 #include "itt.hpp"
 #include "openvino/core/validation_util.hpp"
@@ -55,6 +57,9 @@ bool Tile::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
     const auto output_shape = shape_infer(this, input_shapes, make_tensor_accessor(inputs)).front().to_shape();
     outputs[0].set_shape(output_shape);
     repeats.insert(repeats.begin(), output_shape.size() - repeats.size(), 1);
+    std::transform(repeats.begin(), repeats.end(), repeats.begin(), [](int64_t repeat) {
+        return std::max<int64_t>(0, repeat);
+    });
     reference::tile(static_cast<const char*>(d.data()),
                     static_cast<char*>(outputs[0].data()),
                     d.get_shape(),

--- a/src/plugins/template/tests/functional/op_reference/tile.cpp
+++ b/src/plugins/template/tests/functional/op_reference/tile.cpp
@@ -123,6 +123,10 @@ std::vector<TileParams> generateParamsNegativeRepeats() {
                    reference_tests::Tensor(ET_INT, {1}, std::vector<T_INT>{-1}),
                    reference_tests::Tensor(ET, {0}, std::vector<T>{}),
                    "tile_1d_to_1d_with_negative_repeats"),
+        TileParams(reference_tests::Tensor(ET, {2, 2}, std::vector<T>{1, 2, 3, 4}),
+                   reference_tests::Tensor(ET_INT, {2}, std::vector<T_INT>{2, -1}),
+                   reference_tests::Tensor(ET, {4, 0}, std::vector<T>{}),
+                   "tile_2d_mixed_sign_repeats_with_negative_axis"),
     };
     return params;
 }

--- a/src/plugins/template/tests/functional/op_reference/tile.cpp
+++ b/src/plugins/template/tests/functional/op_reference/tile.cpp
@@ -115,6 +115,19 @@ std::vector<TileParams> generateParams() {
 }
 
 template <element::Type_t ET, element::Type_t ET_INT>
+std::vector<TileParams> generateParamsNegativeRepeats() {
+    using T = typename element_type_traits<ET>::value_type;
+    using T_INT = typename element_type_traits<ET_INT>::value_type;
+    std::vector<TileParams> params{
+        TileParams(reference_tests::Tensor(ET, {3}, std::vector<T>{1, 2, 3}),
+                   reference_tests::Tensor(ET_INT, {1}, std::vector<T_INT>{-1}),
+                   reference_tests::Tensor(ET, {0}, std::vector<T>{}),
+                   "tile_1d_to_1d_with_negative_repeats"),
+    };
+    return params;
+}
+
+template <element::Type_t ET, element::Type_t ET_INT>
 std::vector<TileParams> generateParamsFloatValue() {
     using T = typename element_type_traits<ET>::value_type;
     using T_INT = typename element_type_traits<ET_INT>::value_type;
@@ -261,7 +274,12 @@ std::vector<TileParams> generateCombinedParams() {
         generateParamsFloatValue<element::Type_t::bf16, element::Type_t::u8>(),
         generateParamsFloatValue<element::Type_t::bf16, element::Type_t::u16>(),
         generateParamsFloatValue<element::Type_t::bf16, element::Type_t::u32>(),
-        generateParamsFloatValue<element::Type_t::bf16, element::Type_t::u64>()};
+        generateParamsFloatValue<element::Type_t::bf16, element::Type_t::u64>(),
+        // test negative repeats
+        generateParamsNegativeRepeats<element::Type_t::f32, element::Type_t::i8>(),
+        generateParamsNegativeRepeats<element::Type_t::f32, element::Type_t::i16>(),
+        generateParamsNegativeRepeats<element::Type_t::f32, element::Type_t::i32>(),
+        generateParamsNegativeRepeats<element::Type_t::f32, element::Type_t::i64>()};
     std::vector<TileParams> combinedParams;
 
     for (const auto& params : generatedParams) {


### PR DESCRIPTION
### Details:
Adds clamp to zero on Tile repeats input.

### Tickets:
* [CVS-192832](https://jira.devtools.intel.com/browse/CVS-192832)

### AI Assistance:
* AI assistance used: yes
* Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
