### PR TITLE
[NPUW] Restore MoE shared head default for non-Whisper models

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -759,9 +759,8 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
             m_cfg.update({{"NPUW_LLM_GENERATE_MOE_HINT", "DEVICE_ROUTED"}});
         }
 
-        // MoE models are not supposed to share the LM head into a third model unless the user opts in explicitly.
-        // The global default for NPUW_LLM_SHARED_HEAD is YES, so when the user does not set it we default MoE
-        // (non-Whisper) models to NO to keep the intended 2-model pipeline and avoid an unsupported 3-model config.
+        // Restore the MoE default from #33847: keep the LM head in the generate
+        // model unless the user sets NPUW_LLM_SHARED_HEAD explicitly.
         if (npuw_llm_props.find("NPUW_LLM_SHARED_HEAD") == npuw_llm_props.end() && !m_is_whisper) {
             m_cfg.update({{"NPUW_LLM_SHARED_HEAD", "NO"}});
         }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -758,6 +758,13 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
             npudesc->compiler_ver >= ONEAPI_MAKE_VERSION(7, 29)) {
             m_cfg.update({{"NPUW_LLM_GENERATE_MOE_HINT", "DEVICE_ROUTED"}});
         }
+
+        // MoE models are not supposed to share the LM head into a third model unless the user opts in explicitly.
+        // The global default for NPUW_LLM_SHARED_HEAD is YES, so when the user does not set it we default MoE
+        // (non-Whisper) models to NO to keep the intended 2-model pipeline and avoid an unsupported 3-model config.
+        if (npuw_llm_props.find("NPUW_LLM_SHARED_HEAD") == npuw_llm_props.end() && !m_is_whisper) {
+            m_cfg.update({{"NPUW_LLM_SHARED_HEAD", "NO"}});
+        }
     }
 
     // NB: PREFILL_HINT is now compatible with the PREFILL_CONFIG section, unlike for

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_compiled_model_factory_options_test.cpp
@@ -1002,4 +1002,39 @@ TEST_F(LLMCompiledModelFactoryOptionsTest, TextEmbedEncoderClampsPromptLenToMaxP
     EXPECT_EQ(compiled->get_property("NPUW_LLM_MAX_PROMPT_LEN").as<uint32_t>(), 512u);
 }
 
+// MoE models must keep the 2-model pipeline (prefill + generate) unless the user explicitly
+// opts into a shared LM head. The global default for NPUW_LLM_SHARED_HEAD is YES, so without
+// the MoE-specific override an unsupported 3-model pipeline (with a separate _lm_head model)
+// would be created silently. See issue #36913.
+TEST_F(LLMCompiledModelFactoryOptionsTest, MoeModelDefaultsToNoSharedHead) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+        build_moe_llm_model(),
+        {{"NPUW_LLM_PREFILL_MOE_HINT", "HOST_ROUTED"},
+         {"NPUW_LLM_GENERATE_MOE_HINT", "HOST_ROUTED"}},
+        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_EQ(recorder.calls().size(), 2u);
+    EXPECT_EQ(recorder.find_suffix("_lm_head"), nullptr);
+}
+
+TEST_F(LLMCompiledModelFactoryOptionsTest, MoeModelRespectsExplicitSharedHead) {
+    RecordingFactory recorder;
+    std::unique_ptr<ov::npuw::LLMCompiledModel> compiled;
+
+    ASSERT_NO_THROW(compiled = create_compiled_model(
+        build_moe_llm_model(),
+        {{"NPUW_LLM_SHARED_HEAD", "YES"},
+         {"NPUW_LLM_PREFILL_MOE_HINT", "HOST_ROUTED"},
+         {"NPUW_LLM_GENERATE_MOE_HINT", "HOST_ROUTED"}},
+        recorder));
+    ASSERT_NE(compiled, nullptr);
+
+    EXPECT_EQ(recorder.calls().size(), 3u);
+    EXPECT_NE(recorder.find_suffix("_lm_head"), nullptr);
+}
+
 }  // namespace


### PR DESCRIPTION
## Issue

#36913 — `is_moe` constructor block removed the override that set `NPUW_LLM_SHARED_HEAD` to `NO` for MoE models when the user did not set it explicitly. Since the global default for `NPUW_LLM_SHARED_HEAD` is `YES` (npuw_option_defs.inc:67), MoE (non-Whisper) models silently switched from the intended 2-model pipeline to an unsupported 3-model pipeline (the LM head gets cut into a separate `_lm_head` model via `check_and_cut_lm_head`).

## Root cause

The MoE branch in `llm_compiled_model.cpp` only set `NPUW_LLM_GENERATE_MOE_HINT` to `DEVICE_ROUTED` and never restored the `NPUW_LLM_SHARED_HEAD=NO` default, while the only surviving `NO` override was for Whisper.

## Fix

In the MoE branch, when `NPUW_LLM_SHARED_HEAD` is not present in the user-provided props and the model is not Whisper, set it to `NO`. This keeps the 2-model pipeline for MoE models by default and lets users opt into the shared head with `NPUW_LLM_SHARED_HEAD=YES`. The `!m_is_whisper` guard avoids double-applying the override that Whisper already gets earlier.

## Tests

Added two unit tests to `llm_compiled_model_factory_options_test.cpp`:
- `MoeModelDefaultsToNoSharedHead` — a MoE model with no explicit `NPUW_LLM_SHARED_HEAD` compiles to 2 models and produces no `_lm_head` model.
- `MoeModelRespectsExplicitSharedHead` — an explicit `NPUW_LLM_SHARED_HEAD=YES` still produces the 3rd `_lm_head` model.

These guard against the regression; the C++ GoogleTest build runs in CI.

Fixes #36913
