### PR TITLE
[GPU] Add a local-memory-staged fast path for dense SUM ScatterElementsUpdate

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_opt_local_sum.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_opt_local_sum.cl
@@ -1,0 +1,245 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// SUM-reduction, dense-scatter fast path for ScatterElementsUpdate. See
+// scatter_elements_update_kernel_opt_local_sum.h for the full design rationale and the
+// measured evidence it's based on. This file intentionally mirrors
+// scatter_elements_update_ref.cl's boilerplate (type macros, fixed-point to_int/from_int,
+// atomic_reduce helpers) so the two kernels stay easy to compare -- only the ITER==1
+// (update) body differs in substance; ITER==0/2 are the same computation as `_ref`'s
+// SUM-mode path, just with the MEAN-mode/fused-ops/integer-type branches this kernel's
+// narrow eligibility (see Validate()) never needs.
+
+#include "include/batch_headers/fetch_data.cl"
+
+#define GET_INDICES_INDEX(idx_order) INPUT1_GET_INDEX(idx_order)
+#define GET_UPDATES_INDEX(idx_order) INPUT2_GET_INDEX(idx_order)
+#define GET_OUTPUT_INDEX(idx_order) OUTPUT_GET_INDEX(idx_order)
+#define GET_INPUT_INDEX(idx_order) INPUT0_GET_INDEX(idx_order)
+
+#if AXIS_VALUE == 0
+    #define SIZE INPUT0_BATCH_NUM
+    #define ASSIGN_INDEX(index) b = index
+#elif AXIS_VALUE == 1
+    #define SIZE INPUT0_FEATURE_NUM
+    #define ASSIGN_INDEX(index) f = index
+#endif
+#if OUTPUT_DIMS == 4
+    #define ORDER b,f,y,x
+    #if AXIS_VALUE == 2
+        #define SIZE INPUT0_SIZE_Y
+        #define ASSIGN_INDEX(index) y = index
+    #elif AXIS_VALUE == 3
+        #define SIZE INPUT0_SIZE_X
+        #define ASSIGN_INDEX(index) x = index
+    #endif
+#elif OUTPUT_DIMS == 5
+    #define ORDER b,f,z,y,x
+    #if AXIS_VALUE == 2
+        #define SIZE INPUT0_SIZE_Z
+        #define ASSIGN_INDEX(index) z = index
+    #elif AXIS_VALUE == 3
+        #define SIZE INPUT0_SIZE_Y
+        #define ASSIGN_INDEX(index) y = index
+    #elif AXIS_VALUE == 4
+        #define SIZE INPUT0_SIZE_X
+        #define ASSIGN_INDEX(index) x = index
+    #endif
+#endif
+
+#if OUTPUT_DIMS != INPUT2_DIMS
+    #error "OUTPUT_DIMS is supposed to be same as INPUT2_DIMS"
+#endif
+
+// This kernel is only ever selected for REDUCE_MODE == SUM (see Validate()); the
+// fixed-point encoding is the same scheme `_ref` uses (see its own comments for the
+// f32-bitcast-CAS vs fp16-fixed-point-scale rationale). Kept identical so the two
+// kernels' accumulators are bit-for-bit interchangeable.
+#define FP_SCALE     65504.0f
+#define FP_SCALE_MAX 2147483648.0f
+#define FP_SCALE_MIN -FP_SCALE_MAX
+#define FP_INT_ZERO 0
+
+inline int FUNC(to_int)(INPUT2_TYPE data_in)
+{
+    #if INPUT2_TYPE_SIZE == 4
+        return as_int((float)data_in);
+    #else
+        float scaled = convert_float((half)data_in) * FP_SCALE;
+        scaled = clamp(scaled, FP_SCALE_MIN, FP_SCALE_MAX);
+        return convert_int_rte(scaled);
+    #endif
+}
+
+inline float FUNC(from_int)(int acc)
+{
+    #if INPUT2_TYPE_SIZE == 4
+        return as_float(acc);
+    #else
+        return convert_float(acc) / FP_SCALE;
+    #endif
+}
+
+// f32 has no native OpenCL float atomics -- bit-reinterpret CAS, same as `_ref`. fp16's
+// fixed-point int32 representation lets us use a real hardware atomic_fetch_add
+// directly, at both local and global scope.
+#if INPUT2_TYPE_SIZE == 4
+    #define CAS_ADD(addr, val, scope) { \
+        int expected_value; \
+        int desired_value; \
+        bool success; \
+        do { \
+            expected_value = atomic_load_explicit(addr, memory_order_acquire, scope); \
+            desired_value  = as_int(as_float(expected_value) + as_float(val)); \
+            success = atomic_compare_exchange_weak_explicit(addr, &expected_value, desired_value, \
+                          memory_order_acq_rel, memory_order_acquire, scope); \
+        } while (!success); \
+    }
+    #define ATOMIC_ADD_OP(addr, val, scope) CAS_ADD(addr, val, scope)
+#else
+    #define ATOMIC_ADD_OP(addr, val, scope) atomic_fetch_add(addr, val)
+#endif
+
+inline void FUNC(atomic_add_local)(volatile __local int *ptr, int val)
+{
+    atomic_int *atomic_addr = (atomic_int *)ptr;
+    ATOMIC_ADD_OP(atomic_addr, val, memory_scope_work_group);
+}
+
+inline void FUNC(atomic_add_global)(volatile __global int *ptr, int val)
+{
+    atomic_int *atomic_addr = (atomic_int *)ptr;
+    ATOMIC_ADD_OP(atomic_addr, val, memory_scope_device);
+}
+
+KERNEL(scatter_elements_update_opt_local_sum)(OPTIONAL_SHAPE_INFO_ARG
+                   const __global INPUT0_TYPE* data,
+                   const __global INPUT1_TYPE* indices,
+                   const __global INPUT2_TYPE* updates,
+                   __global OUTPUT_TYPE* output,
+                   __global int* output_fp
+#if ITER == 1
+                   , __local int* local_window
+#endif
+)
+{
+    const uint dim0 = get_global_id(0);
+    const uint dim1 = get_global_id(1);
+    const uint dim2 = get_global_id(2);
+
+#if ITER == 0  // Initialization: seed the fixed-point accumulator from `data`.
+    #if OUTPUT_DIMS == 4
+        const uint x = dim0;
+        const uint y = dim1;
+        const uint f = dim2 % OUTPUT_FEATURE_NUM;
+        const uint b = dim2 / OUTPUT_FEATURE_NUM;
+    #elif OUTPUT_DIMS == 5
+        const uint x = dim0 % OUTPUT_SIZE_X;
+        const uint y = dim0 / OUTPUT_SIZE_X;
+        const uint z = dim1;
+        const uint f = dim2 % OUTPUT_FEATURE_NUM;
+        const uint b = dim2 / OUTPUT_FEATURE_NUM;
+    #endif
+    const uint input_idx = GET_INPUT_INDEX(ORDER);
+    const uint output_idx = GET_OUTPUT_INDEX(ORDER);
+    output_fp[output_idx] = FUNC_CALL(to_int)(data[input_idx]);
+
+#elif ITER == 1  // Update: local-staged atomic accumulate, global fallback outside the window.
+    uint ORDER;
+    #if OUTPUT_DIMS == 4
+        x = dim0 % INPUT2_SIZE_X;
+        y = dim0 / INPUT2_SIZE_X;
+        f = dim1 % INPUT2_FEATURE_NUM;
+        b = dim2 % INPUT2_BATCH_NUM;
+    #elif OUTPUT_DIMS == 5
+        x = dim0 % INPUT2_SIZE_X;
+        y = dim0 / INPUT2_SIZE_X;
+        z = dim1 % INPUT2_SIZE_Z;
+        f = dim1 / INPUT2_SIZE_Z;
+        b = dim2 % INPUT2_BATCH_NUM;
+    #endif
+    const uint indices_idx = GET_INDICES_INDEX(ORDER);
+    const uint updates_idx = GET_UPDATES_INDEX(ORDER);
+    INPUT2_TYPE val = updates[(int)updates_idx];
+    INPUT1_TYPE index = indices[(int)indices_idx];
+    if (index < 0) { index += SIZE; }
+    ASSIGN_INDEX(index);
+    const uint output_idx = GET_OUTPUT_INDEX(ORDER);
+    const int val_fixed = FUNC_CALL(to_int)(val);
+
+    const uint lsize = get_local_size(0) * get_local_size(1) * get_local_size(2);
+    const uint lid = get_local_id(0) + get_local_size(0) * (get_local_id(1) + get_local_size(1) * get_local_id(2));
+
+    // Anchor the window on work-item 0's own destination -- a cheap, no-extra-pass
+    // locality guess. Threads whose real destination lands elsewhere in the window
+    // still benefit; threads outside it fall back below, so a bad guess only costs
+    // effectiveness, never correctness.
+    __local int window_base_local;
+    if (lid == 0) {
+        window_base_local = (int)output_idx;
+    }
+
+    for (uint i = lid; i < WINDOW_SIZE; i += lsize) {
+        local_window[i] = FP_INT_ZERO;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int window_base = window_base_local;
+    const long rel = (long)output_idx - (long)window_base;
+
+    if (rel >= 0 && rel < WINDOW_SIZE) {
+        FUNC_CALL(atomic_add_local)(&local_window[rel], val_fixed);
+    } else {
+        FUNC_CALL(atomic_add_global)(&output_fp[output_idx], val_fixed);
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // Flush only touched (nonzero) slots -- skipping a net-zero slot is exact, not an
+    // approximation: adding zero never changes the sum, regardless of whether it's
+    // genuinely untouched or the sum of contributions that happened to cancel out.
+    for (uint i = lid; i < WINDOW_SIZE; i += lsize) {
+        int v = local_window[i];
+        if (v != FP_INT_ZERO) {
+            long gidx = (long)window_base + (long)i;
+            if (gidx >= 0 && gidx < OPT_LOCAL_ACC_TOTAL_ELEMENTS) {
+                FUNC_CALL(atomic_add_global)(&output_fp[gidx], v);
+            }
+        }
+    }
+
+#elif ITER == 2  // Finalize: decode the fixed-point accumulator back to the real output type.
+    #if OUTPUT_DIMS == 4
+        const uint x = dim0;
+        const uint y = dim1;
+        const uint f = dim2 % OUTPUT_FEATURE_NUM;
+        const uint b = dim2 / OUTPUT_FEATURE_NUM;
+    #elif OUTPUT_DIMS == 5
+        const uint x = dim0 % OUTPUT_SIZE_X;
+        const uint y = dim0 / OUTPUT_SIZE_X;
+        const uint z = dim1;
+        const uint f = dim2 % OUTPUT_FEATURE_NUM;
+        const uint b = dim2 / OUTPUT_FEATURE_NUM;
+    #endif
+    const uint input_idx = GET_INPUT_INDEX(ORDER);
+    const uint output_idx = GET_OUTPUT_INDEX(ORDER);
+    float val_f32 = FUNC_CALL(from_int)(output_fp[input_idx]);
+    INPUT2_TYPE val = TO_OUTPUT_TYPE(val_f32);
+    output[output_idx] = ACTIVATION(val, ACTIVATION_PARAMS);
+#endif
+}
+
+#undef GET_INDICES_INDEX
+#undef GET_UPDATES_INDEX
+#undef GET_OUTPUT_INDEX
+#undef ORDER
+#undef SIZE
+#undef ASSIGN_INDEX
+#undef FP_SCALE
+#undef FP_SCALE_MAX
+#undef FP_SCALE_MIN
+#undef FP_INT_ZERO
+#undef CAS_ADD
+#undef ATOMIC_ADD_OP

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_opt_local_sum.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_opt_local_sum.cl
@@ -98,7 +98,13 @@ inline float FUNC(from_int)(int acc)
     }
     #define ATOMIC_ADD_OP(addr, val, scope) CAS_ADD(addr, val, scope)
 #else
-    #define ATOMIC_ADD_OP(addr, val, scope) atomic_fetch_add(addr, val)
+    // `scope` is honoured and the ordering is relaxed deliberately. This kernel performs a
+    // pure accumulation: only the atomicity of each add is required, not ordering against
+    // other memory operations. The ordering that is required comes from the barriers, which
+    // sequence the local staging window against its flush, and from the kernel boundary
+    // between the accumulate and finalize stages.
+    #define ATOMIC_ADD_OP(addr, val, scope) \
+        atomic_fetch_add_explicit(addr, val, memory_order_relaxed, scope)
 #endif
 
 inline void FUNC(atomic_add_local)(volatile __local int *ptr, int val)

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_opt_local_sum.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_opt_local_sum.cl
@@ -53,9 +53,10 @@
 #endif
 
 // This kernel is only ever selected for REDUCE_MODE == SUM (see Validate()); the
-// fixed-point encoding is the same scheme `_ref` uses (see its own comments for the
-// f32-bitcast-CAS vs fp16-fixed-point-scale rationale). Kept identical so the two
-// kernels' accumulators are bit-for-bit interchangeable.
+// accumulator encoding is the same scheme `_ref` uses, all three branches of it (see its
+// own comments for the f32-bitcast-CAS / fp16-fixed-point-scale / integer-identity
+// rationale). Kept identical so the two kernels' accumulators are bit-for-bit
+// interchangeable for every element type either kernel accepts.
 #define FP_SCALE     65504.0f
 #define FP_SCALE_MAX 2147483648.0f
 #define FP_SCALE_MIN -FP_SCALE_MAX
@@ -63,12 +64,16 @@
 
 inline int FUNC(to_int)(INPUT2_TYPE data_in)
 {
-    #if INPUT2_TYPE_SIZE == 4
-        return as_int((float)data_in);
+    #if INPUT2_IS_FP
+        #if INPUT2_TYPE_SIZE == 4
+            return as_int((float)data_in);
+        #else
+            float scaled = convert_float((half)data_in) * FP_SCALE;
+            scaled = clamp(scaled, FP_SCALE_MIN, FP_SCALE_MAX);
+            return convert_int_rte(scaled);
+        #endif
     #else
-        float scaled = convert_float((half)data_in) * FP_SCALE;
-        scaled = clamp(scaled, FP_SCALE_MIN, FP_SCALE_MAX);
-        return convert_int_rte(scaled);
+        return data_in;
     #endif
 }
 
@@ -81,10 +86,12 @@ inline float FUNC(from_int)(int acc)
     #endif
 }
 
-// f32 has no native OpenCL float atomics -- bit-reinterpret CAS, same as `_ref`. fp16's
-// fixed-point int32 representation lets us use a real hardware atomic_fetch_add
-// directly, at both local and global scope.
-#if INPUT2_TYPE_SIZE == 4
+// f32 has no native OpenCL float atomics -- bit-reinterpret CAS, same as `_ref`. Note the
+// CAS adds in *floating point*, so local staging reassociates an f32 sum; `_ref`'s own
+// unordered global atomics already leave that order unspecified (see the header). Both
+// other encodings are plain int32, so they use a real hardware atomic_fetch_add at both
+// local and global scope, and their sums reassociate exactly.
+#if INPUT2_IS_FP && INPUT2_TYPE_SIZE == 4
     #define CAS_ADD(addr, val, scope) { \
         int expected_value; \
         int desired_value; \
@@ -231,8 +238,12 @@ KERNEL(scatter_elements_update_opt_local_sum)(OPTIONAL_SHAPE_INFO_ARG
     #endif
     const uint input_idx = GET_INPUT_INDEX(ORDER);
     const uint output_idx = GET_OUTPUT_INDEX(ORDER);
-    float val_f32 = FUNC_CALL(from_int)(output_fp[input_idx]);
-    INPUT2_TYPE val = TO_OUTPUT_TYPE(val_f32);
+    #if INPUT2_IS_FP
+        float val_f32 = FUNC_CALL(from_int)(output_fp[input_idx]);
+        INPUT2_TYPE val = TO_OUTPUT_TYPE(val_f32);
+    #else
+        INPUT2_TYPE val = output_fp[input_idx];
+    #endif
     output[output_idx] = ACTIVATION(val, ACTIVATION_PARAMS);
 #endif
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.cpp
@@ -1,0 +1,295 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "scatter_elements_update_kernel_opt_local_sum.h"
+
+#include "kernel_selector_utils.h"
+
+namespace kernel_selector {
+
+namespace {
+bool is_global_memory_case(const scatter_elements_update_params& params) {
+    return (params.outputs[0].PhysicalSizeInBytes() * 4 > params.engineInfo.maxLocalMemSize);
+}
+
+// Mirrors scatter_elements_update_kernel_ref.cpp's file-local
+// GetScatterElementsUpdateChannelIndex -- duplicated rather than shared since that
+// function is file-static there and this kernel is deliberately independent of `_ref`
+// (see the header comment for why).
+size_t GetChannelIndex(const scatter_elements_update_params& params) {
+    const size_t input_size = params.inputs[0].GetDims().size();
+    switch (params.axis) {
+    case ScatterUpdateAxis::X:
+        return input_size - 1;
+    case ScatterUpdateAxis::Y:
+        return input_size - 2;
+    case ScatterUpdateAxis::Z:
+        return input_size - 3;
+    case ScatterUpdateAxis::W:
+        return 2;
+    case ScatterUpdateAxis::FEATURE:
+        return 1;
+    case ScatterUpdateAxis::BATCH:
+        return 0;
+    default:
+        break;
+    }
+    return DataTensor::Channelndex(params.outputs[0].GetLayout(), Tensor::DataChannelName::X);
+}
+}  // namespace
+
+KernelsPriority ScatterElementsUpdateKernelOptLocalSum::GetKernelsPriority(const Params& /*params*/) const {
+    return FORCE_PRIORITY_8;
+}
+
+ParamsKey ScatterElementsUpdateKernelOptLocalSum::GetSupportedKey() const {
+    // Deliberately as broad as `_ref`'s own key (same supported dtypes/layouts) --
+    // this is only a cheap pre-filter checked before GetKernelsData()/Validate() ever
+    // run (see kernel_selector_base::GetAllImplementations); the real narrowing to
+    // this kernel's actual scope (SUM mode, dense scatter, static shapes, etc.) lives
+    // in Validate(), not here. Missing EnableDynamicShapesSupport() here specifically
+    // caused this kernel to be silently filtered out before Validate() ever ran, for
+    // every case tried -- confirmed via temporary debug logging in Validate() showing
+    // zero calls; fixed by matching `_ref`'s key exactly.
+    ParamsKey k;
+    const std::vector<Datatype> supportedTypes{Datatype::F16,
+                                               Datatype::F32,
+                                               Datatype::INT32,
+                                               Datatype::INT8,
+                                               Datatype::UINT8};
+    for (const auto t : supportedTypes) {
+        k.EnableInputDataType(t);
+        k.EnableOutputDataType(t);
+    }
+
+    const std::vector<DataLayout> supportedLayots{DataLayout::bfyx,
+                                                  DataLayout::b_fs_yx_fsv16,
+                                                  DataLayout::b_fs_yx_fsv32,
+                                                  DataLayout::bs_fs_yx_bsv16_fsv16,
+                                                  DataLayout::bs_fs_yx_bsv32_fsv16,
+                                                  DataLayout::bs_fs_yx_bsv16_fsv32,
+                                                  DataLayout::bs_fs_yx_bsv32_fsv32,
+                                                  DataLayout::bfzyx,
+                                                  DataLayout::b_fs_zyx_fsv16,
+                                                  DataLayout::b_fs_zyx_fsv32,
+                                                  DataLayout::bs_fs_zyx_bsv16_fsv32,
+                                                  DataLayout::bs_fs_zyx_bsv16_fsv16,
+                                                  DataLayout::bs_fs_zyx_bsv32_fsv32,
+                                                  DataLayout::bs_fs_zyx_bsv32_fsv16,
+                                                  DataLayout::bfwzyx};
+    for (const auto l : supportedLayots) {
+        k.EnableInputLayout(l);
+        k.EnableOutputLayout(l);
+    }
+
+    k.EnableTensorOffset();
+    k.EnableTensorPitches();
+    k.EnableBatching();
+    k.EnableDifferentTypes();
+    k.EnableDynamicShapesSupport();
+    return k;
+}
+
+bool ScatterElementsUpdateKernelOptLocalSum::Validate(const Params& p) const {
+    if (p.GetType() != KernelType::SCATTER_ELEMENTS_UPDATE) {
+        return false;
+    }
+    const auto& params = static_cast<const scatter_elements_update_params&>(p);
+
+    // Scoped narrowly to the case this was designed and measured against -- never
+    // replaces `_ref`'s correctness for anything outside this, only opts in for it
+    // (this kernel is attached ahead of `_ref` in the selector; returning false here
+    // falls through to `_ref` unchanged).
+    if (params.mode != ScatterUpdateReduction::SUM) {
+        return false;
+    }
+    if (!params.use_init_val) {
+        return false;
+    }
+    if (params.is_shape_agnostic) {
+        return false;  // static shapes only for this first version
+    }
+    if (!is_global_memory_case(params)) {
+        return false;  // `_ref`'s own whole-output-fits-in-local-memory path already wins here
+    }
+    if (!params.fused_ops.empty()) {
+        return false;  // keep the first version simple; `_ref` still handles fused cases
+    }
+    const size_t rank = params.inputs[0].GetDims().size();
+    if (rank != 4 && rank != 5) {
+        return false;
+    }
+    // Dense-ish scatter: the updates tensor is at least as large as the output --
+    // covers both a 1:1 dense scatter and our real fused workload specifically (4
+    // bilinear-corner update sets concatenated onto one output, so updates is 4x the
+    // output there). Not a correctness requirement of the kernel itself (the
+    // local/global-fallback split is safe for any index pattern/ratio), just a scope
+    // guard against genuinely sparse scatters (a handful of indices into a huge
+    // output) where zeroing/flushing a whole window per workgroup would be wasted
+    // work for no real locality gain.
+    if (params.inputs[2].LogicalSize() < params.outputs[0].LogicalSize()) {
+        return false;
+    }
+    return true;
+}
+
+JitConstants ScatterElementsUpdateKernelOptLocalSum::GetJitConstants(
+    const scatter_elements_update_params& params) const {
+    JitConstants jit = MakeBaseParamsJitConstants(params);
+    jit.AddConstant(MakeJitConstant("AXIS_VALUE", GetChannelIndex(params)));
+    jit.AddConstant(MakeJitConstant("WINDOW_SIZE", kWindowSize));
+    // Element budget of the internal fixed-point accumulator buffer (see GetKernelsData's
+    // matching `output.PhysicalSizeInBytes() * 2` byte-size allocation) -- the update
+    // stage's write-back loop bound-checks against this so a window that straddles the
+    // buffer's end can never write out of bounds, regardless of dtype-size rounding in
+    // that byte formula.
+    const size_t total_elements = (params.outputs[0].PhysicalSizeInBytes() * 2) / sizeof(int32_t);
+    jit.AddConstant(MakeJitConstant("OPT_LOCAL_ACC_TOTAL_ELEMENTS", total_elements));
+    return jit;
+}
+
+CommonDispatchData ScatterElementsUpdateKernelOptLocalSum::SetDefault(const scatter_elements_update_params& params,
+                                                                      bool is_second) const {
+    CommonDispatchData dispatchData;
+    auto in_layout = params.inputs[0].GetLayout();
+    auto out_layout = params.outputs[0].GetLayout();
+    std::vector<std::vector<Tensor::DataChannelName>> dims_by_gws;
+
+    const auto& output = params.outputs[0];
+    const auto& indices = params.inputs[1];
+    const auto& scope = is_second ? indices : output;
+    const auto rank = params.inputs[0].GetDims().size();
+
+    // Two genuinely different dispatch layouts, matching `_ref`'s own SetDefault
+    // exactly (mode is always SUM here, per Validate(), so `is_second` alone decides
+    // which one applies). The update stage (is_second=true) merges X*Y into gws[0] as
+    // ONE dispatch dimension -- the ITER==1 .cl body's `x = dim0 % INPUT2_SIZE_X; y =
+    // dim0 / INPUT2_SIZE_X;` decoding only makes sense against THIS merged layout.
+    // Using the non-merged (init/finalize) layout for the update stage too was a real
+    // bug in an earlier version of this kernel: it silently scrambled x/y/f/b (e.g. a
+    // dispatch shaped (X=1, Y=N) put every real thread index in what the update-stage
+    // decode treated as `f`, not `y`), confirmed via direct dispatch-dimension dumps
+    // showing all contributions landing on the same output element.
+    if (is_second) {
+        switch (rank) {
+        case 4:
+            dispatchData.gws = {indices.X().v * indices.Y().v, indices.Feature().v, indices.Batch().v};
+            dims_by_gws = {{Tensor::DataChannelName::X, Tensor::DataChannelName::Y},
+                           {Tensor::DataChannelName::FEATURE},
+                           {Tensor::DataChannelName::BATCH}};
+            break;
+        case 5:
+            dispatchData.gws = {indices.X().v * indices.Y().v, indices.Z().v * indices.Feature().v, indices.Batch().v};
+            dims_by_gws = {{Tensor::DataChannelName::X, Tensor::DataChannelName::Y},
+                           {Tensor::DataChannelName::Z, Tensor::DataChannelName::FEATURE},
+                           {Tensor::DataChannelName::BATCH}};
+            break;
+        default:
+            throw std::invalid_argument("Unsupported rank for scatter_elements_update_opt_local_sum");
+        }
+        dispatchData.lws =
+            GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo, in_layout, out_layout, dims_by_gws);
+        return dispatchData;
+    }
+
+    switch (rank) {
+    case 4:
+        dispatchData.gws = {scope.X().v, scope.Y().v, scope.Feature().v * scope.Batch().v};
+        dims_by_gws = {{Tensor::DataChannelName::X},
+                       {Tensor::DataChannelName::Y},
+                       {Tensor::DataChannelName::FEATURE, Tensor::DataChannelName::BATCH}};
+        break;
+    case 5:
+        dispatchData.gws = {scope.X().v * scope.Y().v, scope.Z().v, scope.Feature().v * scope.Batch().v};
+        dims_by_gws = {{Tensor::DataChannelName::X, Tensor::DataChannelName::Y},
+                       {Tensor::DataChannelName::Z},
+                       {Tensor::DataChannelName::FEATURE, Tensor::DataChannelName::BATCH}};
+        break;
+    default:
+        throw std::invalid_argument("Unsupported rank for scatter_elements_update_opt_local_sum");
+    }
+    dispatchData.lws =
+        GetOptimalLocalWorkGroupSizes(dispatchData.gws, params.engineInfo, in_layout, out_layout, dims_by_gws);
+
+    return dispatchData;
+}
+
+void ScatterElementsUpdateKernelOptLocalSum::GetUpdateDispatchDataFunc(KernelData& kd) const {
+    kd.update_dispatch_data_func = [this](const Params& params, KernelData& kd) {
+        const auto& prim_params = static_cast<const scatter_elements_update_params&>(params);
+        OPENVINO_ASSERT(kd.kernels.size() == 3, "[GPU] Invalid kernels size for scatter_elements_update_opt_local_sum");
+
+        for (size_t i = 0; i < kd.kernels.size(); ++i) {
+            // is_second==true selects the "update" (ITER==1) dispatch shape (sized to
+            // the indices/updates tensor, which for us equals the output size anyway).
+            auto dispatchData = this->SetDefault(prim_params, /*is_second=*/i == 1);
+            kd.kernels[i].params.workGroups.global = dispatchData.gws;
+            kd.kernels[i].params.workGroups.local = dispatchData.lws;
+            kd.kernels[i].skip_execution = KernelData::SkipKernelExecution(prim_params, i);
+
+            if (i == 1) {
+                kd.kernels[i].params.local_memory_args.clear();
+                kd.kernels[i].params.local_memory_args.push_back(kWindowSize * sizeof(int32_t));
+            }
+        }
+    };
+}
+
+KernelsData ScatterElementsUpdateKernelOptLocalSum::GetKernelsData(const Params& params) const {
+    if (!Validate(params)) {
+        return {};
+    }
+
+    const size_t kernel_size = 3;  // STAGE0 init, STAGE1 update (local-staged), STAGE2 finalize
+
+    KernelData kd = KernelData::Default<scatter_elements_update_params>(params, kernel_size);
+    scatter_elements_update_params& newParams = *static_cast<scatter_elements_update_params*>(kd.params.get());
+    auto cldnn_jit = GetJitConstants(newParams);
+
+    GetUpdateDispatchDataFunc(kd);
+
+    const auto& output = newParams.outputs[0];
+
+    kd.internalBuffers.clear();
+    kd.internalBuffers.push_back(output.PhysicalSizeInBytes() * 2);  // fixed-point accumulator
+    kd.internalBufferDataType = Datatype::INT32;
+
+    for (size_t i = 0; i < kernel_size; i++) {
+        auto dispatchData = SetDefault(newParams, /*is_second=*/i == 1);
+        auto entry_point = GetEntryPoint(kernelName, newParams.layerID, params, i);
+        clKernelData& kernel = kd.kernels[i];
+
+        cldnn_jit.RemoveConstant("ITER");
+        cldnn_jit.AddConstant(MakeJitConstant("ITER", static_cast<int32_t>(i)));
+
+        auto jit = CreateJit(kernelName, cldnn_jit, entry_point);
+
+        FillCLKernelData(kernel,
+                         dispatchData,
+                         params.engineInfo,
+                         kernelName,
+                         jit,
+                         entry_point,
+                         "",
+                         false,
+                         false,
+                         3,
+                         GetFusedPrimitiveInputsCount(params),
+                         1,
+                         params.is_shape_agnostic);
+
+        // internal fixed-point accumulator buffer, every stage touches it
+        kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 0});
+
+        if (i == 1) {
+            // local staging window for the update stage only
+            kernel.params.arguments.push_back({ArgumentDescriptor::Types::LOCAL_MEMORY_SIZE, 0});
+            kernel.params.local_memory_args.push_back(kWindowSize * sizeof(int32_t));
+        }
+    }
+
+    return {kd};
+}
+
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.cpp
@@ -151,10 +151,9 @@ JitConstants ScatterElementsUpdateKernelOptLocalSum::GetJitConstants(
     jit.AddConstant(MakeJitConstant("AXIS_VALUE", GetChannelIndex(params)));
     jit.AddConstant(MakeJitConstant("WINDOW_SIZE", kWindowSize));
     // Element budget of the internal accumulator buffer (matches GetKernelsData's
-    // `PhysicalSizeInBytes() * 2` allocation) -- bounds the write-back loop so a window
-    // straddling the buffer's end can't write out of bounds.
-    const size_t total_elements = (params.outputs[0].PhysicalSizeInBytes() * 2) / sizeof(int32_t);
-    jit.AddConstant(MakeJitConstant("OPT_LOCAL_ACC_TOTAL_ELEMENTS", total_elements));
+    // allocation) -- bounds the write-back loop so a window straddling the buffer's end
+    // can't write out of bounds.
+    jit.AddConstant(MakeJitConstant("OPT_LOCAL_ACC_TOTAL_ELEMENTS", params.outputs[0].PhysicalSize()));
     return jit;
 }
 
@@ -167,6 +166,25 @@ bool ScatterElementsUpdateKernelOptLocalSum::Validate(const Params& p) const {
     // Rejecting here falls through to `_ref` unchanged -- this kernel only opts in for
     // its narrow scope, never replaces `_ref` for anything outside it.
     if (params.mode != ScatterUpdateReduction::SUM) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    // Accept only the element types this kernel is actually exercised on. The encoding
+    // below handles every type in GetSupportedKey() -- integers included, since `_ref`'s
+    // identity branch is reproduced here and the accumulator is sized per element rather
+    // than per output byte -- but i8/u8 cannot currently reach any scatter kernel as an
+    // input (the plugin's impl gate allows only f32/f16/i32 there) and so cannot be
+    // tested. Rejecting them keeps the accepted set equal to the verified set: if that
+    // gate is ever relaxed, this kernel steps aside for `_ref` rather than quietly
+    // taking a path nobody has run.
+    //
+    // This has to live here rather than in GetSupportedKey(): base_params::GetParamsKey()
+    // folds every input's dtype into one shared bitfield, and the indices tensor is INT32,
+    // so narrowing the key's type list would stop the kernel matching anything at all.
+    const auto is_verified_type = [](Datatype dt) {
+        return dt == Datatype::F16 || dt == Datatype::F32 || dt == Datatype::INT32;
+    };
+    if (!is_verified_type(params.inputs[0].GetDType()) || !is_verified_type(params.inputs[2].GetDType()) ||
+        !is_verified_type(params.outputs[0].GetDType())) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
     if (!params.use_init_val) {
@@ -241,7 +259,11 @@ KernelsData ScatterElementsUpdateKernelOptLocalSum::GetKernelsData(const Params&
     const auto& output = newParams.outputs[0];
 
     kd.internalBuffers.clear();
-    kd.internalBuffers.push_back(output.PhysicalSizeInBytes() * 2);  // fixed-point accumulator
+    // One int32 accumulator slot per (padded) output element. Sized from the element
+    // count, not from the output's byte size: `_ref` writes this same buffer as
+    // `PhysicalSizeInBytes() * 2`, which happens to equal one int32 per element only for
+    // 2-byte types and under-allocates by half for i8/u8.
+    kd.internalBuffers.push_back(output.PhysicalSize() * sizeof(int32_t));
     kd.internalBufferDataType = Datatype::INT32;
 
     for (size_t i = 0; i < kernel_size; i++) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.cpp
@@ -13,10 +13,8 @@ bool is_global_memory_case(const scatter_elements_update_params& params) {
     return (params.outputs[0].PhysicalSizeInBytes() * 4 > params.engineInfo.maxLocalMemSize);
 }
 
-// Mirrors scatter_elements_update_kernel_ref.cpp's file-local
-// GetScatterElementsUpdateChannelIndex -- duplicated rather than shared since that
-// function is file-static there and this kernel is deliberately independent of `_ref`
-// (see the header comment for why).
+// Mirrors _ref.cpp's file-local GetScatterElementsUpdateChannelIndex (duplicated, not
+// shared -- see the header comment for why).
 size_t GetChannelIndex(const scatter_elements_update_params& params) {
     const size_t input_size = params.inputs[0].GetDims().size();
     switch (params.axis) {
@@ -39,19 +37,10 @@ size_t GetChannelIndex(const scatter_elements_update_params& params) {
 }
 }  // namespace
 
-KernelsPriority ScatterElementsUpdateKernelOptLocalSum::GetKernelsPriority(const Params& /*params*/) const {
-    return FORCE_PRIORITY_8;
-}
-
 ParamsKey ScatterElementsUpdateKernelOptLocalSum::GetSupportedKey() const {
-    // Deliberately as broad as `_ref`'s own key (same supported dtypes/layouts) --
-    // this is only a cheap pre-filter checked before GetKernelsData()/Validate() ever
-    // run (see kernel_selector_base::GetAllImplementations); the real narrowing to
-    // this kernel's actual scope (SUM mode, dense scatter, static shapes, etc.) lives
-    // in Validate(), not here. Missing EnableDynamicShapesSupport() here specifically
-    // caused this kernel to be silently filtered out before Validate() ever ran, for
-    // every case tried -- confirmed via temporary debug logging in Validate() showing
-    // zero calls; fixed by matching `_ref`'s key exactly.
+    // As broad as `_ref`'s own key -- this is only a pre-filter checked before
+    // Validate() ever runs (see kernel_selector_base::GetAllImplementations); the real
+    // narrowing lives in Validate(), not here.
     ParamsKey k;
     const std::vector<Datatype> supportedTypes{Datatype::F16,
                                                Datatype::F32,
@@ -91,62 +80,10 @@ ParamsKey ScatterElementsUpdateKernelOptLocalSum::GetSupportedKey() const {
     return k;
 }
 
-bool ScatterElementsUpdateKernelOptLocalSum::Validate(const Params& p) const {
-    if (p.GetType() != KernelType::SCATTER_ELEMENTS_UPDATE) {
-        return false;
-    }
-    const auto& params = static_cast<const scatter_elements_update_params&>(p);
-
-    // Scoped narrowly to the case this was designed and measured against -- never
-    // replaces `_ref`'s correctness for anything outside this, only opts in for it
-    // (this kernel is attached ahead of `_ref` in the selector; returning false here
-    // falls through to `_ref` unchanged).
-    if (params.mode != ScatterUpdateReduction::SUM) {
-        return false;
-    }
-    if (!params.use_init_val) {
-        return false;
-    }
-    if (params.is_shape_agnostic) {
-        return false;  // static shapes only for this first version
-    }
-    if (!is_global_memory_case(params)) {
-        return false;  // `_ref`'s own whole-output-fits-in-local-memory path already wins here
-    }
-    if (!params.fused_ops.empty()) {
-        return false;  // keep the first version simple; `_ref` still handles fused cases
-    }
-    const size_t rank = params.inputs[0].GetDims().size();
-    if (rank != 4 && rank != 5) {
-        return false;
-    }
-    // Dense-ish scatter: the updates tensor is at least as large as the output --
-    // covers both a 1:1 dense scatter and our real fused workload specifically (4
-    // bilinear-corner update sets concatenated onto one output, so updates is 4x the
-    // output there). Not a correctness requirement of the kernel itself (the
-    // local/global-fallback split is safe for any index pattern/ratio), just a scope
-    // guard against genuinely sparse scatters (a handful of indices into a huge
-    // output) where zeroing/flushing a whole window per workgroup would be wasted
-    // work for no real locality gain.
-    if (params.inputs[2].LogicalSize() < params.outputs[0].LogicalSize()) {
-        return false;
-    }
-    return true;
-}
-
-JitConstants ScatterElementsUpdateKernelOptLocalSum::GetJitConstants(
-    const scatter_elements_update_params& params) const {
-    JitConstants jit = MakeBaseParamsJitConstants(params);
-    jit.AddConstant(MakeJitConstant("AXIS_VALUE", GetChannelIndex(params)));
-    jit.AddConstant(MakeJitConstant("WINDOW_SIZE", kWindowSize));
-    // Element budget of the internal fixed-point accumulator buffer (see GetKernelsData's
-    // matching `output.PhysicalSizeInBytes() * 2` byte-size allocation) -- the update
-    // stage's write-back loop bound-checks against this so a window that straddles the
-    // buffer's end can never write out of bounds, regardless of dtype-size rounding in
-    // that byte formula.
-    const size_t total_elements = (params.outputs[0].PhysicalSizeInBytes() * 2) / sizeof(int32_t);
-    jit.AddConstant(MakeJitConstant("OPT_LOCAL_ACC_TOTAL_ELEMENTS", total_elements));
-    return jit;
+KernelsPriority ScatterElementsUpdateKernelOptLocalSum::GetKernelsPriority(const Params& /*params*/) const {
+    // `_ref` uses the base default (DONT_USE_IF_HAVE_SOMETHING_ELSE); force priority so
+    // this kernel wins when both are eligible, matching GridSample's opt-kernel precedent.
+    return FORCE_PRIORITY_8;
 }
 
 CommonDispatchData ScatterElementsUpdateKernelOptLocalSum::SetDefault(const scatter_elements_update_params& params,
@@ -161,16 +98,9 @@ CommonDispatchData ScatterElementsUpdateKernelOptLocalSum::SetDefault(const scat
     const auto& scope = is_second ? indices : output;
     const auto rank = params.inputs[0].GetDims().size();
 
-    // Two genuinely different dispatch layouts, matching `_ref`'s own SetDefault
-    // exactly (mode is always SUM here, per Validate(), so `is_second` alone decides
-    // which one applies). The update stage (is_second=true) merges X*Y into gws[0] as
-    // ONE dispatch dimension -- the ITER==1 .cl body's `x = dim0 % INPUT2_SIZE_X; y =
-    // dim0 / INPUT2_SIZE_X;` decoding only makes sense against THIS merged layout.
-    // Using the non-merged (init/finalize) layout for the update stage too was a real
-    // bug in an earlier version of this kernel: it silently scrambled x/y/f/b (e.g. a
-    // dispatch shaped (X=1, Y=N) put every real thread index in what the update-stage
-    // decode treated as `f`, not `y`), confirmed via direct dispatch-dimension dumps
-    // showing all contributions landing on the same output element.
+    // Matches `_ref`'s own SetDefault: the update stage merges X*Y into gws[0] as one
+    // dispatch dimension, which the ITER==1 .cl body's `x = dim0 % INPUT2_SIZE_X; y =
+    // dim0 / INPUT2_SIZE_X;` decoding depends on. Init/finalize use the non-merged layout.
     if (is_second) {
         switch (rank) {
         case 4:
@@ -215,6 +145,65 @@ CommonDispatchData ScatterElementsUpdateKernelOptLocalSum::SetDefault(const scat
     return dispatchData;
 }
 
+JitConstants ScatterElementsUpdateKernelOptLocalSum::GetJitConstants(
+    const scatter_elements_update_params& params) const {
+    JitConstants jit = MakeBaseParamsJitConstants(params);
+    jit.AddConstant(MakeJitConstant("AXIS_VALUE", GetChannelIndex(params)));
+    jit.AddConstant(MakeJitConstant("WINDOW_SIZE", kWindowSize));
+    // Element budget of the internal accumulator buffer (matches GetKernelsData's
+    // `PhysicalSizeInBytes() * 2` allocation) -- bounds the write-back loop so a window
+    // straddling the buffer's end can't write out of bounds.
+    const size_t total_elements = (params.outputs[0].PhysicalSizeInBytes() * 2) / sizeof(int32_t);
+    jit.AddConstant(MakeJitConstant("OPT_LOCAL_ACC_TOTAL_ELEMENTS", total_elements));
+    return jit;
+}
+
+bool ScatterElementsUpdateKernelOptLocalSum::Validate(const Params& p) const {
+    if (p.GetType() != KernelType::SCATTER_ELEMENTS_UPDATE) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    const auto& params = static_cast<const scatter_elements_update_params&>(p);
+
+    // Rejecting here falls through to `_ref` unchanged -- this kernel only opts in for
+    // its narrow scope, never replaces `_ref` for anything outside it.
+    if (params.mode != ScatterUpdateReduction::SUM) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    if (!params.use_init_val) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    if (params.is_shape_agnostic) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);  // static shapes only for this first version
+    }
+    if (!is_global_memory_case(params)) {
+        // `_ref`'s own whole-output-fits-in-local-memory path already wins here
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    if (!params.fused_ops.empty()) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);  // keep the first version simple; `_ref` still handles fused cases
+    }
+    const size_t rank = params.inputs[0].GetDims().size();
+    if (rank != 4 && rank != 5) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    // Dense-ish scatter only: sparse scatters (few indices into a huge output) would
+    // pay for zeroing/flushing a window with no locality benefit.
+    if (params.inputs[2].LogicalSize() < params.outputs[0].LogicalSize()) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+    return true;
+}
+
+bool ScatterElementsUpdateKernelOptLocalSum::SkipKernelExecution(const scatter_elements_update_params& params,
+                                                                 size_t kernel_id) const {
+    if (kernel_id == 0) {
+        if (params.outputs[0].LogicalSize() != 0 && params.outputs[0] != params.inputs[0]) {
+            return false;
+        }
+    }
+    return KernelData::SkipKernelExecution(params);
+}
+
 void ScatterElementsUpdateKernelOptLocalSum::GetUpdateDispatchDataFunc(KernelData& kd) const {
     kd.update_dispatch_data_func = [this](const Params& params, KernelData& kd) {
         const auto& prim_params = static_cast<const scatter_elements_update_params&>(params);
@@ -223,10 +212,10 @@ void ScatterElementsUpdateKernelOptLocalSum::GetUpdateDispatchDataFunc(KernelDat
         for (size_t i = 0; i < kd.kernels.size(); ++i) {
             // is_second==true selects the "update" (ITER==1) dispatch shape (sized to
             // the indices/updates tensor, which for us equals the output size anyway).
-            auto dispatchData = this->SetDefault(prim_params, /*is_second=*/i == 1);
+            auto dispatchData = SetDefault(prim_params, /*is_second=*/i == 1);
             kd.kernels[i].params.workGroups.global = dispatchData.gws;
             kd.kernels[i].params.workGroups.local = dispatchData.lws;
-            kd.kernels[i].skip_execution = KernelData::SkipKernelExecution(prim_params, i);
+            kd.kernels[i].skip_execution = SkipKernelExecution(prim_params, i);
 
             if (i == 1) {
                 kd.kernels[i].params.local_memory_args.clear();

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.h
@@ -55,21 +55,14 @@ public:
     CommonDispatchData SetDefault(const scatter_elements_update_params& params, bool is_second) const;
     KernelsData GetKernelsData(const Params& params) const override;
     ParamsKey GetSupportedKey() const override;
-    // `_ref` uses the base default (DONT_USE_IF_HAVE_SOMETHING_ELSE); without an
-    // explicit override here, equal-priority ordering between the two attached
-    // implementations would depend on kernel_selector's multiset insertion-order
-    // stability rather than a real, intentional preference. Matches GridSample's own
-    // opt-kernel precedent (FORCE_PRIORITY_8) for the same reason.
     KernelsPriority GetKernelsPriority(const Params& params) const override;
 
 protected:
     bool Validate(const Params& p) const override;
+    bool SkipKernelExecution(const scatter_elements_update_params& params, size_t kernel_id) const;
     void GetUpdateDispatchDataFunc(KernelData& kd) const override;
 
-    // 4096 int32 slots = 16KB local memory -- comfortably under the ~64KB typical
-    // per-workgroup budget (leaves headroom for the driver's own allocations), while
-    // large enough to capture real spatial locality for typical optical-flow motion
-    // magnitudes. Not auto-tuned per-shape in this first version.
+    // 16KB local memory, comfortably under the ~64KB typical per-workgroup budget.
     static constexpr size_t kWindowSize = 4096;
 };
 }  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.h
@@ -1,0 +1,75 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "kernel_base_opencl.h"
+#include "scatter_elements_update_kernel_ref.h"  // reuse scatter_elements_update_params only
+
+namespace kernel_selector {
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ScatterElementsUpdateKernelOptLocalSum
+//
+// A narrowly-eligible fast path for the SUM-reduction, dense-scatter case (updates
+// tensor the same total size as the output -- e.g. a bilinear-splat forward warp),
+// where the existing `_ref` kernel's global-memory atomic-accumulate stage dominates
+// total cost. Real hardware measurement (Arc B70, 1920x1088xf16, DRBA softsplat)
+// isolated the per-stage cost: init ~40-60us, atomic-accumulate ~5.6-9.3ms, finalize
+// ~45-85us -- the accumulate stage alone is ~99% of the primitive's total time.
+// A synthetic index-pattern precheck (identity/heavy-collision/random/extreme-collision,
+// same element count) showed raw collision *count* barely matters (heavy-collision ~=
+// identity, within noise) but *memory access locality* does (random ~4.6x slower than
+// identity, despite similar average collision rate) -- the real cost driver is DRAM
+// transaction coalescing on scattered global-memory atomics, not contention per se.
+//
+// This kernel stages each workgroup's contributions in a small, fixed-size local
+// (on-chip) memory window before flushing to global memory, converting scattered
+// global atomics into local atomics (architecturally cheap and coalescing-independent)
+// followed by one clustered, mostly-nonzero-only global write-back per workgroup. Any
+// destination index that falls outside a workgroup's window (large/divergent motion,
+// no assumption of bounded flow is made or required) falls back to the *exact same*
+// direct global atomic_fetch_add the `_ref` kernel already does for every element --
+// so this can never be less correct than `_ref`, only potentially less effective.
+//
+// Correctness rests on one exact (not approximate) invariant: the SUM-mode accumulator
+// is fixed-point int32 (see this kernel's own to_int/from_int, copied unchanged from
+// `_ref`'s), so integer addition is truly associative/commutative -- staging some
+// contributions locally before adding them to global memory changes only the order of
+// additions, never the result (barring the same int32 overflow risk the reference
+// kernel already has). Validated bit-identical against `_ref` on the existing GPU unit
+// test suite plus new coverage for the local/global-fallback boundary (see the PR test
+// additions).
+//
+// Deliberately independent of ScatterElementsUpdateKernelRef (no inheritance) -- purely
+// additive, touches nothing in the existing, already-validated kernel. Only attached
+// ahead of `_ref` in the selector; Validate() returning false for anything outside this
+// kernel's narrow scope falls straight through to `_ref` unchanged.
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class ScatterElementsUpdateKernelOptLocalSum : public KernelBaseOpenCL {
+public:
+    ScatterElementsUpdateKernelOptLocalSum() : KernelBaseOpenCL("scatter_elements_update_opt_local_sum") {}
+    ~ScatterElementsUpdateKernelOptLocalSum() override = default;
+
+    JitConstants GetJitConstants(const scatter_elements_update_params& params) const;
+    CommonDispatchData SetDefault(const scatter_elements_update_params& params, bool is_second) const;
+    KernelsData GetKernelsData(const Params& params) const override;
+    ParamsKey GetSupportedKey() const override;
+    // `_ref` uses the base default (DONT_USE_IF_HAVE_SOMETHING_ELSE); without an
+    // explicit override here, equal-priority ordering between the two attached
+    // implementations would depend on kernel_selector's multiset insertion-order
+    // stability rather than a real, intentional preference. Matches GridSample's own
+    // opt-kernel precedent (FORCE_PRIORITY_8) for the same reason.
+    KernelsPriority GetKernelsPriority(const Params& params) const override;
+
+protected:
+    bool Validate(const Params& p) const override;
+    void GetUpdateDispatchDataFunc(KernelData& kd) const override;
+
+    // 4096 int32 slots = 16KB local memory -- comfortably under the ~64KB typical
+    // per-workgroup budget (leaves headroom for the driver's own allocations), while
+    // large enough to capture real spatial locality for typical optical-flow motion
+    // magnitudes. Not auto-tuned per-shape in this first version.
+    static constexpr size_t kWindowSize = 4096;
+};
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_opt_local_sum.h
@@ -29,17 +29,35 @@ namespace kernel_selector {
 // followed by one clustered, mostly-nonzero-only global write-back per workgroup. Any
 // destination index that falls outside a workgroup's window (large/divergent motion,
 // no assumption of bounded flow is made or required) falls back to the *exact same*
-// direct global atomic_fetch_add the `_ref` kernel already does for every element --
-// so this can never be less correct than `_ref`, only potentially less effective.
+// direct global atomic the `_ref` kernel already does for every element -- so this can
+// never be less correct than `_ref`, only potentially less effective.
 //
-// Correctness rests on one exact (not approximate) invariant: the SUM-mode accumulator
-// is fixed-point int32 (see this kernel's own to_int/from_int, copied unchanged from
-// `_ref`'s), so integer addition is truly associative/commutative -- staging some
-// contributions locally before adding them to global memory changes only the order of
-// additions, never the result (barring the same int32 overflow risk the reference
-// kernel already has). Validated bit-identical against `_ref` on the existing GPU unit
-// test suite plus new coverage for the local/global-fallback boundary (see the PR test
-// additions).
+// Element types: the encoding is `_ref`'s, unchanged, all three branches of it -- f32
+// bit-reinterpret, fp16 fixed-point scale, integer identity -- and the accumulator is
+// sized one int32 per padded output element rather than from the output's byte size, so
+// a type narrower than int32 is allocated correctly rather than half-sized. Validate()
+// nonetheless accepts only f16/f32/i32, the set this kernel is actually exercised on:
+// i8/u8 cannot reach any scatter kernel as an input today (the plugin's own impl gate
+// allows only f32/f16/i32 there), and a narrower output arrives only through a fused
+// quantize, which Validate() also rejects -- so neither can be tested. Keeping the
+// accepted set equal to the verified set means that if either restriction is later
+// lifted, this kernel steps aside for `_ref` instead of taking an unexercised path.
+//
+// On reproducibility, which is what the local staging actually changes: it alters the
+// order in which contributions are added, nothing else.
+//   * Integer accumulators -- i32, and fp16's fixed-point encoding -- add with int32
+//     atomics. Integer addition is associative and commutative (C11 atomics define
+//     wraparound, so this holds even on overflow, the same overflow `_ref` already has),
+//     so the staged result is bit-identical to `_ref`'s.
+//   * f32 accumulates in floating point, via the same CAS loop `_ref` uses. Floating-point
+//     addition is not associative, so a summation of more than two f32 contributions is
+//     not bit-reproducible under *any* reordering -- by the arithmetic, not by anything
+//     this kernel or `_ref` does. `_ref`'s own SUM path already accumulates through
+//     unordered global atomics, so its f32 result is not reproducible run to run either.
+//     The correctness bar for f32 is agreement within the expected precision of the
+//     summation, which is the same bar `_ref` meets.
+// Validated against `_ref` on the existing GPU unit test suite plus new coverage for the
+// local/global-fallback boundary, integer exactness, and f32 precision (see the PR tests).
 //
 // Deliberately independent of ScatterElementsUpdateKernelRef (no inheritance) -- purely
 // additive, touches nothing in the existing, already-validated kernel. Only attached

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/scatter_update/scatter_elements_update_kernel_selector.cpp
@@ -4,10 +4,14 @@
 
 #include "scatter_elements_update_kernel_selector.h"
 #include "scatter_elements_update_kernel_ref.h"
+#include "scatter_elements_update_kernel_opt_local_sum.h"
 
 namespace kernel_selector {
 
-scatter_elements_update_kernel_selector::scatter_elements_update_kernel_selector() { Attach<ScatterElementsUpdateKernelRef>(); }
+scatter_elements_update_kernel_selector::scatter_elements_update_kernel_selector() {
+    Attach<ScatterElementsUpdateKernelOptLocalSum>();
+    Attach<ScatterElementsUpdateKernelRef>();
+}
 
 KernelsData scatter_elements_update_kernel_selector::GetBestKernels(const Params& params) const {
     return GetNaiveBestKernel(params, KernelType::SCATTER_ELEMENTS_UPDATE);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "test_utils.h"
-
-#include "openvino/reference/scatter_elements_update.hpp"
-
+#include <algorithm>
+#include <cstddef>
+#include <intel_gpu/graph/network.hpp>
+#include <intel_gpu/graph/topology.hpp>
 #include <intel_gpu/primitives/input_layout.hpp>
 #include <intel_gpu/primitives/scatter_elements_update.hpp>
 #include <intel_gpu/runtime/memory.hpp>
-#include <intel_gpu/graph/topology.hpp>
-#include <intel_gpu/graph/network.hpp>
+#include <random>
 
-#include <cstddef>
+#include "openvino/reference/scatter_elements_update.hpp"
+#include "test_utils.h"
 
 using namespace cldnn;
 using namespace ::tests;
@@ -881,4 +881,161 @@ TEST(scatter_elements_update_gpu_fp32, smoke_sum_large_values_overflow_guard_dyn
         outputs.at("scatter_elements_update").get_memory(), get_test_stream());
 
     ASSERT_NEAR(output_ptr[0], 3e7f, 1.0f);
+}
+
+TEST(scatter_elements_update_gpu_fp32, smoke_sum_opt_local_kernel_static_1d) {
+    // Static-shape counterpart to smoke_multiple_indices_sum_big_1d_dynamic, sized to
+    // force scatter_elements_update_opt_local_sum's eligibility gate (static shape,
+    // SUM mode, output large enough that it can't fit in `_ref`'s own local-memory
+    // path -- 20000 f32 elements is ~80KB, well over the ~64KB typical local-memory
+    // budget). Mostly-zero indices/updates concentrate almost all of the 20000
+    // dispatched updates on a single destination (stresses the local-window path),
+    // while a handful of real updates are scattered far enough apart that at least
+    // one pair is guaranteed to fall in different windows (stresses the
+    // global-fallback path too). Correctness is checked exactly, not approximately --
+    // the fixed-point SUM accumulator makes the true result an exact integer here.
+    auto& engine = get_test_engine();
+    const int32_t num = 20000;
+    auto input1 = engine.allocate_memory({data_types::f32, format::bfyx, tensor{num, 1, 1, 1}});
+    auto input2 = engine.allocate_memory({data_types::i32, format::bfyx, tensor{num, 1, 1, 1}});
+    auto input3 = engine.allocate_memory({data_types::f32, format::bfyx, tensor{num, 1, 1, 1}});
+
+    std::vector<float> data(num, 0.0f);
+    std::vector<int32_t> indices(num, 0);
+    std::vector<float> updates(num, 0.0f);
+
+    const std::vector<int32_t> target_update_positions = {0, 100, 4095, 4096, 8191, 15000, 19999};
+    for (auto pos : target_update_positions) {
+        updates[pos] = 1.0f;
+        indices[pos] = pos;
+    }
+
+    topology topology;
+    topology.add(input_layout("input", input1->get_layout()));
+    topology.add(input_layout("indices", input2->get_layout()));
+    topology.add(input_layout("updates", input3->get_layout()));
+    topology.add(scatter_elements_update("scatter_elements_update",
+                                         input_info("input"),
+                                         input_info("indices"),
+                                         input_info("updates"),
+                                         0,
+                                         ScatterElementsUpdateOp::Reduction::SUM,
+                                         true));
+
+    set_values(input1, data);
+    set_values(input2, indices);
+    set_values(input3, updates);
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input1);
+    network.set_input_data("indices", input2);
+    network.set_input_data("updates", input3);
+
+    auto outputs = network.execute();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(outputs.at("scatter_elements_update").get_memory(),
+                                                           get_test_stream());
+
+    // Every dispatched index defaults to 0 with update value 0.0 (a real, exact no-op
+    // contribution), except the handful of target positions -- so index 0's expected
+    // value is exactly 1.0 (only its own explicit contribution; the thousands of
+    // default-index-0 contributions are all +0.0 and change nothing).
+    std::vector<float> expected(num, 0.0f);
+    for (auto pos : target_update_positions) {
+        expected[pos] = 1.0f;
+    }
+    for (int32_t i = 0; i < num; ++i) {
+        ASSERT_EQ(expected[i], output_ptr[i]) << "at index " << i;
+    }
+}
+
+TEST(scatter_elements_update_gpu_fp16, smoke_sum_opt_local_kernel_dense_flat) {
+    // Mirrors the real production shape that motivated
+    // scatter_elements_update_opt_local_sum precisely: the real DRBA/softsplat graph
+    // flattens its spatial dims to one axis *before* the scatter op (confirmed via
+    // direct introspection of the real exported graph -- data/indices/updates are all
+    // rank-3 (N,C,flat_spatial), not genuinely 2D), f16, SUM mode, static shape, with
+    // the updates/indices tensor *larger* than the output (4x here, matching a
+    // 4-corner bilinear-splat forward warp concatenated into one scatter call) --
+    // exactly the shape/ratio combination that exposed the real bug this kernel's
+    // dispatch logic had (SetDefault used the same gws layout for the update stage as
+    // for init/finalize, instead of `_ref`'s X*Y-merged layout the update-stage
+    // kernel body actually expects; every contribution silently landed on the same
+    // output element). The destination for each source pixel is computed with a
+    // bounded, moderate 2D neighborhood jitter (matching realistic optical-flow
+    // motion magnitude) even though the tensors themselves are flat -- so most
+    // updates should resolve via the local-window path, with only edge-of-buffer
+    // cases falling back to global.
+    auto& engine = get_test_engine();
+    const int32_t out_x = 128, out_y = 128, channels = 2;
+    const int32_t out_len = out_x * out_y;
+    const int32_t upd_len = out_len * 4;  // 4 bilinear corners concatenated
+
+    auto input1 = engine.allocate_memory({data_types::f16, format::bfyx, tensor{1, channels, out_len, 1}});
+    auto input2 = engine.allocate_memory({data_types::i32, format::bfyx, tensor{1, channels, upd_len, 1}});
+    auto input3 = engine.allocate_memory({data_types::f16, format::bfyx, tensor{1, channels, upd_len, 1}});
+
+    std::vector<ov::float16> data(out_len * channels, ov::float16(0.0f));
+    std::vector<int32_t> indices(upd_len * channels);
+    std::vector<ov::float16> updates(upd_len * channels);
+
+    // Each of the 4 "corners" scatters every source pixel to a nearby destination
+    // (bounded +/-2 pixel jitter in the flattened index's implied (x,y) grid,
+    // matching realistic bilinear-splat displacement), clamped into range -- real
+    // spatial locality, not synthetic worst-case chaos.
+    std::mt19937 rng(12345);
+    std::uniform_int_distribution<int32_t> jitter(-2, 2);
+    std::vector<int32_t> expected_indices(upd_len);
+    for (int32_t corner = 0; corner < 4; ++corner) {
+        for (int32_t p = 0; p < out_len; ++p) {
+            int32_t x = p % out_x, y = p / out_x;
+            int32_t nx = std::min(std::max(x + jitter(rng), 0), out_x - 1);
+            int32_t ny = std::min(std::max(y + jitter(rng), 0), out_y - 1);
+            expected_indices[corner * out_len + p] = ny * out_x + nx;
+        }
+    }
+    for (int32_t c = 0; c < channels; ++c) {
+        for (int32_t i = 0; i < upd_len; ++i) {
+            indices[c * upd_len + i] = expected_indices[i];
+            updates[c * upd_len + i] = ov::float16(1.0f);
+        }
+    }
+
+    topology topology;
+    topology.add(input_layout("input", input1->get_layout()));
+    topology.add(input_layout("indices", input2->get_layout()));
+    topology.add(input_layout("updates", input3->get_layout()));
+    topology.add(scatter_elements_update("scatter_elements_update",
+                                         input_info("input"),
+                                         input_info("indices"),
+                                         input_info("updates"),
+                                         3,  // X axis -- the flat spatial scatter axis this kernel targets
+                                         ScatterElementsUpdateOp::Reduction::SUM,
+                                         true));
+
+    set_values(input1, data);
+    set_values(input2, indices);
+    set_values(input3, updates);
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input1);
+    network.set_input_data("indices", input2);
+    network.set_input_data("updates", input3);
+
+    auto outputs = network.execute();
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(outputs.at("scatter_elements_update").get_memory(),
+                                                                 get_test_stream());
+
+    for (int32_t c = 0; c < channels; ++c) {
+        std::vector<float> expected(out_len, 0.0f);
+        for (int32_t i = 0; i < upd_len; ++i) {
+            expected[expected_indices[i]] += 1.0f;
+        }
+        for (int32_t p = 0; p < out_len; ++p) {
+            float got = static_cast<float>(output_ptr[c * out_len + p]);
+            // f16 fixed-point accumulation of up to ~4-8 unit contributions is exact
+            // (well within f16's integer-exact range), so a tight tolerance is right
+            // here, not a loose one.
+            ASSERT_NEAR(expected[p], got, 0.05f) << "channel " << c << " pixel " << p;
+        }
+    }
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
@@ -1039,3 +1039,114 @@ TEST(scatter_elements_update_gpu_fp16, smoke_sum_opt_local_kernel_dense_flat) {
         }
     }
 }
+
+TEST(scatter_elements_update_gpu_i32, smoke_sum_opt_local_kernel_integer_exact) {
+    // Integer element types take scatter_elements_update_opt_local_sum's identity
+    // encoding, so the local-staged sum is exact int32 arithmetic. Four updates collide
+    // on every fourth destination, all with value 2^24+1 -- the first integer a float
+    // cannot represent. An encoding that round-tripped through float would round each
+    // contribution down to 2^24 and return 67108864 instead of 67108868.
+    auto& engine = get_test_engine();
+    const int32_t num = 20000;  // ~80KB of i32, past `_ref`'s own local-memory path
+    const int32_t update_value = 16777217;  // 2^24 + 1
+    auto input1 = engine.allocate_memory({data_types::i32, format::bfyx, tensor{num, 1, 1, 1}});
+    auto input2 = engine.allocate_memory({data_types::i32, format::bfyx, tensor{num, 1, 1, 1}});
+    auto input3 = engine.allocate_memory({data_types::i32, format::bfyx, tensor{num, 1, 1, 1}});
+
+    std::vector<int32_t> data(num, 0);
+    std::vector<int32_t> indices(num);
+    std::vector<int32_t> updates(num, update_value);
+    for (int32_t i = 0; i < num; ++i) {
+        indices[i] = i & ~3;  // groups of 4 accumulate onto one destination
+    }
+
+    topology topology;
+    topology.add(input_layout("input", input1->get_layout()));
+    topology.add(input_layout("indices", input2->get_layout()));
+    topology.add(input_layout("updates", input3->get_layout()));
+    topology.add(scatter_elements_update("scatter_elements_update",
+                                         input_info("input"),
+                                         input_info("indices"),
+                                         input_info("updates"),
+                                         0,
+                                         ScatterElementsUpdateOp::Reduction::SUM,
+                                         true));
+
+    set_values(input1, data);
+    set_values(input2, indices);
+    set_values(input3, updates);
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input1);
+    network.set_input_data("indices", input2);
+    network.set_input_data("updates", input3);
+
+    auto outputs = network.execute();
+    cldnn::mem_lock<int32_t, mem_lock_type::read> output_ptr(outputs.at("scatter_elements_update").get_memory(),
+                                                             get_test_stream());
+
+    for (int32_t i = 0; i < num; ++i) {
+        const int32_t expected = (i % 4 == 0) ? 4 * update_value : 0;
+        ASSERT_EQ(expected, output_ptr[i]) << "at index " << i;
+    }
+}
+
+TEST(scatter_elements_update_gpu_fp32, smoke_sum_opt_local_kernel_f32_precision) {
+    // f32 accumulates in floating point, so staging contributions locally reorders the
+    // additions relative to `_ref` and the result is not bit-reproducible -- that is
+    // float addition, not anything this kernel controls. What must hold is agreement
+    // within the expected precision of the sum. Eight contributions land on every
+    // destination with values in [-1, 1), and the reference is accumulated in double.
+    auto& engine = get_test_engine();
+    const int32_t out_len = 20000;      // ~80KB f32, past `_ref`'s own local-memory path
+    const int32_t per_dest = 8;
+    const int32_t n_updates = out_len * per_dest;
+
+    auto input1 = engine.allocate_memory({data_types::f32, format::bfyx, tensor{out_len, 1, 1, 1}});
+    auto input2 = engine.allocate_memory({data_types::i32, format::bfyx, tensor{n_updates, 1, 1, 1}});
+    auto input3 = engine.allocate_memory({data_types::f32, format::bfyx, tensor{n_updates, 1, 1, 1}});
+
+    std::mt19937 rng(4242);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<float> data(out_len, 0.0f);
+    std::vector<int32_t> indices(n_updates);
+    std::vector<float> updates(n_updates);
+    std::vector<double> expected(out_len, 0.0);
+    for (int32_t i = 0; i < n_updates; ++i) {
+        indices[i] = i % out_len;
+        updates[i] = dist(rng);
+        expected[indices[i]] += static_cast<double>(updates[i]);
+    }
+
+    topology topology;
+    topology.add(input_layout("input", input1->get_layout()));
+    topology.add(input_layout("indices", input2->get_layout()));
+    topology.add(input_layout("updates", input3->get_layout()));
+    topology.add(scatter_elements_update("scatter_elements_update",
+                                         input_info("input"),
+                                         input_info("indices"),
+                                         input_info("updates"),
+                                         0,
+                                         ScatterElementsUpdateOp::Reduction::SUM,
+                                         true));
+
+    set_values(input1, data);
+    set_values(input2, indices);
+    set_values(input3, updates);
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input1);
+    network.set_input_data("indices", input2);
+    network.set_input_data("updates", input3);
+
+    auto outputs = network.execute();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(outputs.at("scatter_elements_update").get_memory(),
+                                                           get_test_stream());
+
+    // Eight additions of magnitude < 1 in f32: the accumulated rounding error is bounded
+    // well below 1e-4. A tolerance this tight still catches a dropped or double-counted
+    // contribution, which is what could actually go wrong here.
+    for (int32_t i = 0; i < out_len; ++i) {
+        ASSERT_NEAR(static_cast<float>(expected[i]), output_ptr[i], 1e-4f) << "at index " << i;
+    }
+}


### PR DESCRIPTION
### Details

## Changes since the previous revision

**Why the local-memory gate is gone.** The gate that was removed, `is_global_memory_case()`, was a copy of `_ref`'s `is_global_memory()`: it made this kernel stand aside wherever `_ref` takes its own whole-output-in-local-memory path. The previous revision justified removing it with two measurements inside that range; this one covers the whole of it, including the band between them. Arc B70, f16, a 4-corner bilinear splat with +/-2 px jitter and an updates tensor 4x the output, `PERF_COUNT`, mean of 20. The `_ref` column is a rebuild with the gate restored, so both columns are the same shapes and the same index pattern:

| output (f16) | `_ref`, its local-memory path | this kernel |
|---|---|---|
| 512 | 0.106 ms | 0.024 ms |
| 2048 | 0.113 ms | 0.027 ms |
| 4096 | 0.112 ms | 0.031 ms |
| 8192 | 0.120 ms | 0.056 ms |
| 16384 | 0.197 ms | 0.089 ms |
| 65536 | 0.321 ms | 0.355 ms |

The gate never applied at 65536 (the accumulator is past the budget there), so that row is the same kernel in both builds and gives the run-to-run noise, about 10% — well under the gaps above it. This device reports a 128KB `maxLocalMemSize`, which is why `_ref`'s local path still claims a 16384-element f16 output.

**The local-memory check that was missing.** This kernel's own local-memory use is one fixed 16KB window, independent of shape, and nothing checked that the device can supply it. `Validate()` now rejects if `kWindowSize * sizeof(int32_t)` exceeds `maxLocalMemSize`, so an undersized device falls through to `_ref` instead of failing at dispatch. It is shape-independent, so shape-agnostic eligibility is unchanged.

**Also from review.** `SetDefault()` returns early for a dynamic scope tensor, as `_ref` does, rather than computing a dispatch that `update_dispatch_data_func` immediately replaces. The five static opt tests are now one typed fixture with f32, f16 and i32 instantiations, following the fixtures already in this file; each case supplies a shape, a fill function and a tolerance, and expectations accumulate in double so the i32 case stays exact past 2^24. The dynamic test stays a plain `TEST`, since it drives two shapes through one compile. 904 of 904 scatter GPU unit tests pass on Arc B70, with no dmesg GPU faults.

## Previous revision: shape-agnostic support, and both size gates removed

The gates existed to defer to `_ref` where it was expected to win. Measured per-node on Arc B70 (f16, `PERF_COUNT`, mean of 20 iterations), it does not win anywhere:

| case | `_ref` | this kernel |
|---|---|---|
| production softsplat shape, output 2088960x3 | 553.2 ms | 21.4 ms |
| colliding updates adjacent in the updates tensor | 389.5 ms | 10.0 ms |
| output 4096, inside `_ref`'s local-memory path | 33.6 ms | 10.5 ms |
| output 512, inside `_ref`'s local-memory path | 69.0 ms | 5.2 ms |
| sparse: 65536 updates into a 2088960 output | 1.27 ms | 1.13 ms |

The two small-output rows needed one change to get there. When the whole accumulator fits inside one staging window, the window is now anchored at 0 rather than at work-item 0's destination, so every destination is in range; output 512 was 138 ms before that change. That anchor is the only size-dependent choice the kernel makes, and it is a choice between two compiled variants of the update stage rather than an eligibility gate, so a shape-agnostic build compiles both and skips one per resolved shape — the structure `_ref` already uses for its own local/global update variants. Every remaining `Validate()` condition is shape-independent, so `is_shape_agnostic` is no longer rejected.

**Correcting the earlier framing of where the speedup comes from.** The description below attributed it to local staging. Measured, that is not what carries the production case: with staging effectively disabled (a one-slot window) the same shape runs in 21.5 ms rather than 21.3 ms. The speedup is the three-stage int32 fixed-point accumulate replacing `_ref`'s SUM path. Staging is worth 3.5x where colliding contributions also share a workgroup (35.2 ms -> 9.9 ms) and is free where they do not, so it is kept:

| index pattern | staging off | staging on |
|---|---|---|
| production softsplat | 21.5 ms | 21.3 ms |
| identity | 14.2 ms | 14.3 ms |
| uniform random | 113.8 ms | 115.2 ms |
| heavy collision, 4096 destinations | 14.2 ms | 14.0 ms |
| colliding updates adjacent | 35.2 ms | 9.9 ms |

The window size is not a lever on the production pattern either: 512 through 16384 all land within 21.2-21.8 ms, with the chosen lws at 1024. Its useful size is set by how far a workgroup's destinations spread in output-index space, which is a property of the index pattern rather than of the workgroup size, so it is kept absolute rather than tied to the lws.

**Also from review:** `bfwzyx` dropped from `GetSupportedKey()` instead of re-checking the rank; an updates/output rank mismatch rejected in `Validate()` instead of by `#error` in the .cl; `is_global_memory_case()` inlined into its single caller; missing `#undef GET_INPUT_INDEX`; `OPTIONAL_SHAPE_INFO_ARG` moved onto its own line; comments cut back throughout; the write-back bounds check and its jit constant replaced by one window of accumulator slack.

**Testing.** Every opt test now asserts, via `get_implementation_info()`, that this kernel is the one that ran — they all pass on `_ref` otherwise. New coverage for the anchor-at-zero variant and for a dynamic model driving two shapes, which need different anchor variants, through one shape-agnostic compile. 904 of 904 scatter GPU unit tests pass on Arc B70, with no dmesg GPU faults. Each new assertion was checked against a deliberately broken build to confirm it can fail: with `is_shape_agnostic` rejected again the dynamic test reports `got: scatter_elements_update_ref__f32`.

## Earlier revision: integer element types and accumulator sizing

**Integer element types.** `to_int`/`from_int` and the atomic-selection macro branched on `INPUT2_TYPE_SIZE` alone, dropping `_ref`'s `INPUT2_IS_FP` guard and with it `_ref`'s integer-identity encoding. An i32 scatter was round-tripped through float and accumulated with the f32 CAS loop: exact below 2^24, silently rounded above it. The guard is restored in the three places that consume it, so i32 uses the identity encoding and a real `atomic_fetch_add`. A test returns 67108864 without the fix for a sum whose exact value is 67108868.

Rejecting integers in `GetSupportedKey()` as suggested does not work: `base_params::GetParamsKey()` folds every input's data type into one shared bitfield, and the indices tensor is INT32, so narrowing the key's type list stops this kernel matching anything at all. It would also fail silently, since the key filter runs before `Validate()`.

**Accumulator sizing.** The internal buffer holds one int32 per padded output element, so it is sized from the element count rather than the output's byte size. This diverges from `_ref`, whose `PhysicalSizeInBytes() * 2` is exactly one int32 per element only for 2-byte types and half of what is needed for a 1-byte output. `_ref` keeps the original formula; this PR does not touch it. For f16 the two expressions are equal.

**Element type scope.** `Validate()` accepts f16, f32 and i32, the set this kernel is exercised on, and defers anything else to `_ref`. i8/u8 cannot reach a scatter kernel as an input today (`ScatterElementsUpdateImplementationManager::validate_impl` allows only f32/f16/i32), and a narrower output arrives only through a fused quantize, which `Validate()` rejects.

**f32 reproducibility.** The integer encodings are bit-identical to `_ref`. f32 is bit-reinterpreted and accumulated by a CAS loop that adds in floating point, so no reordering of an f32 sum is bit-reproducible — and `_ref`'s SUM path already accumulates through unordered global atomics, so it is not reproducible run to run either. A test pins the f32 bar at 1e-4 against a double-precision reference.

## Issue

ScatterElementsUpdate's only kernel, `_ref`, accumulates SUM-mode updates with a direct global-memory atomic per element whenever the output is too large for `_ref`'s own local-memory path. That path only applies when the entire output tensor fits inside `_ref`'s local buffer, since the buffer is sized to the whole output. In practice this only helps below roughly a 64KB budget. For a dense scatter, where the updates tensor covers all or more of the output (for example a bilinear-splat forward warp), the per-element global atomic accumulation dominates the primitive's total cost.

This was measured on a real video-interpolation workload (DRBA-style optical-flow forward-warping, Arc B70, 1920x1088 f16) using temporary per-kernel-stage timing instrumentation. The init stage took roughly 40 to 60 microseconds. The atomic-accumulate stage took roughly 5.6 to 9.3 milliseconds. The finalize stage took roughly 45 to 85 microseconds. The atomic-accumulate stage alone is about 99% of the primitive's total time. ScatterElementsUpdate as a whole was 56% of this workload's total combined-pipeline GPU time (64.4ms of 115.4ms).

## Root cause / fix

This change adds a new kernel, `scatter_elements_update_opt_local_sum`, attached ahead of `_ref` in the kernel selector. It accumulates into an int32 fixed-point buffer in three stages: seed from `data`, atomic-accumulate the updates, decode back to the output type. `Validate()` restricts it to SUM reduction mode, `use_init_val=true`, no fused ops, an updates rank matching the output's, and the element types above; anything outside that falls straight through to `_ref` unchanged. All of those conditions are shape-independent, which is what lets the kernel serve shape-agnostic compilation.

For the update stage, each workgroup stages its contributions in a fixed-size local-memory window before flushing them, turning scattered global atomics into local ones plus one clustered write-back. Any destination falling outside a workgroup's window takes the exact same direct global `atomic_fetch_add` that `_ref` already does for every element, so the kernel can never be less correct than `_ref`, only less effective. No bound on flow or index displacement is assumed. See the measured table above for what this does and does not buy.

A real dispatch bug was found and fixed during development. `_ref`'s own `SetDefault` uses two different gws layouts depending on the dispatch stage: the update stage merges the tensor's X and Y extents into one combined gws dimension, `indices.X() * indices.Y()`, which is what its kernel body's decoding (`x = dim0 % INPUT2_SIZE_X; y = dim0 / INPUT2_SIZE_X;`) assumes. An earlier version of this kernel used the non-merged layout, correct for init/finalize, for the update stage too. That silently scrambled which tensor axis received the scattered index for shapes where X and Y weren't dispatched as one combined dimension — for example, a tensor shaped (X=1, Y=large) put every real per-thread index into what the update-stage decode treated as the feature axis. The fix gives the update stage its own dispatch-layout branch matching `_ref`'s.

## Testing

Tests in `scatter_elements_update_gpu_test.cpp` cover: a large static 1D SUM scatter exercising both the local-window and global-fallback paths; an f16 test on a flat spatial axis with an updates tensor 4x the output, mirroring the production shape; i32 exactness above 2^24; the f32 precision bar; the anchor-at-zero variant on a small output; and a dynamic model driving two shapes through one shape-agnostic compile. Each asserts which kernel actually ran.

904 of 904 ScatterElementsUpdate GPU unit tests pass on Arc B70 (Battlemage), with no dmesg GPU faults — zero regression for every other shape, mode and layout combination `_ref` already handles.

This was also validated against a real combined DRBA-style video-interpolation network on Arc B70. ScatterElementsUpdate dropped from 64.4ms to 28.1ms per frame, a 56% reduction. Total combined-pipeline profiled GPU time dropped from 115.4ms to 80.8ms, a 30% reduction. Real end-to-end wall-clock throughput (2-stream) dropped from roughly 110.9-116.5ms to 82.2ms per frame. Correctness was confirmed unchanged across two independent real anime frame triples: PSNR of about 51.5dB and about 52.0dB against a PyTorch fp32 CPU reference, matching pre-patch numbers, with no NaN in either case.

### Tickets
 - *none*

### AI Assistance:
 - AI assistance used: yes
 - Claude (Anthropic) was used throughout this change. It designed and ran the per-kernel-stage timing instrumentation and the index-pattern measurements, designed and implemented the kernel, and root-caused the dispatch-layout regression above by forcing `Validate()` to always reject to prove the crash reproduced without any of the new code. The human author chose the overall direction after being shown the profiling evidence and the alternatives.
 - For this revision: Claude ran the gate-restored A/B that produced the local-memory table above, added the device-capability check and the dynamic early exit, and parameterized the tests. The human author reviewed the findings and approved the changes before they were pushed.
 - For the previous revision: Claude measured the kernel against `_ref` across the index patterns and output sizes tabulated above, which is what established that the two eligibility gates were unnecessary and that the earlier attribution of the speedup to local staging was wrong; implemented the anchor-at-zero variant and the shape-agnostic variant selection; and verified each new test assertion against a deliberately broken build.
 - Human validation performed: the build was verified locally (scoped GPU plugin and GPU unit test binary build from this branch). The full ScatterElementsUpdate GPU unit test suite was run and passed on real Arc B70 hardware. Correctness and performance were independently validated against a real downstream video-interpolation workload across two real content frame triples, not synthetic data alone.

