### PR TITLE
Fix exceeds maximum supported size in allocator

### DIFF
--- a/src/core/src/runtime/allocator.cpp
+++ b/src/core/src/runtime/allocator.cpp
@@ -8,15 +8,15 @@
 
 namespace ov {
 namespace {
-constexpr size_t max_supported_allocation_size = size_t{1} << 40;  // 1 TiB
+constexpr uint64_t max_supported_allocation_size = uint64_t{1} << 40;  // 1 TiB
 }  // namespace
 
 struct DefaultAllocator {
     void* allocate(const size_t bytes, const size_t alignment) {
-        OPENVINO_ASSERT(bytes <= max_supported_allocation_size,
+        OPENVINO_ASSERT(static_cast<uint64_t>(bytes) <= max_supported_allocation_size,
                         "Requested allocation size ",
                         bytes,
-                        " exceeds the maximum supported allocation size");
+                        " exceeds maximum supported allocation size");
         if (alignment == alignof(max_align_t)) {
             return ::operator new(bytes);
         } else {

--- a/src/core/src/runtime/allocator.cpp
+++ b/src/core/src/runtime/allocator.cpp
@@ -7,9 +7,16 @@
 #include "openvino/core/except.hpp"
 
 namespace ov {
+namespace {
+constexpr size_t max_supported_allocation_size = size_t{1} << 40;  // 1 TiB
+}  // namespace
 
 struct DefaultAllocator {
     void* allocate(const size_t bytes, const size_t alignment) {
+        OPENVINO_ASSERT(bytes <= max_supported_allocation_size,
+                        "Requested allocation size ",
+                        bytes,
+                        " exceeds the maximum supported allocation size");
         if (alignment == alignof(max_align_t)) {
             return ::operator new(bytes);
         } else {

--- a/src/core/tests/ov_default_allocator_test.cpp
+++ b/src/core/tests/ov_default_allocator_test.cpp
@@ -71,4 +71,10 @@ TEST_F(OVDefaultAllocatorTest, compareIfImplIsNull) {
     EXPECT_FALSE(a2 == a1);
     OV_EXPECT_THROW(std::ignore = (a1 == a2), ov::Exception, _);
 }
+
+TEST_F(OVDefaultAllocatorTest, throwsOnAllocationLargerThanOneTiB) {
+    ov::Allocator allocator;
+    constexpr size_t one_tib = size_t{1} << 40;
+    OV_EXPECT_THROW(std::ignore = allocator.allocate(one_tib + 1), ov::Exception, _);
+}
 }  // namespace ov::test

--- a/src/core/tests/ov_default_allocator_test.cpp
+++ b/src/core/tests/ov_default_allocator_test.cpp
@@ -73,8 +73,14 @@ TEST_F(OVDefaultAllocatorTest, compareIfImplIsNull) {
 }
 
 TEST_F(OVDefaultAllocatorTest, throwsOnAllocationLargerThanOneTiB) {
+    if (sizeof(size_t) < sizeof(uint64_t)) {
+        GTEST_SKIP() << "Allocation larger than 1 TiB cannot be represented by size_t";
+    }
+
     ov::Allocator allocator;
-    constexpr size_t one_tib = size_t{1} << 40;
-    OV_EXPECT_THROW(std::ignore = allocator.allocate(one_tib + 1), ov::Exception, _);
+    constexpr uint64_t one_tib = uint64_t{1} << 40;
+    OV_EXPECT_THROW_HAS_SUBSTRING(std::ignore = allocator.allocate(static_cast<size_t>(one_tib + 1)),
+                                  ov::Exception,
+                                  "exceeds maximum supported allocation size");
 }
 }  // namespace ov::test


### PR DESCRIPTION
### Details:
 - Fix exceeds maximum supported size in allocator
 - Set max allocation size to 1TB

### Tickets:
 - CVS-192457

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
