### PR TITLE
[ONNX FE] [Coverity Enterprise] Division or modulo by zero in the "Split" operation

### DIFF
--- a/src/frontends/onnx/frontend/src/op/split.cpp
+++ b/src/frontends/onnx/frontend/src/op/split.cpp
@@ -6,6 +6,7 @@
 
 #include "core/null_node.hpp"
 #include "core/operator_set.hpp"
+#include "exceptions.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/variadic_split.hpp"
 using namespace ov::op;
@@ -53,6 +54,7 @@ ov::OutputVector split(const ov::frontend::onnx::Node& node) {
     if (node.has_attribute("num_outputs")) {
         const auto inputs = node.get_ov_inputs();
         const auto outputs_number = node.get_attribute_value<int64_t>("num_outputs", 0);
+        CHECK_VALID_NODE(node, outputs_number > 0, "'num_outputs' must be greater than zero, got: ", outputs_number);
         const auto axis = node.get_attribute_value<int64_t>("axis", 0);
         return ov::op::util::make_split(inputs.at(0), outputs_number, axis);
     }

--- a/src/frontends/onnx/tests/tests_python/test_ops_reshape.py
+++ b/src/frontends/onnx/tests/tests_python/test_ops_reshape.py
@@ -409,6 +409,31 @@ def test_split_1d():
     assert all_arrays_equal(graph_results, expected_outputs)
 
 
+def test_split_opset18_coherent_num_outputs_zero_raises():
+    node = onnx.helper.make_node(
+        "Split", inputs=["input"], outputs=[], num_outputs=0,
+    )
+    input_tensor = make_tensor_value_info("input", onnx.TensorProto.FLOAT, [6])
+    graph = make_graph([node], "compute_graph", [input_tensor], [])
+    model = make_model(graph, producer_name="OpenVINO ONNX Frontend")
+    model.opset_import[0].version = 18
+    with pytest.raises(onnx.onnx_cpp2py_export.checker.ValidationError, match="has output size 0 not in range"):
+        import_onnx_model(model)
+
+
+def test_split_opset18_malicious_num_outputs_zero_raises():
+    node = onnx.helper.make_node(
+        "Split", inputs=["input"], outputs=["out"], num_outputs=0,
+    )
+    input_tensor = make_tensor_value_info("input", onnx.TensorProto.FLOAT, [6])
+    output_tensor = make_tensor_value_info("out", onnx.TensorProto.FLOAT, [6])
+    graph = make_graph([node], "compute_graph", [input_tensor], [output_tensor])
+    model = make_model(graph, producer_name="OpenVINO ONNX Frontend")
+    model.opset_import[0].version = 18
+    with pytest.raises(RuntimeError, match="'num_outputs' must be greater than zero"):
+        import_onnx_model(model)
+
+
 def test_depth_to_space():
     b, c, h, w = shape = (2, 8, 3, 3)  # noqa: VNE001
     blocksize = 2


### PR DESCRIPTION
### Details:
 - A malicious or invalid model with an a `Split` operation with the attribute `num_outputs` equal zero causes division by zero in subsequent calculations
 - Fixed by asserting on the valid value in the `num_outputs` attribute.

### Tickets:
 - *CVS-192431*

### AI Assistance:
 - *AI assistance used: yes*
 - *How: tests generation*