### PR TITLE
[GPU] Fix out-of-bounds read in `Gather`

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -104,8 +104,8 @@ void CreateGatherOpBase(ProgramBuilder& p, const std::shared_ptr<T>& op, const i
     bool is_indices_constant = static_cast<bool>(indices_constant);
 
     if (is_static && axis == 0 && input_rank > 1 && indices.get_partial_shape().rank().get_length() == 0 &&
-        out_shape_original.size() + 1 == input_shape.size() &&
-        std::equal(input_shape.begin()+1, input_shape.end(), out_shape_original.begin()) && is_indices_constant) {
+        out_shape.size() == static_cast<size_t>(input_rank) &&
+        std::equal(input_shape.begin()+1, input_shape.end(), out_shape.begin()+1) && is_indices_constant) {
         // Gather -> Crop
         // this Gather simply divides an input tensor along Batch axis
         auto get_crop_layer_name = [&](std::string name, size_t idx)->std::string {

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/gather.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/gather.cpp
@@ -218,6 +218,11 @@ const std::vector<GatherShapeParams> dynamicAxisStaticOutputScalarIndices = {
         ov::test::InputShape(ov::PartialShape({-1, 300}), {{271, 300}}),
         ov::test::InputShape(ov::PartialShape({}), {{}}),
         0, 0
+    },
+    {
+        ov::test::InputShape(ov::PartialShape({8, 300}), {{8, 300}}),
+        ov::test::InputShape(ov::PartialShape({}), {{}}),
+        0, 0
     }
 };
 
@@ -225,7 +230,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_dynamic_axis0_scalar_indices_static_output, Gathe
                 ::testing::Combine(
                     ::testing::ValuesIn(dynamicAxisStaticOutputScalarIndices),  // input shapes
                     ::testing::Values(ov::element::f32),                        // network precision
-                    ::testing::Values(false),                                   // is const indices
+                    ::testing::Values(false, true),                             // is const indices
                     ::testing::Values(true)),                                   // is const axis
                 GatherGPUTest::getTestCaseName);
 } // namespace


### PR DESCRIPTION
### Details:
 - `CreateGatherOpBase()` in the GPU plugin decides whether to lower a `Gather` to a `Crop` primitive. The previous fix correctly identified an out-of-bounds read in that decision. `out_shape` is padded back up to `input_rank` only on the legacy shape-infer path. Under new shape inference the padding never happens, so for a scalar-index gather along axis 0 `out_shape` has rank `input_rank - 1` and the `begin()+1` offset walks one past the end.
 - However, the applied fix replaced `out_shape` with the unpadded `out_shape_original` in the predicate, which also changed which graphs take the Crop path. As a result the Crop primitive is emitted with a wrong physical tensor shape and nothing restores the original rank, corrupting shapes for downstream ops.
 - The fix is to restore the original `out_shape`-based comparison and make it bounds-safe with an explicit rank guard placed before the comparison.