### PR TITLE
test: add dynamic shape coverage for transformer encoder layer

### DIFF
--- a/tests/layer_tests/pytorch_tests/test_transformer_encoder_layer.py
+++ b/tests/layer_tests/pytorch_tests/test_transformer_encoder_layer.py
@@ -127,3 +127,26 @@ class TestTransformerEncoderLayerFwd(PytorchLayerTest):
         self._test(aten_transformer_encoder_layer_module(norm_first, activation, mask_type, mask_data),
                    "aten::_transformer_encoder_layer_fwd", ie_device, precision, ir_version,
                    trace_model=True, custom_eps=1e-4)
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    def test_transformer_encoder_layer_dynamic_shapes(
+        self, ie_device, precision, ir_version
+    ):
+        self._test(
+            aten_transformer_encoder_layer_module(False, "relu"),
+            "aten::scaled_dot_product_attention",
+            ie_device,
+            precision,
+            ir_version,
+            dynamic_shapes=True,
+            dynamic_shapes_for_export={
+                "src": {
+                    0: torch.export.Dim("batch", min=1, max=4),
+                    1: torch.export.Dim("sequence", min=2, max=12),
+                }
+            },
+            fx_kind="aten.scaled_dot_product_attention.default",
+            custom_eps=1e-4,
+        )


### PR DESCRIPTION
### Details:
- Added dynamic-shape regression coverage for `torch.nn.TransformerEncoderLayer` using the PyTorch `torch.export` path.
- Added dynamic dimensions for batch size (`1–4`) and sequence length (`2–12`).
- Added validation for the `aten.scaled_dot_product_attention.default` FX operation.
- Verified `torch.export` generates the expected dynamic shape constraints.
- Built OpenVINO successfully and verified the CPU FP32/FP16 dynamic-shape test cases.
- GPU validation could not be completed due to the local GPU/Python runtime environment.

### Tickets:
- #37455

### AI Assistance:
- AI assistance used: yes
- AI was used to assist with debugging the local OpenVINO build/test environment, reviewing the test changes, and preparing the validation steps. Human validation included reviewing the code changes, successfully building OpenVINO, verifying the exported graph and dynamic shape constraints, and running the dynamic-shape tests. CPU FP32 and FP16 cases passed; GPU validation remained blocked by the local runtime environment. 