### PR TITLE
[NPU] Keep weights defer logic entirely inside the CompiledModel

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -190,7 +190,7 @@ ov::device::Type ZeroDevice::getDeviceType() const {
 
 std::shared_ptr<InferRequest> ZeroDevice::createInferRequest(const std::shared_ptr<const ICompiledModel>& compiledModel,
                                                              const Config& config) {
-    if (compiledModel->get_graph()->is_dynamic()) {
+    if (compiledModel->get_graph()->get_kind() == GraphKind::Dynamic) {
         return std::make_shared<ZeroDynamicInferRequest>(_initStructs, compiledModel, config);
     }
     return std::make_shared<ZeroInferRequest>(_initStructs, compiledModel, config);

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -283,7 +283,7 @@ std::vector<ov::SoPtr<ov::IVariableState>> ZeroInferRequest::query_state() const
 void ZeroInferRequest::setup_pipeline() {
     _logger.debug("setup_pipeline - started");
     std::optional<size_t> batchSize;
-    if (!_graph->is_dynamic()) {
+    if (_graph->get_kind() != GraphKind::Dynamic) {
         batchSize = _graph->get_batch_size();
     }
 
@@ -428,7 +428,7 @@ void ZeroInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
         }
 
         std::optional<size_t> batchSizeCandidate;
-        if (!_graph->is_dynamic()) {
+        if (_graph->get_kind() != GraphKind::Dynamic) {
             const auto& ioShape = _compiledModel->inputs()[foundPort.idx].get_partial_shape();
             batchSizeCandidate =
                 determine_dynamic_batch_size(_metadata.inputs.at(foundPort.idx), ioShape, tensor._ptr, std::nullopt);
@@ -474,7 +474,7 @@ void ZeroInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
         }
 
         std::optional<size_t> batchSizeCandidate;
-        if (!_graph->is_dynamic()) {
+        if (_graph->get_kind() != GraphKind::Dynamic) {
             const auto& ioShape = _compiledModel->outputs()[foundPort.idx].get_partial_shape();
             batchSizeCandidate =
                 determine_dynamic_batch_size(_metadata.outputs.at(foundPort.idx), ioShape, tensor._ptr, std::nullopt);
@@ -594,7 +594,7 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
     _logger.debug("set_tensors - tensor count: %zu", tensors.size());
 
     std::optional<size_t> batchSizeCandidate;
-    if (!_graph->is_dynamic()) {
+    if (_graph->get_kind() != GraphKind::Dynamic) {
         const auto& ioShape = _compiledModel->inputs()[foundPort.idx].get_partial_shape();
         batchSizeCandidate =
             determine_dynamic_batch_size(_metadata.inputs.at(foundPort.idx), ioShape, nullptr, tensors.size());
@@ -616,7 +616,7 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
         } else if (batchSizeCandidate.value() != _graph->get_batch_size().value()) {
             OPENVINO_THROW("Batching size is not matching all the tensors.");
         }
-    } else if (!_graph->is_dynamic()) {
+    } else if (_graph->get_kind() != GraphKind::Dynamic) {
         batchSizeCandidate = _graph->get_batch_size();
     }
 
@@ -728,7 +728,7 @@ ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::N
     auto& userTensor = isInput ? get_user_input(ioIndex) : _userOutputTensors.at(ioIndex);
 
     std::optional<size_t> batchSize;
-    if (!_graph->is_dynamic()) {
+    if (_graph->get_kind() != GraphKind::Dynamic) {
         batchSize = _graph->get_batch_size();
     }
 
@@ -950,7 +950,7 @@ void ZeroInferRequest::prepare_inputs() {
     }
 
     std::optional<size_t> batch_size;
-    if (!_graph->is_dynamic()) {
+    if (_graph->get_kind() != GraphKind::Dynamic) {
         batch_size = _graph->get_batch_size();
     }
     size_t inputIndex = 0;

--- a/src/plugins/intel_npu/src/backend/src/zero_profiling.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_profiling.cpp
@@ -37,7 +37,7 @@ struct ZeProfilingTypeId<uint8_t> {
 bool ProfilingPool::create() {
     // To avoid  dynamic infer flow + perf_count_enabled calling static_cast<ze_graph_handle_t> which is not supported
     // in dynamic graph
-    if (_graph->is_dynamic()) {
+    if (_graph->get_kind() == GraphKind::Dynamic) {
         return false;
     }
 

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -21,6 +21,20 @@ namespace intel_npu {
 
 enum class BlobType : uint8_t { ELF, LLVM, BYTECODE };
 
+enum class GraphKind : uint8_t { Weightful, Weightless, Dynamic };
+
+constexpr const char* to_string(GraphKind kind) noexcept {
+    switch (kind) {
+    case GraphKind::Weightful:
+        return "weightful";
+    case GraphKind::Weightless:
+        return "weightless";
+    case GraphKind::Dynamic:
+        return "dynamic";
+    }
+    return "unknown";
+}
+
 class IGraph : public std::enable_shared_from_this<IGraph> {
 public:
     IGraph() = default;
@@ -53,8 +67,8 @@ public:
     // Callers must static_cast the result to the type matching the concrete graph implementation.
     virtual void* get_handle() const;
 
-    // Returns true if the graph is executed through the VM runtime (dynamic graph), false otherwise.
-    virtual bool is_dynamic() const;
+    // Returns the concrete kind of this graph. Derived classes override to identify themselves.
+    virtual GraphKind get_kind() const;
 
     virtual BlobType get_blob_type() const;
 

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -50,8 +50,8 @@ void* IGraph::get_handle() const {
     OPENVINO_THROW("get_handle not implemented");
 }
 
-bool IGraph::is_dynamic() const {
-    return false;
+GraphKind IGraph::get_kind() const {
+    return GraphKind::Weightful;
 }
 
 BlobType IGraph::get_blob_type() const {

--- a/src/plugins/intel_npu/src/compiler_adapter/include/dynamic_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/dynamic_graph.hpp
@@ -27,8 +27,8 @@ public:
 
     void* get_handle() const override;
 
-    bool is_dynamic() const override {
-        return true;
+    GraphKind get_kind() const override {
+        return GraphKind::Dynamic;
     }
 
     // HostCompile has no fixed plugin-side batch size; return nullopt for the shared import path.

--- a/src/plugins/intel_npu/src/compiler_adapter/include/graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/graph.hpp
@@ -27,8 +27,7 @@ public:
           std::optional<ov::Tensor> blob,
           const FilteredConfig& config,
           const std::optional<std::string>& compatibilityDescriptor = std::nullopt,
-          const bool blobIsPersistent = false,
-          const bool calledFromWeightlessGraph = false);
+          const bool blobIsPersistent = false);
 
     std::pair<uint64_t, std::optional<std::vector<uint64_t>>> export_blob(std::ostream& stream) const override;
 

--- a/src/plugins/intel_npu/src/compiler_adapter/include/weightless_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/weightless_graph.hpp
@@ -48,6 +48,10 @@ public:
      */
     std::pair<uint64_t, std::optional<std::vector<uint64_t>>> export_blob(std::ostream& stream) const override;
 
+    GraphKind get_kind() const override {
+        return GraphKind::Weightless;
+    }
+
     /**
      * @brief Implementation hook for "IGraph::initialize" that initializes all underlying graph handles.
      * In addition to this, the init schedules are run and the result of this is set as inputs to the main

--- a/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
@@ -193,17 +193,10 @@ DynamicGraph::DynamicGraph(const std::shared_ptr<ZeroInitStructsHolder>& zeroIni
       _blobType(blobType),
       _logger("DynamicGraph", config.get<LOG_LEVEL>()) {
     _logger.info("Create DynamicGraph");
-    if (!config.get<CREATE_EXECUTOR>() || config.get<DEFER_WEIGHTS_LOAD>()) {
-        _logger.info("Graph initialize is deferred from the \"Graph\" constructor");
-        return;
-    }
-
-    // TODO: metadata needs to be parsed even when CREATE_EXECUTOR is 0 or DEFER_WEIGHTS_LOAD is YES, keep here to
-    // support pure compilation without vm runtime initialize VM execution engine, metadata, input&output
-    // descriptors
+    // Metadata comes from the VM runtime parsing the blob; unlike a regular Graph, it is not prefetched by the
+    // compiler/parser and must be available before plugin builds a dummy ov::Model for the CompiledModel.
+    // This is CPU-side parsing only - no L0/device setup.
     initialize_engine();
-
-    initialize(config);
 }
 
 std::pair<uint64_t, std::optional<std::vector<uint64_t>>> DynamicGraph::export_blob(std::ostream& stream) const {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -24,8 +24,7 @@ Graph::Graph(const std::shared_ptr<ZeGraphExtWrappers>& zeGraphExt,
              std::optional<ov::Tensor> blob,
              const FilteredConfig& config,
              const std::optional<std::string>& compatibilityDescriptor,
-             const bool blobIsPersistent,
-             const bool calledFromWeightlessGraph)
+             const bool blobIsPersistent)
     : IGraph(),
       _zeGraphExt(zeGraphExt),
       _zeroInitStruct(zeroInitStruct),
@@ -34,21 +33,7 @@ Graph::Graph(const std::shared_ptr<ZeGraphExtWrappers>& zeGraphExt,
       _blob(std::move(blob)),
       _compatibilityDescriptor(compatibilityDescriptor),
       _blobIsPersistent(blobIsPersistent),
-      _logger("Graph", config.get<LOG_LEVEL>()) {
-    if (!calledFromWeightlessGraph) {
-        _logger.info("The current compiled model is a weightful one");
-    }
-
-    if (!config.get<CREATE_EXECUTOR>() || config.get<DEFER_WEIGHTS_LOAD>()) {
-        _logger.info("Graph initialize is deferred from the \"Graph\" constructor");
-        return;
-    }
-
-    if (!calledFromWeightlessGraph) {
-        // Will be called at a later stage from WeightlessGraph::initialize() in order to save some memory
-        initialize(config);
-    }
-}
+      _logger("Graph", config.get<LOG_LEVEL>()) {}
 
 const NetworkMetadata& Graph::get_metadata() const {
     return _metadata;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -269,21 +269,13 @@ WeightlessGraph::WeightlessGraph(
             std::move(mainBlob),
             config,
             /* compatibilityDescriptor = */ std::nullopt,
-            blobIsPersistent,
-            /* calledFromWeightlessGraph = */ true),
+            blobIsPersistent),
       _initsGraphDesc(initGraphDesc),
       _initBlobs(std::move(initBlobs)),
       _initsMetadata(std::move(initMetadata)),
       _constants(extract_constants_map(std::move(weightsSource), _initsMetadata)),
       _wgLogger("WeightlessGraph", config.get<LOG_LEVEL>()) {
     _wgLogger.info("The current compiled model is a weightless one");
-
-    if (!config.get<CREATE_EXECUTOR>() || config.get<DEFER_WEIGHTS_LOAD>()) {
-        _wgLogger.info("Graph initialize is deferred from the \"WeightlessGraph\" constructor");
-        return;
-    }
-
-    initialize(config);
 }
 
 std::pair<uint64_t, std::optional<std::vector<uint64_t>>> WeightlessGraph::export_blob(std::ostream& stream) const {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -274,9 +274,7 @@ WeightlessGraph::WeightlessGraph(
       _initBlobs(std::move(initBlobs)),
       _initsMetadata(std::move(initMetadata)),
       _constants(extract_constants_map(std::move(weightsSource), _initsMetadata)),
-      _wgLogger("WeightlessGraph", config.get<LOG_LEVEL>()) {
-    _wgLogger.info("The current compiled model is a weightless one");
-}
+      _wgLogger("WeightlessGraph", config.get<LOG_LEVEL>()) {}
 
 std::pair<uint64_t, std::optional<std::vector<uint64_t>>> WeightlessGraph::export_blob(std::ostream& stream) const {
     if (_blobIsReleased) {

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -49,6 +49,8 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
         !_propertiesManager->getConfig().get<DEFER_WEIGHTS_LOAD>()) {
         OPENVINO_ASSERT(_graph != nullptr, "Invalid graph handle! Failed to initialize compiled model!");
         _graph->initialize(_propertiesManager->getConfig());
+    } else {
+        _logger.info("Graph initialize is deferred; weights will be loaded on the first infer request creation.");
     }
 
     OV_ITT_TASK_SKIP(COMPILED_MODEL);

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -43,6 +43,14 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
     OV_ITT_TASK_CHAIN(COMPILED_MODEL, itt::domains::NPUPlugin, "CompiledModel::CompiledModel", "initialize_properties");
     _propertiesManager = std::make_unique<CompiledModelPropertyManager>(localConfig, _graph, _batchSize, _logger);
 
+    // Immediate-init path: when weights load is not deferred, initialize the graph now.
+    // The deferred path (CREATE_EXECUTOR off or DEFER_WEIGHTS_LOAD on) is handled in create_infer_request().
+    if (_propertiesManager->getConfig().get<CREATE_EXECUTOR>() &&
+        !_propertiesManager->getConfig().get<DEFER_WEIGHTS_LOAD>()) {
+        OPENVINO_ASSERT(_graph != nullptr, "Invalid graph handle! Failed to initialize compiled model!");
+        _graph->initialize(_propertiesManager->getConfig());
+    }
+
     OV_ITT_TASK_SKIP(COMPILED_MODEL);
 }
 

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -43,11 +43,13 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
     OV_ITT_TASK_CHAIN(COMPILED_MODEL, itt::domains::NPUPlugin, "CompiledModel::CompiledModel", "initialize_properties");
     _propertiesManager = std::make_unique<CompiledModelPropertyManager>(localConfig, _graph, _batchSize, _logger);
 
+    OPENVINO_ASSERT(_graph != nullptr, "Invalid graph handle! Failed to initialize compiled model!");
+    _logger.info("The current compiled model is a %s one", to_string(_graph->get_kind()));
+
     // Immediate-init path: when weights load is not deferred, initialize the graph now.
     // The deferred path (CREATE_EXECUTOR off or DEFER_WEIGHTS_LOAD on) is handled in create_infer_request().
     if (_propertiesManager->getConfig().get<CREATE_EXECUTOR>() &&
         !_propertiesManager->getConfig().get<DEFER_WEIGHTS_LOAD>()) {
-        OPENVINO_ASSERT(_graph != nullptr, "Invalid graph handle! Failed to initialize compiled model!");
         _graph->initialize(_propertiesManager->getConfig());
     } else {
         _logger.info("Graph initialize is deferred; weights will be loaded on the first infer request creation.");

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -48,9 +48,9 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
 
     // Immediate-init path: when weights load is not deferred, initialize the graph now.
     // The deferred path (CREATE_EXECUTOR off or DEFER_WEIGHTS_LOAD on) is handled in create_infer_request().
-    if (_propertiesManager->getConfig().get<CREATE_EXECUTOR>() &&
-        !_propertiesManager->getConfig().get<DEFER_WEIGHTS_LOAD>()) {
-        _graph->initialize(_propertiesManager->getConfig());
+    const FilteredConfig& modelConfig = _propertiesManager->getConfig();
+    if (modelConfig.get<CREATE_EXECUTOR>() && !modelConfig.get<DEFER_WEIGHTS_LOAD>()) {
+        _graph->initialize(modelConfig);
     } else {
         _logger.info("Graph initialize is deferred; weights will be loaded on the first infer request creation.");
     }

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -551,7 +551,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
     std::optional<int64_t> batch = std::nullopt;
     if (originalBatch.has_value() && successfullyDebatched) {
         batch = originalBatch.value().is_static() ? originalBatch.value().get_length() : -1;
-        if (batch > 0 && !graph->is_dynamic()) {
+        if (batch > 0 && graph->get_kind() != GraphKind::Dynamic) {
             // Initial batch setup for static cases
             graph->set_batch_size(batch.value());
         }


### PR DESCRIPTION
### Details:
 - *Keep all checks for CREATE_EXECUTOR and DEFER_WEIGHTS_LOAD inside the CompiledModel*
 - *Remove the _calledFromWeightlessGraph_ argument from the Graph constructor  ( not needed anymore)*
 - *Replace is_dynamic() with a GraphKind enum and log the model kind and deferred-init status once from the CompiledModel constructor*

### Tickets:
 - *CVS-192917*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
