### PR TITLE
[PyOV] Fix coverity issue in `~AsyncInferQueue()`

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp
+++ b/src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp
@@ -47,8 +47,7 @@ public:
             // eventually joins plugin executor threads (via CoreImpl dtor).
             py::gil_scoped_release release;
             m_requests.clear();
-        } catch (const std::exception&) {
-            // Destructors must not throw (would std::terminate); teardown-time callback errors aren't actionable.
+        } catch (...) {
         }
     }
 

--- a/src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp
+++ b/src/bindings/python/src/pyopenvino/core/async_infer_queue.cpp
@@ -42,10 +42,14 @@ public:
     }
 
     ~AsyncInferQueue() {
-        // Release the GIL before destroying requests. m_requests.clear() triggers a C++ destructor chain that
-        // eventually joins plugin executor threads (via CoreImpl dtor).
-        py::gil_scoped_release release;
-        m_requests.clear();
+        try {
+            // Release the GIL before destroying requests. m_requests.clear() triggers a C++ destructor chain that
+            // eventually joins plugin executor threads (via CoreImpl dtor).
+            py::gil_scoped_release release;
+            m_requests.clear();
+        } catch (const std::exception&) {
+            // Destructors must not throw (would std::terminate); teardown-time callback errors aren't actionable.
+        }
     }
 
     bool _is_ready() {


### PR DESCRIPTION
### Details:
```bash
exn_spec_violation: An exception of type pybind11::error_already_set is thrown but the exception specification /*implicit*/noexcept doesn't allow it to be thrown. This will result in a call to terminate().
```

### Tickets:
 - CVS-192443
