### PR TITLE
[`NPU`] [`WS`] [`ONNX`] Enable `.data_proxy` and `.data` extensions for memory mapped constants

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -32,6 +32,7 @@ namespace {
 
 constexpr uint8_t MAIN_SCHEDULE_INDEX = 0;
 constexpr std::string_view WEIGHTS_IR_EXTENSION = ".bin";
+constexpr std::string_view WEIGHTS_ONNX_EXTENSION = ".data_proxy";
 constexpr std::string_view ONNX_EXTENSION = ".onnx";
 
 constexpr std::string_view CONSTANT_OVERFLOW_MESSAGE = "Overflow while computing byte size for constant: ";
@@ -136,12 +137,12 @@ std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> extract_consta
         if (ext == ONNX_EXTENSION) {
             const auto model = core->read_model(weightsPath, weightsPath, {});
             return get_all_constants_in_topological_order(model);
-        } else if (ext == WEIGHTS_IR_EXTENSION) {
+        } else if (ext == WEIGHTS_IR_EXTENSION || ext == WEIGHTS_ONNX_EXTENSION) {
             return get_all_constants_memory_mapped(weightsPath, initNetworkMetadata);
         } else {
             OPENVINO_THROW("Invalid path to the weights: ",
                            weightsPath,
-                           ". A \".bin\" or \".onnx\" extension was expected.");
+                           ". A \".bin\", \".data_proxy\" or \".onnx\" extension was expected.");
         }
     }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/weightless_graph.cpp
@@ -32,7 +32,8 @@ namespace {
 
 constexpr uint8_t MAIN_SCHEDULE_INDEX = 0;
 constexpr std::string_view WEIGHTS_IR_EXTENSION = ".bin";
-constexpr std::string_view WEIGHTS_ONNX_EXTENSION = ".data_proxy";
+constexpr std::string_view WEIGHTS_ONNX_EXTENSION = ".data";
+constexpr std::string_view WEIGHTS_ONNX_PROXY_EXTENSION = ".data_proxy";
 constexpr std::string_view ONNX_EXTENSION = ".onnx";
 
 constexpr std::string_view CONSTANT_OVERFLOW_MESSAGE = "Overflow while computing byte size for constant: ";
@@ -137,12 +138,13 @@ std::unordered_map<size_t, std::shared_ptr<ov::op::v0::Constant>> extract_consta
         if (ext == ONNX_EXTENSION) {
             const auto model = core->read_model(weightsPath, weightsPath, {});
             return get_all_constants_in_topological_order(model);
-        } else if (ext == WEIGHTS_IR_EXTENSION || ext == WEIGHTS_ONNX_EXTENSION) {
+        } else if (ext == WEIGHTS_IR_EXTENSION || ext == WEIGHTS_ONNX_EXTENSION ||
+                   ext == WEIGHTS_ONNX_PROXY_EXTENSION) {
             return get_all_constants_memory_mapped(weightsPath, initNetworkMetadata);
         } else {
             OPENVINO_THROW("Invalid path to the weights: ",
                            weightsPath,
-                           ". A \".bin\", \".data_proxy\" or \".onnx\" extension was expected.");
+                           ". A \".bin\", \".data\", \".data_proxy\" or \".onnx\" extension was expected.");
         }
     }
 

--- a/src/plugins/intel_npu/tests/functional/behavior/weights_separation.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/weights_separation.cpp
@@ -345,6 +345,30 @@ TEST_P(WeightsSeparationTests, CorrectInferenceResultIfWeightsPathUsed) {
 }
 
 /**
+ * @brief compile -> import the result, ov::weights_path with .data extension provided -> create inference request ->
+ * run one inference and check the result
+ */
+TEST_P(WeightsSeparationTests, CorrectInferenceResultIfWeightsPathWithDataExtensionUsed) {
+    model = createTestModel();
+
+    model_path = ov::util::path_join({utils::getCurrentWorkingDir(), utils::generateTestFilePrefix()}).string();
+    ov::serialize(model, model_path + ".xml", model_path + ".data");
+
+    configuration.insert(ov::enable_weightless(true));
+    OV_ASSERT_NO_THROW(compiled_model = core->compile_model(model, target_device, configuration));
+    ASSERT_TRUE(compiled_model);
+
+    std::stringstream export_stream;
+    compiled_model.export_model(export_stream);
+
+    configuration.insert(ov::weights_path(model_path + ".data"));
+    OV_ASSERT_NO_THROW(compiled_model = core->import_model(export_stream, target_device, configuration));
+    ASSERT_TRUE(compiled_model);
+
+    create_infer_request_and_check_result();
+}
+
+/**
  * @brief Providing the wrong weights to a weightless compiled model should produce incorrect results.
  */
 TEST_P(WeightsSeparationTests, WrongInferenceResultIfWrongWeightsProvided) {


### PR DESCRIPTION
### Details:
 - *Follow-up PR for 36669*
 - *Adds `.data_proxy` <b>and `.data`</b> extension**s** for memory mapping constants of a weightless blob*
 - *Old flow for reading constants was to pass the `.onnx` model to weights path and read it*

### Tickets:
 - *C192540*

### AI Assistance:
 - *AI assistance used: no / <s>yes</s>*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
