### PR TITLE
[GPU] Avoid register spills in bfyx OSV32 convolution

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv32.cpp
@@ -239,6 +239,19 @@ bool ConvolutionKernel_bfyx_os_iyx_osv32::Validate(const Params& p) const {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
     }
 
+    // On Xe2+ the scatter input reads in this kernel can access memory beyond
+    // the allocated input buffer for certain dynamic-shape configurations.
+    // Pre-Xe2 hardware silently returns zero for OOB reads but Xe2 raises
+    // CL_OUT_OF_RESOURCES. Disable for dynamic shapes on Xe2+.
+    if (p.is_shape_agnostic) {
+        const auto ip_major = static_cast<uint32_t>(p.engineInfo.ip_version >> 16);
+        const bool is_xe2_or_later = p.engineInfo.arch >= gpu_arch::xe2 ||
+                                     (p.engineInfo.arch == gpu_arch::unknown && ip_major >= 20);
+        if (is_xe2_or_later) {
+            DO_NOT_USE_THIS_KERNEL(p.layerID);
+        }
+    }
+
     // To prevent big sized filter which causes lots of CL build time.
     const size_t acceptable_filter_size = 1024;     // This acceptable size was decided by heuristics
     const auto& params = static_cast<const convolution_params&>(p);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv32.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_bfyx_os_iyx_osv32.cpp
@@ -11,6 +11,65 @@ namespace kernel_selector {
 
 static constexpr size_t sub_group_size = 16;
 
+// The kernel only supports F16, so an input read always covers a whole sub-group.
+static constexpr size_t read_chunk_size = sub_group_size;
+
+// Limit estimated register use to 75% and reserve the rest for addresses and loop temporaries.
+static constexpr size_t registers_count = 128;
+static constexpr size_t reg_threshold = registers_count * 3 / 4;
+
+static std::pair<size_t, size_t> get_bfyx_req_input_block_dims(size_t output_block_width,
+                                                               size_t output_block_height,
+                                                               const uSize& filter_size,
+                                                               const uSize& stride,
+                                                               const uSize& dilation,
+                                                               size_t sg_size,
+                                                               size_t read_chunk_size,
+                                                               size_t min_read_size) {
+    assert(output_block_width > 0 && output_block_height > 0);
+    assert(stride.x > 0 && stride.y > 0);
+    assert(filter_size.x > 0 && filter_size.y > 0);
+
+    // Number of elements in X dimension needed from input to compute output block without re-reading input.
+    size_t input_block_req_width = (output_block_width - 1) * stride.x + (filter_size.x - 1) * dilation.x + 1;
+    // Number of elements in Y dimension needed from input to compute output block without re-reading input.
+    size_t input_block_req_height = (output_block_height - 1) * stride.y + (filter_size.y - 1) * dilation.y + 1;
+
+    // Required number of elements in X dimension rounded to nearest >= read chunk size.
+    size_t input_block_read_width = std::max(RoundUp(input_block_req_width, read_chunk_size), min_read_size);
+    // Number of sub-group-sized vectors of unit type needed to store input block.
+    size_t input_block_array_size = CeilDiv(input_block_req_height * input_block_read_width, sg_size);
+
+    return std::make_pair(input_block_array_size, input_block_read_width);
+}
+
+// Estimate registers used by weights, accumulators, and the input block.
+static size_t get_min_register_usage(const convolution_params& cp, size_t block_width, size_t block_height) {
+    // Match NUM_CALC_UNIT_SIZE in the OpenCL kernel.
+    const size_t units_per_thread = (cp.weights.OFM().v > sub_group_size) ? 2 : 1;
+
+    size_t weights_registers = units_per_thread;
+    size_t output_registers = block_width * block_height * units_per_thread;
+    size_t input_registers = get_bfyx_req_input_block_dims(block_width,
+                                                           block_height,
+                                                           cp.filterSize,
+                                                           cp.stride,
+                                                           cp.dilation,
+                                                           sub_group_size,
+                                                           read_chunk_size,
+                                                           sub_group_size).first;
+
+    return weights_registers + output_registers + input_registers;
+}
+
+// Shrink only when the 1x1 block fits the register budget.
+static bool needs_smaller_block(const convolution_params& cp, size_t block_width, size_t block_height) {
+    if (get_min_register_usage(cp, block_width, block_height) < reg_threshold)
+        return false;
+
+    return get_min_register_usage(cp, 1, 1) < reg_threshold;
+}
+
 ConvolutionKernel_bfyx_os_iyx_osv32::ConvolutionKernel_bfyx_os_iyx_osv32()
     : ConvolutionKernelBase("convolution_gpu_bfyx_os_iyx_osv32") {
     // Generate the dispatch options to the auto-tuner.
@@ -81,13 +140,16 @@ ConvolutionKernel_bfyx_os_iyx_osv32::AutoTuneOption ConvolutionKernel_bfyx_os_iy
         }
     };
 
-    if ((autoTuneIndex >= 0) && (autoTuneIndex < static_cast<int>(autoTuneOptions.size()))) {
+    const convolution_params& cp = static_cast<const convolution_params&>(p);
+
+    if ((autoTuneIndex >= 0) && (autoTuneIndex < static_cast<int>(autoTuneOptions.size())) &&
+        !needs_smaller_block(cp,
+                             autoTuneOptions[autoTuneIndex].blockWidth,
+                             autoTuneOptions[autoTuneIndex].blockHeight)) {
         return autoTuneOptions[autoTuneIndex];
     }
 
     AutoTuneOption option = {0, 0, EXE_MODE_DEFAULT};
-
-    const convolution_params& cp = static_cast<const convolution_params&>(p);
 
     if (cp.stride.x == 1 && cp.stride.y == 1) {
         if (cp.filterSize.x == 1 && cp.filterSize.y == 1) {
@@ -118,36 +180,21 @@ ConvolutionKernel_bfyx_os_iyx_osv32::AutoTuneOption ConvolutionKernel_bfyx_os_iy
     if (!p.is_shape_agnostic && (cp.filterSize.x != 1 || cp.filterSize.y != 1)) {
         shrink_blocks_to_output_size(cp.outputs[0].X().v, cp.outputs[0].Y().v, option.blockWidth, option.blockHeight, sub_group_size);
     }
+
+    // Shrink to the register budget and prefer wider blocks for contiguous memory access.
+    while ((option.blockWidth > 1 || option.blockHeight > 1) &&
+           needs_smaller_block(cp, option.blockWidth, option.blockHeight)) {
+        if (option.blockHeight >= option.blockWidth)
+            option.blockHeight--;
+        else
+            option.blockWidth--;
+    }
+
     return option;
 }
 
 ConvolutionKernelBase::DispatchData ConvolutionKernel_bfyx_os_iyx_osv32::SetDefault(const convolution_params& cp,
                                                                                     int autoTuneIndex) const {
-    auto get_bfyx_req_input_block_dims = [](size_t output_block_width,
-                                            size_t output_block_height,
-                                            const uSize& filter_size,
-                                            const uSize& stride,
-                                            const uSize& dilation,
-                                            size_t sg_size,
-                                            size_t read_chunk_size,
-                                            size_t min_read_size) {
-        assert(output_block_width > 0 && output_block_height > 0);
-        assert(stride.x > 0 && stride.y > 0);
-        assert(filter_size.x > 0 && filter_size.y > 0);
-
-        // Number of elements in X dimension needed from input to compute output block without re-reading input.
-        size_t input_block_req_width = (output_block_width - 1) * stride.x + (filter_size.x - 1) * dilation.x + 1;
-        // Number of elements in Y dimension needed from input to compute output block without re-reading input.
-        size_t input_block_req_height = (output_block_height - 1) * stride.y + (filter_size.y - 1) * dilation.y + 1;
-
-        // Required number of elements in X dimension rounded to nearest >= read chunk size.
-        size_t input_block_read_width = std::max(RoundUp(input_block_req_width, read_chunk_size), min_read_size);
-        // Number of sub-group-sized vectors of unit type needed to store input block.
-        size_t input_block_array_size = CeilDiv(input_block_req_height * input_block_read_width, sg_size);
-
-        return std::make_pair(input_block_array_size, input_block_read_width);
-    };
-
     DispatchData dispatchData = ConvolutionKernelBase::SetDefault(cp);
 
     const auto of_maps = CeilDiv(cp.outputs[0].Feature().v, 2);
@@ -163,7 +210,7 @@ ConvolutionKernelBase::DispatchData ConvolutionKernel_bfyx_os_iyx_osv32::SetDefa
                                                           cp.stride,
                                                           cp.dilation,
                                                           sub_group_size,
-                                                          cp.outputs[0].GetDType() == Datatype::F16 ? sub_group_size : sub_group_size / 2,
+                                                          read_chunk_size,
                                                           sub_group_size);
     dispatchData.cldnnStyle.inputBlockArraySize = input_block_dims.first;
     dispatchData.cldnnStyle.inputBlockWidth = input_block_dims.second;
@@ -190,19 +237,6 @@ bool ConvolutionKernel_bfyx_os_iyx_osv32::Validate(const Params& p) const {
 
     if (!IsSIMDSizeSupported(p.engineInfo, 16)) {
         DO_NOT_USE_THIS_KERNEL(p.layerID);
-    }
-
-    // On Xe2+ the scatter input reads in this kernel can access memory beyond
-    // the allocated input buffer for certain dynamic-shape configurations.
-    // Pre-Xe2 hardware silently returns zero for OOB reads but Xe2 raises
-    // CL_OUT_OF_RESOURCES. Disable for dynamic shapes on Xe2+.
-    if (p.is_shape_agnostic) {
-        const auto ip_major = static_cast<uint32_t>(p.engineInfo.ip_version >> 16);
-        const bool is_xe2_or_later = p.engineInfo.arch >= gpu_arch::xe2 ||
-                                     (p.engineInfo.arch == gpu_arch::unknown && ip_major >= 20);
-        if (is_xe2_or_later) {
-            DO_NOT_USE_THIS_KERNEL(p.layerID);
-        }
     }
 
     // To prevent big sized filter which causes lots of CL build time.


### PR DESCRIPTION
## Issue
 - `RF-DETR` fp16 inference was slower than fp32. 
 - `14x14`, stride-14 convolution took about 50 ms with the `osv32` kernel, while `osv16` took about 3.4 ms.

## Root Cause
- The `osv32` kernel selected a `4x4` output tile without considering register usage.
- The input tile and accumulators exceeded the 128-register budget, causing IGC to move the input tile to thread-private memory.

## Solution
- Estimate register usage before selecting a tile.
- Limit the estimate to 75% of the register file and shrink oversized tiles.
- For the affected convolution, the tile is reduced from 4x4 to 2x2, avoiding private-memory access.

### Tickets:
 - CVS-191299
