### PR TITLE
[GPU] Fix batch broadcasting of Gemm inputs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -276,13 +276,20 @@ layout gemm_inst::transform_output_layout(const std::shared_ptr<const gemm> prim
         auto N = transposed_input1_pshape[transposed_input1_pshape.size() - 1];
 
         auto output_pshape = transposed_input0_pshape;
-        for (size_t i = 0; i != primitive->input_size(); ++i) {
-            auto input_pshape = (i == 0) ? transposed_input0_pshape :
-                                (i == 1) ? transposed_input1_pshape :
-                                input_layouts[i].get_partial_shape();
-            for (size_t j = 0; j != input_pshape.size(); ++j) {
-                if (input_pshape[j].get_max_length() != input_pshape[j].get_min_length())
-                    ov::Dimension::merge(output_pshape[j], output_pshape[j], input_pshape[j]);
+
+        // Output batch is the broadcast of all inputs, not just input0. max() for static dims,
+        // to match calc_output_layout() and ov::intel_gpu::op::shape_infer().
+        for (size_t i = 1; i != primitive->input_size(); ++i) {
+            auto input_pshape = (i == 1) ? transposed_input1_pshape : input_layouts[i].get_partial_shape();
+            const auto rank = std::min(output_pshape.size(), input_pshape.size());
+            for (size_t j = 0; j != rank; ++j) {
+                if (output_pshape[j].is_static() && input_pshape[j].is_static()) {
+                    output_pshape[j] = std::max(output_pshape[j].get_length(), input_pshape[j].get_length());
+                } else {
+                    ov::Dimension broadcasted_dim;
+                    if (ov::Dimension::broadcast_merge(broadcasted_dim, output_pshape[j], input_pshape[j]))
+                        output_pshape[j] = std::move(broadcasted_dim);
+                }
             }
         }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/gemm.cpp
@@ -84,15 +84,19 @@ std::vector<ov::PartialShape> shape_infer(const Gemm* op,
 
     // broadcast all batch dimensions
     const auto is_broadcastable = shape_a_t.rank().is_static() &&
-                                  shape_a_t.rank().is_static() &&
+                                  shape_b_t.rank().is_static() &&
                                   shape_a_t.size() > 1 &&
-                                  shape_b_t.size() > 1 &&
-                                  (shape_a_t.size() == shape_b_t.size());
+                                  shape_b_t.size() > 1;
     if (is_broadcastable) {
-        size_t max_rank = shape_a_t.size();
+        const size_t max_rank = std::max(shape_a_t.size(), shape_b_t.size());
+        shape_a_t.insert(shape_a_t.begin(), max_rank - shape_a_t.size(), ov::Dimension(1));
+        shape_b_t.insert(shape_b_t.begin(), max_rank - shape_b_t.size(), ov::Dimension(1));
+
+        // max(), not numpy broadcast: UnsqueezeBroadcastReshapeMatmulFusion leaves the GQA head
+        // expansion (num_kv_heads -> num_heads) implicit, so neither dim is necessarily 1.
         for (size_t i = 0; i < max_rank - 2; ++i) {
             if (shape_a_t[i].is_static() && shape_b_t[i].is_static()) {
-                auto result = std::max(shape_a_t[i].get_length(), shape_b_t[i].get_length());
+                const auto result = std::max(shape_a_t[i].get_length(), shape_b_t[i].get_length());
                 shape_a_t[i] = result;
                 shape_b_t[i] = result;
             }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -1834,6 +1834,78 @@ public:
             ASSERT_NEAR(output_ptr[i], ref_out_data[i], abs_error) << "at " << i;
         }
     }
+
+    // Same as test_dynamic_static_broadcast_3dim, but the batch which has to be broadcast
+    // belongs to the *first* input: [1, M, K] x [B, K, N] -> [B, M, N].
+    // gemm_inst::transform_output_layout seeds the output shape from input0, so only this
+    // direction exposes a missing batch broadcast in it.
+    void test_static_dynamic_broadcast_3dim_in0(std::vector<size_t> BMKN, bool is_caching_test, const double abs_error = 0.0001) {
+        tests::random_generator rg;
+        rg.set_seed(GET_SUITE_NAME);
+
+        auto& engine = get_test_engine();
+
+        std::vector<int64_t> input0_order = {0, 1, 2};
+        std::vector<int64_t> input1_order = {0, 1, 2};
+        std::vector<int64_t> output_order = {0, 1, 2};
+
+        size_t BATCH_SIZE = BMKN[0];
+        size_t M_SIZE = BMKN[1];
+        size_t K_SIZE = BMKN[2];
+        size_t N_SIZE = BMKN[3];
+
+        ov::Shape input0_shape = {          1, M_SIZE, K_SIZE };
+        ov::Shape input1_shape = { BATCH_SIZE, K_SIZE, N_SIZE };
+        ov::Shape output_shape = { BATCH_SIZE, M_SIZE, N_SIZE };
+
+        auto input0_layout = layout{ov::PartialShape(input0_shape), data_types::f16, format::bfyx};
+        auto input1_layout = layout{ov::PartialShape::dynamic(input1_shape.size()), data_types::f16, format::bfyx};
+
+        auto input0_mem = engine.allocate_memory(layout{ov::PartialShape(input0_shape), data_types::f16, format::bfyx});
+        auto input1_mem = engine.allocate_memory(layout{ov::PartialShape(input1_shape), data_types::f16, format::bfyx});
+
+        auto input_0_data = rg.generate_random_1d<ov::float16>(ov::shape_size(input0_shape), -2, 2);
+        auto input_1_data = rg.generate_random_1d<ov::float16>(ov::shape_size(input1_shape), -2, 2);
+
+        set_values(input0_mem, input_0_data);
+        set_values(input1_mem, input_1_data);
+
+        topology topology;
+        topology.add(input_layout("input0", input0_layout),
+                     input_layout("input1", input1_layout),
+                     gemm("gemm", { input_info("input0"), input_info("input1") }, data_types::f16, input0_order, input1_order, output_order)
+        );
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
+        network->set_input_data("input0", input0_mem);
+        network->set_input_data("input1", input1_mem);
+
+        auto outputs = network->execute();
+
+        auto output_mem = outputs.at("gemm").get_memory();
+        cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(output_mem, get_test_stream());
+
+        std::vector<ov::float16> ref_out_data;
+        ref_out_data.resize(ov::shape_size(output_shape));
+
+        ov::reference::matmul<ov::float16>(input_0_data.data(),
+                                     input_1_data.data(),
+                                     ref_out_data.data(),
+                                     input0_shape,
+                                     input1_shape,
+                                     output_shape,
+                                     false,
+                                     false);
+
+        ASSERT_EQ(output_ptr.size(), ref_out_data.size());
+
+        for (uint32_t i = 0; i < ref_out_data.size(); ++i) {
+            ASSERT_NEAR(output_ptr[i], ref_out_data[i], abs_error) << "at " << i;
+        }
+    }
 };
 
 TEST_F(gemm_gpu_tests, basic_bfyx_t2_inplace_crop_with_pad) {
@@ -1979,6 +2051,14 @@ TEST_F(gemm_gpu_tests, transpose_matmul_static_4d_f32_n_tile_32_input1_ylast) {
 
 TEST_F(gemm_gpu_tests, test_dynamic_static_broadcast_3dim) {
     this->test_dynamic_static_broadcast_3dim(/*BMKN*/{2, 16, 2, 2}, false);
+}
+
+TEST_F(gemm_gpu_tests, test_static_dynamic_broadcast_3dim_in0) {
+    this->test_static_dynamic_broadcast_3dim_in0(/*BMKN*/{2, 16, 2, 2}, false);
+}
+
+TEST_F(gemm_gpu_tests, test_static_dynamic_broadcast_3dim_in0_cached) {
+    this->test_static_dynamic_broadcast_3dim_in0(/*BMKN*/{2, 16, 2, 2}, true);
 }
 
 TEST_F(gemm_gpu_tests, transpose_matmul_in0_indirect) {


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)

- **Symptom** — Accuracy drop on GPU for models whose MatMul relies on implicit
  broadcasting of the batch dimension. Most of the output is left uninitialized.
- **Root cause** — GPU `Gemm` does not broadcast the batch when it has to be expanded from
  the *first* input (`[1, M, K] x [B, K, N]`), so the output layout keeps `batch = 1` and
  only the first slice is computed. `gemm_inst::transform_output_layout()` seeds the output
  shape from input0 and its merge loop only ran for dynamic dimensions, but the impls call
  it with concrete shapes, so it never executed. `ov::Dimension::merge()` would not have
  helped either - it is an intersection, not a broadcast: `merge(1, 1000)` does not give
  `1000`.
- **How it was resolved** — `transform_output_layout()` now merges the batch of every input
  into the output: `std::max()` for static dimension pairs, `ov::Dimension::broadcast_merge()`
  for the rest. This matches the legacy static path `gemm_inst::calc_output_layout()` and
  `ov::intel_gpu::op::shape_infer(Gemm)`, so the oneDNN matmul dst dims can no longer drift
  from the shape the ov-level inference produced.

`std::max()` is deliberate, not numpy broadcasting. `UnsqueezeBroadcastReshapeMatmulFusion`
removes the Unsqueeze/Broadcast/Reshape chain in front of a `Gemm` and leaves the GQA head
expansion (`num_kv_heads` -> `num_heads`) to be done implicitly by the kernel, so the two
batch dimensions are legitimately non-broadcastable (e.g. `2` vs `32`, neither being `1`).
`gemm_gpu_tests.unsqueeze_broadcast_reshape_transpose_matmul` and
`mark_shape_of_subgraphs.gemm_not_marked` cover that path.

`ov::intel_gpu::op::shape_infer(Gemm)` is fixed separately as hardening: `is_broadcastable`
checked `shape_a_t.rank().is_static()` twice instead of also checking `shape_b_t`, and it
bailed out entirely on a rank mismatch. Rank mismatches are now normalized by left-padding
with `1`. This does not change the ov-level output shape, since
`ov::op::v0::shape_infer(MatMul)` runs right after and already broadcasts.

#### The code and line that caused this issue (if it is not changed directly)

- `common/transformations/.../broadcast_matmul_fusion.cpp` — `BroadcastMatMulFusion`,
  registered in `moc_transformations.cpp`, removes the explicit `Broadcast` in front of a
  `MatMul` and relies on implicit broadcasting. It runs at model-conversion time only, so
  older IRs are unaffected.


#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
Any model with a `MatMul` whose first input has batch 1 and second input a larger batch, after the explicit `Broadcast` has been fused away. Reproduced with `who_what_benchmark` against a CPU reference:

```
$ wwb --target-model <ov_model_dir> --gt-data <reference.csv> \
      --model-type text --genai --device GPU
```

#### Problematic graph

```
before:  MatMul <- Broadcast [-1,128,1] <- Constant [1,128,1]
                <- Convert   [-1,1,-1]

after:   MatMul <- Constant  [1,128,1]     (Broadcast removed)
                <- Convert   [-1,1,-1]
```

Runtime shapes are `[1, 128, 1] x [B, 1, 1]`. Without the fix the output layout stays `[1, 128, 1]` and the remaining `B-1` rows are uninitialized memory.

#### Checklist

- [x] Is it a proper fix? (not a workaround)

  Yes — the output layout now follows the same `broadcast_merge()` semantics as `ov::op::v0::MatMul` shape inference, instead of relying on an explicit `Broadcast` in the graph.

- [x] Did you include test case for this fix, if necessary?

  Yes, added to `gemm_gpu_test.cpp`.

- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?

  `gemm_gpu_tests.test_dynamic_static_broadcast_3dim` — it broadcasts the *second* input's batch, which is correct even without the fix. The new test is its mirror image.

### Tickets:
 - *192876*