### PR TITLE
[CPU] Add WidenGatherMatmulWeights transformation

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/widen_gather_matmul_weights.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/widen_gather_matmul_weights.cpp
@@ -1,0 +1,165 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "widen_gather_matmul_weights.hpp"
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "openvino/cc/pass/itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/core/type/element_iterator.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/reference/convert.hpp"
+#include "openvino/runtime/tensor.hpp"
+#include "ov_ops/gather_matmul.hpp"
+
+namespace {
+
+struct Widening {
+    ov::element::Type_t from;
+    ov::element::Type_t to;
+};
+
+// Narrow types GatherMatmul has no executor for, paired with the narrowest type it does support
+// that represents them losslessly. u2 holds [0..3] and u4 a nibble, so the values survive.
+constexpr std::array<Widening, 1> kWidenings{{{ov::element::u2, ov::element::u4}}};
+
+// Re-emit `src` with the same values stored as `to`. element::iterator handles the sub-byte
+// (un)packing, so this is just a value copy between two integer types.
+// One explicit branch per kWidenings entry: the iterator element types are template arguments.
+std::shared_ptr<ov::op::v0::Constant> widen_constant(const ov::op::v0::Constant& src, ov::element::Type to) {
+    ov::Tensor dst(to, src.get_shape());
+    const size_t count = ov::shape_size(src.get_shape());
+    if (src.get_element_type() == ov::element::u2 && to == ov::element::u4) {
+        ov::reference::convert(ov::element::iterator<ov::element::u2>(static_cast<const int8_t*>(src.get_data_ptr())),
+                               ov::element::iterator<ov::element::u4>(static_cast<int8_t*>(dst.data())),
+                               count);
+    } else {
+        OPENVINO_THROW("WidenGatherMatmulWeights: no widening implemented for ",
+                       src.get_element_type(),
+                       " -> ",
+                       to);
+    }
+    return std::make_shared<ov::op::v0::Constant>(dst);
+}
+
+// Is `out` consumed, through the rest of a CompressedWeightsBlock, as a GatherMatmul's weight
+// input? Traversal is restricted to the block's own op types -- all of which preserve the element
+// type -- so it cannot wander into the surrounding model.
+bool feeds_gather_matmul_weights(const ov::Output<ov::Node>& out) {
+    constexpr size_t kWeightsInput = 1;
+    std::vector<ov::Output<ov::Node>> stack{out};
+    std::unordered_set<const ov::Node*> visited;
+    while (!stack.empty()) {
+        const auto cur = stack.back();
+        stack.pop_back();
+        for (const auto& target : cur.get_target_inputs()) {
+            auto* node = target.get_node();
+            if (ov::is_type<ov::op::internal::GatherMatmul>(node)) {
+                if (target.get_index() == kWeightsInput) {
+                    return true;
+                }
+                continue;
+            }
+            if (!ov::is_type_any_of<ov::op::v1::Subtract,
+                                    ov::op::v1::Multiply,
+                                    ov::op::v1::Reshape,
+                                    ov::op::v1::Transpose,
+                                    ov::op::v0::Convert>(node) ||
+                !visited.insert(node).second) {
+                continue;
+            }
+            for (const auto& o : node->outputs()) {
+                stack.push_back(o);
+            }
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+ov::intel_cpu::WidenGatherMatmulWeights::WidenGatherMatmulWeights(
+    const std::vector<ov::element::Type>& supported_weights_types) {
+    MATCHER_SCOPE(WidenGatherMatmulWeights);
+
+    const auto supported = [&supported_weights_types](ov::element::Type t) {
+        return std::find(supported_weights_types.begin(), supported_weights_types.end(), t) !=
+               supported_weights_types.end();
+    };
+
+    // Only widenings this build actually needs: source unsupported, target supported.
+    std::vector<Widening> widenings;
+    for (const auto& w : kWidenings) {
+        if (!supported(w.from) && supported(w.to)) {
+            widenings.push_back(w);
+        }
+    }
+    if (widenings.empty()) {
+        return;
+    }
+
+    const auto is_widenable = [widenings](const ov::Output<ov::Node>& out) {
+        return std::any_of(widenings.begin(), widenings.end(), [&](const Widening& w) {
+            return out.get_element_type() == w.from;
+        });
+    };
+
+    // Match the head of the dequantization subgraph (Constant -> Convert), not the whole
+    // CompressedWeightsBlock: the block's shape between there and the GatherMatmul varies
+    // (Reshape / Transpose / extra Convert), and only the Constant's storage type changes here.
+    auto weights = ov::pass::pattern::wrap_type<ov::op::v0::Constant>(is_widenable);
+    auto convert = ov::pass::pattern::wrap_type<ov::op::v0::Convert>({weights});
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto weights_out = pattern_map.at(weights);
+        auto constant = ov::as_type_ptr<ov::op::v0::Constant>(weights_out.get_node_shared_ptr());
+        if (!constant) {
+            return false;
+        }
+
+        // Widening costs real bytes, so do it only where it buys the compressed path: a weight
+        // input of a GatherMatmul. Walk forward from the Convert through the remaining
+        // CompressedWeightsBlock shapes only (Subtract / Multiply / Reshape / Transpose / Convert,
+        // all element-type-preserving), so the search stays inside the dequantization subgraph
+        // instead of escaping into the rest of the model.
+        if (!feeds_gather_matmul_weights(pattern_map.at(convert))) {
+            return false;
+        }
+
+        ov::element::Type to;
+        for (const auto& w : kWidenings) {
+            if (constant->get_element_type() == w.from) {
+                to = w.to;
+                break;
+            }
+        }
+        if (to == ov::element::dynamic) {
+            return false;
+        }
+
+        auto widened = widen_constant(*constant, to);
+        widened->set_friendly_name(constant->get_friendly_name());
+        ov::copy_runtime_info(constant, widened);
+        ov::replace_node(constant, widened);
+        return true;
+    };
+
+    this->register_matcher(std::make_shared<ov::pass::pattern::Matcher>(convert, matcher_name), callback);
+}

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/widen_gather_matmul_weights.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/widen_gather_matmul_weights.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/pass/matcher_pass.hpp"
+
+namespace ov::intel_cpu {
+
+// ============================================================================
+// WidenGatherMatmulWeights
+// ============================================================================
+//
+// Widens a GatherMatmul's compressed weight Constant to the narrowest element type the node
+// actually supports, when its own type is not supported but can be represented losslessly by
+// one that is.
+//
+// GatherMatmul accepts fewer compressed weight types than FullyConnected does (see
+// GatherMatmul::getSupportedCompressedWeightsTypes) -- notably it has no u2 executor, while
+// FullyConnected does. Without this pass a u2 weight tensor is simply not matched by
+// ConvertGatherMatmulToGatherMatmulCompressed, so its Convert -> Subtract -> Multiply
+// dequantization subgraph stays in the graph and constant folding materializes the weights in
+// f32: a 16x expansion off a 2-bit type, which on a wide MoE model is many gigabytes. Paying
+// 2x to reach a supported type is far cheaper than falling off the compressed path entirely.
+//
+// The widening is lossless (u2's [0..3] fits a nibble) and leaves the dequantization arithmetic
+// untouched -- only the storage type of the weight Constant changes -- so the following
+// compression pass matches and numerics are unaffected. Must run BEFORE
+// ConvertGatherMatmulToGatherMatmulCompressed.
+//
+// This is a workaround for a missing executor, not a desirable state: when GatherMatmul gains
+// native support for a type listed in kWidenings below, drop that entry.
+class WidenGatherMatmulWeights : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("WidenGatherMatmulWeights");
+
+    // `supported_weights_types` is the node's own capability list, i.e.
+    // GatherMatmul::getSupportedCompressedWeightsTypes(). A widening is applied only if its
+    // source type is absent from that list and its target type is present, so the pass is a
+    // no-op on a build/architecture where the narrow type is already supported.
+    explicit WidenGatherMatmulWeights(const std::vector<ov::element::Type>& supported_weights_types);
+};
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/tests/unit/transformations/widen_gather_matmul_weights_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/widen_gather_matmul_weights_test.cpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/cpu_opset/common/pass/widen_gather_matmul_weights.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "openvino/core/model.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/pass/manager.hpp"
+#include "ov_ops/gather_matmul.hpp"
+
+using namespace ov::intel_cpu;
+
+namespace {
+
+// GatherMatmul's x86_64 capability list (see GatherMatmul::getSupportedCompressedWeightsTypes):
+// no u2, hence the pass.
+const std::vector<ov::element::Type> kSupported{ov::element::u8, ov::element::i8, ov::element::u4, ov::element::i4};
+
+constexpr size_t kExperts = 4;
+constexpr size_t kOc = 8;
+constexpr size_t kGroups = 2;
+constexpr size_t kGroupSize = 16;
+constexpr size_t kIc = kGroups * kGroupSize;
+
+std::vector<int32_t> weight_values() {
+    std::vector<int32_t> v(kExperts * kOc * kIc);
+    for (size_t i = 0; i < v.size(); ++i) {
+        v[i] = static_cast<int32_t>(i % 4);  // covers the full u2 range
+    }
+    return v;
+}
+
+// weights(`wt`, grouped) -> Convert -> Subtract(zp) -> Multiply(scale) -> Reshape: a
+// CompressedWeightsBlock over per-expert weights.
+std::shared_ptr<ov::Node> make_weights_block(ov::element::Type wt, const std::vector<int32_t>& values) {
+    const ov::Shape grouped{kExperts, kOc, kGroups, kGroupSize};
+    const ov::Shape per_group{kExperts, kOc, kGroups, 1};
+    auto weights = std::make_shared<ov::op::v0::Constant>(wt, grouped, values);
+    auto convert = std::make_shared<ov::op::v0::Convert>(weights, ov::element::f32);
+    auto zp = ov::op::v0::Constant::create(ov::element::u8, per_group, {1});
+    auto sub =
+        std::make_shared<ov::op::v1::Subtract>(convert, std::make_shared<ov::op::v0::Convert>(zp, ov::element::f32));
+    auto scale = ov::op::v0::Constant::create(ov::element::f32, per_group, {0.5f});
+    auto mul = std::make_shared<ov::op::v1::Multiply>(sub, scale);
+    auto pattern =
+        ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{kExperts, kOc, kIc});
+    return std::make_shared<ov::op::v1::Reshape>(mul, pattern, false);
+}
+
+std::shared_ptr<ov::Model> make_gather_matmul_model(ov::element::Type wt, const std::vector<int32_t>& values) {
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 6, kIc});
+    auto index = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{6, 2}, {1});
+    auto bgm = std::make_shared<ov::op::internal::GatherMatmul>(input, make_weights_block(wt, values), index);
+    return std::make_shared<ov::Model>(ov::OutputVector{bgm}, ov::ParameterVector{input});
+}
+
+void run_pass(const std::shared_ptr<ov::Model>& model, const std::vector<ov::element::Type>& supported) {
+    ov::pass::Manager manager;
+    manager.register_pass<WidenGatherMatmulWeights>(supported);
+    manager.run_passes(model);
+}
+
+// The weight Constant at the head of the decompression subgraph: the one feeding the Convert.
+std::shared_ptr<ov::op::v0::Constant> find_weights(const std::shared_ptr<ov::Model>& model) {
+    std::shared_ptr<ov::op::v0::Constant> found;
+    for (const auto& node : model->get_ordered_ops()) {
+        auto convert = ov::as_type_ptr<ov::op::v0::Convert>(node);
+        if (!convert) {
+            continue;
+        }
+        auto c = ov::as_type_ptr<ov::op::v0::Constant>(convert->get_input_node_shared_ptr(0));
+        if (c && c->get_shape() == ov::Shape{kExperts, kOc, kGroups, kGroupSize}) {
+            EXPECT_EQ(found, nullptr) << "expected exactly one weight Constant";
+            found = c;
+        }
+    }
+    return found;
+}
+
+}  // namespace
+
+// A u2 expert-weight Constant is re-emitted as u4, values preserved. Only the storage type
+// changes: the rest of the decompression subgraph is untouched, so the compression pass that runs
+// next can match it.
+TEST(WidenGatherMatmulWeights, U2WeightsWidenedToU4) {
+    const auto values = weight_values();
+    auto model = make_gather_matmul_model(ov::element::u2, values);
+    const size_t ops_before = model->get_ordered_ops().size();
+
+    run_pass(model, kSupported);
+
+    auto weights = find_weights(model);
+    ASSERT_NE(weights, nullptr);
+    EXPECT_EQ(weights->get_element_type(), ov::element::u4);
+    EXPECT_EQ(weights->get_shape(), (ov::Shape{kExperts, kOc, kGroups, kGroupSize}));
+    EXPECT_EQ(weights->cast_vector<int32_t>(), values) << "widening must be lossless";
+    EXPECT_EQ(model->get_ordered_ops().size(), ops_before) << "no node added or removed";
+}
+
+// u4 is natively supported: nothing to do.
+TEST(WidenGatherMatmulWeights, SupportedTypeIsUntouched) {
+    auto model = make_gather_matmul_model(ov::element::u4, weight_values());
+    run_pass(model, kSupported);
+    EXPECT_EQ(find_weights(model)->get_element_type(), ov::element::u4);
+}
+
+// The pass is driven by the node's own capability list, so on a build where u2 is supported it is
+// a no-op rather than a wasted 2x.
+TEST(WidenGatherMatmulWeights, NoOpWhenNarrowTypeIsSupported) {
+    auto model = make_gather_matmul_model(ov::element::u2, weight_values());
+    std::vector<ov::element::Type> supported_with_u2{kSupported};
+    supported_with_u2.push_back(ov::element::u2);
+
+    run_pass(model, supported_with_u2);
+
+    EXPECT_EQ(find_weights(model)->get_element_type(), ov::element::u2);
+}
+
+// Widening costs 2x the weight bytes, so it must not touch weights that no GatherMatmul consumes:
+// those reach FullyConnected, which supports u2 natively.
+TEST(WidenGatherMatmulWeights, NonGatherMatmulConsumerIsUntouched) {
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{kExperts, 6, kIc});
+    auto mm = std::make_shared<ov::op::v0::MatMul>(input,
+                                                  make_weights_block(ov::element::u2, weight_values()),
+                                                  false,
+                                                  true);
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{mm}, ov::ParameterVector{input});
+
+    run_pass(model, kSupported);
+
+    EXPECT_EQ(find_weights(model)->get_element_type(), ov::element::u2);
+}


### PR DESCRIPTION
### Details:
 - Adds `WidenGatherMatmulWeights`, a `MatcherPass` that widens a GatherMatmul's compressed weight `Constant` to the narrowest element type the node actually supports, when its own type isn't supported but can be represented losslessly by one that is.
 - GatherMatmul accepts fewer compressed weight types than FullyConnected does (see `GatherMatmul::getSupportedCompressedWeightsTypes`) — notably it has no u2 executor, while FullyConnected does. Without this pass a u2 weight tensor is simply not matched by `ConvertGatherMatmulToGatherMatmulCompressed`, so its Convert -> Subtract -> Multiply dequantization subgraph stays in the graph and constant folding materializes the weights in f32: a 16x expansion off a 2-bit type, which on a wide MoE model is many gigabytes. Paying 2x to reach a supported type is far cheaper than falling off the compressed path entirely.
 - The widening is lossless (u2's [0..3] fits a nibble) and leaves the dequantization arithmetic untouched — only the storage type of the weight Constant changes — so the following compression pass matches and numerics are unaffected.
 - Extracted from #37421 (GGUF native `.gguf` graph builder). Draft for now: the pass is not yet wired into the CPU plugin's transformation pipeline — that follows once its MoE expert-weight caller lands.

### Tickets:
 - CVS-188634

### AI Assistance:
 - *AI assistance used: yes*
 - AI wrote the pass and its unit test as part of the larger GGUF MoE effort; extracted here unchanged. Human-validated by building and running the accompanying unit test.