### PR TITLE
[NPU][compile_tool] Fix --raw_blob enable logic

### DIFF
--- a/src/plugins/intel_npu/tools/compile_tool/main.cpp
+++ b/src/plugins/intel_npu/tools/compile_tool/main.cpp
@@ -130,6 +130,15 @@ std::vector<std::string> splitStringList(const std::string& str, char delim) {
     return result;
 }
 
+// Splits a device string such as "NPU.3720" into the base device name ("NPU") and platform suffix ("3720").
+std::pair<std::string, std::string> splitDeviceAndPlatform(const std::string& device) {
+    const auto separator = device.find('.');
+    if (separator == std::string::npos) {
+        return {device, std::string()};
+    }
+    return {device.substr(0, separator), device.substr(separator + 1)};
+}
+
 std::map<std::string, std::string> parseArgMap(std::string argMap) {
     argMap.erase(std::remove_if(argMap.begin(), argMap.end(), ::isspace), argMap.end());
 
@@ -505,9 +514,20 @@ int main(int argc, char* argv[]) {
         auto configs = parseConfigFile();
         if (FLAGS_pc) {
             configs["PERF_COUNT"] = "YES";
+        }        
+        const auto [device, platform] = splitDeviceAndPlatform(FLAGS_d);
+        if (!platform.empty()) {
+            if (device == "NPU") {
+                // set only if was not previously parsed from config
+                if (configs.find("NPU_PLATFORM") == configs.end()) {
+                    configs["NPU_PLATFORM"] = platform;
+                } else {
+                    std::cout << "Ignoring -d platform suffix already set via -load_config." << std::endl;
+                }
+            }   
         }
         if (FLAGS_raw_blob) {
-            if (FLAGS_d == "NPU") {
+            if (device == "NPU") {
                 // set only if was not previously parsed from config
                 if (configs.find("NPU_EXPORT_RAW_BLOB") == configs.end()) {
                     configs["NPU_EXPORT_RAW_BLOB"] = "YES";

--- a/src/plugins/intel_npu/tools/compile_tool/main.cpp
+++ b/src/plugins/intel_npu/tools/compile_tool/main.cpp
@@ -130,15 +130,6 @@ std::vector<std::string> splitStringList(const std::string& str, char delim) {
     return result;
 }
 
-// Splits a device string such as "NPU.3720" into the base device name ("NPU") and platform suffix ("3720").
-std::pair<std::string, std::string> splitDeviceAndPlatform(const std::string& device) {
-    const auto separator = device.find('.');
-    if (separator == std::string::npos) {
-        return {device, std::string()};
-    }
-    return {device.substr(0, separator), device.substr(separator + 1)};
-}
-
 std::map<std::string, std::string> parseArgMap(std::string argMap) {
     argMap.erase(std::remove_if(argMap.begin(), argMap.end(), ::isspace), argMap.end());
 
@@ -514,20 +505,9 @@ int main(int argc, char* argv[]) {
         auto configs = parseConfigFile();
         if (FLAGS_pc) {
             configs["PERF_COUNT"] = "YES";
-        }        
-        const auto [device, platform] = splitDeviceAndPlatform(FLAGS_d);
-        if (!platform.empty()) {
-            if (device == "NPU") {
-                // set only if was not previously parsed from config
-                if (configs.find("NPU_PLATFORM") == configs.end()) {
-                    configs["NPU_PLATFORM"] = platform;
-                } else {
-                    std::cout << "Ignoring -d platform suffix already set via -load_config." << std::endl;
-                }
-            }   
         }
         if (FLAGS_raw_blob) {
-            if (device == "NPU") {
+            if (FLAGS_d.find("NPU") != std::string::npos) {
                 // set only if was not previously parsed from config
                 if (configs.find("NPU_EXPORT_RAW_BLOB") == configs.end()) {
                     configs["NPU_EXPORT_RAW_BLOB"] = "YES";


### PR DESCRIPTION
### Details:
 - Bugfix: Export Raw Blob argument would be ignored when `-d` strings didn't match `NPU` exactly.

### Tickets:
 - E230245
 
### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
