### PR TITLE
[GPU] Tune FC transpose policy for medium-K f16 matmuls

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -257,8 +257,34 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected(bool supports_immad
              // non-transposed kernel can regress by up to ~1.3x there). Restrict
              // the non-transposed path to XMX-capable GPUs (supports_immad) with
              // K >= 8192 and (M <= 512 or N <= 4096) to keep the wins while avoiding those regressions.
-             if (k >= 8192 && (m <= 512 || n <= 4096) &&
-                 matmul->get_input_element_type(0) == ov::element::f16 && !is_compressed_weight) {
+             const bool large_k_thin_output = k >= 8192 && (m <= 512 || n <= 4096);
+             const bool input_is_f16 = matmul->get_input_element_type(0) == ov::element::f16;
+
+             // Empirical benchdnn and model-level benchmarking showed that
+             // f16 matmuls with a medium reduction dimension and thin output
+             // dimensions can benefit from keeping weights non-transposed.
+             //
+             // This covers the visual MLP-down projection shape observed in
+             // VLA workloads:
+             //   M = 256, K = 3420, N = 1280.
+             //
+             // Keep the condition narrow to avoid changing broad FC behavior.
+             const bool medium_k_thin_output =
+                 input_is_f16 &&
+                 !is_compressed_weight &&
+                 k >= 2048 &&
+                 k < 8192 &&
+                 m >= 128 &&
+                 m <= 512 &&
+                 n >= 1024 &&
+                 n <= 4096 &&
+                 k > n;
+
+             if (large_k_thin_output && input_is_f16 && !is_compressed_weight) {
+                 is_small_matmul = false;
+             }
+
+             if (medium_k_thin_output) {
                  is_small_matmul = false;
              }
         }

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -35,6 +35,30 @@
 using namespace testing;
 using namespace ov::intel_gpu;
 
+namespace {
+
+class ConvertMatMulToFullyConnectedPolicyTestsF : public TransformationTestsF {
+public:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+};
+
+struct MediumF16MatMulPolicyParams {
+    size_t m;
+    size_t k;
+    size_t n;
+    bool expect_non_transposed;
+    std::string test_name;
+};
+
+class ConvertMatMulToFullyConnectedMediumF16PolicyTestsF
+    : public ConvertMatMulToFullyConnectedPolicyTestsF,
+      public WithParamInterface<MediumF16MatMulPolicyParams> {};
+
+}  // namespace
+
 TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest1) {
     {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 3, 2, 2 });
@@ -948,7 +972,8 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_NonTranspose
 }
 
 // Medium f16 matmul matching visual MLP-down shape: non-transposed path (transpose_b=false).
-TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_NonTransposed_VisualMlpDown) {
+TEST_F(ConvertMatMulToFullyConnectedPolicyTestsF,
+       ConvertMatMulToFullyConnected_MediumF16_NonTransposed_VisualMlpDown) {
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 3420});
         auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{3420, 1280}, {1});
@@ -968,7 +993,8 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_NonTranspos
 }
 
 // Medium f16 matmul near the target range: non-transposed path (transpose_b=false).
-TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_NonTransposed_Nearby) {
+TEST_F(ConvertMatMulToFullyConnectedPolicyTestsF,
+       ConvertMatMulToFullyConnected_MediumF16_NonTransposed_Nearby) {
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 4096});
         auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{4096, 1280}, {1});
@@ -988,7 +1014,8 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_NonTranspos
 }
 
 // Medium f16 language-side shape with small M and small N: transposed path (transpose_b=true).
-TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_LanguageShape_Transposed) {
+TEST_F(ConvertMatMulToFullyConnectedPolicyTestsF,
+       ConvertMatMulToFullyConnected_MediumF16_LanguageShape_Transposed) {
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{92, 3584});
         auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{3584, 512}, {1});
@@ -1010,7 +1037,8 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_LanguageSha
 }
 
 // Medium f16 shape below the M bound: transposed path (transpose_b=true).
-TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_LowerM_Transposed) {
+TEST_F(ConvertMatMulToFullyConnectedPolicyTestsF,
+       ConvertMatMulToFullyConnected_MediumF16_LowerM_Transposed) {
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{64, 5120});
         auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{5120, 3584}, {1});
@@ -1032,7 +1060,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_LowerM_Tran
 }
 
 // Medium non-f16 matmul matching target dimensions: transposed path (transpose_b=true).
-TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF32_Transposed) {
+TEST_F(ConvertMatMulToFullyConnectedPolicyTestsF, ConvertMatMulToFullyConnected_MediumF32_Transposed) {
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{256, 3420});
         auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3420, 1280}, {1});
@@ -1054,7 +1082,8 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF32_Transposed)
 }
 
 // Medium f16 target-like shape with compressed weights: transposed path (transpose_b=true).
-TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_CompressedWeights_Transposed) {
+TEST_F(ConvertMatMulToFullyConnectedPolicyTestsF,
+       ConvertMatMulToFullyConnected_MediumF16_CompressedWeights_Transposed) {
     {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 3420});
         auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{3420, 1280}, {1});
@@ -1084,6 +1113,50 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_CompressedW
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
     }
 }
+
+TEST_P(ConvertMatMulToFullyConnectedMediumF16PolicyTestsF,
+       ConvertMatMulToFullyConnected_MediumF16_BoundaryAndPredicateCases) {
+    const auto& params = GetParam();
+
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{params.m, params.k});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{params.k, params.n}, {1});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
+    }
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{params.m, params.k});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{params.k, params.n}, {1});
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+
+        if (params.expect_non_transposed) {
+            auto fc = std::make_shared<op::FullyConnected>(input, weights, no_bias, ov::element::f16, false);
+            model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+        } else {
+            auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0});
+            auto transpose = std::make_shared<ov::opset1::Transpose>(weights, transpose_constant);
+            auto fc = std::make_shared<op::FullyConnected>(input, transpose, no_bias, ov::element::f16, true);
+            model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ConvertMatMulToFullyConnected_MediumF16Policy,
+    ConvertMatMulToFullyConnectedMediumF16PolicyTestsF,
+    Values(MediumF16MatMulPolicyParams{128, 2048, 1024, true, "LowerBoundsIncluded"},
+           MediumF16MatMulPolicyParams{512, 4097, 4096, true, "UpperBoundsIncluded"},
+           MediumF16MatMulPolicyParams{256, 2047, 1024, false, "BelowKLowerBound"},
+           MediumF16MatMulPolicyParams{127, 3420, 1280, false, "BelowMLowerBound"},
+           MediumF16MatMulPolicyParams{513, 3420, 1280, false, "AboveMUpperBound"},
+           MediumF16MatMulPolicyParams{256, 3420, 1023, false, "BelowNLowerBound"},
+           MediumF16MatMulPolicyParams{256, 4098, 4097, false, "AboveNUpperBound"},
+           MediumF16MatMulPolicyParams{256, 2048, 2048, false, "KNotGreaterThanN"}),
+    [](const TestParamInfo<MediumF16MatMulPolicyParams>& info) {
+        return info.param.test_name;
+    });
 
 // Large f16 matmul K>=8192, N<=4096: transposed path (transpose_b=true) when supports_immad=false.
 TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_NoImmad_Transposed) {

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -947,6 +947,144 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_NonTranspose
     }
 }
 
+// Medium f16 matmul matching visual MLP-down shape: non-transposed path (transpose_b=false).
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_NonTransposed_VisualMlpDown) {
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 3420});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{3420, 1280}, {1});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
+    }
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 3420});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{3420, 1280}, {1});
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<op::FullyConnected>(input, weights, no_bias, ov::element::f16, false);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+    }
+}
+
+// Medium f16 matmul near the target range: non-transposed path (transpose_b=false).
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_NonTransposed_Nearby) {
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 4096});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{4096, 1280}, {1});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
+    }
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 4096});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{4096, 1280}, {1});
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<op::FullyConnected>(input, weights, no_bias, ov::element::f16, false);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+    }
+}
+
+// Medium f16 language-side shape with small M and small N: transposed path (transpose_b=true).
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_LanguageShape_Transposed) {
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{92, 3584});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{3584, 512}, {1});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
+    }
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{92, 3584});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{3584, 512}, {1});
+        auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0});
+        auto transpose = std::make_shared<ov::opset1::Transpose>(weights, transpose_constant);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<op::FullyConnected>(input, transpose, no_bias, ov::element::f16, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+    }
+}
+
+// Medium f16 shape below the M bound: transposed path (transpose_b=true).
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_LowerM_Transposed) {
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{64, 5120});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{5120, 3584}, {1});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
+    }
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{64, 5120});
+        auto weights = ov::opset1::Constant::create(ov::element::f16, ov::Shape{5120, 3584}, {1});
+        auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0});
+        auto transpose = std::make_shared<ov::opset1::Transpose>(weights, transpose_constant);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<op::FullyConnected>(input, transpose, no_bias, ov::element::f16, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+    }
+}
+
+// Medium non-f16 matmul matching target dimensions: transposed path (transpose_b=true).
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF32_Transposed) {
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{256, 3420});
+        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3420, 1280}, {1});
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, weights, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
+    }
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{256, 3420});
+        auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3420, 1280}, {1});
+        auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0});
+        auto transpose = std::make_shared<ov::opset1::Transpose>(weights, transpose_constant);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<op::FullyConnected>(input, transpose, no_bias, ov::element::f32, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+    }
+}
+
+// Medium f16 target-like shape with compressed weights: transposed path (transpose_b=true).
+TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_MediumF16_CompressedWeights_Transposed) {
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 3420});
+        auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{3420, 1280}, {1});
+        auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f16);
+        auto sub_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 1280}, {1});
+        auto sub = std::make_shared<ov::opset1::Subtract>(convert, sub_const);
+        auto mul_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 1280}, {1});
+        auto mul = std::make_shared<ov::opset1::Multiply>(sub, mul_const);
+        auto matmul = std::make_shared<ov::opset1::MatMul>(input, mul, false, false);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input});
+        manager.register_pass<ConvertMatMulToFullyConnected>(true);  // supports_immad=true (XMX available)
+    }
+    {
+        auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f16, ov::Shape{256, 3420});
+        auto weights = ov::opset1::Constant::create(ov::element::u8, ov::Shape{3420, 1280}, {1});
+        auto convert = std::make_shared<ov::opset1::Convert>(weights, ov::element::f16);
+        auto sub_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 1280}, {1});
+        auto sub = std::make_shared<ov::opset1::Subtract>(convert, sub_const);
+        auto mul_const = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 1280}, {1});
+        auto mul = std::make_shared<ov::opset1::Multiply>(sub, mul_const);
+        auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0});
+        auto transpose = std::make_shared<ov::opset1::Transpose>(mul, transpose_constant);
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto fc = std::make_shared<op::FullyConnected>(input, transpose, no_bias, ov::element::f16, true);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input});
+    }
+}
+
 // Large f16 matmul K>=8192, N<=4096: transposed path (transpose_b=true) when supports_immad=false.
 TEST_F(TransformationTestsF, ConvertMatMulToFullyConnected_LargeF16_NoImmad_Transposed) {
     {


### PR DESCRIPTION
### Details

This PR extends the Intel GPU `ConvertMatMulToFullyConnected` transpose policy for a narrow class of f16 medium-K MatMuls.

The existing policy already keeps FC weights non-transposed for selected large-K thin-output f16 MatMuls. This change adds a bounded medium-K case:

```text
input dtype: f16
weights: not compressed
K >= 2048
K < 8192
M >= 128
M <= 512
N >= 1024
N <= 4096
K > N
```

The target shape motivating this policy is:

```text
M=256, K=3420, N=1280
```

This shape appears in visual MLP-down projection workloads. For this shape, keeping weights non-transposed maps to a faster oneDNN GPU FC/matmul layout.

The bounds are intentionally narrow. In particular, the `M >= 128` and `N >= 1024` guards avoid applying this to small language-side projection shapes such as:

```text
M=92, K=3584, N=512
```

which regressed in standalone layout testing.

### Validation

Standalone target GEMM:

```text
0.786244 ms -> 0.119171 ms
84.84% faster
```

Model-level A/B validation from the development build:

```text
VLM-only:
233.489268 ms -> 206.772920 ms
11.44% faster

Full VLA chain:
287.753138 ms -> 267.878446 ms
6.91% faster
```

Correctness:

```text
shape=[1, 92, 3584]
max_abs_diff=0.0
mean_abs_diff=0.0
exact_match_ratio=1.0
```

Final clean-branch rebuild validation:

```text
openvino_intel_gpu_plugin.dll rebuild: passed
VLM correctness comparison: passed
VLM-only clean rerun mean: 210.199024 ms
Full-chain clean rerun mean: 264.601232 ms
```

### Tests

Added unit coverage in `convert_matmul_to_fc_test.cpp` for:

- target medium-K f16 visual MLP-down shape selecting `transpose_b=false`;
- nearby selected medium-K f16 shape;
- language-side small-M/small-N shape staying on the default transposed path;
- lower-M excluded shape;
- non-f16 excluded shape;
- compressed-weights excluded shape.
