### PR TITLE
[NPU] Fix potential NPU DMA OOB write via forged OpenVINO state-tensor names

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_variable_state.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_variable_state.hpp
@@ -7,6 +7,8 @@
 #include "intel_npu/utils/logger/logger.hpp"
 #include "intel_npu/utils/zero/zero_init.hpp"
 #include "intel_npu/utils/zero/zero_tensor.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/ivariable_state.hpp"
 
 namespace intel_npu {
@@ -91,6 +93,12 @@ private:
     // large: the state input and its state output share this buffer, so a smaller one would let the device write
     // past it through the state output.
     size_t _required_byte_size;
+
+    // Shape and element type of the model's state buffer. The compiled graph interprets the shared Level Zero buffer
+    // using these, so a tensor set through set_state must match both: a differently shaped or typed tensor would be
+    // read and written with the wrong layout even when it is large enough, silently corrupting the state.
+    ov::Shape _expected_shape;
+    ov::element::Type _expected_element_type;
 
     std::shared_ptr<ZeroTensor> _zero_state;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_variable_state.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_variable_state.hpp
@@ -7,8 +7,6 @@
 #include "intel_npu/utils/logger/logger.hpp"
 #include "intel_npu/utils/zero/zero_init.hpp"
 #include "intel_npu/utils/zero/zero_tensor.hpp"
-#include "openvino/core/shape.hpp"
-#include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/ivariable_state.hpp"
 
 namespace intel_npu {
@@ -88,17 +86,6 @@ private:
     std::shared_ptr<ZeroInitStructsHolder> _init_structs;
     size_t _tensor_index;
     size_t _related_tensor_index;
-
-    // Byte size of the state buffer allocated for the model. A tensor set through set_state must be at least this
-    // large: the state input and its state output share this buffer, so a smaller one would let the device write
-    // past it through the state output.
-    size_t _required_byte_size;
-
-    // Shape and element type of the model's state buffer. The compiled graph interprets the shared Level Zero buffer
-    // using these, so a tensor set through set_state must match both: a differently shaped or typed tensor would be
-    // read and written with the wrong layout even when it is large enough, silently corrupting the state.
-    ov::Shape _expected_shape;
-    ov::element::Type _expected_element_type;
 
     std::shared_ptr<ZeroTensor> _zero_state;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_variable_state.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_variable_state.hpp
@@ -87,6 +87,11 @@ private:
     size_t _tensor_index;
     size_t _related_tensor_index;
 
+    // Byte size of the state buffer allocated for the model. A tensor set through set_state must be at least this
+    // large: the state input and its state output share this buffer, so a smaller one would let the device write
+    // past it through the state output.
+    size_t _required_byte_size;
+
     std::shared_ptr<ZeroTensor> _zero_state;
 
     bool _is_state_updated = false;

--- a/src/plugins/intel_npu/src/backend/src/zero_variable_state.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_variable_state.cpp
@@ -22,6 +22,8 @@ ZeroVariableState::ZeroVariableState(const std::shared_ptr<ZeroInitStructsHolder
       _tensor_index(tensor_index),
       _related_tensor_index(related_tensor_index),
       _required_byte_size(zero_tensor != nullptr ? zero_tensor->get_byte_size() : 0),
+      _expected_shape(zero_tensor != nullptr ? zero_tensor->get_shape() : ov::Shape{}),
+      _expected_element_type(zero_tensor != nullptr ? zero_tensor->get_element_type() : ov::element::dynamic),
       _zero_state(zero_tensor),
       _logger("ZeroVariableState", Logger::global().level()) {
     m_state = _zero_state;
@@ -34,9 +36,37 @@ void ZeroVariableState::set_state(const ov::SoPtr<ov::ITensor>& new_state) {
         return;
     }
 
-    // The state input and its state output share one Level Zero buffer, sized for the model's state. A smaller
-    // tensor would later let the device write past that buffer through the state output, so reject it here.
-    OPENVINO_ASSERT(new_state._ptr != nullptr && new_state->get_byte_size() >= _required_byte_size,
+    // The state input and its state output share one Level Zero buffer, sized and typed for the model's state. The
+    // compiled graph interprets that buffer using the model's state metadata, so a replacement tensor must match the
+    // state's element type and shape, not merely be large enough: a differently shaped or typed tensor would be read
+    // and written with the wrong layout, and a smaller one would let the state output write past the shared buffer.
+    OPENVINO_ASSERT(new_state._ptr != nullptr, "The tensor set for state '", get_name(), "' is null.");
+
+    const auto& new_element_type = new_state->get_element_type();
+    if (new_element_type != _expected_element_type) {
+        // Exception case for boolean treated as u8 by the NPU driver (mirrors ZeroInferRequest::check_tensor).
+        OPENVINO_ASSERT(
+            (new_element_type == ov::element::boolean || new_element_type == ov::element::u8) &&
+                (_expected_element_type == ov::element::boolean || _expected_element_type == ov::element::u8),
+            "The tensor set for state '",
+            get_name(),
+            "' has element type ",
+            new_element_type,
+            " but the model's state requires ",
+            _expected_element_type,
+            ".");
+    }
+
+    OPENVINO_ASSERT(new_state->get_shape() == _expected_shape,
+                    "The tensor set for state '",
+                    get_name(),
+                    "' has shape ",
+                    new_state->get_shape(),
+                    " but the model's state requires ",
+                    _expected_shape,
+                    ".");
+
+    OPENVINO_ASSERT(new_state->get_byte_size() >= _required_byte_size,
                     "The tensor set for state '",
                     get_name(),
                     "' is smaller than the model's state requires.");

--- a/src/plugins/intel_npu/src/backend/src/zero_variable_state.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_variable_state.cpp
@@ -9,6 +9,8 @@
 #include "intel_npu/utils/zero/zero_remote_tensor.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 #include "openvino/core/except.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_type.hpp"
 
 namespace intel_npu {
 
@@ -21,9 +23,6 @@ ZeroVariableState::ZeroVariableState(const std::shared_ptr<ZeroInitStructsHolder
       _init_structs(init_structs),
       _tensor_index(tensor_index),
       _related_tensor_index(related_tensor_index),
-      _required_byte_size(zero_tensor != nullptr ? zero_tensor->get_byte_size() : 0),
-      _expected_shape(zero_tensor != nullptr ? zero_tensor->get_shape() : ov::Shape{}),
-      _expected_element_type(zero_tensor != nullptr ? zero_tensor->get_element_type() : ov::element::dynamic),
       _zero_state(zero_tensor),
       _logger("ZeroVariableState", Logger::global().level()) {
     m_state = _zero_state;
@@ -36,40 +35,47 @@ void ZeroVariableState::set_state(const ov::SoPtr<ov::ITensor>& new_state) {
         return;
     }
 
-    // The state input and its state output share one Level Zero buffer, sized and typed for the model's state. The
-    // compiled graph interprets that buffer using the model's state metadata, so a replacement tensor must match the
-    // state's element type and shape, not merely be large enough: a differently shaped or typed tensor would be read
-    // and written with the wrong layout, and a smaller one would let the state output write past the shared buffer.
     OPENVINO_ASSERT(new_state._ptr != nullptr, "The tensor set for state '", get_name(), "' is null.");
 
-    const auto& new_element_type = new_state->get_element_type();
-    if (new_element_type != _expected_element_type) {
-        // Exception case for boolean treated as u8 by the NPU driver (mirrors ZeroInferRequest::check_tensor).
-        OPENVINO_ASSERT(
-            (new_element_type == ov::element::boolean || new_element_type == ov::element::u8) &&
-                (_expected_element_type == ov::element::boolean || _expected_element_type == ov::element::u8),
-            "The tensor set for state '",
-            get_name(),
-            "' has element type ",
-            new_element_type,
-            " but the model's state requires ",
-            _expected_element_type,
-            ".");
+    // m_state currently holds the model's state buffer: the initial allocation, or a previously accepted replacement
+    // that this same validation proved matches it. The state input and its state output share that Level Zero buffer
+    // and the compiled graph interprets it with the model's state metadata, so a replacement must match the state's
+    // element type and shape, not merely be large enough: a differently shaped or typed tensor would be read and
+    // written with the wrong layout, and a smaller one would let the state output write past the shared buffer.
+    if (m_state._ptr != nullptr) {
+        const auto expected_element_type = m_state->get_element_type();
+        const auto expected_shape = m_state->get_shape();
+        const auto required_byte_size = m_state->get_byte_size();
+
+        const auto new_element_type = new_state->get_element_type();
+        if (new_element_type != expected_element_type) {
+            // Exception case for boolean treated as u8 by the NPU driver (mirrors ZeroInferRequest::check_tensor).
+            OPENVINO_ASSERT(
+                (new_element_type == ov::element::boolean || new_element_type == ov::element::u8) &&
+                    (expected_element_type == ov::element::boolean || expected_element_type == ov::element::u8),
+                "The tensor set for state '",
+                get_name(),
+                "' has element type ",
+                new_element_type,
+                " but the model's state requires ",
+                expected_element_type,
+                ".");
+        }
+
+        OPENVINO_ASSERT(new_state->get_shape() == expected_shape,
+                        "The tensor set for state '",
+                        get_name(),
+                        "' has shape ",
+                        new_state->get_shape(),
+                        " but the model's state requires ",
+                        expected_shape,
+                        ".");
+
+        OPENVINO_ASSERT(new_state->get_byte_size() >= required_byte_size,
+                        "The tensor set for state '",
+                        get_name(),
+                        "' is smaller than the model's state requires.");
     }
-
-    OPENVINO_ASSERT(new_state->get_shape() == _expected_shape,
-                    "The tensor set for state '",
-                    get_name(),
-                    "' has shape ",
-                    new_state->get_shape(),
-                    " but the model's state requires ",
-                    _expected_shape,
-                    ".");
-
-    OPENVINO_ASSERT(new_state->get_byte_size() >= _required_byte_size,
-                    "The tensor set for state '",
-                    get_name(),
-                    "' is smaller than the model's state requires.");
 
     m_state = new_state;
     _is_state_updated = true;

--- a/src/plugins/intel_npu/src/backend/src/zero_variable_state.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_variable_state.cpp
@@ -8,6 +8,7 @@
 #include "intel_npu/utils/zero/zero_host_tensor.hpp"
 #include "intel_npu/utils/zero/zero_remote_tensor.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
+#include "openvino/core/except.hpp"
 
 namespace intel_npu {
 
@@ -20,6 +21,7 @@ ZeroVariableState::ZeroVariableState(const std::shared_ptr<ZeroInitStructsHolder
       _init_structs(init_structs),
       _tensor_index(tensor_index),
       _related_tensor_index(related_tensor_index),
+      _required_byte_size(zero_tensor != nullptr ? zero_tensor->get_byte_size() : 0),
       _zero_state(zero_tensor),
       _logger("ZeroVariableState", Logger::global().level()) {
     m_state = _zero_state;
@@ -31,6 +33,13 @@ void ZeroVariableState::set_state(const ov::SoPtr<ov::ITensor>& new_state) {
         _logger.debug("ZeroVariableState::set_state - got the same state, do nothing");
         return;
     }
+
+    // The state input and its state output share one Level Zero buffer, sized for the model's state. A smaller
+    // tensor would later let the device write past that buffer through the state output, so reject it here.
+    OPENVINO_ASSERT(new_state._ptr != nullptr && new_state->get_byte_size() >= _required_byte_size,
+                    "The tensor set for state '",
+                    get_name(),
+                    "' is smaller than the model's state requires.");
 
     m_state = new_state;
     _is_state_updated = true;

--- a/src/plugins/intel_npu/src/common/src/network_metadata.cpp
+++ b/src/plugins/intel_npu/src/common/src/network_metadata.cpp
@@ -4,6 +4,8 @@
 
 #include "intel_npu/common/network_metadata.hpp"
 
+#include "openvino/core/except.hpp"
+
 namespace intel_npu {
 
 void NetworkMetadata::bindRelatedDescriptors() {
@@ -24,6 +26,15 @@ void NetworkMetadata::bindRelatedDescriptors() {
             if (relatedDescriptorIterator != outputs.end()) {
                 input.relatedDescriptorIndex = std::distance(outputs.begin(), relatedDescriptorIterator);
                 outputs.at(*input.relatedDescriptorIndex).relatedDescriptorIndex = ioIndex;
+
+                // A state input and its state output are two views of the same variable, so their shape and
+                // precision must match. Otherwise the buffer shared between them, which is sized from the input,
+                // would be undersized for the output.
+                OPENVINO_ASSERT(relatedDescriptorIterator->shapeFromCompiler == input.shapeFromCompiler &&
+                                    relatedDescriptorIterator->precision == input.precision,
+                                "State input '",
+                                input.nameFromCompiler,
+                                "' does not match its state output in shape or precision.");
             }
         } else if (input.isShapeTensor) {
             const auto relatedDescriptorIterator =

--- a/src/plugins/intel_npu/tests/functional/internal/backend/zero_variable_state_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/backend/zero_variable_state_tests.cpp
@@ -146,6 +146,21 @@ TEST_P(ZeroVariableStateTests, CreateZeroStateAndUseSetStateWithZeroTensor) {
     OV_ASSERT_NO_THROW(zero_state->reset());
 }
 
+TEST_P(ZeroVariableStateTests, SetStateRejectsTensorSmallerThanStateBuffer) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    auto shape = Shape{1, 2, 2, 2};
+    auto zero_tensor = std::make_shared<::intel_npu::ZeroTensor>(init_struct, element::f32, shape, true);
+    auto zero_state = std::make_shared<::intel_npu::ZeroVariableState>(init_struct, "state", zero_tensor, 1, 1);
+
+    // The state input and its state output share this buffer; a smaller tensor would let the device write past it
+    // through the state output, so set_state must reject it instead of aliasing the undersized buffer.
+    auto smaller_shape = Shape{1};
+    auto smaller_tensor = std::make_shared<::intel_npu::ZeroTensor>(init_struct, element::f32, smaller_shape, true);
+
+    EXPECT_THROW(zero_state->set_state(smaller_tensor), ov::Exception);
+}
+
 TEST_P(ZeroVariableStateTests, CreateZeroStateAndUseSetStateWithNormalTensor) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 

--- a/src/plugins/intel_npu/tests/functional/internal/backend/zero_variable_state_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/backend/zero_variable_state_tests.cpp
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <array>
-#include <cstddef>
-#include <exception>
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <exception>
 #include <memory>
 #include <random>
 #include <thread>
@@ -159,6 +160,37 @@ TEST_P(ZeroVariableStateTests, SetStateRejectsTensorSmallerThanStateBuffer) {
     auto smaller_tensor = std::make_shared<::intel_npu::ZeroTensor>(init_struct, element::f32, smaller_shape, true);
 
     EXPECT_THROW(zero_state->set_state(smaller_tensor), ov::Exception);
+}
+
+TEST_P(ZeroVariableStateTests, SetStateRejectsTensorWithDifferentElementType) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    auto shape = Shape{1, 2, 2, 2};
+    auto zero_tensor = std::make_shared<::intel_npu::ZeroTensor>(init_struct, element::f32, shape, true);
+    auto zero_state = std::make_shared<::intel_npu::ZeroVariableState>(init_struct, "state", zero_tensor, 1, 1);
+
+    // A tensor with the same shape but a wider element type is larger than the state buffer, so it passes the capacity
+    // check; the compiled graph would still read the shared buffer as f32, so set_state must reject the type mismatch.
+    auto f64_tensor = std::make_shared<::intel_npu::ZeroTensor>(init_struct, element::f64, shape, true);
+    ASSERT_GT(f64_tensor->get_byte_size(), zero_tensor->get_byte_size());
+
+    EXPECT_THROW(zero_state->set_state(f64_tensor), ov::Exception);
+}
+
+TEST_P(ZeroVariableStateTests, SetStateRejectsTensorWithDifferentShape) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    auto shape = Shape{1, 2, 2, 2};
+    auto zero_tensor = std::make_shared<::intel_npu::ZeroTensor>(init_struct, element::f32, shape, true);
+    auto zero_state = std::make_shared<::intel_npu::ZeroVariableState>(init_struct, "state", zero_tensor, 1, 1);
+
+    // A tensor with the same element type and byte size but a different shape passes the capacity check; the compiled
+    // graph would interpret the shared buffer with the state's shape, so set_state must reject the shape mismatch.
+    auto reshaped = Shape{ov::shape_size(shape)};
+    auto reshaped_tensor = std::make_shared<::intel_npu::ZeroTensor>(init_struct, element::f32, reshaped, true);
+    ASSERT_EQ(reshaped_tensor->get_byte_size(), zero_tensor->get_byte_size());
+
+    EXPECT_THROW(zero_state->set_state(reshaped_tensor), ov::Exception);
 }
 
 TEST_P(ZeroVariableStateTests, CreateZeroStateAndUseSetStateWithNormalTensor) {

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -157,6 +157,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/executor_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/compiler_option_support_helper_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/option_support_cache_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npu/state_tensor_binding_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_compiled_model_graph_options_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/flux2_compiled_model_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/gqa_compiled_model_test.cpp

--- a/src/plugins/intel_npu/tests/unit/npu/state_tensor_binding_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/state_tensor_binding_test.cpp
@@ -1,0 +1,77 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Verifies that NetworkMetadata::bindRelatedDescriptors() rejects a state input
+// and state output that share a name but differ in shape or precision.
+//
+// A state input and its state output are two views of the same variable, so
+// their shape and precision must match; the plugin later shares a single Level
+// Zero buffer between them, sized from the input. If the output were larger, the
+// device would write past that buffer. These tests run on the host with no NPU.
+
+#include <gtest/gtest.h>
+
+#include "intel_npu/common/network_metadata.hpp"
+#include "openvino/core/except.hpp"
+
+using intel_npu::IODescriptor;
+using intel_npu::NetworkMetadata;
+
+namespace {
+
+IODescriptor makeStateInput(const std::string& name,
+                            const ov::PartialShape& shape,
+                            const ov::element::Type& precision) {
+    IODescriptor desc;
+    desc.nameFromCompiler = name;
+    desc.precision = precision;
+    desc.shapeFromCompiler = shape;
+    desc.isStateInput = true;
+    return desc;
+}
+
+IODescriptor makeStateOutput(const std::string& name,
+                             const ov::PartialShape& shape,
+                             const ov::element::Type& precision) {
+    IODescriptor desc;
+    desc.nameFromCompiler = name;
+    desc.precision = precision;
+    desc.shapeFromCompiler = shape;
+    desc.isStateOutput = true;
+    return desc;
+}
+
+}  // namespace
+
+// A shape mismatch between the paired state descriptors must be rejected.
+TEST(NpuStateTensorBindingTest, BindThrowsOnStateShapeMismatch) {
+    NetworkMetadata metadata;
+    metadata.inputs.push_back(makeStateInput("state", ov::PartialShape{1}, ov::element::f32));
+    metadata.outputs.push_back(makeStateOutput("state", ov::PartialShape{1048576}, ov::element::f32));
+
+    EXPECT_THROW(metadata.bindRelatedDescriptors(), ov::Exception);
+}
+
+// A precision mismatch between the paired state descriptors must be rejected.
+TEST(NpuStateTensorBindingTest, BindThrowsOnStatePrecisionMismatch) {
+    NetworkMetadata metadata;
+    metadata.inputs.push_back(makeStateInput("state", ov::PartialShape{4}, ov::element::u8));
+    metadata.outputs.push_back(makeStateOutput("state", ov::PartialShape{4}, ov::element::f32));
+
+    EXPECT_THROW(metadata.bindRelatedDescriptors(), ov::Exception);
+}
+
+// Matching state descriptors are bound to each other without error.
+TEST(NpuStateTensorBindingTest, BindAcceptsMatchingStateDescriptors) {
+    NetworkMetadata metadata;
+    metadata.inputs.push_back(makeStateInput("state", ov::PartialShape{2, 3}, ov::element::f32));
+    metadata.outputs.push_back(makeStateOutput("state", ov::PartialShape{2, 3}, ov::element::f32));
+
+    ASSERT_NO_THROW(metadata.bindRelatedDescriptors());
+
+    ASSERT_TRUE(metadata.inputs.at(0).relatedDescriptorIndex.has_value());
+    ASSERT_TRUE(metadata.outputs.at(0).relatedDescriptorIndex.has_value());
+    EXPECT_EQ(*metadata.inputs.at(0).relatedDescriptorIndex, 0u);
+    EXPECT_EQ(*metadata.outputs.at(0).relatedDescriptorIndex, 0u);
+}


### PR DESCRIPTION
### Details:
Overview: The OpenVINO intel_npu backend pairs state-input and state-output operands based solely on truncated string prefix matching, without validating tensor shapes. By crafting heavily padded WebNN operand names, an attacker can exploit Level-Zero driver string truncation to bypass unique ID suffixes, tricking the backend into pairing a small input with a large output. This aliases a smaller host buffer to a larger output argument, potentially leading to an out-of-bounds DMA write in the sandboxed GPU or WebNN Compiler process.

### Tickets:
[CVS-192904](https://jira.devtools.intel.com/browse/CVS-192904)

### AI Assistance:
 - *AI assistance used: yes*
 - *Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.*
