### PR TITLE
[GPU] Add split-KV SDPA fusion for LiteRT static decode

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/op/sdpa.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/sdpa.hpp
@@ -20,13 +20,20 @@ public:
 
     SDPA() = default;
 
+    // split_kv: when true, the input list carries K and V as two pieces each, in the fixed order
+    // [Q, K_cache, V_cache, mask, K_new, V_new, kv_len]. There is no scale input (scale is the
+    // scale_val attribute, fixed at 1.0 by the fusion). The trailing i32 kv_len is the valid cache
+    // length; the kernel caps its cache loops there. The op attends over the logical sequence
+    // concatenation of the cache and new chunks without materializing it, avoiding a per-step
+    // full-cache KV Concat. Defaults to false, leaving the standard single-K/single-V op unchanged.
     SDPA(const OutputVector& inputs,
          const bool is_causal,
          const std::vector<int64_t>& order_q,
          const std::vector<int64_t>& order_k,
          const std::vector<int64_t>& order_v,
          const std::vector<int64_t>& order_out,
-         const ov::element::Type output_type = ov::element::dynamic);
+         const ov::element::Type output_type = ov::element::dynamic,
+         bool split_kv = false);
 
     SDPA(const OutputVector& inputs,
          const bool is_causal,
@@ -55,6 +62,9 @@ public:
     QuantizationAttribute get_quantization_attrs() const { return m_quantization_attrs; }
     size_t get_compression_inputs_num() const;
 
+    // True when K/V are supplied as two chunks each (cache + new); see the split_kv constructor.
+    bool get_split_kv() const { return m_split_kv; }
+
     static std::vector<int64_t> default_order(size_t rank) {
         std::vector<int64_t> order(rank);
         std::iota(order.begin(), order.end(), 0);
@@ -71,6 +81,7 @@ protected:
 
     bool m_compressed = false;
     QuantizationAttribute m_quantization_attrs = {};
+    bool m_split_kv = false;
 };
 
 std::vector<ov::PartialShape> shape_infer(const SDPA* op,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp
@@ -73,6 +73,21 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
     bool has_sink_input = false;
     int64_t indirect_axis = -1;
 
+    // split_kv: K and V are supplied as two chunks each (persistent cache + current step), so the
+    // kernel attends over their logical sequence concatenation without materializing a full-cache
+    // copy. The input order is [Q, K_cache, V_cache, mask, K_new, V_new, kv_len] (no scale input;
+    // scale is the scale_val attribute). The trailing i32 kv_len carries the valid cache length
+    // (last attended cache index + 1, derived in-graph from the mask) so the kernel caps its cache
+    // loops there, skipping the padding tail of the allocated cache. When false (default) the
+    // primitive behaves exactly as the standard single-K/single-V SDPA.
+    //
+    // NOTE: this is a settable field (like scale_val / attn_mask_val), not a constructor argument,
+    // so the base constructor's auto-derivation of has_attn_mask_input / has_scale_input /
+    // has_sink_input (which counts inputs) is unaware of the trailing K_new/V_new/kv_len inputs. The
+    // lowering that builds a split_kv primitive MUST set split_kv = true AND set has_attn_mask_input
+    // / has_scale_input explicitly, and leave has_sink_input == false (sink is unsupported here).
+    bool split_kv = false;
+
     bool is_kv_compressed = false;
     QuantizationAttributes quantization_attributes;
 
@@ -90,6 +105,7 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
         seed = hash_combine(seed, has_attn_mask_input);
         seed = hash_combine(seed, has_scale_input);
         seed = hash_combine(seed, has_sink_input);
+        seed = hash_combine(seed, split_kv);
         seed = hash_combine(seed, indirect_axis);
         seed = hash_range(seed, input_q_transpose_order.begin(), input_q_transpose_order.end());
         seed = hash_range(seed, input_k_transpose_order.begin(), input_k_transpose_order.end());
@@ -125,6 +141,7 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
                has_attn_mask_input == rhs_casted.has_attn_mask_input &&
                has_scale_input == rhs_casted.has_scale_input &&
                has_sink_input == rhs_casted.has_sink_input &&
+               split_kv == rhs_casted.split_kv &&
                indirect_axis == rhs_casted.indirect_axis &&
                input_q_transpose_order == rhs_casted.input_q_transpose_order &&
                input_k_transpose_order == rhs_casted.input_k_transpose_order &&
@@ -149,6 +166,7 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
         ob << has_attn_mask_input;
         ob << has_scale_input;
         ob << has_sink_input;
+        ob << split_kv;
         ob << indirect_axis;
         ob << input_q_transpose_order;
         ob << input_k_transpose_order;
@@ -178,6 +196,7 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
         ib >> has_attn_mask_input;
         ib >> has_scale_input;
         ib >> has_sink_input;
+        ib >> split_kv;
         ib >> indirect_axis;
         ib >> input_q_transpose_order;
         ib >> input_k_transpose_order;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
@@ -31,6 +31,12 @@ static std::string get_broadcast_input_str(const size_t input_rank, const int64_
     return dims[axes] + " /= " + std::to_string(val) + ";";
 }
 
+size_t get_beam_table_id(const std::shared_ptr<const scaled_dot_product_attention>& primitive) {
+    return primitive->input_size() - 1;
+}
+
+}  // namespace
+
 std::string get_dims_order(const std::vector<int64_t>& order_idx) {
     auto get_order_idx = [](const std::vector<int64_t>& order_idx, int64_t dim_idx) {
         int loc = 0;
@@ -67,12 +73,6 @@ std::string get_dims_order(const std::vector<int64_t>& order_idx) {
     }
     return dims_order;
 }
-
-size_t get_beam_table_id(const std::shared_ptr<const scaled_dot_product_attention>& primitive) {
-    return primitive->input_size() - 1;
-}
-
-}  // namespace
 
 // 4-bit KV-cache packs two u4 values into one i8 byte, halving the physical
 // innermost dimension (head_size) of K/V layouts.  Any code that reads head_size

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.hpp
@@ -54,6 +54,11 @@ struct sdpa_configuration {
     int64_t input_num;
 };
 
+// Build the comma-separated dims-order string (e.g. "b,f,w,z,y,x") for the given transpose order.
+// Declared here (lifted out of sdpa_base.cpp's anonymous namespace) so the split-KV jit emission in
+// sdpa_gen_opt.cpp can reuse it for the KEY_NEW/VALUE_NEW chunks.
+std::string get_dims_order(const std::vector<int64_t>& order_idx);
+
 struct SDPABase : public KernelGenerator {
     SDPABase(std::string_view name, std::string_view suffix, bool indirect) : KernelGenerator(name, suffix), m_indirect(indirect) {}
     [[nodiscard]] JitConstants get_jit_constants(const kernel_impl_params& params) const override;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.cpp
@@ -176,7 +176,138 @@ Arguments SDPAOptGeneratorBase::get_arguments_desc_impl(const kernel_impl_params
     return args;
 }
 
+// ============================================================================================
+// split-KV decode helpers. The split-KV decode path reuses the single-token + finalization opt
+// generators below (same sdpa_opt.cl template); when desc->split_kv is set they emit a few deltas
+// via these helpers: the SPLIT_KV jit (+ KEY_NEW/VALUE_NEW layout macros, SOURCE_SEQ_LEN_CACHE), a
+// different argument list (no scale input; trailing K_new/V_new/kv_len), and one extra partition
+// for the new chunk. split_kv is part of the op hash, so split / non-split kernels never collide.
+// ============================================================================================
+namespace {
+
+// split_kv inputs end with [.., K_new, V_new, kv_len], so K_new/V_new are the 3rd/2nd from last
+// (the last input is the i32 kv_len control tensor).
+size_t split_kv_k_new_idx(const scaled_dot_product_attention& desc) {
+    return desc.input_size() - 3;
+}
+size_t split_kv_v_new_idx(const scaled_dot_product_attention& desc) {
+    return desc.input_size() - 2;
+}
+
+bool is_default_order(const std::vector<int64_t>& order) {
+    for (size_t i = 0; i < order.size(); i++) {
+        if (order[i] != static_cast<int64_t>(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Emit the split-KV jit deltas on top of the single-token base jit: SPLIT_KV, the KEY_NEW/VALUE_NEW
+// layout macros (so the kernel indexes the new chunk exactly like INPUT1/INPUT2), SOURCE_SEQ_LEN_CACHE
+// (the static cache boundary), and the redefined SOURCE_SEQ_LEN = cache + new.
+void add_split_kv_jit_constants(JitConstants& jit, const kernel_impl_params& params, const scaled_dot_product_attention& desc) {
+    const auto& in_offsets_map = params.in_port_to_shape_info_offset;
+    const uint32_t k_new_idx = static_cast<uint32_t>(split_kv_k_new_idx(desc));
+    const uint32_t v_new_idx = static_cast<uint32_t>(split_kv_v_new_idx(desc));
+
+    jit.add(make_layout_jit_constants("KEY_NEW", params.input_layouts[k_new_idx], in_offsets_map.at(k_new_idx)));
+    jit.add(make_layout_jit_constants("VALUE_NEW", params.input_layouts[v_new_idx], in_offsets_map.at(v_new_idx)));
+
+    const auto extended_k_order = extend_order_in_num_heads_dim(desc.input_k_transpose_order);
+    const auto extended_v_order = extend_order_in_num_heads_dim(desc.input_v_transpose_order);
+    if (!extended_k_order.empty() && !is_default_order(extended_k_order)) {
+        jit.make("KEY_NEW_DIMS_ORDER", get_dims_order(extended_k_order));
+    }
+    if (!extended_v_order.empty() && !is_default_order(extended_v_order)) {
+        jit.make("VALUE_NEW_DIMS_ORDER", get_dims_order(extended_v_order));
+    }
+
+    // Seq axis is Y in transposed [B,H,S,D] space. SOURCE_SEQ_LEN_CACHE = K_cache seq; redefine
+    // SOURCE_SEQ_LEN = cache + new (string exprs valid for dynamic shapes, though this path is static).
+    const auto updated_params = SDPABase::static_canonicalize_shapes(params);
+    LayoutJitter k_new_jitter(updated_params.input_layouts[k_new_idx], in_offsets_map.at(k_new_idx));
+    const auto new_seq = k_new_jitter.dim(get_transposed_channel(ChannelName::Y, extended_k_order));
+    LayoutJitter k_cache_jitter(updated_params.input_layouts[1], in_offsets_map.at(1));
+    const auto cache_seq = k_cache_jitter.dim(get_transposed_channel(ChannelName::Y, extended_k_order));
+
+    jit.make("SPLIT_KV", 1);
+    jit.make("SOURCE_SEQ_LEN_CACHE", cache_seq);
+    jit.remove("SOURCE_SEQ_LEN");
+    jit.make("SOURCE_SEQ_LEN", "(" + cache_seq + " + " + new_seq + ")");
+}
+
+// Build the split-KV argument list: [Q, K_cache, V_cache, (mask), K_new, V_new, kv_len, output,
+// exp_sums, max_logits, tmp_out]. The new chunk + kv_len are inserted between the base inputs and
+// the output; the finalization stage takes only the buffers + num_of_partitions scalar. There is
+// no scale input (scale is baked via STATIC_SCALE_VALUE) and no compression / beam table.
+Arguments split_kv_arguments(const kernel_impl_params& params, bool is_finalization) {
+    Arguments args;
+    if (params.is_dynamic()) {
+        args.push_back({ArgumentDescriptor::Types::SHAPE_INFO, 0});
+    }
+    auto desc = params.typed_desc<scaled_dot_product_attention>();
+
+    if (!is_finalization) {
+        const size_t attn_mask_idx = ScaledDotProductAttentionInputIdx::ATTN_MASK;
+        const bool has_attn_mask_input = sdpa_has_runtime_attn_mask_input(params);
+        // Base inputs Q, K_cache, V_cache, [mask] (split_kv has no scale input).
+        args.push_back({ArgumentDescriptor::Types::INPUT, ScaledDotProductAttentionInputIdx::QUERY});
+        args.push_back({ArgumentDescriptor::Types::INPUT, ScaledDotProductAttentionInputIdx::KEY});
+        args.push_back({ArgumentDescriptor::Types::INPUT, ScaledDotProductAttentionInputIdx::VALUE});
+        if (has_attn_mask_input) {
+            args.push_back({ArgumentDescriptor::Types::INPUT, static_cast<uint32_t>(attn_mask_idx)});
+        }
+        // Trailing split-KV inputs in kernel-arg order: K_new, V_new, kv_len.
+        args.push_back({ArgumentDescriptor::Types::INPUT, static_cast<uint32_t>(split_kv_k_new_idx(*desc))});
+        args.push_back({ArgumentDescriptor::Types::INPUT, static_cast<uint32_t>(split_kv_v_new_idx(*desc))});
+        args.push_back({ArgumentDescriptor::Types::INPUT, static_cast<uint32_t>(desc->input_size() - 1)});
+    }
+
+    args.push_back({ArgumentDescriptor::Types::OUTPUT, 0});
+    args.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 0});  // exp_sums
+    args.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 1});  // max_logits
+    args.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 2});  // tmp_out
+
+    if (is_finalization) {
+        args.push_back({ArgumentDescriptor::Types::SCALAR, 0});
+    }
+    return args;
+}
+
+// Number of decode partitions for split-KV: sdpa_opt partitions the static cache seq into
+// ceil(S_cache / SEQ_LEN_PARTITION_SIZE), and the new chunk gets ONE additional partition (it is
+// short -- S_new tokens, typically 1). Cache partitions beyond the runtime valid length early-exit
+// in the kernel, so dispatching all static cache partitions is correct (and dynamic-value-free).
+size_t split_kv_partitions_num(const kernel_impl_params& params) {
+    return get_partitions_num(params, SDPAStage::SINGLE_TOKEN) + 1;
+}
+
+}  // namespace
+
+bool split_kv_opt_supported(const kernel_impl_params& params) {
+    if (params.is_dynamic()) {
+        return false;
+    }
+    auto desc = params.typed_desc<scaled_dot_product_attention>();
+    if (!desc->split_kv) {
+        return false;
+    }
+    // Default contiguous [B,H,S,D] K/V only (matches the fusion's layout restriction); the SPLIT_KV
+    // split-load assumes the head dim is contiguous. The new chunk gets its own partition
+    // (index ceil(S_cache / partition_size)), so S_cache need NOT be partition-aligned: the last
+    // cache partition is just a short unaligned tail (sdpa_opt already handles that), and the new
+    // partition remaps its mask column to the true logical position S_cache + j.
+    const auto extended_q_order = extend_order_in_num_heads_dim(desc->input_q_transpose_order);
+    const auto extended_k_order = extend_order_in_num_heads_dim(desc->input_k_transpose_order);
+    const auto extended_v_order = extend_order_in_num_heads_dim(desc->input_v_transpose_order);
+    return is_default_order(extended_q_order) && is_default_order(extended_k_order) && is_default_order(extended_v_order);
+}
+
 Arguments SDPAOptGeneratorSingleToken::get_arguments_desc(const kernel_impl_params& params) const {
+    if (params.typed_desc<scaled_dot_product_attention>()->split_kv) {
+        return split_kv_arguments(params, /*is_finalization=*/false);
+    }
     return get_arguments_desc_impl(params, SDPAStage::SINGLE_TOKEN);
 }
 
@@ -184,6 +315,10 @@ JitConstants SDPAOptGeneratorSingleToken::get_jit_constants(const kernel_impl_pa
     auto jit = SDPAOptGeneratorBase::get_jit_constants_base(params, SDPAStage::SINGLE_TOKEN);
     jit.make("SDPA_STAGE_0", 1);
     jit.make("TARGET_SEQ_LEN_BLOCK_SIZE", 1);
+    auto desc = params.typed_desc<scaled_dot_product_attention>();
+    if (desc->split_kv) {
+        add_split_kv_jit_constants(jit, params, *desc);
+    }
     return jit;
 }
 
@@ -200,7 +335,8 @@ DispatchDataFunc SDPAOptGeneratorSingleToken::get_dispatch_data_func() const {
             const size_t batch_size = get_batch_size(params.get_output_layout(0), extended_output_transpose_order);
             const size_t target_seq_len = get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order);
             const size_t heads_num = get_num_heads(params.get_output_layout(0), extended_output_transpose_order);
-            const size_t num_of_partitions = get_partitions_num(params, SDPAStage::SINGLE_TOKEN);
+            // split-KV adds one partition for the new chunk; see split_kv_partitions_num.
+            const size_t num_of_partitions = desc->split_kv ? split_kv_partitions_num(params) : get_partitions_num(params, SDPAStage::SINGLE_TOKEN);
             auto head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
 
             // 4-bit KV-cache: V layout has head_size/2 due to u4→i8 packing.
@@ -268,6 +404,9 @@ DispatchDataFunc SDPAOptGeneratorMultiToken::get_dispatch_data_func() const {
 }
 
 Arguments SDPAOptGeneratorFinalization::get_arguments_desc(const kernel_impl_params& params) const {
+    if (params.typed_desc<scaled_dot_product_attention>()->split_kv) {
+        return split_kv_arguments(params, /*is_finalization=*/true);
+    }
     return get_arguments_desc_impl(params, SDPAStage::FINALIZATION);
 }
 
@@ -275,6 +414,10 @@ JitConstants SDPAOptGeneratorFinalization::get_jit_constants(const kernel_impl_p
     auto jit = SDPAOptGeneratorBase::get_jit_constants_base(params, SDPAStage::FINALIZATION);
     jit.make("SDPA_STAGE_1", 1);
     jit.make("TARGET_SEQ_LEN_BLOCK_SIZE", get_target_seq_len_block_size());
+    auto desc = params.typed_desc<scaled_dot_product_attention>();
+    if (desc->split_kv) {
+        add_split_kv_jit_constants(jit, params, *desc);
+    }
     return jit;
 }
 
@@ -296,7 +439,8 @@ DispatchDataFunc SDPAOptGeneratorFinalization::get_dispatch_data_func() const {
             const size_t batch_size = get_batch_size(params.get_output_layout(0), extended_output_transpose_order);
             const size_t target_seq_len = get_seq_length(params.get_input_layout(0), extended_input_q_transpose_order);
             const size_t heads_num = get_num_heads(params.get_output_layout(0), extended_output_transpose_order);
-            const size_t num_of_partitions = get_partitions_num(params, SDPAStage::FINALIZATION);
+            // split-KV adds one partition for the new chunk; see split_kv_partitions_num.
+            const size_t num_of_partitions = desc->split_kv ? split_kv_partitions_num(params) : get_partitions_num(params, SDPAStage::FINALIZATION);
             auto head_size = get_head_size(params.get_input_layout(2), extended_input_v_transpose_order);
 
             // 4-bit KV-cache: V layout has head_size/2 due to u4→i8 packing.

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_opt.hpp
@@ -75,6 +75,11 @@ protected:
     [[nodiscard]] Arguments get_arguments_desc_impl(const kernel_impl_params& params, size_t stage) const;
 };
 
+// Single-token decode generator. Also serves split-KV decode when desc->split_kv is set: the
+// split-KV deltas (trailing K_new/V_new/kv_len args, the SPLIT_KV jit, one extra partition for the
+// current-step chunk) are applied inside the methods, reusing the same sdpa_opt.cl template and all
+// of the opt partitioning / dispatch machinery. split_kv is part of the op hash, so split and
+// non-split kernels never collide. See split_kv_opt_supported (sdpa_opt.hpp) for the conditions.
 class SDPAOptGeneratorSingleToken : public SDPAOptGeneratorBase {
 public:
     explicit SDPAOptGeneratorSingleToken(bool indirect) : SDPAOptGeneratorBase("sdpa_opt", indirect ? "_single_ind" : "_single_reg", indirect) {}
@@ -93,6 +98,8 @@ public:
     [[nodiscard]] DispatchDataFunc get_dispatch_data_func() const override;
 };
 
+// Finalization (flash-combine) generator. Like the single-token generator above, it also serves
+// split-KV decode when desc->split_kv is set (extra new-chunk partition + split-KV argument list).
 class SDPAOptGeneratorFinalization : public SDPAOptGeneratorBase {
 public:
     explicit SDPAOptGeneratorFinalization(bool indirect) : SDPAOptGeneratorBase("sdpa_opt", "_finalization", false) {}

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
@@ -66,6 +66,15 @@ public:
             }
 #endif
             GPU_DEBUG_TRACE_DETAIL << "add stage for dynamic done \n";
+        } else if (params.typed_desc<scaled_dot_product_attention>()->split_kv) {
+            // split-KV decode reuses the regular single-token + finalization stages (they emit the
+            // split-KV deltas when desc->split_kv is set). Validated by SDPAOpt::validate_impl ->
+            // split_kv_opt_supported (static shapes, default layout).
+            GPU_DEBUG_TRACE_DETAIL << "add stage for split-KV decode\n";
+            add_stage(regular_single_token, params);
+            // Always >= 2 partitions (>=1 cache + 1 new-chunk), so finalization always runs to
+            // flash-combine the per-partition partials.
+            add_stage(regular_finalization, params);
         } else {
             auto is_indirect = params.typed_desc<scaled_dot_product_attention>()->indirect_axis != -1;
             GPU_DEBUG_TRACE_DETAIL << "add stage for non-dynamic, is_indirect = " << is_indirect << "\n";
@@ -116,6 +125,12 @@ public:
 
         kernel_dump_info.clear_entries();
 
+        if (new_params.typed_desc<scaled_dot_product_attention>()->split_kv) {
+            GPU_DEBUG_TRACE_DETAIL << "execute split-KV decode single_token + finalization\n";
+            auto ev = execute_stage(events, instance, regular_single_token);
+            return execute_stage({ev}, instance, regular_finalization);
+        }
+
 #ifdef ENABLE_ONEDNN_FOR_GPU
         // Check if INT4 KV cache is in use (micro kernel doesn't support INT4 for non-PA SDPA)
         // Only apply this check when the SDPA node actually uses compressed KV cache (i8/u8/i4/u4 K/V inputs).
@@ -160,8 +175,12 @@ public:
         auto params_canonicalization = SDPABase::requires_shape_canonicalization(params) ? SDPABase::static_canonicalize_shapes(params) : params;
         const auto head_size = get_head_size(params_canonicalization.get_input_layout(0), extended_input_q_transpose_order);
 
-        const auto num_of_partitions = get_partitions_num(params_canonicalization, SDPAStage::SINGLE_TOKEN);
-        const auto is_prefill = is_prefill_stage(params_canonicalization);
+        // split-KV decode adds one new-chunk partition and is never a prefill; its partitioned
+        // buffers must always be full-sized (>=2 partitions, finalization always runs).
+        const bool is_split_kv = desc->split_kv;
+        const auto num_of_partitions = is_split_kv ? (get_partitions_num(params_canonicalization, SDPAStage::SINGLE_TOKEN) + 1)
+                                                   : get_partitions_num(params_canonicalization, SDPAStage::SINGLE_TOKEN);
+        const auto is_prefill = !is_split_kv && is_prefill_stage(params_canonicalization);
         const size_t buf_elements_count = (num_of_partitions == 1 || is_prefill) ? 1 : params.output_layouts[0].count() / head_size * num_of_partitions;
         const size_t tmp_out_elements_count = (num_of_partitions == 1 || is_prefill) ? 2 : params.output_layouts[0].count() * num_of_partitions;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.hpp
@@ -23,6 +23,11 @@ struct SDPAStage {
     constexpr static size_t MICRO = 3;
 };
 
+// Defined in sdpa_gen_opt.cpp. Forward-declared here (rather than including sdpa_gen_opt.hpp, which
+// includes this header for SDPAStage) to avoid a circular include. True when the split-KV op can be
+// lowered by the partitioned opt decode path (static shapes, default [B,H,S,D] layout).
+[[nodiscard]] bool split_kv_opt_supported(const kernel_impl_params& params);
+
 struct SDPAOpt : public ImplementationManager {
     OV_GPU_PRIMITIVE_IMPL("ocl::sdpa::opt")
     explicit SDPAOpt(shape_types shape_type, ValidateFunc vf = nullptr) : ImplementationManager(impl_types::ocl, shape_type, std::move(vf)) {}
@@ -30,6 +35,12 @@ struct SDPAOpt : public ImplementationManager {
     [[nodiscard]] static bool supports_micro_sdpa(const kernel_impl_params& params);
     [[nodiscard]] bool validate_impl(const program_node& node) const override {
         const auto desc = node.as<scaled_dot_product_attention>().get_primitive();
+        // split_kv: handled by the SPLIT_KV-gated single-token decode path (sdpa_opt.cl + the
+        // SDPASplitKVOpt* generators). The fusion only produces a split-KV op for the cases this
+        // path supports (static shapes, default [B,H,S,D] layout), so gate on split_kv_opt_supported.
+        if (desc->split_kv) {
+            return split_kv_opt_supported(*node.get_kernel_impl_params());
+        }
         static constexpr std::array supported_q_types = {
             ov::element::f32,
             ov::element::f16,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
@@ -18,6 +18,12 @@ inline size_t get_data_inputs_num(const cldnn::scaled_dot_product_attention& des
         data_inputs_num--;
     }
 
+    // split_kv appends a trailing i32 control input (the valid cache length). It is not a
+    // Q/K/V/mask/scale data input, so exclude it from the count (mask detection, base loop, etc.).
+    if (desc.split_kv) {
+        data_inputs_num--;
+    }
+
     if (desc.is_kv_compressed) {
         data_inputs_num -= 2;
         if (desc.get_compression_zp_inputs_num() > 0) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -17,6 +17,26 @@
 // exp_sums      [batch, heads_num, q_len, partition_idx]
 // max_logits    [batch, heads_num, q_len, partition_idx]
 // tmp_out       [batch, heads_num, q_len, partition_idx, head_size]
+//
+// ============================================================================================
+// SPLIT_KV mode (jit-gated; #ifdef SPLIT_KV). The single-token (2nd+ token) decode path doubles as
+// the split-KV decode kernel: the persistent KV cache (key_input/value_input) and the current
+// step's KV (key_new_input/value_new_input) are kept SEPARATE -- no full-cache Concat copy every
+// step -- and the kernel attends over the logical concatenation [K_cache; K_new] / [V_cache;
+// V_new]. The ONLY extension is the K/V load; KV-sequence partitioning, the SLM softmax
+// reductions, the finalization stage, GQA broadcast (DO_BROADCAST_KEY_VALUE) and dispatch are the
+// non-split path, unchanged. Split-KV is decode-only (q_len == 1), so only SDPA_STAGE_0 with
+// TARGET_SEQ_LEN_BLOCK_SIZE == 1 is exercised in that mode.
+//
+// Split-load: each partition runs the cache loops UNCHANGED, bounded by the live cache length
+// cache_len = min(kv_len, SOURCE_SEQ_LEN_CACHE). The new chunk runs as its own (highest) partition,
+// reading key_new/value_new with the same index helpers + GQA broadcast as the cache. In decode
+// S_new == 1, so that partition is trivial and never straddles a subgroup boundary. Extra inputs
+// in SPLIT_KV mode:
+//   key_new_input    [batch, kv_heads_num, S_new, head_size]   (K_new)
+//   value_new_input  [batch, kv_heads_num, S_new, head_size]   (V_new)
+//   kv_len_input     scalar i32 valid-cache-length (attended prefix; caps the cache loops)
+// and attn_mask then spans [*, *, q_len, S_cache + S_new].
 
 inline uint FUNC(get_input0_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
 #if INPUT0_SIMPLE
@@ -96,6 +116,41 @@ inline uint FUNC(get_input2_index)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint 
 #endif
 }
 
+#ifdef SPLIT_KV
+// K_new / V_new chunk index helpers. They mirror get_input1_index / get_input2_index but use the
+// KEY_NEW_* / VALUE_NEW_* layout macros (and optional *_DIMS_ORDER), applying the SAME GQA
+// broadcast (DO_BROADCAST_KEY_VALUE) as the cache chunk. Split-KV is restricted to the default
+// contiguous [B,H,S,D] layout and is mutually exclusive with KV compression / beam table, so only
+// the simple 4D index path is needed here.
+inline uint FUNC(get_key_new_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
+#ifdef DO_BROADCAST_KEY_VALUE
+    DO_BROADCAST_KEY_VALUE;
+#endif
+    return KEY_NEW_GET_INDEX(b, f, y, x);
+}
+inline uint FUNC(get_key_new_index)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
+#ifdef KEY_NEW_DIMS_ORDER
+    return FUNC_CALL(get_key_new_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR KEY_NEW_DIMS_ORDER);
+#else
+    return FUNC_CALL(get_key_new_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
+#endif
+}
+
+inline uint FUNC(get_value_new_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
+#ifdef DO_BROADCAST_KEY_VALUE
+    DO_BROADCAST_KEY_VALUE;
+#endif
+    return VALUE_NEW_GET_INDEX(b, f, y, x);
+}
+inline uint FUNC(get_value_new_index)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
+#ifdef VALUE_NEW_DIMS_ORDER
+    return FUNC_CALL(get_value_new_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR VALUE_NEW_DIMS_ORDER);
+#else
+    return FUNC_CALL(get_value_new_index_nt)(OPTIONAL_SHAPE_INFO_TENSOR b, f, w, z, y, x);
+#endif
+}
+#endif // SPLIT_KV
+
 #ifdef BEAM_TABLE_TYPE
 inline uint FUNC(get_bt_index_nt)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uint w, uint z, uint y, uint x) {
 #if BEAM_TABLE_SIMPLE
@@ -167,6 +222,14 @@ KERNEL(sdpa_opt)(
 #if HAS_SINK_INPUT
     const __global SINK_DATA_T* sink_ptr,
 #endif
+#ifdef SPLIT_KV
+    // split_kv: K_new / V_new / kv_len follow Q,K,V,mask (no scale input; scale is
+    // STATIC_SCALE_VALUE), matching the split-KV generator's argument order. kv_len[0] is the valid
+    // cache length (attended prefix), used to cap the cache loops.
+    const __global INPUT1_TYPE* key_new_input,
+    const __global INPUT2_TYPE* value_new_input,
+    const __global int* kv_len_input,
+#endif
     __global OUTPUT_TYPE* output,
 #if IS_KV_COMPRESSED
     const __global KEY_COMPRESSION_SCALE_TYPE* key_scale,
@@ -206,9 +269,66 @@ KERNEL(sdpa_opt)(
     const uint wi_num_per_partition = get_local_size(2);
 
     const uint start_partition_idx = partition_idx * SEQ_LEN_PARTITION_SIZE;
+#ifdef SPLIT_KV
+    // ---- split-KV partition classification ----------------------------------------------------
+    // Cache occupies logical positions [0, SOURCE_SEQ_LEN_CACHE); the new chunk occupies
+    // [SOURCE_SEQ_LEN_CACHE, SOURCE_SEQ_LEN). The new chunk gets its OWN partition (the highest
+    // partition index), so S_cache need NOT be partition-aligned: each partition is wholly cache or
+    // wholly new and reuses sdpa_opt's loop body verbatim against one source buffer.
+    //   * cache partition: read key_input/value_input at the global cache position; live length is
+    //     truncated by the dynamic valid-cache-length cache_len. Partitions entirely beyond cache_len
+    //     are pure padding -> early-exit.
+    //   * new partition: read key_new_input/value_new_input restarting at seq 0; full S_new length.
+    // Because S_cache may be unaligned, the new partition's start_partition_idx (a multiple of the
+    // partition size) is NOT the logical position. seq_pos_base gives the true logical position of
+    // in-partition index 0, used for the attention-mask column: SOURCE_SEQ_LEN_CACHE for the new
+    // partition, start_partition_idx for cache partitions.
+    const bool is_new_partition = (start_partition_idx >= SOURCE_SEQ_LEN_CACHE);
+    const uint seq_pos_base = is_new_partition ? (uint)SOURCE_SEQ_LEN_CACHE : start_partition_idx;
+    const uint cache_len = min((uint)kv_len_input[0], (uint)SOURCE_SEQ_LEN_CACHE);
+    uint partition_seq_len;
+    if (is_new_partition) {
+        partition_seq_len = SOURCE_SEQ_LEN - SOURCE_SEQ_LEN_CACHE;  // S_new
+    } else {
+        partition_seq_len = (start_partition_idx >= cache_len) ? 0u
+                          : min((uint)SEQ_LEN_PARTITION_SIZE, cache_len - start_partition_idx);
+    }
+    // Pure-padding cache partition: emit a neutral partial (max_logit = -inf, exp_sum = 0) so the
+    // finalization stage's flash-combine ignores it, then exit. The condition is uniform across the
+    // whole work-group (depends only on partition_idx / cache_len), so this return is barrier-safe.
+    if (partition_seq_len == 0) {
+        if (num_of_partitions > 1 && lid == 0) {
+            const uint part_offset = b0_idx * (NUM_HEADS * TARGET_SEQ_LEN * num_of_partitions) +
+                                     b1_idx * (TARGET_SEQ_LEN * num_of_partitions) +
+                                     target_seq_idx * (num_of_partitions) + partition_idx;
+            exp_sums[part_offset] = SOFTMAX_ACCUMULATOR_VAL_ZERO;
+            max_logits[part_offset] = SOFTMAX_ACCUMULATOR_VAL_MIN;
+        }
+        return;
+    }
+    // Source-buffer seq origin: cache positions are global (start_partition_idx + s); the new chunk
+    // restarts at 0 within key_new/value_new. SPLIT_KV_KEY_OFFSET / SPLIT_KV_VALUE_OFFSET below map
+    // an in-partition index s to the correct buffer offset (b_idx fixed to b0_idx: split-KV has no
+    // beam table). The chosen *_ptr selects which global buffer the load reads from.
+    #define SPLIT_KV_KEY_OFFSET(s) (is_new_partition \
+        ? FUNC_CALL(get_key_new_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, (s), 0) \
+        : FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (s), 0))
+    #define SPLIT_KV_VALUE_OFFSET(s) (is_new_partition \
+        ? FUNC_CALL(get_value_new_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, (s), head_size_idx) \
+        : FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b0_idx, b1_idx, 0, 0, start_partition_idx + (s), head_size_idx))
+    const __global INPUT1_TYPE* key_src = is_new_partition ? key_new_input : key_input;
+    const __global INPUT2_TYPE* value_src = is_new_partition ? value_new_input : value_input;
+    // Aliases so the shared (sdpa_opt-verbatim) load bodies below name the right source buffer in
+    // both split-KV (cache vs new) and non-split builds without further #ifdefs at each read site.
+    #define KEY_LOAD_SRC key_src
+    #define VALUE_LOAD_SRC value_src
+#else
+    #define KEY_LOAD_SRC key_input
+    #define VALUE_LOAD_SRC value_input
     const uint partition_seq_len =
         ((partition_idx + 1) < num_of_partitions) ? (SEQ_LEN_PARTITION_SIZE)
                                                   : (SOURCE_SEQ_LEN - partition_idx * SEQ_LEN_PARTITION_SIZE);
+#endif
 
     // SLM for query inputs
     __local INPUT0_TYPE query_local[K_HEAD_SIZE * TARGET_SEQ_LEN_BLOCK_SIZE];
@@ -292,7 +412,12 @@ KERNEL(sdpa_opt)(
                 const uint b_idx = b0_idx;
 #endif
 
-#if IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
+#ifdef SPLIT_KV
+                // Cache reads from key_input at the global position; the new chunk reads from
+                // key_new_input restarting at seq 0. SPLIT_KV_KEY_OFFSET encodes that origin; the
+                // matching key_src buffer is selected for the block reads below.
+                uint key_offset = SPLIT_KV_KEY_OFFSET(seq_len);
+#elif IS_INT4_COMPRESSED && !defined(BEAM_TABLE_TYPE)
                 uint key_offset = key_base_p0 + (start_partition_idx + seq_len) * key_packed_pitch_p0;
 #elif defined(INPUT1_DIMS_ORDER)
                 uint key_offset = FUNC_CALL(get_input1_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + seq_len, 0);
@@ -370,7 +495,7 @@ KERNEL(sdpa_opt)(
                     #define TO_KEY_BLOCK_UNCOMPRESSED_TYPE(val) CAT(convert_, KEY_BLOCK_UNCOMPRESSED)(val)
                     #define QUERY_BLOCK MAKE_VECTOR_TYPE(INPUT0_TYPE, KEY_BLOCK_SIZE)
 
-                    KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(key_input, key_offset + head_idx_index);
+                    KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(KEY_LOAD_SRC, key_offset + head_idx_index);
 #if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                     KEY_BLOCK_UNCOMPRESSED key_vals = (TO_KEY_BLOCK_UNCOMPRESSED_TYPE(key_vec_packed) - comp_zp) * comp_scale;
 #elif IS_KV_COMPRESSED
@@ -402,7 +527,7 @@ KERNEL(sdpa_opt)(
                     #define TO_KEY_BLOCK_UNCOMPRESSED_TYPE(val) CAT(convert_, KEY_BLOCK_UNCOMPRESSED)(val)
                     #define QUERY_BLOCK MAKE_VECTOR_TYPE(INPUT0_TYPE, KEY_BLOCK_SIZE)
 
-                    KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(key_input, key_offset + head_idx_index);
+                    KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(KEY_LOAD_SRC, key_offset + head_idx_index);
 #if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                     KEY_BLOCK_UNCOMPRESSED key_vals = (TO_KEY_BLOCK_UNCOMPRESSED_TYPE(key_vec_packed) - comp_zp) * comp_scale;
 #elif IS_KV_COMPRESSED
@@ -434,7 +559,7 @@ KERNEL(sdpa_opt)(
                     #define TO_KEY_BLOCK_UNCOMPRESSED_TYPE(val) CAT(convert_, KEY_BLOCK_UNCOMPRESSED)(val)
                     #define QUERY_BLOCK MAKE_VECTOR_TYPE(INPUT0_TYPE, KEY_BLOCK_SIZE)
 
-                    KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(key_input, key_offset + head_idx_index);
+                    KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(KEY_LOAD_SRC, key_offset + head_idx_index);
 #if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                     KEY_BLOCK_UNCOMPRESSED key_vals = (TO_KEY_BLOCK_UNCOMPRESSED_TYPE(key_vec_packed) - comp_zp) * comp_scale;
 #elif IS_KV_COMPRESSED
@@ -466,7 +591,7 @@ KERNEL(sdpa_opt)(
                     #define TO_KEY_BLOCK_UNCOMPRESSED_TYPE(val) CAT(convert_, KEY_BLOCK_UNCOMPRESSED)(val)
                     #define QUERY_BLOCK MAKE_VECTOR_TYPE(INPUT0_TYPE, KEY_BLOCK_SIZE)
 
-                    KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(key_input, key_offset + head_idx_index);
+                    KEY_BLOCK key_vec_packed = KEY_BLOCK_READ(KEY_LOAD_SRC, key_offset + head_idx_index);
 #if IS_KV_COMPRESSED && USE_ASYMMETRIC_QUANTIZATION
                     KEY_BLOCK_UNCOMPRESSED key_vals = (TO_KEY_BLOCK_UNCOMPRESSED_TYPE(key_vec_packed) - comp_zp) * comp_scale;
 #elif IS_KV_COMPRESSED
@@ -512,7 +637,14 @@ KERNEL(sdpa_opt)(
                         if (start_partition_idx + seq_len > target_seq_idx + seq_idx)
                             qk_val[seq_idx] += INPUT0_VAL_MIN;
 #elif !IS_CAUSAL && HAS_ATTN_MASK_INPUT
+#ifdef SPLIT_KV
+                        // seq_pos_base maps in-partition seq_len to the logical mask column (cache:
+                        // start_partition_idx; new chunk: SOURCE_SEQ_LEN_CACHE, since S_cache may be
+                        // unaligned to the partition size).
+                        const uint attn_mask_offset = INPUT3_GET_INDEX_SAFE(b0_idx, b1_idx, target_seq_idx + seq_idx, seq_pos_base + seq_len);
+#else
                         const uint attn_mask_offset = INPUT3_GET_INDEX_SAFE(b0_idx, b1_idx, target_seq_idx + seq_idx, start_partition_idx + seq_len);
+#endif
                         INPUT3_TYPE mask_val = attn_mask[attn_mask_offset];
 #ifdef CLAMP_ATTN_MASK_INPUT
                         // Conditionally clamp attention mask when attention mask differs from SOFTMAX_ACCUMULATOR_TYPE(f32)
@@ -759,7 +891,12 @@ KERNEL(sdpa_opt)(
     #endif
 #else
             const uint b_idx = b0_idx;
-    #if IS_INT4_COMPRESSED
+    #ifdef SPLIT_KV
+                // Cache vs new chunk: SPLIT_KV_VALUE_OFFSET encodes the seq origin (global vs 0),
+                // value_src selects the buffer. value_pitch is identical for both (same [B,H,S,D]
+                // layout), so the per-step increment below is unchanged.
+                uint value_offset = SPLIT_KV_VALUE_OFFSET(seq_len * SUBGROUP_SIZE);
+    #elif IS_INT4_COMPRESSED
                 uint value_offset = value_base_p0 + (start_partition_idx + (seq_len * SUBGROUP_SIZE)) * value_pitch;
     #elif defined(INPUT2_DIMS_ORDER)
                 uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + (seq_len * SUBGROUP_SIZE), head_size_idx);
@@ -790,7 +927,7 @@ KERNEL(sdpa_opt)(
                 const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(value_input, sub_group_broadcast(value_offset, i));
     #endif
 #else
-                const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(value_input, value_offset);
+                const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(VALUE_LOAD_SRC, value_offset);
 #endif
 
 #if IS_KV_COMPRESSED && IS_INT4_COMPRESSED
@@ -840,6 +977,10 @@ KERNEL(sdpa_opt)(
     #else
             const uint value_offset = value_base_p0 + (start_partition_idx + seq_len) * value_pitch;
     #endif
+#elif defined(SPLIT_KV)
+            // Unaligned-tail seq positions of a homogeneous partition (cache: truncated by the
+            // dynamic cache_len; new: the S_new remainder). Same buffer-select as the main loop.
+            const uint value_offset = SPLIT_KV_VALUE_OFFSET(seq_len);
 #elif defined(INPUT2_DIMS_ORDER)
             const uint value_offset = FUNC_CALL(get_input2_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, b1_idx, 0, 0, start_partition_idx + seq_len, head_size_idx);
 #else
@@ -863,7 +1004,7 @@ KERNEL(sdpa_opt)(
             const INPUT2_TYPE value_packed = (val_packed_x + sglid < K_HEAD_SIZE / 2)
                 ? VALUE_BLOCK_READ(value_input, value_offset) : (INPUT2_TYPE)0;
 #else
-            const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(value_input, value_offset);
+            const INPUT2_TYPE value_packed = VALUE_BLOCK_READ(VALUE_LOAD_SRC, value_offset);
 #endif
 #if IS_KV_COMPRESSED && IS_INT4_COMPRESSED
             // INT4 adjacent packing: shuffle to get correct byte, select nibble by lane parity
@@ -931,6 +1072,13 @@ KERNEL(sdpa_opt)(
 #endif
     } // Gemm2 calculation end
 }
+
+#undef KEY_LOAD_SRC
+#undef VALUE_LOAD_SRC
+#ifdef SPLIT_KV
+#undef SPLIT_KV_KEY_OFFSET
+#undef SPLIT_KV_VALUE_OFFSET
+#endif
 
 #else
 /* This version is used for 1st token */

--- a/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
@@ -115,12 +115,23 @@ static void CreateScaledDotProductAttentionOp(ProgramBuilder& p, const std::shar
     p.add_primitive(*op, sdpa_prim);
 }
 
+// split-KV input layout: [Q, K_cache, V_cache, mask, K_new, V_new, kv_len] (7 inputs). No scale
+// INPUT (scale is the scale_val attribute, fixed at 1.0 by the fusion). mask is always present for
+// the matched pattern; the trailing i32 kv_len carries the valid cache length.
+constexpr size_t split_kv_input_count = 7;
+
 static void CreateSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op::internal::SDPA>& op) {
-    validate_inputs_count(op, {cnt_inputs_with_qkv, cnt_inputs_with_mask, cnt_inputs_with_scale, cnt_inputs_with_sink});
+    const bool split_kv = op->get_split_kv();
+    if (split_kv) {
+        validate_inputs_count(op, {split_kv_input_count});
+    } else {
+        validate_inputs_count(op, {cnt_inputs_with_qkv, cnt_inputs_with_mask, cnt_inputs_with_scale, cnt_inputs_with_sink});
+    }
     auto inputs = p.GetInputInfo(op);
     auto layerName = layer_type_name_ID(op);
 
-    auto scalar_scale = GetScalarConstInput(op, scale_idx);
+    // For split_kv there is no scale input (indices 4/5 are K_new/V_new); only probe the mask slot.
+    auto scalar_scale = split_kv ? nullptr : GetScalarConstInput(op, scale_idx);
     auto scalar_attn_mask = GetScalarConstInput(op, mask_idx);
 
     ReshapeInput(p, op, inputs);
@@ -139,6 +150,18 @@ static void CreateSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op::intern
                                                          transpose_orders[1],
                                                          transpose_orders[2],
                                                          transpose_orders[3]);
+    if (split_kv) {
+        // Inputs are [Q, K_cache, V_cache, mask, K_new, V_new, kv_len]. The base ctor auto-derived
+        // the has_* flags from the raw input count (7), which is wrong (it would treat the trailing
+        // K_new/V_new/kv_len as scale/sink). Set them explicitly: mask is present, scale is a baked
+        // constant (no input), no sink. scale_val = 1.0 is applied by the kernel as STATIC_SCALE_VALUE.
+        sdpa_prim.split_kv = true;
+        sdpa_prim.has_attn_mask_input = true;
+        sdpa_prim.has_scale_input = false;
+        sdpa_prim.has_sink_input = false;
+        sdpa_prim.scale_val = 1.0f;
+    }
+
     if (scalar_scale) {
         sdpa_prim.scale_val = scalar_scale->cast_vector<float>()[0];
     }

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/sdpa.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/sdpa.cpp
@@ -18,14 +18,16 @@ SDPA::SDPA(const OutputVector& inputs,
            const std::vector<int64_t>& order_k,
            const std::vector<int64_t>& order_v,
            const std::vector<int64_t>& order_out,
-           const ov::element::Type output_type)
+           const ov::element::Type output_type,
+           bool split_kv)
     : m_is_causal(is_causal)
     , m_order_q(order_q)
     , m_order_k(order_k)
     , m_order_v(order_v)
     , m_order_out(order_out)
     , m_output_type(output_type)
-    , m_compressed(false) {
+    , m_compressed(false)
+    , m_split_kv(split_kv) {
     set_arguments(inputs);
     set_causal(is_causal);
     validate_and_infer_types();
@@ -61,18 +63,34 @@ std::shared_ptr<ov::Node> SDPA::clone_with_new_inputs(const ov::OutputVector& ne
                                   m_order_k,
                                   m_order_v,
                                   m_order_out,
-                                  m_output_type);
+                                  m_output_type,
+                                  m_split_kv);
 }
 
 void SDPA::validate_and_infer_types() {
     const auto input_size = get_input_size();
 
-    const auto compression_inputs = get_compression_inputs_num();
-    NODE_VALIDATION_CHECK(this,
-        input_size >= 3 + compression_inputs && input_size <= 5 + compression_inputs,
-        "Number of inputs is incorrect. Current value is: ",
-        input_size,
-        ", expected 3, 4 or 5 data inputs and ", compression_inputs, " KV-cache compression related inputs");
+    if (m_split_kv) {
+        // split_kv layout: [Q, K_cache, V_cache, mask, K_new, V_new, kv_len] -- 7 inputs. mask is
+        // always present (the fusion pattern that builds split_kv nodes requires one); there is no
+        // scale INPUT (scale is the scale_val attribute). KV-cache compression / indirect / sink are
+        // not supported together with split_kv.
+        NODE_VALIDATION_CHECK(this,
+            !m_compressed,
+            "split_kv SDPA does not support KV-cache compression.");
+        NODE_VALIDATION_CHECK(this,
+            input_size == 7,
+            "Number of inputs is incorrect for split_kv SDPA. Current value is: ",
+            input_size,
+            ", expected [Q, K_cache, V_cache, mask, K_new, V_new, kv_len]");
+    } else {
+        const auto compression_inputs = get_compression_inputs_num();
+        NODE_VALIDATION_CHECK(this,
+            input_size >= 3 + compression_inputs && input_size <= 5 + compression_inputs,
+            "Number of inputs is incorrect. Current value is: ",
+            input_size,
+            ", expected 3, 4 or 5 data inputs and ", compression_inputs, " KV-cache compression related inputs");
+    }
 
     std::vector<ov::PartialShape> input_shapes;
     for (size_t i = 0; i < input_size; i++) {
@@ -96,6 +114,7 @@ bool SDPA::visit_attributes(ov::AttributeVisitor &visitor) {
     visitor.on_attribute("order_v", m_order_v);
     visitor.on_attribute("order_out", m_order_out);
     visitor.on_attribute("output_type", m_output_type);
+    visitor.on_attribute("split_kv", m_split_kv);
     return true;
 }
 
@@ -135,6 +154,31 @@ std::vector<ov::PartialShape> shape_infer(const SDPA* op,
     auto shape_q_t = (order_q.size() > 1) ? transpose_pshape(shape_q, order_q) : shape_q;
     auto shape_k_t = (order_k.size() > 1) ? transpose_pshape(shape_k, order_k) : shape_k;
     auto shape_v_t = (order_v.size() > 1) ? transpose_pshape(shape_v, order_v) : shape_v;
+
+    // split_kv: K and V are supplied as two chunks each. input_shapes is
+    // [Q, K_cache, V_cache, mask, K_new, V_new, kv_len] (K_new/V_new are the 3rd/2nd from last, see
+    // below); the new chunks reuse K/V's transpose order. The op attends over the logical sequence
+    // concatenation, so the effective K/V seq length is (cache_seq + new_seq). Fold the new chunk's
+    // seq dim into the cache shape here so the standard v13 inference below produces the
+    // concatenated output shape. In transposed [B,H,S,D] space the sequence axis is the
+    // second-to-last dimension.
+    if (op != nullptr && op->get_split_kv() && shape_k_t.rank().is_static() && shape_v_t.rank().is_static() &&
+        shape_k_t.size() >= 2 && shape_v_t.size() >= 2 && input_shapes.size() >= 3) {
+        // Inputs end with [.., K_new, V_new, kv_len], so K_new/V_new are the 3rd/2nd from last
+        // (the trailing slot is the i32 kv_len control tensor, not a K/V chunk).
+        const auto shape_k_new = input_shapes[input_shapes.size() - 3];
+        const auto shape_v_new = input_shapes[input_shapes.size() - 2];
+        const auto shape_k_new_t = (order_k.size() > 1) ? transpose_pshape(shape_k_new, order_k) : shape_k_new;
+        const auto shape_v_new_t = (order_v.size() > 1) ? transpose_pshape(shape_v_new, order_v) : shape_v_new;
+        const auto k_seq_axis = shape_k_t.size() - 2;
+        const auto v_seq_axis = shape_v_t.size() - 2;
+        if (shape_k_new_t.rank().is_static() && shape_k_new_t.size() == shape_k_t.size()) {
+            shape_k_t[k_seq_axis] += shape_k_new_t[k_seq_axis];
+        }
+        if (shape_v_new_t.rank().is_static() && shape_v_new_t.size() == shape_v_t.size()) {
+            shape_v_t[v_seq_axis] += shape_v_new_t[v_seq_axis];
+        }
+    }
 
     const auto is_broadcastable = shape_k_t.rank().is_static() &&
                                   shape_v_t.rank().is_static() &&

--- a/src/plugins/intel_gpu/src/plugin/transformations/sdpa_split_kv_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/sdpa_split_kv_fusion.cpp
@@ -1,0 +1,302 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "sdpa_split_kv_fusion.hpp"
+
+#include <vector>
+
+#include "intel_gpu/op/sdpa.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reduce_max.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/scaled_dot_product_attention.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+namespace ov::intel_gpu {
+
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+namespace v8 = ov::op::v8;
+namespace v13 = ov::op::v13;
+
+using ov::pass::pattern::any_input;
+using ov::pass::pattern::consumers_count;
+using ov::pass::pattern::Matcher;
+using ov::pass::pattern::rank_equals;
+using ov::pass::pattern::wrap_type;
+
+namespace {
+// The K/V Concat of the (already core-fused) split-attention pattern must operate on the sequence
+// axis of the canonical [B,H,S,D] layout, i.e. rank-2 (not rank-1, which is the head dim D). Returns
+// false on dynamic rank (a non-static graph never reaches the split-KV path anyway).
+bool is_seq_axis(const std::shared_ptr<const ov::Node>& node, int64_t axis) {
+    const auto rank = node->get_output_partial_shape(0).rank();
+    if (rank.is_dynamic()) {
+        return false;
+    }
+    const auto r = rank.get_length();
+    return (axis < 0 ? axis + r : axis) == r - 2;
+}
+}  // namespace
+
+SDPASplitKVFusion::SDPASplitKVFusion() {
+    // Anchored on the fused v13::ScaledDotProductAttention that ov::pass::SDPASplitAttentionFusionMatcher
+    // (registered immediately before this pass in the GPU pipeline -- see transformations_pipeline.cpp)
+    // already builds from the raw split-attention sub-graph:
+    //
+    //   sdpa = v13::SDPA(Q, Concat(K_cache, K_new, seq_axis), Concat(V_cache, V_new, seq_axis), mask, scale=1.0)
+    //
+    // Concatenating the whole KV cache into a single tensor every decode step would copy it (the
+    // cache is a host-owned Parameter that cannot be concatenated in place), so this pass un-does
+    // the K/V concat for GPU and keeps K_cache/K_new and V_cache/V_new as separate op::SDPA inputs
+    // (split_kv = true) instead. The structural checks below are verified explicitly in the callback.
+    auto q_input = any_input(rank_equals(4));
+    auto k_cache_input = any_input(rank_equals(4));
+    auto k_new_input = any_input(rank_equals(4));
+    auto v_cache_input = any_input(rank_equals(4));
+    auto v_new_input = any_input(rank_equals(4));
+    auto mask_input = any_input();
+    auto scale_input = any_input();
+
+    auto k_concat = wrap_type<v0::Concat>({k_cache_input, k_new_input}, consumers_count(1));
+    auto v_concat = wrap_type<v0::Concat>({v_cache_input, v_new_input}, consumers_count(1));
+    auto sdpa_m = wrap_type<v13::ScaledDotProductAttention>({q_input, k_concat, v_concat, mask_input, scale_input});
+
+    ov::matcher_pass_callback callback = [=](Matcher& m) {
+        auto sdpa_node = ov::as_type_ptr<v13::ScaledDotProductAttention>(m.get_match_root());
+        if (!sdpa_node || sdpa_node->get_causal()) {
+            return false;
+        }
+
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto k_concat_node = ov::as_type_ptr<v0::Concat>(pattern_map.at(k_concat).get_node_shared_ptr());
+        auto v_concat_node = ov::as_type_ptr<v0::Concat>(pattern_map.at(v_concat).get_node_shared_ptr());
+        if (!k_concat_node || !v_concat_node) {
+            return false;
+        }
+
+        // Only the default contiguous [B,H,S,D] layout is supported: the core fusion concats
+        // directly on the sequence axis (no intervening Transpose) only for this layout; a
+        // transposed K/V ([B,H,D,S]) shows up here as Transpose(Concat(...)) instead of a bare
+        // Concat feeding the SDPA, which this pattern does not match, so such graphs fall through
+        // to the regular (non-split) SDPA path untouched.
+        if (!is_seq_axis(k_concat_node, k_concat_node->get_axis()) ||
+            !is_seq_axis(v_concat_node, v_concat_node->get_axis())) {
+            return false;
+        }
+
+        // The split-KV kernel hardcodes STATIC_SCALE_VALUE = 1.0 (there is no scale input); the core
+        // fusion always emits exactly this constant (any scaling is assumed pre-baked into Q), so
+        // require it here too -- a different scale value has no split-KV kernel to lower to.
+        auto scale_const = ov::as_type_ptr<v0::Constant>(pattern_map.at(scale_input).get_node_shared_ptr());
+        if (!scale_const) {
+            return false;
+        }
+        const auto scale_vals = scale_const->cast_vector<double>();
+        if (scale_vals.size() != 1 || scale_vals[0] != 1.0) {
+            return false;
+        }
+
+        auto Q = pattern_map.at(q_input);
+        auto K_cache = pattern_map.at(k_cache_input);
+        auto K_new = pattern_map.at(k_new_input);
+        auto V_cache = pattern_map.at(v_cache_input);
+        auto V_new = pattern_map.at(v_new_input);
+        auto mask_value = pattern_map.at(mask_input);
+
+        // The kv_len derivation further below assumes the canonical rank-4 mask [B, 1, q, S_kv]
+        // (it slices off the cache columns at a hardcoded axis 3). mask_input has no rank
+        // constraint in the pattern (a lower-rank mask broadcastable to the QK scores is legal per
+        // the SDPA spec), so bail to the regular (non-split) SDPA path rather than build a Slice
+        // with an out-of-range axis.
+        const auto mask_ps = mask_value.get_partial_shape();
+        if (!mask_ps.rank().is_static() || mask_ps.size() != 4) {
+            return false;
+        }
+
+        // Require fully static 4D shapes (rank 4 is already guaranteed by the pattern above). The
+        // split-KV op is lowered only by the partitioned opt decode path (SDPAOpt's single-token
+        // generators with SPLIT_KV, which need static shapes to size their SLM scores[] and
+        // partition bounds); there is no dynamic-shape split-KV kernel, so a dynamic match would
+        // have no implementation. Dynamic graphs fall back to the regular (non-split) SDPA path.
+        for (const auto& in : {Q, K_cache, K_new, V_cache, V_new}) {
+            if (in.get_partial_shape().is_dynamic()) {
+                return false;
+            }
+        }
+
+        // ---- GQA un-fold (Q only) --------------------------------------------------------------
+        // The Gemma split-attention export folds the GQA group (q_heads / kv_heads) into Q's query
+        // axis, so Q reaches the fused SDPA as [B, kv_heads, group*S_q, D] through a Reshape (in
+        // prefill preceded by a Transpose). That producer chain is NOT matched here (the pattern is
+        // anchored on the fused SDPA and Q is read structurally as its 1st input), so we walk
+        // up from the already-matched Q to read its shape hints. Feeding the folded Q straight to the
+        // split-KV op makes heads == kv_heads with an inflated q_len, and the kernel dispatches its
+        // work-group grid over (batch*kv_heads, group*S_q) instead of (batch*q_heads, S_q) -- decode
+        // gets misclassified as multi-token prefill. Recover the canonical Q [B, q_heads, S_q, D] (a
+        // pure reshape of the folded Q: the group is the outer part of the folded query axis, folded
+        // row f*S_q + s -> head k*group+f, seq s). K/V stay SPLIT with kv_heads -- the split-KV kernel
+        // broadcasts them up to q_heads itself (DO_BROADCAST_KEY_VALUE), so unlike a naive concat-based
+        // fusion we do not Concat/Broadcast K/V here. Any assumption that does not hold falls through
+        // to the folded inputs below, which stay numerically correct.
+        ov::Output<ov::Node> q_sdpa = Q;
+        ov::Output<ov::Node> mask_sdpa = mask_value;
+        bool refolded = false;  // true once Q is un-folded to canonical [B, q_heads, S_q, D]
+        {
+            const auto q_ps = Q.get_partial_shape();
+            const auto kc_head_ps = K_cache.get_partial_shape();
+            if (q_ps.is_static() && kc_head_ps[1].is_static()) {
+                const int64_t B = q_ps[0].get_length();
+                const int64_t kvh = kc_head_ps[1].get_length();
+                const int64_t F = q_ps[2].get_length();  // group * S_q
+                const int64_t D = q_ps[3].get_length();
+
+                // Recover (q_heads, S_q) by inspecting Q's producer (outside the matched pattern):
+                //  (a) a Reshape (prefill: preceded by a Transpose) whose projection is
+                //      [B, S_q, q_heads, D] -- read q_heads / S_q straight off it; or
+                //  (b) no fold Reshape at all, which the export emits only when the fold is an
+                //      identity, i.e. kvh == 1 and S_q == 1, so q_heads == F.
+                int64_t qh = 0, s_q = 0;
+                if (auto fold_reshape = ov::as_type_ptr<v1::Reshape>(Q.get_node_shared_ptr())) {
+                    ov::Output<ov::Node> proj = fold_reshape->input_value(0);
+                    if (auto tr = ov::as_type_ptr<v1::Transpose>(proj.get_node_shared_ptr())) {
+                        proj = tr->input_value(0);
+                    }
+                    const auto proj_ps = proj.get_partial_shape();
+                    if (proj_ps.rank().is_static() && proj_ps.size() == 4 && proj_ps[1].is_static() &&
+                        proj_ps[2].is_static()) {
+                        s_q = proj_ps[1].get_length();
+                        qh = proj_ps[2].get_length();
+                    }
+                } else if (q_ps[1].is_static() && q_ps[1].get_length() == 1 && kvh == 1) {
+                    // Folded Q is the projection itself ([B, 1, q_heads, D] with S_q == 1).
+                    qh = F;
+                    s_q = 1;
+                }
+
+                if (qh > 0 && kvh > 0 && qh > kvh && qh % kvh == 0 && s_q > 0 && (qh / kvh) * s_q == F) {
+                    // Canonical Q: pure reshape [B, kvh, group*S_q, D] -> [B, q_heads, S_q, D].
+                    auto q_tgt = v0::Constant::create(ov::element::i64, {4}, std::vector<int64_t>{B, qh, s_q, D});
+                    q_sdpa = std::make_shared<v1::Reshape>(Q, q_tgt, false);
+                    refolded = true;
+
+                    // The mask [B, 1, group*S_q, S_kv] is group-replicated along the query axis (it
+                    // depends on key/query position, not head), so the first S_q rows are the
+                    // canonical per-sequence mask, broadcastable across q_heads. mask_ps is already
+                    // known rank-4 (checked above).
+                    if (F != s_q && mask_ps[2].is_static() && mask_ps[2].get_length() == F) {
+                        auto start = v0::Constant::create(ov::element::i64, {1}, std::vector<int64_t>{0});
+                        auto stop = v0::Constant::create(ov::element::i64, {1}, std::vector<int64_t>{s_q});
+                        auto step = v0::Constant::create(ov::element::i64, {1}, std::vector<int64_t>{1});
+                        auto axis = v0::Constant::create(ov::element::i64, {1}, std::vector<int64_t>{2});
+                        mask_sdpa = std::make_shared<v8::Slice>(mask_value, start, stop, step, axis);
+                    }
+                }
+            }
+        }
+
+        // K and V are both stored [B,H,S,D] (seq axis = 2): the bare-Concat check above already
+        // guarantees the contiguous layout, since a transposed K/V would route through a Transpose
+        // node instead of feeding the SDPA concat directly (see the pattern comment above).
+        const int64_t seq_axis = 2;  // K/V seq axis for the contiguous [B,H,S,D] layout
+
+        // Decode only (q_len == 1). The split-KV path is the SPLIT_KV-gated branch of sdpa_opt's
+        // single-token decode kernel (see sdpa_opt.cl, #ifdef SPLIT_KV). Prefill / multi-token chunks
+        // (q_len > 1) fall through to the regular (non-split) SDPA path. The query length is read from
+        // the fused op's Q (q_sdpa): the canonical S_q after the GQA un-fold, else the folded Q's
+        // dim 2. The new-chunk seq lengths must be STATIC (the kernel sizes its SLM scores[] and
+        // partition bounds on SOURCE_SEQ_LEN at compile time).
+        const auto& q_sdpa_ps = q_sdpa.get_partial_shape();
+        if (!q_sdpa_ps[seq_axis].is_static() || q_sdpa_ps[seq_axis].get_length() != 1) {
+            return false;
+        }
+        const auto& k_new_ps = K_new.get_partial_shape();
+        const auto& v_new_ps = V_new.get_partial_shape();
+        if (!k_new_ps[seq_axis].is_static() || !v_new_ps[seq_axis].is_static()) {
+            return false;
+        }
+
+        // Derive the valid cache length from the additive mask, as the trailing kv_len input so the
+        // kernel can cap its cache loops (the cache is allocated for the full context but in decode
+        // only the first `time_step+1` positions are real; the rest are padding the mask drives to
+        // exp(-100)~=0). Compute valid_cache_len = (last attended cache index) + 1. Using the LAST-
+        // attended index (not the zero count) keeps this correct for BOTH global (causal prefix
+        // [0,t]) and local sliding-window (window [t-w, t]) masks: the bound is a superset of the
+        // attended set, and any masked interior position still gets the additive mask -> exp~=0.
+        //
+        //   keep   = Equal(mask_cache, 0)        ; bool [B,1,q,S_cache]
+        //   idx1   = Convert(keep, i32) * ramp   ; i32  [B,1,q,S_cache]   ramp = [1..S_cache]
+        //   kv_len = ReduceMax(idx1, all axes)   ; i32  scalar = last_attended + 1
+        // The mask spans [cache | new]; slice off the cache columns first. S_cache is static (the
+        // fusion requires fully static shapes), so the ramp constant is well-defined.
+        const int64_t s_cache = K_cache.get_partial_shape()[2].get_length();  // [B,H,S,D]
+        auto sl_start = v0::Constant::create(ov::element::i64, {1}, {0});
+        auto sl_stop = v0::Constant::create(ov::element::i64, {1}, {s_cache});
+        auto sl_step = v0::Constant::create(ov::element::i64, {1}, {1});
+        auto sl_axis = v0::Constant::create(ov::element::i64, {1}, {3});
+        auto mask_cache = std::make_shared<v8::Slice>(mask_value, sl_start, sl_stop, sl_step, sl_axis);
+
+        auto zero = v0::Constant::create(mask_value.get_element_type(), {}, {0.0f});
+        auto keep = std::make_shared<v1::Equal>(mask_cache, zero);
+        auto keep_i = std::make_shared<v0::Convert>(keep, ov::element::i32);
+        std::vector<int32_t> ramp_vals(static_cast<size_t>(s_cache));
+        for (int64_t i = 0; i < s_cache; ++i)
+            ramp_vals[static_cast<size_t>(i)] = static_cast<int32_t>(i + 1);  // 1-based
+        auto ramp = v0::Constant::create(ov::element::i32, ov::Shape{static_cast<size_t>(s_cache)}, ramp_vals);
+        auto idx1 = std::make_shared<v1::Multiply>(keep_i, ramp);
+        auto axes = v0::Constant::create(ov::element::i64, {4}, {0, 1, 2, 3});
+        auto kv_len = std::make_shared<v1::ReduceMax>(idx1, axes, /*keep_dims=*/false);
+
+        // Build the split-KV op inputs [Q, K_cache, V_cache, mask, K_new, V_new, kv_len]. No scale
+        // INPUT: the matched pattern has no scale node and any scaling is baked into Q (e.g. Gemma's
+        // query_pre_attn_scalar), so the lowering sets scale_val = 1.0 and the kernel applies it via
+        // STATIC_SCALE_VALUE. K/V stay split -- the kernel broadcasts them across heads. Q and mask
+        // carry the GQA un-fold (q_sdpa / mask_sdpa), falling back to the folded Q / full mask when
+        // the un-fold did not apply. Layout is always default contiguous [B,H,S,D].
+        ov::OutputVector inputs{q_sdpa, K_cache, V_cache, mask_sdpa, K_new, V_new, kv_len};
+        const auto order = op::SDPA::default_order(/*rank=*/4);
+        auto sdpa = std::make_shared<op::SDPA>(inputs,
+                                               /*is_causal=*/false,
+                                               order,
+                                               order,
+                                               order,
+                                               order,
+                                               ov::element::dynamic,
+                                               /*split_kv=*/true);
+
+        ov::copy_runtime_info(m.get_matched_nodes(), sdpa);
+
+        // The split-KV op emits the canonical attention output [B, q_heads, S_q, D]. When Q was
+        // un-folded above, the matched SDPA (the graph's consumer/output) still expects the folded
+        // GQA layout [B, kvh, group*S_q, D]. Re-fold the canonical output back with the inverse pure
+        // reshape to sdpa_node's own static output shape so downstream shapes are unchanged; without
+        // it the replacement node carries the canonical shape and breaks the model's output binding.
+        // When no un-fold happened the SDPA output already matches sdpa_node, so replace directly.
+        ov::Output<ov::Node> result = sdpa;
+        if (refolded) {
+            const auto& out_shape = sdpa_node->get_output_shape(0);  // static (checked above)
+            auto out_tgt = v0::Constant::create(ov::element::i64, {out_shape.size()},
+                                                std::vector<int64_t>(out_shape.begin(), out_shape.end()));
+            result = std::make_shared<v1::Reshape>(sdpa, out_tgt, false);
+        }
+        result.get_node_shared_ptr()->set_friendly_name(sdpa_node->get_friendly_name());
+        ov::replace_node(sdpa_node, result.get_node_shared_ptr());
+        return true;
+    };
+
+    auto m = std::make_shared<Matcher>(sdpa_m, "SDPASplitKVFusion");
+    this->register_matcher(m, callback);
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/sdpa_split_kv_fusion.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/sdpa_split_kv_fusion.hpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+
+namespace ov::intel_gpu {
+
+/// Fuses the fused v13::ScaledDotProductAttention that ov::pass::SDPASplitAttentionFusionMatcher
+/// builds for Gemma-style models keeping the persistent KV cache and the current step's KV separate,
+/// into a single split-KV ov::intel_gpu::op::SDPA (split_kv = true), WITHOUT materializing a
+/// full-cache KV Concat.
+///
+/// ov::pass::SDPASplitAttentionFusionMatcher is registered immediately before this pass in the GPU
+/// pipeline (see transformations_pipeline.cpp) and has already rewritten the raw
+/// MatMul/Concat/Softmax/VariadicSplit sub-graph into:
+///
+///     sdpa = v13::SDPA(Q, Concat(K_cache, K_new, seq_axis), Concat(V_cache, V_new, seq_axis), mask, scale=1.0)
+///
+/// On GPU that Concat copies the entire cache every step (its first input is the host-owned
+/// kv_cache Parameter, which cannot be concatenated in-place). This pass instead un-does the K/V
+/// concat and builds a split-KV op that attends over the logical concatenation directly, so no
+/// per-step cache copy is created.
+///
+/// Fires for DECODE ONLY (q_len == 1; K_new / V_new contribute the single newest step). The forked
+/// split-KV kernel mirrors sdpa_opt's single-token decode path (KV-sequence partitioning +
+/// finalization) with the cache loops kept byte-identical to sdpa_opt and the new chunk appended as
+/// a tail on the last partition. Prefill / multi-token chunks (q_len > 1) fall through to the
+/// regular multi-token SDPA path. Scope: Q/K/V must be static 4D, the new-chunk seq length must be
+/// static, and KV-cache compression / indirect / sink are not supported. Otherwise it does not fire.
+class SDPASplitKVFusion : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("SDPASplitKVFusion");
+    SDPASplitKVFusion();
+};
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -116,7 +116,9 @@
 #include "plugin/transformations/sink_reshape.hpp"
 #include "plugin/transformations/transpose_fusion.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.hpp"
+#include "plugin/transformations/sdpa_split_kv_fusion.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.hpp"
+#include "transformations/common_optimizations/sdpa_fusion.hpp"
 #include "plugin/transformations/disable_fp16_comp_rms.hpp"
 #include "plugin/transformations/swiglu_fusion_with_clamp.hpp"
 #include "plugin/transformations/disable_fp16_comp_cumsum_sin_gen.hpp"
@@ -1591,6 +1593,19 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::pass::ConvertWeightCompressedConv1x1ToMatmul>();
         manager.register_pass<ov::intel_gpu::IncreaseRMSInputPrecision>();
         manager.register_pass<ov::intel_gpu::ClampFP16Output>();
+        // Build a split-KV SDPA for the "split attention" sub-graph (cache + new K/V attended
+        // separately then summed) in decode (q_len == 1). SDPASplitAttentionFusionMatcher (core
+        // transformations) is registered explicitly right before it: models normally reach this
+        // already fused into v13::SDPA(Q, Concat(K_cache,K_new), Concat(V_cache,V_new), mask) by an
+        // earlier offline conversion step (e.g. ovc, which runs MOCTransformations), but
+        // CommonOptimizations above does NOT include that fusion, so re-running it here guarantees
+        // the Concat+SDPA shape SDPASplitKVFusion matches is present even for models compiled
+        // directly from a raw (un-converted) graph. A naive single-SDPA lowering of that shape is
+        // avoided because materializing the Concats would force a full-cache copy every step. Must
+        // run before TransposeFusion (further below), which converts v13::SDPA into the plugin's
+        // internal op::SDPA and would consume the anchor node.
+        manager.register_pass<ov::pass::SDPASplitAttentionFusionMatcher>();
+        manager.register_pass<ov::intel_gpu::SDPASplitKVFusion>();
         manager.register_pass<ov::intel_gpu::ConvertMatMulToFullyConnected>(device_info.supports_immad);
         manager.register_pass<ov::pass::MoveFCReshapeToWeights<ov::intel_gpu::op::FullyConnected>>();
         if (!device_info.supports_immad) {

--- a/src/plugins/intel_gpu/tests/unit/transformations/sdpa_split_kv_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/sdpa_split_kv_fusion_test.cpp
@@ -1,0 +1,237 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Unit tests for SDPASplitKVFusion: the GPU plugin pass that fuses the Gemma-style split-attention
+// decode sub-graph (cache + new K/V attended separately, then summed) into a single split-KV
+// op::SDPA. In the real pipeline, ov::pass::SDPASplitAttentionFusionMatcher (registered immediately
+// before this pass in the GPU pipeline) already rewrites the raw MatMul/Concat/Softmax/VariadicSplit
+// sub-graph into v13::SDPA(Q, Concat(K_cache,K_new), Concat(V_cache,V_new), mask) before this pass
+// runs, so these tests build the raw sub-graph and run both passes in that order. Covers the
+// plain-decode and GQA-folded positive cases, plus the multi-token and dynamic-shape cases that must
+// be left unfused.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <openvino/core/model.hpp>
+#include <openvino/pass/manager.hpp>
+
+#include "intel_gpu/op/sdpa.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/op/variadic_split.hpp"
+#include "plugin/transformations/sdpa_split_kv_fusion.hpp"
+#include "transformations/common_optimizations/sdpa_fusion.hpp"
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+namespace {
+namespace v0 = ov::op::v0;
+namespace v1 = ov::op::v1;
+namespace v8 = ov::op::v8;
+
+// Dimensions for the non-GQA path: q_heads == kv_heads == H, so Q reaches the QK matmul already in
+// canonical [B, H, S_q, D] layout (no fold Reshape) and the fusion takes its no-un-fold branch.
+struct SplitKVDims {
+    int64_t B = 1;
+    int64_t H = 8;
+    int64_t D = 64;
+    int64_t S_q = 1;  // decode
+    int64_t S_cache = 128;
+    int64_t S_new = 1;
+};
+
+// Build the split-attention decode sub-graph that SDPASplitKVFusion matches, with the default
+// contiguous [B,H,S,D] K/V layout (qk transpose_b=true, attn transpose_b=false):
+//
+//   qk_cache = MatMul(Q, K_cache, transpose_b)   qk_new = MatMul(Q, K_new, transpose_b)
+//   scores   = Concat(qk_cache, qk_new, -1)
+//   probs    = Softmax(scores + mask, -1)
+//   [pc, pn] = VariadicSplit(probs, -1, {S_cache, S_new})
+//   out      = MatMul(pc, V_cache) + MatMul(pn, V_new)
+std::shared_ptr<ov::Model> build_split_kv_decode_model(const SplitKVDims& d, bool dynamic_cache = false) {
+    const auto et = ov::element::f32;
+    const auto cache = dynamic_cache ? ov::Dimension::dynamic() : ov::Dimension(d.S_cache);
+    const auto mask_kv = dynamic_cache ? ov::Dimension::dynamic() : ov::Dimension(d.S_cache + d.S_new);
+
+    auto Q = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, d.S_q, d.D});
+    auto Kc = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, cache, d.D});
+    auto Kn = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, d.S_new, d.D});
+    auto Vc = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, cache, d.D});
+    auto Vn = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, d.S_new, d.D});
+    auto M = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, 1, d.S_q, mask_kv});
+
+    auto qk_cache = std::make_shared<v0::MatMul>(Q, Kc, /*transpose_a*/ false, /*transpose_b*/ true);
+    auto qk_new = std::make_shared<v0::MatMul>(Q, Kn, /*transpose_a*/ false, /*transpose_b*/ true);
+
+    auto scores = std::make_shared<v0::Concat>(ov::OutputVector{qk_cache, qk_new}, -1);
+    auto masked = std::make_shared<v1::Add>(scores, M);
+    auto probs = std::make_shared<v8::Softmax>(masked, -1);
+
+    auto split_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {-1});
+    auto split_sizes = v0::Constant::create(ov::element::i64, ov::Shape{2}, {dynamic_cache ? -1 : d.S_cache, d.S_new});
+    auto split = std::make_shared<v1::VariadicSplit>(probs, split_axis, split_sizes);
+
+    auto attn_cache = std::make_shared<v0::MatMul>(split->output(0), Vc, false, false);
+    auto attn_new = std::make_shared<v0::MatMul>(split->output(1), Vn, false, false);
+    auto out = std::make_shared<v1::Add>(attn_cache, attn_new);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{out}, ov::ParameterVector{Q, Kc, Kn, Vc, Vn, M});
+}
+
+// Build a GQA decode sub-graph where the export folds the group (q_heads / kv_heads) into Q's
+// query axis: Q is projected as [B, S_q, q_heads, D], then a Reshape folds it to the QK operand
+// [B, kv_heads, group*S_q, D] (with S_q == 1, group*S_q == group). The matcher's QK operands then
+// batch over kv_heads, and the fusion must un-fold Q (and slice the group-replicated mask) back to
+// the canonical [B, q_heads, S_q, D], re-folding the SDPA output to the matched Add's layout.
+std::shared_ptr<ov::Model> build_gqa_fold_decode_model(int64_t q_heads, int64_t kv_heads) {
+    const auto et = ov::element::f32;
+    const int64_t B = 1, D = 64, S_q = 1, S_cache = 128, S_new = 1;
+    const int64_t group = q_heads / kv_heads;
+
+    // Unfolded Q projection [B, S_q, q_heads, D]; reshape folds it to [B, kv_heads, group*S_q, D].
+    auto Qproj = std::make_shared<v0::Parameter>(et, ov::PartialShape{B, S_q, q_heads, D});
+    auto fold = v0::Constant::create(ov::element::i64, ov::Shape{4}, {B, kv_heads, group * S_q, D});
+    auto Q = std::make_shared<v1::Reshape>(Qproj, fold, false);
+
+    auto Kc = std::make_shared<v0::Parameter>(et, ov::PartialShape{B, kv_heads, S_cache, D});
+    auto Kn = std::make_shared<v0::Parameter>(et, ov::PartialShape{B, kv_heads, S_new, D});
+    auto Vc = std::make_shared<v0::Parameter>(et, ov::PartialShape{B, kv_heads, S_cache, D});
+    auto Vn = std::make_shared<v0::Parameter>(et, ov::PartialShape{B, kv_heads, S_new, D});
+    // Mask is group-replicated along the query axis: [B, 1, group*S_q, S_cache + S_new].
+    auto M = std::make_shared<v0::Parameter>(et, ov::PartialShape{B, 1, group * S_q, S_cache + S_new});
+
+    auto qk_cache = std::make_shared<v0::MatMul>(Q, Kc, false, true);
+    auto qk_new = std::make_shared<v0::MatMul>(Q, Kn, false, true);
+    auto scores = std::make_shared<v0::Concat>(ov::OutputVector{qk_cache, qk_new}, -1);
+    auto masked = std::make_shared<v1::Add>(scores, M);
+    auto probs = std::make_shared<v8::Softmax>(masked, -1);
+    auto split_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {-1});
+    auto split_sizes = v0::Constant::create(ov::element::i64, ov::Shape{2}, {S_cache, S_new});
+    auto split = std::make_shared<v1::VariadicSplit>(probs, split_axis, split_sizes);
+    auto attn_cache = std::make_shared<v0::MatMul>(split->output(0), Vc, false, false);
+    auto attn_new = std::make_shared<v0::MatMul>(split->output(1), Vn, false, false);
+    auto out = std::make_shared<v1::Add>(attn_cache, attn_new);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{out}, ov::ParameterVector{Qproj, Kc, Kn, Vc, Vn, M});
+}
+
+// Same sub-graph as build_split_kv_decode_model, but with a rank-2 mask [S_q, S_cache + S_new]
+// broadcastable to the QK scores (legal per the SDPA spec) instead of the canonical rank-4
+// [B, 1, S_q, S_cache + S_new]. The kv_len derivation only knows how to slice a rank-4 mask, so this
+// must be left unfused rather than build an out-of-range Slice.
+std::shared_ptr<ov::Model> build_split_kv_decode_model_with_rank2_mask(const SplitKVDims& d) {
+    const auto et = ov::element::f32;
+
+    auto Q = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, d.S_q, d.D});
+    auto Kc = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, d.S_cache, d.D});
+    auto Kn = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, d.S_new, d.D});
+    auto Vc = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, d.S_cache, d.D});
+    auto Vn = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.B, d.H, d.S_new, d.D});
+    auto M = std::make_shared<v0::Parameter>(et, ov::PartialShape{d.S_q, d.S_cache + d.S_new});
+
+    auto qk_cache = std::make_shared<v0::MatMul>(Q, Kc, /*transpose_a*/ false, /*transpose_b*/ true);
+    auto qk_new = std::make_shared<v0::MatMul>(Q, Kn, /*transpose_a*/ false, /*transpose_b*/ true);
+
+    auto scores = std::make_shared<v0::Concat>(ov::OutputVector{qk_cache, qk_new}, -1);
+    auto masked = std::make_shared<v1::Add>(scores, M);
+    auto probs = std::make_shared<v8::Softmax>(masked, -1);
+
+    auto split_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {-1});
+    auto split_sizes = v0::Constant::create(ov::element::i64, ov::Shape{2}, {d.S_cache, d.S_new});
+    auto split = std::make_shared<v1::VariadicSplit>(probs, split_axis, split_sizes);
+
+    auto attn_cache = std::make_shared<v0::MatMul>(split->output(0), Vc, false, false);
+    auto attn_new = std::make_shared<v0::MatMul>(split->output(1), Vn, false, false);
+    auto out = std::make_shared<v1::Add>(attn_cache, attn_new);
+
+    return std::make_shared<ov::Model>(ov::OutputVector{out}, ov::ParameterVector{Q, Kc, Kn, Vc, Vn, M});
+}
+
+std::shared_ptr<op::SDPA> find_split_kv_sdpa(const std::shared_ptr<ov::Model>& model) {
+    for (const auto& op : model->get_ops()) {
+        if (auto sdpa = ov::as_type_ptr<op::SDPA>(op)) {
+            if (sdpa->get_split_kv()) {
+                return sdpa;
+            }
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<op::SDPA> run_fusion(const std::shared_ptr<ov::Model>& model) {
+    ov::pass::Manager manager;
+    // Mirrors the real pipeline order: SDPASplitAttentionFusionMatcher fuses the raw sub-graph into
+    // v13::SDPA + Concat(K)/Concat(V) first, then the GPU pass un-does the Concat for split-KV.
+    manager.register_pass<ov::pass::SDPASplitAttentionFusionMatcher>();
+    manager.register_pass<SDPASplitKVFusion>();
+    manager.run_passes(model);
+    return find_split_kv_sdpa(model);
+}
+}  // namespace
+
+// Decode (S_q == 1), static shapes, default layout: the sub-graph fuses into a single split-KV
+// op::SDPA with the 7-input layout [Q, K_cache, V_cache, mask, K_new, V_new, kv_len].
+TEST(SDPASplitKVFusionTest, Decode) {
+    auto model = build_split_kv_decode_model(SplitKVDims{});
+
+    auto sdpa = run_fusion(model);
+    ASSERT_NE(sdpa, nullptr) << "split-KV decode sub-graph was not fused into op::SDPA(split_kv=true)";
+    EXPECT_EQ(sdpa->get_input_size(), 7u);  // [Q, K_cache, V_cache, mask, K_new, V_new, kv_len]
+    EXPECT_EQ(sdpa->get_output_partial_shape(0), (ov::PartialShape{1, 8, 1, 64}));
+}
+
+// GQA decode: the export folds the group into Q's query axis. The fusion must un-fold Q to the
+// canonical [B, q_heads, S_q, D] (so the op batches over q_heads, not kv_heads), and re-fold the
+// SDPA output back to the matched Add's folded layout [B, kv_heads, group*S_q, D] so downstream
+// shapes are preserved. q_heads=32, kv_heads=8 (group=4).
+TEST(SDPASplitKVFusionTest, GqaFoldDecode) {
+    auto model = build_gqa_fold_decode_model(/*q_heads=*/32, /*kv_heads=*/8);
+
+    auto sdpa = run_fusion(model);
+    ASSERT_NE(sdpa, nullptr) << "GQA-folded split-KV decode sub-graph was not fused";
+    EXPECT_EQ(sdpa->get_input_size(), 7u);
+    // The op carries the canonical (un-folded) Q layout [B, q_heads, S_q, D].
+    EXPECT_EQ(sdpa->get_output_partial_shape(0), (ov::PartialShape{1, 32, 1, 64}));
+    // Its single consumer is the output re-fold Reshape back to the folded [B, kv_heads, group, D].
+    const auto consumers = sdpa->get_output_target_inputs(0);
+    ASSERT_EQ(consumers.size(), 1u);
+    auto refold = ov::as_type_ptr<ov::op::v1::Reshape>(consumers.begin()->get_node()->shared_from_this());
+    ASSERT_NE(refold, nullptr) << "expected an output re-fold Reshape after the un-folded SDPA";
+    EXPECT_EQ(refold->get_output_partial_shape(0), (ov::PartialShape{1, 8, 4, 64}));
+}
+
+// Prefill / multi-token chunk (S_q > 1, S_new > 1) is out of scope for the decode-only kernel and
+// must be left unfused.
+TEST(SDPASplitKVFusionTest, MultiTokenNoFusion) {
+    SplitKVDims d;
+    d.S_q = 16;
+    d.S_new = 16;
+    auto model = build_split_kv_decode_model(d);
+
+    EXPECT_EQ(run_fusion(model), nullptr) << "multi-token chunk must not fuse into split-KV SDPA";
+}
+
+// Dynamic shapes have no split-KV kernel implementation, so the match must bail.
+TEST(SDPASplitKVFusionTest, DynamicNoFusion) {
+    auto model = build_split_kv_decode_model(SplitKVDims{}, /*dynamic_cache=*/true);
+
+    EXPECT_EQ(run_fusion(model), nullptr) << "dynamic shapes must not fuse into split-KV SDPA";
+}
+
+// A rank-2 mask broadcastable to the QK scores is legal per the SDPA spec, but the kv_len
+// derivation only knows how to slice a rank-4 mask. The fusion must bail (not throw building an
+// out-of-range Slice) and leave the sub-graph unfused.
+TEST(SDPASplitKVFusionTest, NonRank4MaskNoFusion) {
+    auto model = build_split_kv_decode_model_with_rank2_mask(SplitKVDims{});
+
+    EXPECT_EQ(run_fusion(model), nullptr) << "non-rank-4 mask must not fuse into split-KV SDPA";
+}


### PR DESCRIPTION
### Details:
Some LLM exports (e.g. LiteRT Gemma-4) compute attention against the persistent KV cache and the current step's KV separately, then merge:

    qk_cache = MatMul(Q, K_cache)
    qk_new   = MatMul(Q, K_new)
    scores   = Concat(qk_cache, qk_new, axis=-1)
    probs    = Softmax(scores + mask, axis=-1)
    [pc, pn] = VariadicSplit(probs, axis=-1)
    output   = MatMul(pc, V_cache) + MatMul(pn, V_new)

Core transformations (SDPASplitAttentionFusionMatcher) fuse this into a single v13::SDPA(Q, Concat(K_cache,K_new), Concat(V_cache,V_new), mask, scale=1.0), but on GPU that Concat copies the entire KV cache every decode step (its first input is the host-owned cache Parameter, which cannot be concatenated in place). Add a GPU split-KV path that attends over the logical [K_cache; K_new] / [V_cache; V_new] concatenation directly, keeping the four tensors as separate op::SDPA inputs (split_kv = true) with no per-step copy:

- SDPASplitKVFusion (plugin transformation) is anchored on the fused v13::SDPA node: it requires the K/V inputs to each be a bare 2-input Concat on the sequence axis (a Transpose-wrapped Concat means the core fusion normalized a transposed layout, which this pass does not support and falls through to the regular SDPA path), the fusion's scale to be exactly 1.0 (the split-KV kernel hardcodes STATIC_SCALE_VALUE=1.0), and the mask to be rank-4 (the kv_len derivation below slices it at a fixed axis; a lower-rank mask that's merely broadcastable to the QK scores -- legal per the SDPA spec -- falls through to the regular SDPA path instead of risking an out-of-range Slice). It un-folds the GQA group that the export folds into Q's query axis (recovering canonical Q [B, q_heads, S_q, D]) and re-folds the SDPA output back to the matched node's layout, and derives the valid cache length from the mask, passed as a trailing kv_len input so the kernel skips the cache's padding tail.

  SDPASplitAttentionFusionMatcher is registered directly in front of it in the GPU pipeline: that core matcher is only wired into the offline MOCTransformations pass (used by ovc/model conversion), not into ov::pass::CommonOptimizations that the GPU plugin runs at compile_model time, so a model compiled directly from a raw (un-converted) graph would otherwise never present the fused Concat+SDPA shape SDPASplitKVFusion matches. Re-running it here makes the fusion chain self-sufficient regardless of whether the model was pre-fused offline.

- op::SDPA / scaled_dot_product_attention primitive plumbing for the split_kv inputs [Q, K_cache, V_cache, mask, K_new, V_new, kv_len] (mask is always present -- the fusion pattern that builds split_kv nodes requires one -- so op::SDPA validates the input count as exactly 7), including shape inference over the logical concatenation.

- The decode path is a SPLIT_KV-gated branch of sdpa_opt's single-token path (same sdpa_opt.cl template + host generators): same KV-sequence partitioning and finalization flash-combine, extended only in the K/V load. The cache is partitioned exactly as sdpa_opt (each partition reuses its loop body, the live length capped by kv_len); the new chunk runs as one extra partition. Reusing the tuned opt partitioning keeps decode latency flat as the cache grows. The static-shape requirement lets the kernel size its SLM scores[] and partition bounds at compile time. Prefill, dynamic shapes, and other layouts fall back to the regular (non-split) SDPA path.

Tests: sdpa_split_kv_fusion_test.cpp runs SDPASplitAttentionFusionMatcher before SDPASplitKVFusion to mirror the real pipeline order, covering the plain-decode and GQA-folded positive cases (asserting the fused split-KV op::SDPA, its 7-input layout and the un-fold / output re-fold shapes), the multi-token and dynamic-shape cases that must stay unfused, and a non-rank-4 mask case that must also stay unfused.

### Tickets:
CVS-189216

### AI Assistance:
 - *AI assistance used: no / yes*
yes

 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
 build/tests/manual checks
