### PR TITLE
[CPU] Fix BinaryConvolution accuracy regression from unsigned padding math

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -1296,19 +1296,26 @@ void BinaryConvolution::executeOptimized(const uint8_t* src,
 
         auto par_conv = jit_bin_conv_call_args();
 
-        const size_t ij = oh * jcp.stride_h;
-        const size_t i_t_overflow =
-            nstl::min(jcp.kh, div_up(nstl::max(static_cast<size_t>(0), jcp.t_pad - ij), (jcp.dilate_h + 1)));
-        const size_t i_b_overflow =
-            nstl::min(jcp.kh,
-                      div_up(nstl::max(jcp.ih, ij + (jcp.kh - 1) * (jcp.dilate_h + 1) - jcp.t_pad + 1) - jcp.ih,
-                             (jcp.dilate_h + 1)));
+        // Padding-overflow math must be signed: with size_t, nstl::max(0, ...) can no longer clamp
+        // the negative t_pad - ij / ij - t_pad cases and underflows, corrupting the convolution.
+        const int ij = static_cast<int>(oh * jcp.stride_h);
+        const int i_t_overflow =
+            nstl::min(static_cast<int>(jcp.kh),
+                      div_up(nstl::max(0, static_cast<int>(jcp.t_pad) - ij), static_cast<int>(jcp.dilate_h) + 1));
+        const int i_b_overflow =
+            nstl::min(static_cast<int>(jcp.kh),
+                      div_up(nstl::max(static_cast<int>(jcp.ih),
+                                       ij + (static_cast<int>(jcp.kh) - 1) * (static_cast<int>(jcp.dilate_h) + 1) -
+                                           static_cast<int>(jcp.t_pad) + 1) -
+                                 static_cast<int>(jcp.ih),
+                             static_cast<int>(jcp.dilate_h) + 1));
 
         const size_t _oc = g * jcp.nb_oc + ocb;
         const size_t _ic = g * jcp.nb_ic;
 
-        const auto ih = nstl::max(ij - jcp.t_pad + i_t_overflow * (jcp.dilate_h + 1), static_cast<size_t>(0));
-        par_conv.src = &src[(n * s_str[0] + _ic * jcp.ic_block * s_str[1] + ih * s_str[2]) / nbits];
+        const int ih =
+            nstl::max(ij - static_cast<int>(jcp.t_pad) + i_t_overflow * (static_cast<int>(jcp.dilate_h) + 1), 0);
+        par_conv.src = &src[(n * s_str[0] + _ic * jcp.ic_block * s_str[1] + static_cast<size_t>(ih) * s_str[2]) / nbits];
 
         if (jcp.with_binarization) {
             par_conv.dst = &dst[(n * d_str[0] + _oc * jcp.oc_block * d_str[1] + oh * d_str[2]) / nbits];
@@ -1316,16 +1323,16 @@ void BinaryConvolution::executeOptimized(const uint8_t* src,
             par_conv.dst = &dst_f32[n * d_str[0] + _oc * jcp.oc_block * d_str[1] + oh * d_str[2]];
         }
 
-        const auto wh = jcp.exclude_pad ? i_t_overflow : static_cast<size_t>(0);
-        par_conv.filt = &weights[(ocb * w_str[0] + wh * w_str[2]) / nbits];
+        const int wh = jcp.exclude_pad ? i_t_overflow : 0;
+        par_conv.filt = &weights[(ocb * w_str[0] + static_cast<size_t>(wh) * w_str[2]) / nbits];
 
         par_conv.oc_work = nstl::min((ocb + ocb_num) * jcp.oc_block, jcp.oc) - ocb * jcp.oc_block;
 
         par_conv.kw_padding = 0;
-        const auto kh_padding = jcp.kh - i_t_overflow - i_b_overflow;
-        par_conv.kh_padding = nstl::max(static_cast<size_t>(0), kh_padding);
-        par_conv.t_overflow = i_t_overflow;
-        par_conv.b_overflow = i_b_overflow;
+        const int kh_padding = static_cast<int>(jcp.kh) - i_t_overflow - i_b_overflow;
+        par_conv.kh_padding = static_cast<size_t>(nstl::max(0, kh_padding));
+        par_conv.t_overflow = static_cast<size_t>(i_t_overflow);
+        par_conv.b_overflow = static_cast<size_t>(i_b_overflow);
 
         par_conv.oc_off = _oc * jcp.oc_block * sizeof(float);
         par_conv.post_op_data = postOpsDataPtrs.data();


### PR DESCRIPTION
Fixes  BinaryConvolution accuracy regression from unsigned padding math.

### Details:

The optimized BinaryConvolution executor computed the vertical padding overflow (i_t_overflow, i_b_overflow), the input row offset (ih) and kh_padding using size_t. With unsigned arithmetic the nstl::max(0, ...) guards can no longer clamp the negative `t_pad - ij` / `ij - t_pad` cases: they underflow to huge values, so for every output row where ij > t_pad the effective kernel height and source offset are wrong and the convolution produces garbage.

This regressed CPU accuracy of binary/XNOR models (e.g. resnet50-binary-0001, resnet18-xnor-binary-onnx-0001) while GPU, which uses its own kernel, was unaffected. The executeReference path already used signed int and was correct.

Restore signed int for the padding-overflow computation and cast to size_t only at the call-args/pointer assignments, keeping the JIT call-args layout unchanged.

### Tickets:
 - CVS-190468

### AI Assistance:
 - *AI assistance used: yes*
 - *How: bisecting builds, finding the culprit, sketching the solution*
