### PR TITLE
Fix CVS-192439 Coverity uncaught exception in JS API

### DIFF
--- a/src/bindings/js/node/src/tensor_impl.cpp
+++ b/src/bindings/js/node/src/tensor_impl.cpp
@@ -79,10 +79,17 @@ TensorImpl::TensorImpl(Napi::Env env,
 }
 
 // Tears down the shutdown coordination state from any thread-safe destruction path.
+// Destructors are implicitly noexcept: the OPENVINO_ASSERTs inside these cleanup
+// helpers must not be allowed to escape, otherwise a failure would call
+// std::terminate() and abort the whole process during teardown.
 TensorImpl::~TensorImpl() {
-    _cleanup_ctx->remove_cleanup_hook();
-    _cleanup_ctx->release_tsfn();
-    _cleanup_ctx->release_owner();
+    try {
+        _cleanup_ctx->remove_cleanup_hook();
+        _cleanup_ctx->release_tsfn();
+        _cleanup_ctx->release_owner();
+    } catch (...) {
+        // Nothing can be recovered while destroying; swallow to keep the destructor noexcept.
+    }
 }
 
 // Reshapes the wrapped tensor and refreshes cached strides that are exposed by reference.


### PR DESCRIPTION
### Details:
 - What changed: wrapped the three cleanup calls in the destructor in a try/catch(...) so the OPENVINO_ASSERT in remove_cleanup_hook() (and the equivalent one in release_tsfn()) can no longer propagate out of the noexcept destructor and trigger std::terminate().
 - *...*

### Tickets:
 - *CVS-192439*

### AI Assistance:
 - *AI assistance used: yes*
 - *Fix generated by gnai-claude opus 4.8*
