### PR TITLE
[TRANSFORMATIONS] Extend EliminateConvPaddingMaskGating transformation for granite-4.0-h-micro

### DIFF
--- a/src/common/transformations/src/transformations/paged_attention/eliminate_conv_padding_mask_gating.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/eliminate_conv_padding_mask_gating.cpp
@@ -37,18 +37,20 @@ EliminateConvPaddingMaskGating::EliminateConvPaddingMaskGating() {
     auto scale = pattern::optional<v1::Multiply>({convert, any_input()});
     auto shift = pattern::optional<v1::Add>({scale, any_input()});
 
-    // The mask's scale/shift are compile-time constants, so requiring the non-mask operand to be a
-    // runtime value uniquely selects the real gate and rejects the inner mask-scale Multiply, whose
-    // other operand is the constant scale.
-    auto hidden_states = any_input([](const ov::Output<ov::Node>& out) {
-        return ov::util::get_constant_from_source(out) == nullptr;
-    });
+    auto hidden_states = any_input();
     auto mul_gate = wrap_type<v1::Multiply>({hidden_states, shift});
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pm = m.get_pattern_value_map();
-        const auto gate = pm.at(mul_gate).get_node_shared_ptr();
-        gate->output(0).replace(pm.at(hidden_states));
+        const auto& gated = pm.at(hidden_states);
+        // The mask's scale/shift are compile-time constants, so the real gate is the branch that is not
+        // constant-foldable; this rejects the inner mask-scale Multiply, whose other operand is the constant scale.
+        // Checked here rather than in a pattern predicate to avoid running bound evaluation on every Multiply.
+        // (was observed to dramatically worsen the compile-time on large models if put in the pattern predicate)
+        if (ov::util::get_constant_from_source(gated) != nullptr) {
+            return false;
+        }
+        pm.at(mul_gate).get_node_shared_ptr()->output(0).replace(gated);
         return true;
     };
 

--- a/src/common/transformations/src/transformations/paged_attention/eliminate_conv_padding_mask_gating.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/eliminate_conv_padding_mask_gating.cpp
@@ -5,6 +5,7 @@
 #include "transformations/paged_attention/eliminate_conv_padding_mask_gating.hpp"
 
 #include "itt.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/multiply.hpp"
@@ -26,21 +27,28 @@ namespace ov::pass {
 EliminateConvPaddingMaskGating::EliminateConvPaddingMaskGating() {
     MATCHER_SCOPE(EliminateConvPaddingMaskGating);
 
-    // Pattern: attention_mask -> Slice -> Unsqueeze -> [Convert] -> Multiply -> Add -> Multiply(H, mask_expr)
+    // Pattern: attention_mask -> Slice -> [Unsqueeze] -> [Convert] -> [Multiply] -> [Add] -> Multiply(H, mask_expr)
     auto attn_mask = wrap_type<v0::Parameter>([](const ov::Output<ov::Node>& output) {
         return output.get_names().count("attention_mask");
     });
     auto slice = wrap_type<v8::Slice>({attn_mask, any_input(), any_input(), any_input(), any_input()});
-    auto unsqueeze = pattern::optional<v0::Unsqueeze>({slice, any_input()});
+    auto unsqueeze = pattern::wrap_type<v0::Unsqueeze>({slice, any_input()});
     auto convert = pattern::optional<v0::Convert>({unsqueeze});
-    auto mul_mask = wrap_type<v1::Multiply>({convert, any_input()});
-    auto add = wrap_type<v1::Add>({mul_mask, any_input()});
-    auto hidden_states = any_input();
-    auto mul_gate = wrap_type<v1::Multiply>({hidden_states, add});
+    auto scale = pattern::optional<v1::Multiply>({convert, any_input()});
+    auto shift = pattern::optional<v1::Add>({scale, any_input()});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    // The mask's scale/shift are compile-time constants, so requiring the non-mask operand to be a
+    // runtime value uniquely selects the real gate and rejects the inner mask-scale Multiply, whose
+    // other operand is the constant scale.
+    auto hidden_states = any_input([](const ov::Output<ov::Node>& out) {
+        return ov::util::get_constant_from_source(out) == nullptr;
+    });
+    auto mul_gate = wrap_type<v1::Multiply>({hidden_states, shift});
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pm = m.get_pattern_value_map();
-        pm.at(mul_gate).get_node_shared_ptr()->output(0).replace(pm.at(hidden_states));
+        const auto gate = pm.at(mul_gate).get_node_shared_ptr();
+        gate->output(0).replace(pm.at(hidden_states));
         return true;
     };
 

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -7174,6 +7174,85 @@ TEST_F(SDPAToPATest, SDPAToPA_LFM2_EliminateConvPaddingMaskGating) {
         model_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{params});
     }
 }
+// Scale without shift (synthetic): the mask-scale Multiply is structurally identical to a collapsed
+// gate, so this checks the gate is still found while the inner Multiply (consumer = gate Multiply)
+// is not mistaken for it.
+TEST_F(SDPAToPATest, SDPAToPA_LFM2_EliminateConvPaddingMaskGating_NoAdd) {
+    {
+        auto attention_mask = make_param(PartialShape{DYN, DYN}, element::i32, "attention_mask");
+        auto slice = makeOP<v8::Slice>({attention_mask, {0}, {1}, {1}, {1}});
+        auto unsqueeze = makeOP<v0::Unsqueeze>({slice, 1});
+        auto convert = makeOP<v0::Convert>({unsqueeze}, {{"destination_type", "f32"}});
+        auto multiply = makeOP<v1::Multiply>({convert, 1024.0f}, {{"auto_broadcast", "numpy"}});
+        auto multiply_gate_param = make_param(PartialShape{DYN, DYN, DYN}, element::f32, "gate_param");
+        auto multiply_gate = makeOP<v1::Multiply>({multiply_gate_param, multiply}, {{"auto_broadcast", "numpy"}});
+
+        auto matmul_param = make_param(PartialShape{48, 16}, element::f32, "weights");
+        auto matmul =
+            makeOP<v0::MatMul>({matmul_param, multiply_gate}, {{"transpose_a", false}, {"transpose_b", true}});
+        auto res = makeOP<v0::Result>({matmul});
+
+        auto params = nodes_to_params({attention_mask, matmul_param, multiply_gate_param});
+        model = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{params});
+
+        ov::pass::Manager pass_manager;
+        pass_manager.set_per_pass_validation(false);
+        pass_manager.register_pass<ov::pass::EliminateConvPaddingMaskGating>();
+        pass_manager.run_passes(model);
+
+        model->remove_parameter(params[0]);
+    }
+    {
+        auto multiply_gate_param = make_param(PartialShape{DYN, DYN, DYN}, element::f32, "gate_param");
+        auto matmul_param = make_param(PartialShape{48, 16}, element::f32, "weights");
+        auto matmul =
+            makeOP<v0::MatMul>({matmul_param, multiply_gate_param}, {{"transpose_a", false}, {"transpose_b", true}});
+        auto res = makeOP<v0::Result>({matmul});
+
+        auto params = nodes_to_params({matmul_param, multiply_gate_param});
+
+        model_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{params});
+    }
+}
+
+// granite-4.0-h-micro shape: hidden_states is gated with the Converted mask directly
+// (no scale Multiply, no shift Add), so mask_expr ends at Convert.
+TEST_F(SDPAToPATest, SDPAToPA_EliminateConvPaddingMaskGating_GraniteMamba) {
+    {
+        auto attention_mask = make_param(PartialShape{DYN, DYN}, element::i32, "attention_mask");
+        auto slice = makeOP<v8::Slice>({attention_mask, {0}, {1}, {1}, {1}});
+        auto unsqueeze = makeOP<v0::Unsqueeze>({slice, 1});
+        auto convert = makeOP<v0::Convert>({unsqueeze}, {{"destination_type", "f32"}});
+        auto multiply_gate_param = make_param(PartialShape{DYN, DYN, DYN}, element::f32, "gate_param");
+        auto multiply_gate = makeOP<v1::Multiply>({multiply_gate_param, convert}, {{"auto_broadcast", "numpy"}});
+
+        auto matmul_param = make_param(PartialShape{48, 16}, element::f32, "weights");
+        auto matmul =
+            makeOP<v0::MatMul>({matmul_param, multiply_gate}, {{"transpose_a", false}, {"transpose_b", true}});
+        auto res = makeOP<v0::Result>({matmul});
+
+        auto params = nodes_to_params({attention_mask, matmul_param, multiply_gate_param});
+        model = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{params});
+
+        ov::pass::Manager pass_manager;
+        pass_manager.set_per_pass_validation(false);
+        pass_manager.register_pass<ov::pass::EliminateConvPaddingMaskGating>();
+        pass_manager.run_passes(model);
+
+        model->remove_parameter(params[0]);
+    }
+    {
+        auto multiply_gate_param = make_param(PartialShape{DYN, DYN, DYN}, element::f32, "gate_param");
+        auto matmul_param = make_param(PartialShape{48, 16}, element::f32, "weights");
+        auto matmul =
+            makeOP<v0::MatMul>({matmul_param, multiply_gate_param}, {{"transpose_a", false}, {"transpose_b", true}});
+        auto res = makeOP<v0::Result>({matmul});
+
+        auto params = nodes_to_params({matmul_param, multiply_gate_param});
+
+        model_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{params});
+    }
+}
 
 // Minimal single-layer stateful SDPA model. With fq_on_k / fq_on_v, a 5-input v0::FakeQuantize is
 // inserted after the KV-cache Concat (the a8w8 / SmoothQuant location) - feeding SDPA directly


### PR DESCRIPTION
### Details:
 - Extend EliminateConvPaddingMaskGating transformation pattern to match the granite-4.0-h-micro model graph to remove the attention_mask parameter correctly.

### Tickets:
 - [CVS-193140](https://jira.devtools.intel.com/browse/CVS-193140)

### AI Assistance:
 - *AI assistance used: yes
