### PR TITLE
[NPU Tests] Extend precision coverage for InferRequest tensor precision tests

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/io_tensor.cpp
@@ -271,6 +271,11 @@ const std::vector<ov::AnyMap> autoConfigs = {
 
 const std::vector<ov::element::Type> prcs = {
     ov::element::boolean,
+    ov::element::nf4,
+    ov::element::f4e2m1,
+    ov::element::f8e4m3,
+    ov::element::f8e5m2,
+    ov::element::f8e8m0,
     ov::element::bf16,
     ov::element::f16,
     ov::element::f32,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -39,6 +39,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests,
 
 const std::vector<ov::element::Type> prcs = {
     ov::element::boolean,
+    ov::element::nf4,
+    ov::element::f4e2m1,
+    ov::element::f8e4m3,
+    ov::element::f8e5m2,
+    ov::element::f8e8m0,
     ov::element::bf16,
     ov::element::f16,
     ov::element::f32,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -47,6 +47,71 @@ Example:
     </skip_config>
 
     <skip_config>
+        <message>Data type u1 not supported by NPU</message>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u1\D.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u1\D.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- E#170977 -->
+    <skip_config>
+        <message>Data type u2 not supported by NPU3720</message>
+        <enable_rules>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u2.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u2.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>4-bit network outputs not supported by NPU3720</message>
+        <enable_rules>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=i4.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u4.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=nf4.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i4.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u4.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=nf4.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>Data type f4e2m1 not supported by NPU</message>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=f4e2m1.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=f4e2m1.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>Data type f8e8m0 not supported by NPU</message>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=f8e8m0.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=f8e8m0.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>Data types f8e4m3, f8e5m2 not supported by NPU3720, NPU4000</message>
+        <enable_rules>
+            <device>3720</device>
+            <device>4000</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=f8e4m3.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=f8e5m2.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=f8e4m3.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=f8e5m2.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
         <message>Data types not supported by NPU3720 PV Driver.</message>
         <enable_rules>
             <device>3720</device>
@@ -54,8 +119,6 @@ Example:
         </enable_rules>
         <filters>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=boolean.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i4.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u4.*</filter>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i16.*</filter>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u16.*</filter>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=bf16.*</filter>
@@ -93,16 +156,6 @@ Example:
         <filters>
             <filter>.*smoke_BehaviorTests_OVClassSpecificDeviceTest/OVSpecificDeviceGetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
             <filter>.*smoke_BehaviorTests_OVClassSpecificDeviceTest/OVSpecificDeviceTestSetConfig.SetConfigSpecificDeviceNoThrow.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>Output I4 / U4 precision is not currently supported.</message>
-        <filters>
-            <filter>.*smoke.*OVInferRequestCheckTensorPrecision.*type=i4.*</filter>
-            <filter>.*smoke.*OVInferRequestCheckTensorPrecision.*type=u4.*</filter>
-            <filter>.*smoke.*OVInferRequestIOTensorSetPrecisionTestNPU.*type=i4.*</filter>
-            <filter>.*smoke.*OVInferRequestIOTensorSetPrecisionTestNPU.*type=u4.*</filter>
         </filters>
     </skip_config>
 
@@ -217,27 +270,6 @@ Example:
         <message>Non "developer build" CiDs don't support weights separation yet</message>
         <filters>
             <filter>.*WeightsSeparationIterativeTests.*DRIVER.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#170977 -->
-    <skip_config>
-        <message>Data type u2 not supported by NPU3720</message>
-        <enable_rules>
-            <device>3720</device>
-        </enable_rules>
-        <filters>
-            <filter>.*InferRequestCheckTensorPrecision.*type=u2.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u2.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E###### -->
-    <skip_config>
-        <message>Data type u1 not supported by NPU</message>
-        <filters>
-            <filter>.*InferRequestCheckTensorPrecision.*type=u1\D.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u1\D.*</filter>
         </filters>
     </skip_config>
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -54,27 +54,17 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- E#170977 -->
     <skip_config>
-        <message>Data type u2 not supported by NPU3720</message>
+        <message>Data type u2 and 4-bit network outputs not supported by NPU3720</message>
         <enable_rules>
             <device>3720</device>
         </enable_rules>
         <filters>
             <filter>.*InferRequestCheckTensorPrecision.*type=u2.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u2.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>4-bit network outputs not supported by NPU3720</message>
-        <enable_rules>
-            <device>3720</device>
-        </enable_rules>
-        <filters>
             <filter>.*InferRequestCheckTensorPrecision.*type=i4.*</filter>
             <filter>.*InferRequestCheckTensorPrecision.*type=u4.*</filter>
             <filter>.*InferRequestCheckTensorPrecision.*type=nf4.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u2.*</filter>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=i4.*</filter>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=u4.*</filter>
             <filter>.*InferRequestIOTensorSetPrecisionTest.*type=nf4.*</filter>


### PR DESCRIPTION
### Details:
 - *Extend precision coverage for `OVInferRequestCheckTensorPrecision` and `OVInferRequestIOTensorSetPrecisionTest`
by adding `nf4`, `f4e2m1`, `f8e4m3`, `f8e5m2` and `f8e8m0` to the tested precisions.*
- *Update npu_skip_func_tests.xml accordingly.*

### Tickets:
 - *E-229266*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
