### PR TITLE
[GPU] Fix runtime graph dump crash on primitives removed during optimization

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -466,35 +466,39 @@ std::shared_ptr<ov::Model> Graph::get_runtime_model(std::vector<cldnn::primitive
 
         // Expose per-primitive extra attributes in rt_info for debugging / testing.
         if (prim_info.type_id != "input_layout" && prim_info.type_id != "data") {
-            const auto& node = get_network()->get_primitive(prim_info.original_id)->get_node();
+            // The primitive may have been removed from the program during graph optimization
+            // (e.g. when dumping intermediate transformation steps), so skip missing nodes.
+            if (get_network()->get_program()->has_node(prim_info.original_id)) {
+                const auto& node = get_network()->get_primitive(prim_info.original_id)->get_node();
 
-            if (node.is_type<cldnn::dynamic_quantize>()) {
-                auto dyn_quan = node.as<cldnn::dynamic_quantize>().get_primitive();
-                info["group_sizes"] = ov::util::join(cldnn::convert_vector<int64_t>(dyn_quan->attrs.group_sizes));
-                if (dyn_quan->attrs.precomputed_reduction) {
-                    info["precomputed_reduction_dt"] = dyn_quan->attrs.precomputed_reduction_dt.c_type_string();
-                }
-            } else if (node.is_type<cldnn::grouped_matmul>()) {
-                auto gm_prim = node.as<cldnn::grouped_matmul>().get_primitive();
-                if (gm_prim->compressed_weights) {
-                    auto wei_layout = node.get_input_layout(cldnn::grouped_matmul::GroupedMatmulInputIdx::WEIGHT);
-                    info["weights_precision"] = ov::element::Type(wei_layout.data_type).get_type_name();
-                    if (gm_prim->decompression_zero_point.is_valid()) {
-                        auto zp_layout = node.get_input_layout(gm_prim->input.size() + 1);
-                        info["wzp_precision"] = ov::element::Type(zp_layout.data_type).get_type_name();
+                if (node.is_type<cldnn::dynamic_quantize>()) {
+                    auto dyn_quan = node.as<cldnn::dynamic_quantize>().get_primitive();
+                    info["group_sizes"] = ov::util::join(cldnn::convert_vector<int64_t>(dyn_quan->attrs.group_sizes));
+                    if (dyn_quan->attrs.precomputed_reduction) {
+                        info["precomputed_reduction_dt"] = dyn_quan->attrs.precomputed_reduction_dt.c_type_string();
                     }
-                }
-            } else if (node.is_type<cldnn::fully_connected>()) {
-                auto fc_prim = node.as<cldnn::fully_connected>().get_primitive();
-                if (fc_prim->decompression_scale.is_valid()) {
-                    auto wei_layout = node.get_input_layout(1);
-                    info["weights_precision"] = ov::element::Type(wei_layout.data_type).get_type_name();
-                    if (fc_prim->decompression_zero_point.is_valid()) {
-                        size_t zp_idx = fc_prim->input.size() + 1 /*weights*/
-                                        + (fc_prim->bias.is_valid() ? 1 : 0)
-                                        + 1 /*scale*/;
-                        auto zp_layout = node.get_input_layout(zp_idx);
-                        info["wzp_precision"] = ov::element::Type(zp_layout.data_type).get_type_name();
+                } else if (node.is_type<cldnn::grouped_matmul>()) {
+                    auto gm_prim = node.as<cldnn::grouped_matmul>().get_primitive();
+                    if (gm_prim->compressed_weights) {
+                        auto wei_layout = node.get_input_layout(cldnn::grouped_matmul::GroupedMatmulInputIdx::WEIGHT);
+                        info["weights_precision"] = ov::element::Type(wei_layout.data_type).get_type_name();
+                        if (gm_prim->decompression_zero_point.is_valid()) {
+                            auto zp_layout = node.get_input_layout(gm_prim->input.size() + 1);
+                            info["wzp_precision"] = ov::element::Type(zp_layout.data_type).get_type_name();
+                        }
+                    }
+                } else if (node.is_type<cldnn::fully_connected>()) {
+                    auto fc_prim = node.as<cldnn::fully_connected>().get_primitive();
+                    if (fc_prim->decompression_scale.is_valid()) {
+                        auto wei_layout = node.get_input_layout(1);
+                        info["weights_precision"] = ov::element::Type(wei_layout.data_type).get_type_name();
+                        if (fc_prim->decompression_zero_point.is_valid()) {
+                            size_t zp_idx = fc_prim->input.size() + 1 /*weights*/
+                                            + (fc_prim->bias.is_valid() ? 1 : 0)
+                                            + 1 /*scale*/;
+                            auto zp_layout = node.get_input_layout(zp_idx);
+                            info["wzp_precision"] = ov::element::Type(zp_layout.data_type).get_type_name();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Commit 654d1126f0 extended the per-primitive rt_info extraction in Graph::get_runtime_model() to query the program node for every primitive (not just dynamic_quantize). When dumping intermediate optimization steps (OV_GPU_DUMP_GRAPHS_PATH), the primitives_info list may reference primitives that were removed from the program in later optimization passes. get_primitive() -> program::get_node() then throws 'Program doesn't contain primitive node'.

Guard the node lookup with program::has_node() and skip the rt_info attribute extraction for primitives no longer present in the program.


### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
