### PR TITLE
[NPU] Validate imported tensor memory capacity

### DIFF
--- a/src/plugins/intel_npu/src/utils/src/zero/zero_tensor.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_tensor.cpp
@@ -95,6 +95,15 @@ ZeroTensor::ZeroTensor(const std::shared_ptr<ZeroInitStructsHolder>& init_struct
     // zero context.
     _logger.debug("ZeroTensor::ZeroTensor - get tensor from pool or import it");
     _mem_ref = zero_mem::import_standard_allocation_memory(_init_structs, _ptr, _bytes_capacity);
+
+    // Hardening: validate that the memory allocation is at least as large as required for this tensor.
+    // This catches cases where compiled port metadata might diverge from the host buffer size.
+    OPENVINO_ASSERT(_mem_ref && _mem_ref->size() >= _bytes_capacity,
+                         "Imported memory size (",
+                         _mem_ref ? _mem_ref->size() : 0,
+                         " bytes) is smaller than required tensor capacity (",
+                         _bytes_capacity,
+                         " bytes)");
 }
 
 // Note: Override data() members to not used OpenVINO library code to improve performance


### PR DESCRIPTION
### Tickets:
 - [CVS-193161](https://jira.devtools.intel.com/browse/CVS-193161)

### Details:
Validate that imported Level Zero memory is large enough for the tensor capacity calculated from its element type, shape, and strides.

Reject inconsistent tensor metadata before execution to improve robustness when compiled port metadata does not match the backing allocation.

### AI Assistance:
AI assistance used: yes
AI helped analyze the tensor metadata and memory import flow, identify the appropriate OpenVINO validation boundary, and draft the hardening change. Human validated the final code and behavior.