### PR TITLE
[GPU] BF16: add CPU impl broadcast tests

### DIFF
--- a/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
@@ -371,6 +371,18 @@ TEST(broadcast_cpu_impl_int64_t, bfyx_1_to_4x5_w_b_axes_0x1x2x3_dynamic_with_sta
     start_broadcast_test_dynamic<int64_t, int32_t>(format::bfyx, data_types::i64, data_types::i32, {4, 5, 2, 3}, {1, 1, 1, 1}, {0, 1, 2, 3}, false, impl_types::cpu);
 }
 
+TEST(broadcast_cpu_impl_bf16, bfyx_1_to_4x5_w_b_axes_0x1_dynamic) {
+    start_broadcast_test_dynamic<ov::bfloat16, ov::bfloat16>(format::bfyx, data_types::bf16, data_types::bf16, {4, 5}, {1, 1}, {0, 1}, false, impl_types::cpu);
+}
+
+TEST(broadcast_cpu_impl_bf16, bfyx_1_to_4x5_w_b_axes_0x1_dynamic_with_static_output) {
+    start_broadcast_test_dynamic<ov::bfloat16, ov::bfloat16>(format::bfyx, data_types::bf16, data_types::bf16, {4, 5}, {1, 1}, {0, 1}, true, impl_types::cpu);
+}
+
+TEST(broadcast_cpu_impl_bf16, bfyx_1_to_4x5_w_b_axes_0x1x2x3_dynamic) {
+    start_broadcast_test_dynamic<ov::bfloat16, ov::bfloat16>(format::bfyx, data_types::bf16, data_types::bf16, {4, 5, 2, 3}, {1, 1, 1, 1}, {0, 1, 2, 3}, false, impl_types::cpu);
+}
+
 /* Expected golden_data = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
                            1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,


### PR DESCRIPTION
Follow-up to #37121 - adds targeted unit tests for the BF16 CPU broadcast path registered in that PR.

The CPU `broadcast.cpp` registration for `data_types::bf16` (#37121) had no test forcing `impl_types::cpu`, so a failure in the `Broadcast::evaluate` BF16 path could go unnoticed. This PR adds `broadcast_cpu_impl_bf16` tests covering dynamic, static-output, and 4D cases.

Ticket: [CVS-187666](https://jira.devtools.intel.com/browse/CVS-187666)