### PR TITLE
[NPU] Cleanup npu private properties

### DIFF
--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -58,7 +58,7 @@ inline std::ostream& operator<<(std::ostream& out, const CompilerType& fmt) {
     return out;
 }
 
-namespace Platform {
+namespace platforms {
 
 constexpr std::string_view AUTO_DETECT = "AUTO_DETECT";  // Auto detection
 constexpr std::string_view NPU3720 = "3720";             // NPU3720
@@ -89,7 +89,7 @@ inline std::string standardize(const std::string_view platform) {
     return std::string(platform);
 }
 
-}  // namespace Platform
+}  // namespace platforms
 
 /**
  * @brief [Only for NPU Plugin]

--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -58,6 +58,39 @@ inline std::ostream& operator<<(std::ostream& out, const CompilerType& fmt) {
     return out;
 }
 
+namespace Platform {
+
+constexpr std::string_view AUTO_DETECT = "AUTO_DETECT";  // Auto detection
+constexpr std::string_view NPU3720 = "3720";             // NPU3720
+constexpr std::string_view NPU4000 = "4000";             // NPU4000
+constexpr std::string_view NPU5010 = "5010";             // NPU5010
+constexpr std::string_view NPU5020 = "5020";             // NPU5020
+constexpr std::string_view NPU6010 = "6010";             // NPU6010
+
+/**
+ * @brief Converts the given platform value to the standard one.
+ * @details The same platform value can be defined in multiple ways (e.g. "3720" vs "VPU3720" vs "NPU3720"). The current
+ * function converts the prefixed variants to the non-prefixed ones in order to enable the comparison between platform
+ * values.
+ *
+ * The values already found in the standard form are returned as they are.
+ *
+ * @param platform The value to be converted.
+ * @return The same platform value given as parameter but converted to the standard form.
+ */
+inline std::string standardize(const std::string_view platform) {
+    constexpr std::string_view VPUPrefix = "VPU";
+    constexpr std::string_view NPUPrefix = "NPU";
+
+    if (!platform.compare(0, VPUPrefix.length(), VPUPrefix) || !platform.compare(0, NPUPrefix.length(), NPUPrefix)) {
+        return std::string(platform).substr(NPUPrefix.length());
+    }
+
+    return std::string(platform);
+}
+
+}  // namespace Platform
+
 /**
  * @brief [Only for NPU Plugin]
  * Type: Arbitrary string.

--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -260,7 +260,7 @@ struct PLATFORM final : OptionBase<PLATFORM, std::string> {
     }
 
     static std::string defaultValue() {
-        return std::string(ov::intel_npu::Platform::AUTO_DETECT);
+        return std::string(ov::intel_npu::platforms::AUTO_DETECT);
     }
 
 #ifdef NPU_PLUGIN_DEVELOPER_BUILD

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
@@ -43,50 +43,6 @@ inline std::string standardize(const std::string_view platform) {
 }  // namespace Platform
 
 /**
- * @enum ColorFormat
- * @brief Extra information about input color format for preprocessing
- * @note Configuration API v 2.0
- */
-enum ColorFormat : uint32_t {
-    RAW = 0u,  ///< Plain blob (default), no extra color processing required
-    RGB,       ///< RGB color format
-    BGR,       ///< BGR color format, default in DLDT
-    RGBX,      ///< RGBX color format with X ignored during inference
-    BGRX,      ///< BGRX color format with X ignored during inference
-};
-
-/**
- * @brief Prints a string representation of ov::intel_npu::ColorFormat to a stream
- * @param out An output stream to send to
- * @param fmt A color format value to print to a stream
- * @return A reference to the `out` stream
- * @note Configuration API v 2.0
- */
-inline std::ostream& operator<<(std::ostream& out, const ColorFormat& fmt) {
-    switch (fmt) {
-    case ColorFormat::RAW: {
-        out << "RAW";
-    } break;
-    case ColorFormat::RGB: {
-        out << "RGB";
-    } break;
-    case ColorFormat::BGR: {
-        out << "BGR";
-    } break;
-    case ColorFormat::RGBX: {
-        out << "RGBX";
-    } break;
-    case ColorFormat::BGRX: {
-        out << "BGRX";
-    } break;
-    default:
-        out << static_cast<uint32_t>(fmt);
-        break;
-    }
-    return out;
-}
-
-/**
  * @brief [Only for NPU Plugin]
  * Type: String. Default is "AUTO".
  * This option is added for enabling batching on plugin.

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
@@ -9,39 +9,6 @@
 namespace ov {
 namespace intel_npu {
 
-namespace Platform {
-
-constexpr std::string_view AUTO_DETECT = "AUTO_DETECT";  // Auto detection
-constexpr std::string_view NPU3720 = "3720";             // NPU3720
-constexpr std::string_view NPU4000 = "4000";             // NPU4000
-constexpr std::string_view NPU5010 = "5010";             // NPU5010
-constexpr std::string_view NPU5020 = "5020";             // NPU5020
-constexpr std::string_view NPU6010 = "6010";             // NPU6010
-
-/**
- * @brief Converts the given platform value to the standard one.
- * @details The same platform value can be defined in multiple ways (e.g. "3720" vs "VPU3720" vs "NPU3720"). The current
- * function converts the prefixed variants to the non-prefixed ones in order to enable the comparison between platform
- * values.
- *
- * The values already found in the standard form are returned as they are.
- *
- * @param platform The value to be converted.
- * @return The same platform value given as parameter but converted to the standard form.
- */
-inline std::string standardize(const std::string_view platform) {
-    constexpr std::string_view VPUPrefix = "VPU";
-    constexpr std::string_view NPUPrefix = "NPU";
-
-    if (!platform.compare(0, VPUPrefix.length(), VPUPrefix) || !platform.compare(0, NPUPrefix.length(), NPUPrefix)) {
-        return std::string(platform).substr(NPUPrefix.length());
-    }
-
-    return std::string(platform);
-}
-
-}  // namespace Platform
-
 /**
  * @brief [Only for NPU Plugin]
  * Type: String. Default is "AUTO".

--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -80,24 +80,24 @@ std::string ZeroDevice::getName() const {
     switch (_device_properties.deviceId) {
     case NPU_3720_P_DEVICE_ID:
     case NPU_3720_S_DEVICE_ID:
-        name = ov::intel_npu::Platform::NPU3720;
+        name = ov::intel_npu::platforms::NPU3720;
         break;
     case NPU_4000_DEVICE_ID:
-        name = ov::intel_npu::Platform::NPU4000;
+        name = ov::intel_npu::platforms::NPU4000;
         break;
     case NPU_5010_DEVICE_ID:
-        name = ov::intel_npu::Platform::NPU5010;
+        name = ov::intel_npu::platforms::NPU5010;
         break;
     case NPU_5020_DEVICE_ID:
-        name = ov::intel_npu::Platform::NPU5020;
+        name = ov::intel_npu::platforms::NPU5020;
         break;
     case NPU_6010_DEVICE_ID:
-        name = ov::intel_npu::Platform::NPU6010;
+        name = ov::intel_npu::platforms::NPU6010;
         break;
     case LEGACY_NPU_3000_DEVICE_ID:
         OPENVINO_THROW("[LEGACY] NPU device ID 0x", std::hex, _device_properties.deviceId, " is not supported!");
     default:
-        name = ov::intel_npu::Platform::AUTO_DETECT;
+        name = ov::intel_npu::platforms::AUTO_DETECT;
     }
 
     return name;

--- a/src/plugins/intel_npu/src/common/src/device_helpers.cpp
+++ b/src/plugins/intel_npu/src/common/src/device_helpers.cpp
@@ -39,13 +39,13 @@ std::string utils::getCompilationPlatform(const std::string_view platform,
                                           const std::string_view deviceId,
                                           std::vector<std::string> availableDevicesNames) {
     // Platform parameter has a higher priority than deviceID
-    if (platform != ov::intel_npu::Platform::AUTO_DETECT) {
-        return ov::intel_npu::Platform::standardize(platform);
+    if (platform != ov::intel_npu::platforms::AUTO_DETECT) {
+        return ov::intel_npu::platforms::standardize(platform);
     }
 
     // Get compilation platform from deviceID
     if (!deviceId.empty()) {
-        return ov::intel_npu::Platform::standardize(utils::getPlatformByDeviceName(deviceId));
+        return ov::intel_npu::platforms::standardize(utils::getPlatformByDeviceName(deviceId));
     }
 
     // Automatic detection of compilation platform
@@ -53,7 +53,7 @@ std::string utils::getCompilationPlatform(const std::string_view platform,
         return std::string();
     }
 
-    return ov::intel_npu::Platform::standardize(utils::getPlatformByDeviceName(availableDevicesNames.at(0)));
+    return ov::intel_npu::platforms::standardize(utils::getPlatformByDeviceName(availableDevicesNames.at(0)));
 }
 
 std::shared_ptr<IDevice> utils::getDeviceById(const ov::SoPtr<IEngineBackend>& engineBackend,
@@ -212,7 +212,7 @@ uint32_t utils::getOptimalNumberOfInferRequestsInParallel(std::string_view platf
         return 1;
     }
 
-    return (platform == ov::intel_npu::Platform::NPU3720) ? 4 : 8;
+    return (platform == ov::intel_npu::platforms::NPU3720) ? 4 : 8;
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_adapter_factory.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_adapter_factory.cpp
@@ -12,8 +12,8 @@ namespace intel_npu {
 
 ov::intel_npu::CompilerType CompilerAdapterFactory::determineAppropriateCompilerTypeBasedOnPlatform(
     std::string_view platform) const {
-    if (platform == ov::intel_npu::Platform::NPU4000 || platform == ov::intel_npu::Platform::NPU5010 ||
-        platform == ov::intel_npu::Platform::NPU5020 || platform == ov::intel_npu::Platform::NPU6010) {
+    if (platform == ov::intel_npu::platforms::NPU4000 || platform == ov::intel_npu::platforms::NPU5010 ||
+        platform == ov::intel_npu::platforms::NPU5020 || platform == ov::intel_npu::platforms::NPU6010) {
         return ov::intel_npu::CompilerType::PLUGIN;
     }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -332,23 +332,23 @@ ov::AnyMap get_default_common_config(const std::optional<NPUDesc>& npudesc) {
 
         // Platform parameter has a higher priority than deviceID
         std::string npu_platform;
-        if (npudesc->arch != ov::intel_npu::Platform::AUTO_DETECT) {
-            npu_platform = ov::intel_npu::Platform::standardize(npudesc->arch);
+        if (npudesc->arch != ov::intel_npu::platforms::AUTO_DETECT) {
+            npu_platform = ov::intel_npu::platforms::standardize(npudesc->arch);
         } else {
             npu_platform = npudesc->arch;
         }
 
         bool set_npu_tiles = false;
         std::string arch_added_compilation_param;
-        if (npu_platform == ov::intel_npu::Platform::NPU3720) {
+        if (npu_platform == ov::intel_npu::platforms::NPU3720) {
             // Keep baseline settings.
-        } else if (npu_platform == ov::intel_npu::Platform::NPU4000) {
+        } else if (npu_platform == ov::intel_npu::platforms::NPU4000) {
             set_npu_tiles = true;
             arch_added_compilation_param = "optimization-level=3";
-        } else if (npu_platform == ov::intel_npu::Platform::NPU5010 ||
-                   npu_platform == ov::intel_npu::Platform::NPU5020) {
+        } else if (npu_platform == ov::intel_npu::platforms::NPU5010 ||
+                   npu_platform == ov::intel_npu::platforms::NPU5020) {
             set_npu_tiles = true;
-        } else if (npu_platform == ov::intel_npu::Platform::AUTO_DETECT) {
+        } else if (npu_platform == ov::intel_npu::platforms::AUTO_DETECT) {
             arch_added_compilation_param = "performance-hint-override=latency";
         } else {
             LOG_WARN("Unknown NPU platform: " << npu_platform << ". Default config will be used.");

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/blob_compatibility.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/blob_compatibility.cpp
@@ -166,9 +166,9 @@ const auto all_models = []() -> std::vector<std::string> {
 
 const auto match_platform =
     !ov::test::utils::NpuTestEnvConfig::getInstance().IE_NPU_TESTS_PLATFORM.empty()
-        ? (PARSED_PLATFORMS.find(ov::intel_npu::Platform::standardize(
+        ? (PARSED_PLATFORMS.find(ov::intel_npu::platforms::standardize(
                ov::test::utils::NpuTestEnvConfig::getInstance().IE_NPU_TESTS_PLATFORM)) != PARSED_PLATFORMS.end()
-               ? PLATFORMS.at(PARSED_PLATFORMS.at(ov::intel_npu::Platform::standardize(
+               ? PLATFORMS.at(PARSED_PLATFORMS.at(ov::intel_npu::platforms::standardize(
                      ov::test::utils::NpuTestEnvConfig::getInstance().IE_NPU_TESTS_PLATFORM)))
                : "")
         : "";

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/compatibility_string.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/compatibility_string.cpp
@@ -109,7 +109,7 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsIsSupported) {
                            model,
                            deviceName,
                            {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-                            ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+                            ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
                                 ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}));
 
     std::vector<ov::PropertyName> properties;
@@ -149,7 +149,7 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsValueIsReadableWhen
                            model,
                            deviceName,
                            {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-                            ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+                            ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
                                 ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}));
 
     std::vector<ov::PropertyName> properties;
@@ -203,7 +203,7 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsIsNotSupportedForWS
                            model,
                            deviceName,
                            {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-                            ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+                            ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
                                 ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),
                             ov::enable_weightless(true)}));
 
@@ -227,7 +227,7 @@ TEST_P(ClassCompatibilityStringTestSuite, RuntimeRequirementsExportImport) {
                            model,
                            deviceName,
                            {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-                            ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+                            ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
                                 ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}));
     std::string reference_requirements;
     OV_ASSERT_NO_THROW(reference_requirements = compiledModel.get_property(ov::runtime_requirements));
@@ -259,7 +259,7 @@ TEST_P(ClassCompatibilityStringTestSuite, CompatibilityStringGenerateAndCheck) {
                            model,
                            deviceName,
                            {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-                            ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+                            ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
                                 ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}));
 
     std::string requirements;

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/import_export.cpp
@@ -148,7 +148,7 @@ TEST_P(OVCompiledGraphImportExportTestNPU, ImportingEncryptedBlobThrows) {
     encrypted_blob_stream.seekg(0, std::ios::beg);
 
     // Parsing corrupted blob on MTL will throw Access Violation 0xC0000005 SEH exceptions
-    if (ov::intel_npu::Platform::standardize(ov::test::utils::getTestPlatform()) != ov::intel_npu::Platform::NPU3720) {
+    if (ov::intel_npu::platforms::standardize(ov::test::utils::getTestPlatform()) != ov::intel_npu::platforms::NPU3720) {
         configuration.insert(ov::intel_npu::import_raw_blob(true));
         OV_EXPECT_THROW(core.import_model(encrypted_blob_stream, target_device, configuration),
                         ov::Exception,

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/model_cache.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/model_cache.cpp
@@ -228,14 +228,14 @@ std::vector<ov::AnyMap> config = {
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),  // only CIP is allowed for ONE_SHOT
-     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+     ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
         ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT),
      ov::enable_mmap(false)},  // enable_mmap for both `import_model(stream)` and `import_model(tensor)` paths
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+     ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
         ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT),
      ov::enable_mmap(true)},
@@ -252,14 +252,14 @@ std::vector<ov::AnyMap> config = {
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+     ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
         ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ITERATIVE),
      ov::enable_mmap(false)},
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+     ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
         ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ITERATIVE),
      ov::enable_mmap(true)}};

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.cpp
@@ -279,7 +279,7 @@ TEST_P(ClassExecutableNetworkInvalidDeviceIDTestSuite, InvalidNPUdeviceIDTest) {
 
     auto backend = std::make_shared<::intel_npu::ZeroEngineBackend>();
     auto device = backend->getDevice();
-    if (device != nullptr && device->getName() == ov::intel_npu::Platform::AUTO_DETECT) {
+    if (device != nullptr && device->getName() == ov::intel_npu::platforms::AUTO_DETECT) {
         if (is_non_negative_numeric_device_id) {
             GTEST_SKIP()
                 << "Skip since AUTO_DETECT platform should ignore numeric suffix and find the device successfully\n";
@@ -937,7 +937,7 @@ std::vector<std::pair<std::string, ov::Any>> plugin_public_mutable_properties = 
 std::vector<std::pair<std::string, ov::Any>> compat_plugin_internal_mutable_properties = {
     {ov::intel_npu::compilation_mode_params.name(), ov::Any("use-user-precision=false propagate-quant-dequant=0")},
     {ov::intel_npu::dma_engines.name(), ov::Any(1)},
-    {ov::intel_npu::platform.name(), ov::Any(ov::intel_npu::Platform::AUTO_DETECT)},
+    {ov::intel_npu::platform.name(), ov::Any(ov::intel_npu::platforms::AUTO_DETECT)},
     {ov::intel_npu::compilation_mode.name(), ov::Any("DefaultHW")},
     {ov::intel_npu::defer_weights_load.name(), ov::Any(true)},
 };

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/infer_request_run.cpp
@@ -2871,12 +2871,12 @@ const std::vector<ov::AnyMap> configsBooleanPrecisionInferRequestRunTests = {
     {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
       ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN),
       // platform needed only for NPU_COMPILER_TYPE_PLUGIN
-      ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+      ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
           ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}},
     {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
       ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER),
       // platform needed only for NPU_COMPILER_TYPE_PLUGIN
-      ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+      ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
           ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}},
     {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
       ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)}},

--- a/src/plugins/intel_npu/tests/functional/behavior/replace_sw_layers.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/replace_sw_layers.cpp
@@ -45,7 +45,7 @@ TEST_P(CompileWithDummy_NPU3720, CompilationForSpecificPlatform) {
     }
 }
 
-const std::vector<ov::AnyMap> configs = {{{ov::intel_npu::platform(ov::intel_npu::Platform::NPU3720)},
+const std::vector<ov::AnyMap> configs = {{{ov::intel_npu::platform(ov::intel_npu::platforms::NPU3720)},
                                           {ov::intel_npu::compilation_mode_params("dummy-op-replacement=true")}}};
 // Must be successfully compiled with dummy-op-replacement=true
 

--- a/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.cpp
+++ b/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.cpp
@@ -176,7 +176,7 @@ std::string getDeviceNameID(const std::string& str) {
 }
 
 std::string getTestPlatform() {
-    return ov::intel_npu::Platform::standardize(NpuTestEnvConfig::getInstance().IE_NPU_TESTS_PLATFORM);
+    return ov::intel_npu::platforms::standardize(NpuTestEnvConfig::getInstance().IE_NPU_TESTS_PLATFORM);
 }
 
 }  // namespace ov::test::utils

--- a/src/plugins/intel_npu/tests/functional/internal/backend/zero_infer_request_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/backend/zero_infer_request_tests.cpp
@@ -342,12 +342,12 @@ const std::vector<ov::AnyMap> configs = {
     {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
       ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN),
       // platform needed only for NPU_COMPILER_TYPE_PLUGIN
-      ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+      ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
           ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}},
     {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
       ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER),
       // platform needed only for NPU_COMPILER_TYPE_PLUGIN
-      ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+      ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
           ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU)))}},
     {{ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER),
       ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)}},

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/model_cache.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/model_cache.cpp
@@ -18,14 +18,14 @@ std::vector<ov::AnyMap> config = {
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),  // only CIP is allowed for ONE_SHOT
-     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+     ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
         ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT),
      ov::enable_mmap(false)},  // enable_mmap for both `import_model(stream)` and `import_model(tensor)` paths
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+     ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
         ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ONE_SHOT),
      ov::enable_mmap(true)},
@@ -42,14 +42,14 @@ std::vector<ov::AnyMap> config = {
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+     ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
         ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ITERATIVE),
      ov::enable_mmap(false)},
     {ov::enable_weightless(true),
      ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN),
-     ov::intel_npu::platform(ov::intel_npu::Platform::standardize(
+     ov::intel_npu::platform(ov::intel_npu::platforms::standardize(
         ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU))),  // platform needed for NPU_COMPILER_TYPE_PLUGIN
      ov::intel_npu::separate_weights_version(ov::intel_npu::WSVersion::ITERATIVE),
      ov::enable_mmap(true)}};

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -58,7 +58,7 @@ const std::vector<ov::AnyMap> compat_CorrectPluginMutableProperties = {
     {{ov::hint::performance_mode.name(), ov::hint::PerformanceMode::THROUGHPUT}},
     {{ov::intel_npu::platform.name(),
       removeDeviceNameOnlyID(
-          ov::test::utils::getTestsDeviceNameFromEnvironmentOr(std::string(ov::intel_npu::Platform::AUTO_DETECT)))}},
+          ov::test::utils::getTestsDeviceNameFromEnvironmentOr(std::string(ov::intel_npu::platforms::AUTO_DETECT)))}},
     {{ov::hint::num_requests.name(), 2u}},
     {{ov::log::level.name(), ov::log::Level::ERR}},
     {{ov::device::id.name(), removeDeviceNameOnlyID(ov::test::utils::getTestsPlatformFromEnvironmentOr("3720"))}},

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -63,8 +63,8 @@ public:
 
         // Private device names may be registered via environment variables
         const std::string environmentDevice =
-            getTestsPlatformFromEnvironmentOr(ov::intel_npu::Platform::AUTO_DETECT.data());
-        const std::string standardizedEnvironmentDevice = ov::intel_npu::Platform::standardize(environmentDevice);
+            getTestsPlatformFromEnvironmentOr(ov::intel_npu::platforms::AUTO_DETECT.data());
+        const std::string standardizedEnvironmentDevice = ov::intel_npu::platforms::standardize(environmentDevice);
 
         if (std::all_of(_availableDevices.begin(), _availableDevices.end(), [&](const std::string& deviceName) {
                 return deviceName.find(standardizedEnvironmentDevice) == std::string::npos;

--- a/src/plugins/intel_npu/tests/unit/npu/offline_compilation.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/offline_compilation.cpp
@@ -106,8 +106,8 @@ TEST_P(OfflineCompilationUnitTests, CompatibilityCheckNotSupportedOffline) {
 INSTANTIATE_TEST_SUITE_P(
     OfflineCompilationPlatforms,
     OfflineCompilationUnitTests,
-    ::testing::Values(ov::AnyMap{{ov::intel_npu::platform.name(), ov::intel_npu::Platform::NPU5010}},
-                      ov::AnyMap{{ov::intel_npu::platform.name(), ov::intel_npu::Platform::NPU5020}}),
+    ::testing::Values(ov::AnyMap{{ov::intel_npu::platform.name(), ov::intel_npu::platforms::NPU5010}},
+                      ov::AnyMap{{ov::intel_npu::platform.name(), ov::intel_npu::platforms::NPU5020}}),
     OfflineCompilationUnitTests::getTestCaseName);
 
 using UnavailableDeviceTests = ::testing::Test;


### PR DESCRIPTION
### Details:
 - *WIP - Updates for `src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp`:*
 - *Remove unused `ov::intel_npu::ColorFormat` enum.*
 - *Move `ov::intel_npu::Platform` namespace to public `src/inference/include/openvino/runtime/intel_npu/properties.hpp`.*
 - *Rename `ov::intel_npu::Platform` to `ov::intel_npu::platforms`.*

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
