### PR TITLE
Update LevelZero repository to v1.33.0

### DIFF
--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <limits.h>
 #include <level_zero/ze_api.h>
+#include <limits.h>
 #include <ze_graph_ext.h>
 
 #include <optional>
@@ -178,7 +178,7 @@ static inline uint64_t get_l0_context_memory_allocation_id(ze_context_handle_t h
     auto res = intel_npu::zeMemGetAllocProperties(handle, ptr, &desc, nullptr);
     if (res == ZE_RESULT_SUCCESS && desc.id > 0 &&
         ((desc.type == ZE_MEMORY_TYPE_HOST) || (desc.type == ZE_MEMORY_TYPE_DEVICE) ||
-         (desc.type == ZE_MEMORY_TYPE_SHARED))) {
+         (desc.type == ZE_MEMORY_TYPE_SHARED) || (desc.type == ZE_MEMORY_TYPE_HOST_IMPORTED))) {
         return desc.id;
     }
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -19,6 +19,7 @@ namespace {
 constexpr uint32_t WIN_DRIVER_NO_MCL_SUPPORT = 2688;
 #endif
 
+constexpr ze_api_version_t TARGET_ZE_API_VERSION = ZE_API_VERSION_1_18;
 constexpr uint32_t TARGET_ZE_DRIVER_NPU_EXT_VERSION = ZE_DRIVER_NPU_EXT_VERSION_1_0;
 constexpr uint32_t TARGET_ZE_GRAPH_NPU_EXT_VERSION = ZE_GRAPH_EXT_VERSION_1_19;
 constexpr uint32_t TARGET_ZE_COMMAND_QUEUE_NPU_EXT_VERSION = ZE_COMMAND_QUEUE_NPU_EXT_VERSION_1_1;
@@ -142,8 +143,12 @@ void ZeroInitStructsHolder::initNpuDriver() {
     if (loader_version.major > 1 || (loader_version.major == 1 && loader_version.minor > 18) ||
         (loader_version.major == 1 && loader_version.minor == 18 && loader_version.patch >= 5)) {
         uint32_t drivers_count = 0;
+        ze_init_driver_app_version_ext_desc_t desc_app_version_ext = {};
+        desc_app_version_ext.stype = ZE_STRUCTURE_TYPE_INIT_DRIVER_APP_VERSION_EXT_DESC;
+        desc_app_version_ext.apiVersionHint = TARGET_ZE_API_VERSION;
         ze_init_driver_type_desc_t desc = {};
         desc.stype = ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC;
+        desc.pNext = &desc_app_version_ext;
         desc.flags = ZE_INIT_DRIVER_TYPE_FLAG_NPU;
         auto result = zeInitDrivers(&drivers_count, nullptr, &desc);
         if (result != ZE_RESULT_SUCCESS) {
@@ -175,19 +180,19 @@ ZeroInitStructsHolder::ZeroInitStructsHolder()
     // Check L0 API version
     THROW_ON_FAIL_FOR_LEVELZERO("zeDriverGetApiVersion", zeDriverGetApiVersion(_driver_handle, &_ze_drv_api_version));
 
-    if (ZE_MAJOR_VERSION(ZE_API_VERSION_CURRENT) != ZE_MAJOR_VERSION(_ze_drv_api_version)) {
+    if (ZE_MAJOR_VERSION(TARGET_ZE_API_VERSION) != ZE_MAJOR_VERSION(_ze_drv_api_version)) {
         OPENVINO_THROW("Incompatibility between NPU plugin and driver! ",
                        "Plugin L0 API major version = ",
-                       ZE_MAJOR_VERSION(ZE_API_VERSION_CURRENT),
+                       ZE_MAJOR_VERSION(TARGET_ZE_API_VERSION),
                        ", ",
                        "Driver L0 API major version = ",
                        ZE_MAJOR_VERSION(_ze_drv_api_version));
     }
-    if (ZE_MINOR_VERSION(ZE_API_VERSION_CURRENT) != ZE_MINOR_VERSION(_ze_drv_api_version)) {
-        _log.warning("Some features might not be available! "
-                     "Plugin L0 API minor version = %d, Driver L0 API minor version = %d",
-                     ZE_MINOR_VERSION(ZE_API_VERSION_CURRENT),
-                     ZE_MINOR_VERSION(_ze_drv_api_version));
+    if (ZE_MINOR_VERSION(TARGET_ZE_API_VERSION) != ZE_MINOR_VERSION(_ze_drv_api_version)) {
+        _log.info("Some features might not be available! "
+                  "Plugin L0 API minor version = %d, Driver L0 API minor version = %d",
+                  ZE_MINOR_VERSION(TARGET_ZE_API_VERSION),
+                  ZE_MINOR_VERSION(_ze_drv_api_version));
     }
 
     uint32_t count = 0;
@@ -538,7 +543,14 @@ void ZeroInitStructsHolder::destroyContextLocked() {
 
 ZeroInitStructsHolder::~ZeroInitStructsHolder() {
     std::lock_guard<std::mutex> lock(_mutex);
-    destroyContextLocked();
+    try {
+        destroyContextLocked();
+    } catch (const std::exception& e) {
+        _log.error("ZeroInitStructsHolder::~ZeroInitStructsHolder - exception during context destruction: %s",
+                   e.what());
+    } catch (...) {
+        _log.error("ZeroInitStructsHolder::~ZeroInitStructsHolder - unknown exception during context destruction");
+    }
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/tests/functional/common/zero_init_mock.cpp
+++ b/src/plugins/intel_npu/tests/functional/common/zero_init_mock.cpp
@@ -51,7 +51,7 @@ std::tuple<uint32_t, std::string> queryDriverExtensionVersion(const char* extNam
 
 namespace intel_npu {
 
-void ZeroInitStructsMock::initNpuDriver() {
+void ZeroInitStructsMock::initNpuDriver(const ze_api_version_t zeApiVersion) {
     auto setNpuDriver = [&](uint32_t drivers_count, std::vector<ze_driver_handle_t> all_drivers) {
         _driver_properties.stype = ZE_STRUCTURE_TYPE_DRIVER_PROPERTIES;
         _log.debug("ZeroInitStructsHolder::initNpuDriver - get NPU driver");
@@ -121,8 +121,12 @@ void ZeroInitStructsMock::initNpuDriver() {
     if (loader_version.major > 1 || (loader_version.major == 1 && loader_version.minor > 18) ||
         (loader_version.major == 1 && loader_version.minor == 18 && loader_version.patch >= 5)) {
         uint32_t drivers_count = 0;
+        ze_init_driver_app_version_ext_desc_t desc_app_version_ext = {};
+        desc_app_version_ext.stype = ZE_STRUCTURE_TYPE_INIT_DRIVER_APP_VERSION_EXT_DESC;
+        desc_app_version_ext.apiVersionHint = zeApiVersion;
         ze_init_driver_type_desc_t desc = {};
         desc.stype = ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC;
+        desc.pNext = &desc_app_version_ext;
         desc.flags = ZE_INIT_DRIVER_TYPE_FLAG_NPU;
         auto result = zeInitDrivers(&drivers_count, nullptr, &desc);
         if (result != ZE_RESULT_SUCCESS) {
@@ -151,27 +155,28 @@ ZeroInitStructsMock::ZeroInitStructsMock(uint32_t zeDriverNpuExtVersion,
                                          uint32_t zeProfilingNpuExtVersion,
                                          uint32_t zeContextNpuExtVersion,
                                          uint32_t zeMutableCommandListExtVersion,
-                                         uint32_t zeExternalMemMapSysMemExtVersion)
+                                         uint32_t zeExternalMemMapSysMemExtVersion,
+                                         ze_api_version_t zeApiVersion)
     : _zero_api(ZeroApi::get_instance()),
       _log("NPUZeroInitStructsHolder", Logger::global().level()) {
     _log.debug("ZeroInitStructsHolder - initialize NPU Driver");
-    initNpuDriver();
+    initNpuDriver(zeApiVersion);
 
     // Check L0 API version
     THROW_ON_FAIL_FOR_LEVELZERO("zeDriverGetApiVersion", zeDriverGetApiVersion(_driver_handle, &_ze_drv_api_version));
 
-    if (ZE_MAJOR_VERSION(ZE_API_VERSION_CURRENT) != ZE_MAJOR_VERSION(_ze_drv_api_version)) {
+    if (ZE_MAJOR_VERSION(zeApiVersion) != ZE_MAJOR_VERSION(_ze_drv_api_version)) {
         OPENVINO_THROW("Incompatibility between NPU plugin and driver! ",
                        "Plugin L0 API major version = ",
-                       ZE_MAJOR_VERSION(ZE_API_VERSION_CURRENT),
+                       ZE_MAJOR_VERSION(zeApiVersion),
                        ", ",
                        "Driver L0 API major version = ",
                        ZE_MAJOR_VERSION(_ze_drv_api_version));
     }
-    if (ZE_MINOR_VERSION(ZE_API_VERSION_CURRENT) != ZE_MINOR_VERSION(_ze_drv_api_version)) {
+    if (ZE_MINOR_VERSION(zeApiVersion) != ZE_MINOR_VERSION(_ze_drv_api_version)) {
         _log.warning("Some features might not be available! "
                      "Plugin L0 API minor version = %d, Driver L0 API minor version = %d",
-                     ZE_MINOR_VERSION(ZE_API_VERSION_CURRENT),
+                     ZE_MINOR_VERSION(zeApiVersion),
                      ZE_MINOR_VERSION(_ze_drv_api_version));
     }
 

--- a/src/plugins/intel_npu/tests/functional/common/zero_init_mock.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/zero_init_mock.hpp
@@ -18,6 +18,7 @@
 namespace intel_npu {
 
 namespace test_constants {
+inline constexpr ze_api_version_t TARGET_ZE_API_VERSION = ZE_API_VERSION_1_18;
 inline constexpr uint32_t TARGET_ZE_DRIVER_NPU_EXT_VERSION = ZE_DRIVER_NPU_EXT_VERSION_1_0;
 inline constexpr uint32_t TARGET_ZE_GRAPH_NPU_EXT_VERSION = ZE_GRAPH_EXT_VERSION_1_19;
 inline constexpr uint32_t TARGET_ZE_COMMAND_QUEUE_NPU_EXT_VERSION = ZE_COMMAND_QUEUE_NPU_EXT_VERSION_1_1;
@@ -37,7 +38,8 @@ public:
         uint32_t zeContextNpuExtVersion = intel_npu::test_constants::TARGET_ZE_CONTEXT_NPU_EXT_VERSION,
         uint32_t zeMutableCommandListExtVersion = intel_npu::test_constants::TARGET_ZE_MUTABLE_COMMAND_LIST_EXT_VERSION,
         uint32_t zeExternalMemMapSysMemExtVersion =
-            intel_npu::test_constants::TARGET_ZE_EXTERNAL_MEMMAP_SYSMEM_EXT_VERSION);
+            intel_npu::test_constants::TARGET_ZE_EXTERNAL_MEMMAP_SYSMEM_EXT_VERSION,
+        ze_api_version_t zeApiVersion = intel_npu::test_constants::TARGET_ZE_API_VERSION);
 
     ~ZeroInitStructsMock();
 
@@ -48,7 +50,7 @@ public:
     static void destroyContextForInstance(std::shared_ptr<ZeroInitStructsMock>& instance);
 
 private:
-    void initNpuDriver();
+    void initNpuDriver(const ze_api_version_t zeApiVersion);
     void getExtensionFunctionAddress(const std::string& name, const uint32_t version, void** function_address);
     void destroyContextLocked();
 


### PR DESCRIPTION
### Details:
 - Need to update Level Zero API to 1.18 for the following features:
     - `ze_init_driver_app_version_ext_desc_t` - Declares the maximum core API version supported by the application.
     - `zeCommandQueueSetPriorityExt` - Updates command queue priority at runtime
     - Using new flag `ZE_MEMORY_TYPE_HOST_IMPORTED` to know if memory was imported

### Tickets:
 - *E#223542*
 - *CVS-193074*

### AI Assistance:
 - *AI assistance used: no*
