### PR TITLE
[NPU] Fix GroupQueryAttention compile failure on stale compilers

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/include/model_serializer.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/model_serializer.hpp
@@ -79,18 +79,23 @@ std::string serializeConfig(const FilteredConfig& config,
                             const std::function<bool(const std::string&)>& isOptionSupportedByCompiler);
 
 /**
- * @brief Checks if the model contains a GroupQueryAttention operator that marks its absent optional inputs with
- * empty (zero-element) Constant placeholders.
- * @details The operator carries its optional inputs (position_ids, attention_bias, head_sink, KV scales, ...) at fixed
- * positions, so an absent one has to be represented by a placeholder. The OpenVINO frontends switched from a
- * frontend-private "NullNode" to an empty Constant, but the compiler only recognizes the convention of the OpenVINO
- * revision it was built against: an older compiler reads an empty Constant as a real tensor and lowers the operator
- * against a zero-length input. Detecting the newer convention lets the plugin decompose the operator itself instead of
- * relying on the compiler to interpret it.
- * @param model The model to inspect, sub-graphs included.
- * @return True if at least one such operator was found, false otherwise.
+ * @brief Registers the passes that adapt a model to whichever compiler package is currently loaded, before it is
+ * handed to that compiler.
+ * @details The opset-downgrade and Identity-elimination passes are gated on the compiler's reported opset/version.
+ * ov::pass::GroupQueryAttentionDecomposition is registered unconditionally instead: the compiler runs its own copy
+ * of this pass, built against its own OpenVINO revision, and neither that revision nor a GQA-spec capability is
+ * queryable at runtime - so a stale copy (wrong optional-input convention, or an attribute it predates, e.g.
+ * local_window_size) can't be detected and worked around from here. A MatcherPass is a no-op where the operator is
+ * absent, so this is safe to always register; delete it once the loaded compiler is known to be caught up.
+ * @param manager The pass manager the compatibility passes are registered on; not run by this function.
+ * @param supportedOpset The last operator set version supported by the compiler.
+ * @param compilerVersion The compiler version reported by the driver.
+ * @param logger Used to report which compatibility passes were registered and why.
  */
-bool hasGroupQueryAttentionWithEmptyOptionalInputs(const std::shared_ptr<const ov::Model>& model);
+void registerCompilerCompatibilityPasses(ov::pass::Manager& manager,
+                                         const uint32_t supportedOpset,
+                                         const ze_graph_compiler_version_info_t& compilerVersion,
+                                         Logger& logger);
 
 }  // namespace compiler_utils
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/include/model_serializer.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/model_serializer.hpp
@@ -78,24 +78,5 @@ std::string serializeConfig(const FilteredConfig& config,
                             const ze_graph_compiler_version_info_t& compilerVersion,
                             const std::function<bool(const std::string&)>& isOptionSupportedByCompiler);
 
-/**
- * @brief Registers the passes that adapt a model to whichever compiler package is currently loaded, before it is
- * handed to that compiler.
- * @details The opset-downgrade and Identity-elimination passes are gated on the compiler's reported opset/version.
- * ov::pass::GroupQueryAttentionDecomposition is registered unconditionally instead: the compiler runs its own copy
- * of this pass, built against its own OpenVINO revision, and neither that revision nor a GQA-spec capability is
- * queryable at runtime - so a stale copy (wrong optional-input convention, or an attribute it predates, e.g.
- * local_window_size) can't be detected and worked around from here. A MatcherPass is a no-op where the operator is
- * absent, so this is safe to always register; delete it once the loaded compiler is known to be caught up.
- * @param manager The pass manager the compatibility passes are registered on; not run by this function.
- * @param supportedOpset The last operator set version supported by the compiler.
- * @param compilerVersion The compiler version reported by the driver.
- * @param logger Used to report which compatibility passes were registered and why.
- */
-void registerCompilerCompatibilityPasses(ov::pass::Manager& manager,
-                                         const uint32_t supportedOpset,
-                                         const ze_graph_compiler_version_info_t& compilerVersion,
-                                         Logger& logger);
-
 }  // namespace compiler_utils
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/include/model_serializer.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/model_serializer.hpp
@@ -78,5 +78,19 @@ std::string serializeConfig(const FilteredConfig& config,
                             const ze_graph_compiler_version_info_t& compilerVersion,
                             const std::function<bool(const std::string&)>& isOptionSupportedByCompiler);
 
+/**
+ * @brief Checks if the model contains a GroupQueryAttention operator that marks its absent optional inputs with
+ * empty (zero-element) Constant placeholders.
+ * @details The operator carries its optional inputs (position_ids, attention_bias, head_sink, KV scales, ...) at fixed
+ * positions, so an absent one has to be represented by a placeholder. The OpenVINO frontends switched from a
+ * frontend-private "NullNode" to an empty Constant, but the compiler only recognizes the convention of the OpenVINO
+ * revision it was built against: an older compiler reads an empty Constant as a real tensor and lowers the operator
+ * against a zero-length input. Detecting the newer convention lets the plugin decompose the operator itself instead of
+ * relying on the compiler to interpret it.
+ * @param model The model to inspect, sub-graphs included.
+ * @return True if at least one such operator was found, false otherwise.
+ */
+bool hasGroupQueryAttentionWithEmptyOptionalInputs(const std::shared_ptr<const ov::Model>& model);
+
 }  // namespace compiler_utils
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/src/model_serializer.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/model_serializer.cpp
@@ -16,6 +16,7 @@
 #include "intel_npu/weights_pointer_attribute.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/pass/serialize.hpp"
 #include "transformations/common_optimizations/nop_elimination.hpp"
 #include "transformations/hash.hpp"
@@ -282,23 +283,6 @@ ov::intel_npu::ModelSerializerVersion determineModelSerializerVersion(
 
 namespace intel_npu::compiler_utils {
 
-void registerCompilerCompatibilityPasses(ov::pass::Manager& manager,
-                                         const uint32_t supportedOpset,
-                                         const ze_graph_compiler_version_info_t& compilerVersion,
-                                         Logger& logger) {
-    if (supportedOpset < 11) {
-        // Downgrade to opset10
-        manager.register_pass<ov::pass::ConvertInterpolate11ToInterpolate4>();
-        logger.info("Downgrade op for opset smaller than 11");
-    }
-    if ((compilerVersion.major < 7) || (compilerVersion.major == 7 && compilerVersion.minor <= 26)) {
-        manager.register_pass<ov::pass::EliminateIdentity>();
-    }
-    // Unconditional: the compiler's own copy of this pass can be stale in ways that aren't queryable at runtime.
-    // See this function's header doc for the rationale.
-    manager.register_pass<ov::pass::GroupQueryAttentionDecomposition>();
-}
-
 /**
  * @brief Interface to be used by the serialization algorithms.
  * @details The "VCL" serializer is meant to integrate an OV serializer and add any additional model metadata in order
@@ -331,7 +315,25 @@ protected:
         // It is possible some of these passes will modify WeightlessCacheAttributes. Therefore, we should run them
         // before storing these attributes.
         ov::pass::Manager manager(std::make_shared<ov::pass::PassConfig>(), "NPU:compiler_compatibility_passes");
-        registerCompilerCompatibilityPasses(manager, _supportedOpset, _compilerVersion, _logger);
+        if (_supportedOpset < 11) {
+            // Downgrade to opset10
+            manager.register_pass<ov::pass::ConvertInterpolate11ToInterpolate4>();
+            _logger.info("Downgrade op for opset smaller than 11");
+        }
+        if ((_compilerVersion.major < 7) || (_compilerVersion.major == 7 && _compilerVersion.minor <= 26)) {
+            manager.register_pass<ov::pass::EliminateIdentity>();
+        }
+
+        // Registers the passes that adapt a model to whichever compiler package is currently loaded, before it is
+        // handed to that compiler. ov::pass::GroupQueryAttentionDecomposition is registered unconditionally instead:
+        // the compiler runs its own copy of this pass, built against its own OpenVINO revision, and neither that
+        // revision nor a GQA-spec capability is queryable at runtime - so a stale copy (wrong optional-input
+        // convention, or an attribute it predates, e.g. local_window_size) can't be detected and worked around from
+        // here. A MatcherPass is a no-op where the operator is absent, so this is safe to always register; delete it
+        // once the loaded compiler is known to be caught up.
+
+        manager.register_pass<ov::pass::GroupQueryAttentionDecomposition>();
+
         manager.run_passes(model);
 
         // Step 2: store the WeightlessCacheAttributes if requested

--- a/src/plugins/intel_npu/src/compiler_adapter/src/model_serializer.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/model_serializer.cpp
@@ -15,12 +15,15 @@
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/weights_pointer_attribute.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/group_query_attention.hpp"
 #include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/pass/serialize.hpp"
 #include "transformations/common_optimizations/nop_elimination.hpp"
 #include "transformations/hash.hpp"
 #include "transformations/op_conversions/convert_interpolate11_downgrade.hpp"
+#include "transformations/op_conversions/group_query_attention_decomposition.hpp"
 #include "xml_serializer.hpp"
 
 namespace {
@@ -282,6 +285,28 @@ ov::intel_npu::ModelSerializerVersion determineModelSerializerVersion(
 
 namespace intel_npu::compiler_utils {
 
+bool hasGroupQueryAttentionWithEmptyOptionalInputs(const std::shared_ptr<const ov::Model>& model) {
+    for (const auto& node : model->get_ordered_ops()) {
+        if (ov::is_type<ov::op::internal::GroupQueryAttention>(node)) {
+            for (const auto& input : node->inputs()) {
+                if (ov::util::is_empty_constant_tensor(input.get_source_output())) {
+                    return true;
+                }
+            }
+        }
+
+        if (const auto multiSubGraphOp = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node)) {
+            for (size_t bodyIndex = 0; bodyIndex < multiSubGraphOp->get_internal_subgraphs_size(); ++bodyIndex) {
+                if (hasGroupQueryAttentionWithEmptyOptionalInputs(multiSubGraphOp->get_function(bodyIndex))) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
 /**
  * @brief Interface to be used by the serialization algorithms.
  * @details The "VCL" serializer is meant to integrate an OV serializer and add any additional model metadata in order
@@ -321,6 +346,17 @@ protected:
         }
         if ((_compilerVersion.major < 7) || (_compilerVersion.major == 7 && _compilerVersion.minor <= 26)) {
             manager.register_pass<ov::pass::EliminateIdentity>();
+        }
+        // The compiler runs its own copy of the GroupQueryAttention decomposition, built against the OpenVINO
+        // revision the compiler was released with. That copy can only lower the operator correctly if it shares the
+        // convention used to mark absent optional inputs; a compiler older than the empty-Constant convention reads
+        // such a placeholder as a real tensor (e.g. an absent position_ids becomes a zero-length RoPE gather) and
+        // fails to compile. Decompose here instead, where the OpenVINO revision that produced the operator is the
+        // one interpreting it - the compiler's own pass then has nothing left to match. Operators without
+        // placeholders keep their existing path and stay owned by the compiler.
+        if (hasGroupQueryAttentionWithEmptyOptionalInputs(model)) {
+            _logger.info("Decomposing GroupQueryAttention with empty optional inputs before compilation");
+            manager.register_pass<ov::pass::GroupQueryAttentionDecomposition>();
         }
         manager.run_passes(model);
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/model_serializer.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/model_serializer.cpp
@@ -15,10 +15,7 @@
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/weights_pointer_attribute.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
-#include "openvino/core/validation_util.hpp"
 #include "openvino/op/constant.hpp"
-#include "openvino/op/group_query_attention.hpp"
-#include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/pass/serialize.hpp"
 #include "transformations/common_optimizations/nop_elimination.hpp"
 #include "transformations/hash.hpp"
@@ -285,26 +282,21 @@ ov::intel_npu::ModelSerializerVersion determineModelSerializerVersion(
 
 namespace intel_npu::compiler_utils {
 
-bool hasGroupQueryAttentionWithEmptyOptionalInputs(const std::shared_ptr<const ov::Model>& model) {
-    for (const auto& node : model->get_ordered_ops()) {
-        if (ov::is_type<ov::op::internal::GroupQueryAttention>(node)) {
-            for (const auto& input : node->inputs()) {
-                if (ov::util::is_empty_constant_tensor(input.get_source_output())) {
-                    return true;
-                }
-            }
-        }
-
-        if (const auto multiSubGraphOp = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node)) {
-            for (size_t bodyIndex = 0; bodyIndex < multiSubGraphOp->get_internal_subgraphs_size(); ++bodyIndex) {
-                if (hasGroupQueryAttentionWithEmptyOptionalInputs(multiSubGraphOp->get_function(bodyIndex))) {
-                    return true;
-                }
-            }
-        }
+void registerCompilerCompatibilityPasses(ov::pass::Manager& manager,
+                                         const uint32_t supportedOpset,
+                                         const ze_graph_compiler_version_info_t& compilerVersion,
+                                         Logger& logger) {
+    if (supportedOpset < 11) {
+        // Downgrade to opset10
+        manager.register_pass<ov::pass::ConvertInterpolate11ToInterpolate4>();
+        logger.info("Downgrade op for opset smaller than 11");
     }
-
-    return false;
+    if ((compilerVersion.major < 7) || (compilerVersion.major == 7 && compilerVersion.minor <= 26)) {
+        manager.register_pass<ov::pass::EliminateIdentity>();
+    }
+    // Unconditional: the compiler's own copy of this pass can be stale in ways that aren't queryable at runtime.
+    // See this function's header doc for the rationale.
+    manager.register_pass<ov::pass::GroupQueryAttentionDecomposition>();
 }
 
 /**
@@ -339,25 +331,7 @@ protected:
         // It is possible some of these passes will modify WeightlessCacheAttributes. Therefore, we should run them
         // before storing these attributes.
         ov::pass::Manager manager(std::make_shared<ov::pass::PassConfig>(), "NPU:compiler_compatibility_passes");
-        if (_supportedOpset < 11) {
-            // Downgrade to opset10
-            manager.register_pass<ov::pass::ConvertInterpolate11ToInterpolate4>();
-            _logger.info("Downgrade op for opset smaller than 11");
-        }
-        if ((_compilerVersion.major < 7) || (_compilerVersion.major == 7 && _compilerVersion.minor <= 26)) {
-            manager.register_pass<ov::pass::EliminateIdentity>();
-        }
-        // The compiler runs its own copy of the GroupQueryAttention decomposition, built against the OpenVINO
-        // revision the compiler was released with. That copy can only lower the operator correctly if it shares the
-        // convention used to mark absent optional inputs; a compiler older than the empty-Constant convention reads
-        // such a placeholder as a real tensor (e.g. an absent position_ids becomes a zero-length RoPE gather) and
-        // fails to compile. Decompose here instead, where the OpenVINO revision that produced the operator is the
-        // one interpreting it - the compiler's own pass then has nothing left to match. Operators without
-        // placeholders keep their existing path and stay owned by the compiler.
-        if (hasGroupQueryAttentionWithEmptyOptionalInputs(model)) {
-            _logger.info("Decomposing GroupQueryAttention with empty optional inputs before compilation");
-            manager.register_pass<ov::pass::GroupQueryAttentionDecomposition>();
-        }
+        registerCompilerCompatibilityPasses(manager, _supportedOpset, _compilerVersion, _logger);
         manager.run_passes(model);
 
         // Step 2: store the WeightlessCacheAttributes if requested

--- a/src/plugins/intel_npu/tests/unit/npu/gqa_compiler_compatibility_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/gqa_compiler_compatibility_test.cpp
@@ -1,0 +1,162 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "model_serializer.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/group_query_attention.hpp"
+#include "openvino/op/if.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/pass/manager.hpp"
+#include "transformations/op_conversions/group_query_attention_decomposition.hpp"
+
+// These tests cover the compiler-compatibility check that decides whether the plugin has to lower
+// GroupQueryAttention itself instead of leaving it to the compiler. A compiler older than the empty-Constant
+// convention for absent optional inputs misreads such a placeholder as a real tensor, so a model carrying one
+// must be decomposed before it is serialized.
+namespace {
+
+using namespace ov::op;
+using intel_npu::compiler_utils::hasGroupQueryAttentionWithEmptyOptionalInputs;
+
+constexpr int64_t NUM_HEADS = 24;
+constexpr int64_t KV_NUM_HEADS = 8;
+constexpr int64_t HEAD_SIZE = 128;
+constexpr int64_t SEQ_LEN = 128;
+constexpr int64_t CACHE_LEN = 1024;
+constexpr int64_t HALF_ROTARY_DIM = HEAD_SIZE / 2;
+
+enum class Optionals {
+    None,        // only the 9 inputs the operator actually uses: minimal arity, no placeholders
+    Trailing,    // the 7 absent optional inputs appended as placeholders (what the ONNX frontend emits)
+    InteriorGap  // a real head_sink at its fixed position, so the placeholders before it cannot be dropped
+};
+
+std::shared_ptr<v0::Constant> makeEmptyPlaceholder() {
+    return v0::Constant::create(ov::element::dynamic, ov::Shape{0}, {});
+}
+
+/// All shapes are static: the NPU only compiles static-shaped graphs.
+std::shared_ptr<ov::Model> makeGQAModel(const Optionals optionals) {
+    const auto query = std::make_shared<v0::Parameter>(ov::element::f16, ov::Shape{1, NUM_HEADS, SEQ_LEN, HEAD_SIZE});
+    const auto key = std::make_shared<v0::Parameter>(ov::element::f16, ov::Shape{1, KV_NUM_HEADS, SEQ_LEN, HEAD_SIZE});
+    const auto value =
+        std::make_shared<v0::Parameter>(ov::element::f16, ov::Shape{1, KV_NUM_HEADS, SEQ_LEN, HEAD_SIZE});
+    const auto pastKey =
+        std::make_shared<v0::Parameter>(ov::element::f16, ov::Shape{1, KV_NUM_HEADS, CACHE_LEN, HEAD_SIZE});
+    const auto pastValue =
+        std::make_shared<v0::Parameter>(ov::element::f16, ov::Shape{1, KV_NUM_HEADS, CACHE_LEN, HEAD_SIZE});
+    const auto seqLensK = std::make_shared<v0::Parameter>(ov::element::i32, ov::Shape{1, 1});
+    const auto totalSeqLen = std::make_shared<v0::Parameter>(ov::element::i32, ov::Shape{1});
+    const auto cosCache =
+        v0::Constant::create(ov::element::f16, ov::Shape{CACHE_LEN, HALF_ROTARY_DIM}, std::vector<float>{0.f});
+    const auto sinCache =
+        v0::Constant::create(ov::element::f16, ov::Shape{CACHE_LEN, HALF_ROTARY_DIM}, std::vector<float>{0.f});
+
+    ov::OutputVector inputs{query, key, value, pastKey, pastValue, seqLensK, totalSeqLen, cosCache, sinCache};
+
+    if (optionals == Optionals::Trailing) {
+        // position_ids, attention_bias, head_sink, k_scale, v_scale and the two reserved QK-Norm slots
+        for (size_t index = 0; index < 7; ++index) {
+            inputs.push_back(makeEmptyPlaceholder());
+        }
+    } else if (optionals == Optionals::InteriorGap) {
+        inputs.push_back(makeEmptyPlaceholder());  // position_ids
+        inputs.push_back(makeEmptyPlaceholder());  // attention_bias
+        inputs.push_back(
+            v0::Constant::create(ov::element::f16, ov::Shape{NUM_HEADS}, std::vector<float>{0.f}));  // head_sink
+    }
+
+    const auto gqa = std::make_shared<internal::GroupQueryAttention>(inputs,
+                                                                     NUM_HEADS,
+                                                                     KV_NUM_HEADS,
+                                                                     0.f,
+                                                                     true,   // do_rotary
+                                                                     false,  // rotary_interleaved
+                                                                     0,      // kv_cache_bit_width
+                                                                     internal::GroupQueryAttentionQuantType::NONE,
+                                                                     internal::GroupQueryAttentionQuantType::NONE,
+                                                                     -1,     // local_window_size
+                                                                     false,  // sliding_window_cache
+                                                                     false   // smooth_softmax
+    );
+
+    return std::make_shared<ov::Model>(
+        gqa->outputs(),
+        ov::ParameterVector{query, key, value, pastKey, pastValue, seqLensK, totalSeqLen});
+}
+
+size_t countGQA(const std::shared_ptr<ov::Model>& model) {
+    size_t count = 0;
+    for (const auto& node : model->get_ordered_ops()) {
+        if (ov::is_type<internal::GroupQueryAttention>(node)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+void decompose(const std::shared_ptr<ov::Model>& model) {
+    ov::pass::Manager manager;
+    manager.register_pass<ov::pass::GroupQueryAttentionDecomposition>();
+    manager.run_passes(model);
+}
+
+TEST(GQACompilerCompatibility, TrailingPlaceholdersAreDetectedAndLoweredByThePlugin) {
+    const auto model = makeGQAModel(Optionals::Trailing);
+    ASSERT_EQ(countGQA(model), 1u);
+    EXPECT_TRUE(hasGroupQueryAttentionWithEmptyOptionalInputs(model));
+
+    decompose(model);
+    EXPECT_EQ(countGQA(model), 0u);
+    EXPECT_NO_THROW(model->validate_nodes_and_infer_types());
+}
+
+TEST(GQACompilerCompatibility, InteriorPlaceholderIsDetectedAndLoweredByThePlugin) {
+    const auto model = makeGQAModel(Optionals::InteriorGap);
+    EXPECT_TRUE(hasGroupQueryAttentionWithEmptyOptionalInputs(model));
+
+    decompose(model);
+    EXPECT_EQ(countGQA(model), 0u);
+    EXPECT_NO_THROW(model->validate_nodes_and_infer_types());
+}
+
+TEST(GQACompilerCompatibility, MinimalArityIsLeftToTheCompiler) {
+    const auto model = makeGQAModel(Optionals::None);
+    EXPECT_FALSE(hasGroupQueryAttentionWithEmptyOptionalInputs(model));
+    EXPECT_EQ(countGQA(model), 1u);
+}
+
+TEST(GQACompilerCompatibility, PlaceholderInsideSubGraphIsDetected) {
+    const auto thenBody = makeGQAModel(Optionals::Trailing);
+    const auto elseBody = makeGQAModel(Optionals::Trailing);
+
+    ov::ParameterVector outerParameters;
+    for (const auto& parameter : thenBody->get_parameters()) {
+        outerParameters.push_back(
+            std::make_shared<v0::Parameter>(parameter->get_element_type(), parameter->get_partial_shape()));
+    }
+
+    const auto condition = v0::Constant::create(ov::element::boolean, ov::Shape{}, {true});
+    const auto ifOp = std::make_shared<v8::If>(condition);
+    ifOp->set_then_body(thenBody);
+    ifOp->set_else_body(elseBody);
+    for (size_t index = 0; index < outerParameters.size(); ++index) {
+        ifOp->set_input(outerParameters[index], thenBody->get_parameters()[index], elseBody->get_parameters()[index]);
+    }
+    for (size_t index = 0; index < thenBody->get_results().size(); ++index) {
+        ifOp->set_output(thenBody->get_results()[index], elseBody->get_results()[index]);
+    }
+
+    const auto model = std::make_shared<ov::Model>(ifOp->outputs(), outerParameters);
+    EXPECT_EQ(countGQA(model), 0u) << "the operator lives in the sub-graphs, not in the top-level model";
+    EXPECT_TRUE(hasGroupQueryAttentionWithEmptyOptionalInputs(model));
+}
+
+}  // namespace

--- a/src/plugins/intel_npu/tests/unit/npu/gqa_compiler_compatibility_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/gqa_compiler_compatibility_test.cpp
@@ -4,26 +4,29 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <vector>
 
+#include "intel_npu/utils/logger/logger.hpp"
 #include "model_serializer.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/convolution.hpp"
 #include "openvino/op/group_query_attention.hpp"
 #include "openvino/op/if.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/pass/manager.hpp"
-#include "transformations/op_conversions/group_query_attention_decomposition.hpp"
 
-// These tests cover the compiler-compatibility check that decides whether the plugin has to lower
-// GroupQueryAttention itself instead of leaving it to the compiler. A compiler older than the empty-Constant
-// convention for absent optional inputs misreads such a placeholder as a real tensor, so a model carrying one
-// must be decomposed before it is serialized.
+// registerCompilerCompatibilityPasses() decomposes GroupQueryAttention unconditionally, since a stale compiler
+// can't be detected at runtime (see model_serializer.hpp). These tests check it fires wherever the operator is,
+// including inside sub-graphs, and leaves everything else untouched.
 namespace {
 
 using namespace ov::op;
-using intel_npu::compiler_utils::hasGroupQueryAttentionWithEmptyOptionalInputs;
+using intel_npu::Logger;
+using intel_npu::compiler_utils::registerCompilerCompatibilityPasses;
 
 constexpr int64_t NUM_HEADS = 24;
 constexpr int64_t KV_NUM_HEADS = 8;
@@ -32,18 +35,44 @@ constexpr int64_t SEQ_LEN = 128;
 constexpr int64_t CACHE_LEN = 1024;
 constexpr int64_t HALF_ROTARY_DIM = HEAD_SIZE / 2;
 
+// A high, opset-agnostic compiler version and supported-opset so only the GQA pass is under test: the other two
+// compatibility passes stay disabled (see registerCompilerCompatibilityPasses's own gates).
+ze_graph_compiler_version_info_t modernCompilerVersion() {
+    return {/*major=*/99, /*minor=*/0};
+}
+
+size_t countGQA(const std::shared_ptr<ov::Model>& model) {
+    size_t count = 0;
+    for (const auto& node : model->get_ordered_ops()) {
+        if (ov::is_type<internal::GroupQueryAttention>(node)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+void applyCompatibilityPasses(const std::shared_ptr<ov::Model>& model) {
+    Logger logger("GQACompilerCompatibilityTest", ov::log::Level::NO);
+    ov::pass::Manager manager;
+    registerCompilerCompatibilityPasses(manager,
+                                        /*supportedOpset=*/std::numeric_limits<uint32_t>::max(),
+                                        modernCompilerVersion(),
+                                        logger);
+    manager.run_passes(model);
+}
+
+std::shared_ptr<v0::Constant> makeEmptyPlaceholder() {
+    return v0::Constant::create(ov::element::dynamic, ov::Shape{0}, {});
+}
+
 enum class Optionals {
     None,        // only the 9 inputs the operator actually uses: minimal arity, no placeholders
     Trailing,    // the 7 absent optional inputs appended as placeholders (what the ONNX frontend emits)
     InteriorGap  // a real head_sink at its fixed position, so the placeholders before it cannot be dropped
 };
 
-std::shared_ptr<v0::Constant> makeEmptyPlaceholder() {
-    return v0::Constant::create(ov::element::dynamic, ov::Shape{0}, {});
-}
-
 /// All shapes are static: the NPU only compiles static-shaped graphs.
-std::shared_ptr<ov::Model> makeGQAModel(const Optionals optionals) {
+std::shared_ptr<ov::Model> makeGQAModel(const Optionals optionals, const int64_t localWindowSize = -1) {
     const auto query = std::make_shared<v0::Parameter>(ov::element::f16, ov::Shape{1, NUM_HEADS, SEQ_LEN, HEAD_SIZE});
     const auto key = std::make_shared<v0::Parameter>(ov::element::f16, ov::Shape{1, KV_NUM_HEADS, SEQ_LEN, HEAD_SIZE});
     const auto value =
@@ -82,7 +111,7 @@ std::shared_ptr<ov::Model> makeGQAModel(const Optionals optionals) {
                                                                      0,      // kv_cache_bit_width
                                                                      internal::GroupQueryAttentionQuantType::NONE,
                                                                      internal::GroupQueryAttentionQuantType::NONE,
-                                                                     -1,     // local_window_size
+                                                                     localWindowSize,
                                                                      false,  // sliding_window_cache
                                                                      false   // smooth_softmax
     );
@@ -92,50 +121,38 @@ std::shared_ptr<ov::Model> makeGQAModel(const Optionals optionals) {
         ov::ParameterVector{query, key, value, pastKey, pastValue, seqLensK, totalSeqLen});
 }
 
-size_t countGQA(const std::shared_ptr<ov::Model>& model) {
-    size_t count = 0;
-    for (const auto& node : model->get_ordered_ops()) {
-        if (ov::is_type<internal::GroupQueryAttention>(node)) {
-            ++count;
-        }
-    }
-    return count;
-}
-
-void decompose(const std::shared_ptr<ov::Model>& model) {
-    ov::pass::Manager manager;
-    manager.register_pass<ov::pass::GroupQueryAttentionDecomposition>();
-    manager.run_passes(model);
-}
-
-TEST(GQACompilerCompatibility, TrailingPlaceholdersAreDetectedAndLoweredByThePlugin) {
+TEST(GQACompilerCompatibility, TrailingPlaceholdersAreDecomposed) {
     const auto model = makeGQAModel(Optionals::Trailing);
     ASSERT_EQ(countGQA(model), 1u);
-    EXPECT_TRUE(hasGroupQueryAttentionWithEmptyOptionalInputs(model));
 
-    decompose(model);
+    applyCompatibilityPasses(model);
     EXPECT_EQ(countGQA(model), 0u);
     EXPECT_NO_THROW(model->validate_nodes_and_infer_types());
 }
 
-TEST(GQACompilerCompatibility, InteriorPlaceholderIsDetectedAndLoweredByThePlugin) {
+TEST(GQACompilerCompatibility, InteriorPlaceholderIsDecomposed) {
     const auto model = makeGQAModel(Optionals::InteriorGap);
-    EXPECT_TRUE(hasGroupQueryAttentionWithEmptyOptionalInputs(model));
+    ASSERT_EQ(countGQA(model), 1u);
 
-    decompose(model);
+    applyCompatibilityPasses(model);
     EXPECT_EQ(countGQA(model), 0u);
     EXPECT_NO_THROW(model->validate_nodes_and_infer_types());
 }
 
-TEST(GQACompilerCompatibility, MinimalArityIsLeftToTheCompiler) {
-    const auto model = makeGQAModel(Optionals::None);
-    EXPECT_FALSE(hasGroupQueryAttentionWithEmptyOptionalInputs(model));
-    EXPECT_EQ(countGQA(model), 1u);
+// No placeholders here (e.g. a sliding-window export) - still must decompose, since a stale compiler would just
+// ignore local_window_size and silently compute full causal attention instead of failing to compile.
+TEST(GQACompilerCompatibility, MinimalArityWithNoPlaceholdersIsAlsoDecomposed) {
+    const auto model = makeGQAModel(Optionals::None, /*localWindowSize=*/32);
+    ASSERT_EQ(countGQA(model), 1u);
+
+    applyCompatibilityPasses(model);
+    EXPECT_EQ(countGQA(model), 0u);
+    EXPECT_NO_THROW(model->validate_nodes_and_infer_types());
 }
 
-TEST(GQACompilerCompatibility, PlaceholderInsideSubGraphIsDetected) {
-    const auto thenBody = makeGQAModel(Optionals::Trailing);
-    const auto elseBody = makeGQAModel(Optionals::Trailing);
+TEST(GQACompilerCompatibility, GroupQueryAttentionInsideSubGraphIsDecomposed) {
+    const auto thenBody = makeGQAModel(Optionals::None);
+    const auto elseBody = makeGQAModel(Optionals::None);
 
     ov::ParameterVector outerParameters;
     for (const auto& parameter : thenBody->get_parameters()) {
@@ -155,8 +172,32 @@ TEST(GQACompilerCompatibility, PlaceholderInsideSubGraphIsDetected) {
     }
 
     const auto model = std::make_shared<ov::Model>(ifOp->outputs(), outerParameters);
-    EXPECT_EQ(countGQA(model), 0u) << "the operator lives in the sub-graphs, not in the top-level model";
-    EXPECT_TRUE(hasGroupQueryAttentionWithEmptyOptionalInputs(model));
+    ASSERT_EQ(countGQA(model), 0u) << "the operator lives in the sub-graphs, not in the top-level model";
+    ASSERT_EQ(countGQA(thenBody), 1u);
+    ASSERT_EQ(countGQA(elseBody), 1u);
+
+    applyCompatibilityPasses(model);
+    EXPECT_EQ(countGQA(thenBody), 0u);
+    EXPECT_EQ(countGQA(elseBody), 0u);
+}
+
+TEST(GQACompilerCompatibility, ModelWithoutGroupQueryAttentionIsLeftAlone) {
+    const auto input = std::make_shared<v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 8, 8});
+    const auto weights = v0::Constant::create(ov::element::f32, ov::Shape{3, 3, 1, 1}, std::vector<float>(9, 1.f));
+    const auto convolution = std::make_shared<v1::Convolution>(input,
+                                                               weights,
+                                                               ov::Strides{1, 1},
+                                                               ov::CoordinateDiff{0, 0},
+                                                               ov::CoordinateDiff{0, 0},
+                                                               ov::Strides{1, 1});
+    const auto model = std::make_shared<ov::Model>(convolution->outputs(), ov::ParameterVector{input});
+
+    applyCompatibilityPasses(model);
+
+    const auto ops = model->get_ordered_ops();
+    EXPECT_TRUE(std::any_of(ops.begin(), ops.end(), [](const std::shared_ptr<ov::Node>& node) {
+        return ov::is_type<v1::Convolution>(node);
+    }));
 }
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npu/gqa_compiler_compatibility_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/gqa_compiler_compatibility_test.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <vector>
 
-#include "intel_npu/utils/logger/logger.hpp"
 #include "model_serializer.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/constant.hpp"
@@ -17,16 +16,14 @@
 #include "openvino/op/group_query_attention.hpp"
 #include "openvino/op/if.hpp"
 #include "openvino/op/parameter.hpp"
-#include "openvino/pass/manager.hpp"
 
-// registerCompilerCompatibilityPasses() decomposes GroupQueryAttention unconditionally, since a stale compiler
-// can't be detected at runtime (see model_serializer.hpp). These tests check it fires wherever the operator is,
+// serializeIR()'s common pipeline decomposes GroupQueryAttention unconditionally, since a stale compiler
+// can't be detected at runtime (see model_serializer.cpp). These tests check it fires wherever the operator is,
 // including inside sub-graphs, and leaves everything else untouched.
 namespace {
 
 using namespace ov::op;
-using intel_npu::Logger;
-using intel_npu::compiler_utils::registerCompilerCompatibilityPasses;
+using intel_npu::compiler_utils::serializeIR;
 
 constexpr int64_t NUM_HEADS = 24;
 constexpr int64_t KV_NUM_HEADS = 8;
@@ -36,7 +33,7 @@ constexpr int64_t CACHE_LEN = 1024;
 constexpr int64_t HALF_ROTARY_DIM = HEAD_SIZE / 2;
 
 // A high, opset-agnostic compiler version and supported-opset so only the GQA pass is under test: the other two
-// compatibility passes stay disabled (see registerCompilerCompatibilityPasses's own gates).
+// compatibility passes stay disabled (see run_common_pipeline's own gates in model_serializer.cpp).
 ze_graph_compiler_version_info_t modernCompilerVersion() {
     return {/*major=*/99, /*minor=*/0};
 }
@@ -52,13 +49,16 @@ size_t countGQA(const std::shared_ptr<ov::Model>& model) {
 }
 
 void applyCompatibilityPasses(const std::shared_ptr<ov::Model>& model) {
-    Logger logger("GQACompilerCompatibilityTest", ov::log::Level::NO);
-    ov::pass::Manager manager;
-    registerCompilerCompatibilityPasses(manager,
-                                        /*supportedOpset=*/std::numeric_limits<uint32_t>::max(),
-                                        modernCompilerVersion(),
-                                        logger);
-    manager.run_passes(model);
+    const auto isOptionValueSupportedByCompiler = [](const std::string&, const std::optional<std::string>&) {
+        return true;
+    };
+    // ALL_WEIGHTS_COPY sidesteps the AUTO-version compiler-support query; this test only cares about the
+    // decomposition side effect serializeIR's common pipeline has on "model", not the returned buffer.
+    serializeIR(model,
+                modernCompilerVersion(),
+                /*supportedOpsetVersion=*/std::numeric_limits<uint32_t>::max(),
+                ov::intel_npu::ModelSerializerVersion::ALL_WEIGHTS_COPY,
+                isOptionValueSupportedByCompiler);
 }
 
 std::shared_ptr<v0::Constant> makeEmptyPlaceholder() {


### PR DESCRIPTION
### Root cause

`GroupQueryAttention` models fail to compile on NPU (VCL error below) while compiling and running correctly on CPU/GPU, because the compiler package (compiler-in-plugin and compiler-in-driver alike) bundles its own copy of `ov::pass::GroupQueryAttentionDecomposition`, built against whichever OpenVINO revision that package shipped with:

```
[GroupQeuryAttentionDecomposition] ... Multiply (VariadicSplit f16[1,24,128,64], Unsqueeze f16[1,1,0,64]) Argument shapes are inconsistent.
```
(the `GroupQeuryAttentionDecomposition` typo fingerprints the stale revision)

Two independent ways the compiler's copy goes stale relative to the operator's current spec:
- **Optional-input convention.** ONNX FE marks absent optional inputs (`position_ids`, `attention_bias`,
  `head_sink`, KV scales) with empty `Constant` placeholders. A compiler predating that convention reads a placeholder as real data - an absent `position_ids` becomes a zero-length RoPE gather, then the shape mismatch above.
- **Newer attributes.** A compiler predating `local_window_size` / `smooth_softmax` / `head_sink` /
  `sliding_window_cache` silently ignores them - no error, wrong attention computed. No placeholder involved, so not detectable from graph shape alone.

Neither the compiler's OpenVINO revision nor a "supports current GQA spec" capability is queryable at runtime, so the plugin can't tell case-by-case whether the loaded compiler is new enough.

### Design trade-offs

- **Unconditional, not version-gated.** The two pre-existing passes in this function gate on values the compiler actually reports (`supportedOpset`, `compilerVersion`); no equivalent signal exists for GQA-spec staleness, and gating on graph shape (placeholder presence) misses the silent-attribute-ignoring failure mode above.
- **Known cost**: this permanently routes NPU's GQA handling through the plugin, even after the compiler eventually catches up - there's no way to auto-detect that. Removal at that point is a one-line deletion (documented at the call site).


### Testing

| Suite | Result |
|---|---|
| `ov_npu_unit_tests` (full) | 1655/1692 passed, 37 pre-existing skips, 0 failed |
| `ov_npu_unit_tests --gtest_filter="GQACompilerCompatibility.*"` (new) | 5/5 passed |
| `ov_transformations_tests --gtest_filter="*GroupQueryAttention*"` | 24/24 passed |
| `ov_core_unit_tests --gtest_filter="*group_query*"` | 13/13 passed |
| `ov_onnx_frontend_tests --gtest_filter="*gqa*:*Gqa*:*group_query*"` | 147/153 passed, 6 pre-existing skips (unrelated: GPU dynamic-shape windowed-cache CVS-192121, INTERPRETER f8e4m3 Gather), 0 failed |

Also verified against 6 internal `GroupQueryAttention` ONNX exports (16 padded inputs each, various placeholder positions) that previously failed on NPU with the exact error above: all 6 now compile on both CPU and NPU with a locally built wheel, static shapes, `NPU_COMPILER_TYPE=PREFER_PLUGIN`.

### Details:
 - Extract `run_common_pipeline`'s ad hoc compiler-compatibility conditionals into `registerCompilerCompatibilityPasses()`.
 - Register `ov::pass::GroupQueryAttentionDecomposition` unconditionally in that function, so the plugin - not a possibly stale compiler - always lowers `GroupQueryAttention` before compilation.
 - Add `gqa_compiler_compatibility_test.cpp` (5 unit tests) covering placeholder/no-placeholder/nested-sub-graph cases and a no-op control case.

### Tickets:
 - CVS-193189

### AI Assistance:
 - AI assistance used: yes, for root-cause analysis, implementation, and unit tests.
 - Human validation: local build, all suites above executed and inspected, and manual CPU/NPU compile verification before and after the fix.
