### PR TITLE
[NPUW] Kokoro: workaround to solve a problem with an MVN layer in subgraph 8

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pipelines/kokoro/kokoro_compiled_model.cpp
@@ -115,6 +115,11 @@ ov::npuw::KokoroCompiledModel::KokoroCompiledModel(const std::shared_ptr<ov::Mod
         properties_model_b["NPUW_ONLINE_AVOID"] = "P:FloorModFP32/NPU,P:CumSumSinGen/NPU,"
                                                   "P:BoxMullerNoise/NPU,P:AngleComplex/NPU";
     }
+    // FIXME: workaround to solve a problem with an MVN layer in subgraph 8
+    // switch to using avoid pattern / remove after a proper fix is introduced
+    if (!properties_model_b.count("NPUW_SUBMODEL_DEVICE")) {
+        properties_model_b["NPUW_SUBMODEL_DEVICE"] = "8:CPU";
+    }
     set_default_cpu_inference_precision(properties_model_b);
     m_model_b_compiled = std::dynamic_pointer_cast<ov::npuw::ICompiledModel>(
         ov::npuw::ICompiledModel::create(split_result.model_b, plugin, properties_model_b));


### PR DESCRIPTION
### Details:
Adds a workaround for Kokoro to solve a problem with an MVN layer in subgraph 8 - puts a hardcode to infer Kokoro_modelB_sub8 on CPU

To be reverted once a proper fix to NPU compiler is provided

### Tickets:
 - EISW-230544

### AI Assistance:
 - AI assistance used: no 
