### PR TITLE
[PyTorch FE] Missing includes in op/flatten.cpp

### DIFF
--- a/src/frontends/pytorch/src/op/flatten.cpp
+++ b/src/frontends/pytorch/src/op/flatten.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/core/validation_util.hpp"
 #include "openvino/frontend/pytorch/node_context.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"


### PR DESCRIPTION
### Details:
 - Needed by reproduction of CVS-181554
 - Missing includes fail the build when building certain OpenVINO targets (e.g. `ie_wheel`).

### Tickets:
 - *CVS-193195*

### AI Assistance:
 - *AI assistance used: no*

