### PR TITLE
[Python API] Add a deprecation warning for "precise_0" behavior 

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/rt_map.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/rt_map.cpp
@@ -78,7 +78,7 @@ void regclass_graph_PyRTMap(py::module m) {
         if (key == "precise_0") {
             Common::utils::deprecation_warning(
                 "Setting 'precise_0' on node rt_info",
-                "",
+                "2027.0",
                 "This relies on a deprecated internal C++ API attribute (DisableFP16Compression).");
         }
     };

--- a/src/bindings/python/src/pyopenvino/graph/rt_map.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/rt_map.cpp
@@ -74,10 +74,20 @@ void regclass_graph_PyRTMap(py::module m) {
         return PyRTMap();
     }));
 
-    py_map.def("__setitem__", [](PyRTMap& m, const std::string& k, const std::string v) {
+    auto warn_if_precise = [](const std::string& key) {
+        if (key == "precise_0") {
+            Common::utils::deprecation_warning(
+                "Setting 'precise_0' on node rt_info",
+                "",
+                "This relies on a deprecated internal C++ API attribute (DisableFP16Compression).");
+        }
+    };
+    py_map.def("__setitem__", [warn_if_precise](PyRTMap& m, const std::string& k, const std::string v) {
+        warn_if_precise(k);
         m[k] = v;
     });
-    py_map.def("__setitem__", [](PyRTMap& m, const std::string& k, const int64_t v) {
+    py_map.def("__setitem__", [warn_if_precise](PyRTMap& m, const std::string& k, const int64_t v) {
+        warn_if_precise(k);
         m[k] = v;
     });
     py_map.def("__getitem__", [](PyRTMap& m, const std::string& k) -> py::object {

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -673,11 +673,8 @@ def test_serialize_rt_info(request, tmp_path):
 
 
 def test_serialize_node_rt_info_disable_fp16(request, tmp_path):
-    # Setting rt_info["precise_0"] = "" on a node from Python simulates
-    # disabling FP16 compression. During serialization, "precise_0" is
-    # converted into a DisablePrecisionConversion attribute so the flag
-    # persists in the IR. After deserialization the key becomes
-    # "DisablePrecisionConversion_0". This test verifies the round-trip.
+    # "precise_0" is the legacy DisableFP16Compression RTTI key.
+    # serialize.cpp converts it into DisablePrecisionConversion before serialization.
     core = Core()
     xml_path, bin_path = create_filenames_for_ir(request.node.name, tmp_path)
 
@@ -685,8 +682,8 @@ def test_serialize_node_rt_info_disable_fp16(request, tmp_path):
     relu = ops.relu(param, name="relu_node")
     model = Model(relu, [param], "TestModel")
 
-    # Set the string-based rt_info that Python users would use
-    relu.get_rt_info()["precise_0"] = ""
+    with pytest.warns(DeprecationWarning, match="precise_0"):
+        relu.get_rt_info()["precise_0"] = ""
     assert "precise_0" in relu.get_rt_info()
 
     serialize(model, xml_path, bin_path)


### PR DESCRIPTION
### Details:
 - Added a deprecation warning in the Python bindings (`rt_map.cpp`) when setting the `precise_0` key in `PyRTMap`, alerting users that this relies on a deprecated internal C++ API attribute (`DisableFP16Compression`).
 
<img width="620" height="57" alt="image" src="https://github.com/user-attachments/assets/d055064a-7b25-458d-bfd5-52848fbfa7ba" />


- `precise_0` "hidden" behaviour was introduced in [pull/1382](https://github.com/openvinotoolkit/openvino/pull/20625/changes#diff-6a91cb0e5781b477826c26a472e31e77a27e2dc090110161c1d97c2b72da9b03R1212) . It was needed for openvino_notebook `deepfloyd-if`. Currently it's used [here](https://github.com/openvinotoolkit/openvino_notebooks/blob/f2960a0b9b84a79680808d32d94c9deb0de690b1/utils/model_upcast_utils.py#L23). However, no notebook imports model_upcast_utils or calls partially_upcast_nodes_to_fp32 anymore. `deepfloyd-if` notebook  has already been deprecated and deleted [pull/1987](https://github.com/openvinotoolkit/openvino_notebooks/pull/1987/)


### Tickets:
 - [CVS-187630](https://jira.devtools.intel.com/browse/CVS-187630), [CVS-105807](https://jira.devtools.intel.com/browse/CVS-105807) 

### AI Assistance:
 - *AI assistance used: yes with human validation*

