### PR TITLE
[OV JS] remove duplicate Core.getAvailableDevices registration

### DIFF
--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -57,7 +57,6 @@ Napi::Function CoreWrap::get_class(Napi::Env env) {
                         InstanceMethod("getAvailableDevices", &CoreWrap::get_available_devices),
                         InstanceMethod("importModel", &CoreWrap::import_model_async),
                         InstanceMethod("importModelSync", &CoreWrap::import_model),
-                        InstanceMethod("getAvailableDevices", &CoreWrap::get_available_devices),
                         InstanceMethod("getVersions", &CoreWrap::get_versions),
                         InstanceMethod("setProperty", &CoreWrap::set_property),
                         InstanceMethod("getProperty", &CoreWrap::get_property),


### PR DESCRIPTION
### Details:
This PR removes the second identical `getAvailableDevices` instance method descriptor from `CoreWrap::get_class()`.

The duplicate has no functional purpose. Runtimes that reject duplicate non-configurable Node-API class descriptors fail while initializing the addon.

In Bun 1.4.0 (this is how this issue found, with recent release of bun 1.4.0), the second descriptor makes `napi_define_class` return `napi_generic_failure`, exposed by `openvino-node` as `Unknown failure`.

### Repro

```bash
mkdir openvino-bun-repro
cd openvino-bun-repro
npm init -y
npm install openvino-node@2026.3.0

node -e 'require("openvino-node"); console.log("loaded")'
npx --yes bun@1.3.9 -e 'require("openvino-node"); console.log("loaded")'
bun -e 'require("openvino-node"); console.log("loaded")'
```

- Register `Core.getAvailableDevices` once.
- Preserve the existing method implementation and public API.
- Keep the change limited to the duplicate source entry.
- The existing `Core.getAvailableDevices()` test in `tests/unit/basic.test.js` continues to cover the method.


### Tickets:
 - Contribution seems to allow opening small PRs without ticket
 - Related closed PR: #32741

### AI Assistance:
 - *AI assistance used: yes*
 - This issue highlighted by OpenAI 5.6 Sol model during upgrading our pinned bun version to 1.4.  AI was used to trace the Node-API failure, search existing issues and PRs, prepare a minimized reproducer. 
 
I've conducted the review of the code and it's a simple removal of a duplication. 
