### PR TITLE
[CI] Fix duplicate 'category: GGUF FE' key breaking labeler.yml for all PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -103,9 +103,6 @@
 - 'src/inference/**/*'
 - 'src/cmake/**/*'
 
-'category: GGUF FE':
-- 'src/frontends/gguf/**/*'
-
 'category: IR FE':
 - 'src/frontends/ir/**/*'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -71,11 +71,6 @@
 - 'src/frontends/common/include/openvino/frontend/extension.hpp'
 - 'src/frontends/common/include/openvino/frontend/extension/**/*'
 
-'category: GGUF FE':
-- 'src/frontends/gguf/**/*'
-- 'tests/model_hub_tests/gguf/**/*'
-- 'tests/requirements_gguf'
-
 'category: GPU':
 - 'src/plugins/intel_gpu/**/*'
 - 'thirdparty/ocl/**/*'
@@ -112,6 +107,11 @@
 'category: OVC':
 - 'tools/ovc/**/*'
 - 'tests/layer_tests/ovc_python_api_tests/**/*'
+
+'category: GGUF FE':
+- 'src/frontends/gguf/**/*'
+- 'tests/model_hub_tests/gguf/**/*'
+- 'tests/requirements_gguf'
 
 'category: ONNX FE':
 - 'src/frontends/onnx/**/*'


### PR DESCRIPTION
### Details:
 - Removes a duplicate `'category: GGUF FE':` mapping key from `.github/labeler.yml`. Two independently-merged GGUF FE PRs (#37421, #37435) each added this key, and since neither conflicted with the other in review, `master` ended up with the same YAML mapping key defined twice.
 - A duplicate key makes the file invalid YAML, so the labeler action fails with `YAMLException: duplicated mapping key` on every PR, cascading into failures for `Smart_CI`, `triage`, and all `ci/gha_overall_status_*` checks across every platform - i.e. broken CI signal for every open/new PR against `master` right now.

### Tickets:
 - N/A
