### PR TITLE
[GPU] Enable sdpa_micro kernel in PA with head size 512

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1421,7 +1421,7 @@ public:
             return false;
         }
 
-        if (desc->k_head_size > 256 || desc->v_head_size > 256) {
+        if (desc->k_head_size > 512 || desc->v_head_size > 512) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -384,7 +384,7 @@ sdpa_config_t xehpc_h256 = {16, 32, 32, 32, 8, 4, 8, 4};
 sdpa_config_t xehpc_h256_s64 = {16, 32, 32, 32, 8, 1, 8, 1};
 sdpa_config_t xehpc_h256_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
 
-sdpa_config_t xehpc_h512_pa = {16, 16, 32, 16, 16, 1, 16, 1};
+sdpa_config_t xehpc_h512_pa = {16, 16, 32, 16, 16, 2, 16, 2};
 sdpa_config_t xehpc_h512 = {32, 16, 64, 16, 8, 4, 8, 4};
 sdpa_config_t xehpc_h512_s64 = {16, 16, 64, 16, 8, 2, 8, 2};
 sdpa_config_t xehpc_h512_s128_2nd = {16, 16, 64, 16, 8, 1, 8, 1};

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -336,7 +336,7 @@ sdpa_config_t xehpg_q_h512_s64_2nd = {8, 16, 32, 8, 32, 1, 16, 2};
 sdpa_config_t xehpg_q_h512_s256_2nd = {16, 8, 32, 8, 16, 2, 16, 2};
 sdpa_config_t xehpg_q_h512_2nd = {16, 8, 16, 8, 32, 1, 32, 1};
 
-sdpa_config_t xehpg_h512_pa = {16, 16, 16, 16, 8, 2, 32, 2};
+sdpa_config_t xehpg_h512_pa = {16, 16, 16, 16, 32, 1, 32, 1};
 sdpa_config_t xehpg_h512 = {8, 16, 32, 16, 16, 2, 16, 2};
 sdpa_config_t xehpg_h512_2nd = {8, 8, 32, 8, 16, 1, 16, 1};
 
@@ -384,7 +384,7 @@ sdpa_config_t xehpc_h256 = {16, 32, 32, 32, 8, 4, 8, 4};
 sdpa_config_t xehpc_h256_s64 = {16, 32, 32, 32, 8, 1, 8, 1};
 sdpa_config_t xehpc_h256_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
 
-sdpa_config_t xehpc_h512_pa = {16, 16, 16, 16, 16, 1, 32, 1};
+sdpa_config_t xehpc_h512_pa = {16, 16, 32, 16, 16, 1, 16, 1};
 sdpa_config_t xehpc_h512 = {32, 16, 64, 16, 8, 4, 8, 4};
 sdpa_config_t xehpc_h512_s64 = {16, 16, 64, 16, 8, 2, 8, 2};
 sdpa_config_t xehpc_h512_s128_2nd = {16, 16, 64, 16, 8, 1, 8, 1};


### PR DESCRIPTION
### Details:
Allow sdpa_micro to support PA head sizes up to 512. Gemma-4 models have 512 head size in full-attention.
Existing 512-head unit tests pass in sdpa_micro

#### Gemma-4 int4 WWB
PTLH-02 | Base | PR | Ratio
-- | -- | -- | --
Gemma-4-e2b | 0.836722 | 0.825497 | 0.99
Gemma-4-26b | 0.898360 | 0.888876 | 0.99
Gemma-4-31b | 0.905616 | 0.910579 | 1.01

B70 (Raptor-01) | Base | PR | Ratio
-- | -- | -- | --
Gemma-4-e2b | 0.836722 | 0.825497 | 0.99
Gemma-4-26b | 0.902046 | 0.888876 | 0.98
Gemma-4-31b | 0.905616 | 0.910579 | 1.01

ARLH-01 | Base | PR | Ratio
-- | -- | -- | --
Gemma-4-e2b | 0.841280 | 0.839239 | 1.00
Gemma-4-26b | 0.899144 | 0.897555 | 1.00
Gemma-4-31b | 0.894143 | 0.912486 | 1.02

#### Gemma-4 int4 Performance on PTLH-02 (B390)
##### Gemma-4-e2b-it
| prompt | 1st base (ms) | 1st poc (ms) | 1st gain | 2nd base tok/s | 2nd poc tok/s | 2nd tok/s gain
| -- | -- | -- | -- | -- | -- | --
| 32 | 40.40 | 39.57 | 1.02x | 58.99 | 58.91 | 1.00x
| 1K | 170.82 | 154.82 | 1.10x | 57.07 | 57.59 | 1.01x
| 4K | 849.04 | 636.98 | 1.33x | 55.01 | 54.95 | 1.00x
| 8K | 2,109.48 | 1,330.34 | 1.59x | 53.25 | 53.81 | 1.01x
| 16K | 6,050.95 | 3,056.29 | 1.98x | 49.22 | 49.52 | 1.01x
| 32K | 23,249.71 | 7,646.43 | 3.04x | 30.09 | 43.51 | 1.45x
##### Gemma-4-E4B-it
| prompt | 1st base (ms) | 1st poc (ms) | 1st gain | 2nd base tok/s | 2nd poc tok/s | 2nd tok/s gain
| -- | -- | -- | -- | -- | -- | --
| 32 | 51.14 | 51.80 | 0.99x | 32.86 | 32.94 | 1.00x
| 1K | 279.43 | 264.34 | 1.06x | 32.26 | 32.43 | 1.01x
| 4K | 1,274.19 | 1,071.94 | 1.19x | 31.33 | 31.40 | 1.00x
| 8K | 2,964.29 | 2,271.82 | 1.31x | 30.70 | 30.55 | 1.00x
| 16K | 8,290.92 | 5,002.02 | 1.66x | 27.01 | 28.11 | 1.04x
| 32K | 29,535.13 | 13,295.75 | 2.22x | 14.97 | 17.55 | 1.17x
##### Gemma-4-12B-it
| prompt | 1st base (ms) | 1st poc (ms) | 1st gain | 2nd base tok/s | 2nd poc tok/s | 2nd tok/s gain
| -- | -- | -- | -- | -- | -- | --
| 32 | 84.74 | 83.62 | 1.01x | 15.20 | 15.23 | 1.00x
| 1K | 531.75 | 500.00 | 1.06x | 14.71 | 14.68 | 1.00x
| 4K | 2,545.49 | 2,161.07 | 1.18x | 14.67 | 14.67 | 1.00x
| 8K | 6,121.05 | 4,449.80 | 1.38x | 14.47 | 14.44 | 1.00x
| 16K | 19,401.89 | 11,509.82 | 1.69x | 13.74 | 13.67 | 0.99x
| 32K | 60,452.24 | 27,886.97 | 2.17x | 12.77 | 12.66 | 0.99x
##### Gemma-4-26b-a4b-it
| prompt | 1st base (ms) | 1st poc (ms) | 1st gain | 2nd base tok/s | 2nd poc tok/s | 2nd tok/s gain
| -- | -- | -- | -- | -- | -- | --
| 32 | 106.26 | 106.19 | 1.00x | 38.33 | 37.83 | 0.99x
| 1K | 416.95 | 398.77 | 1.05x | 36.39 | 36.29 | 1.00x
| 4K | 1,509.80 | 1,262.07 | 1.20x | 35.97 | 35.96 | 1.00x
| 8K | 3,769.40 | 2,648.60 | 1.42x | 35.26 | 35.17 | 1.00x
| 16K | 11,091.76 | 5,603.01 | 1.98x | 31.42 | 33.54 | 1.07x
| 32K | 36,624.52 | 14,980.81 | 2.44x | 28.17 | 27.84 | 0.99x
##### Gemma-4-31b-it
| prompt | 1st base (ms) | 1st poc (ms) | 1st gain | 2nd base tok/s | 2nd poc tok/s | 2nd tok/s gain
| -- | -- | -- | -- | -- | -- | --
| 32 | 178.81 | 175.23 | 1.02x | 6.60 | 6.60 | 1.00x
| 1K | 1,293.42 | 1,210.66 | 1.07x | 6.36 | 6.37 | 1.00x
| 4K | 6,569.81 | 5,310.92 | 1.24x | 6.35 | 6.38 | 1.00x
| 8K | 18,884.65 | 14,177.83 | 1.33x | 6.25 | 6.25 | 1.00x
| 16K | 58,239.48 | 33,869.12 | 1.72x | 5.97 | 6.04 | 1.01x
| 32K | 195,347.64 | 94,258.37 | 2.07x | 4.49 | 4.46 | 0.99x



### Tickets:
 - *CVS-193164*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
