### PR TITLE
Fix duplicated entry in `labeler.yml`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -103,9 +103,6 @@
 - 'src/inference/**/*'
 - 'src/cmake/**/*'
 
-'category: GGUF FE':
-- 'src/frontends/gguf/**/*'
-
 'category: IR FE':
 - 'src/frontends/ir/**/*'
 


### PR DESCRIPTION
### Details:
"triage" job in Pull Request Labeler workflow stopped working after a duplicated entry was introduced in `labeler.yml` in https://github.com/openvinotoolkit/openvino/pull/37421
