### PR TITLE
[GPU] Add BF16 support to rms kernels

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rms.cpp
@@ -70,6 +70,7 @@ attach_rms_impl::attach_rms_impl() {
     auto types = {
         data_types::f32,
         data_types::f16,
+        data_types::bf16,
         data_types::i32
     };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl
@@ -5,6 +5,7 @@
 #include "include/fetch_utils.cl"
 #include "include/batch_headers/sub_group_block_read.cl"
 #include "include/batch_headers/sub_group_block_write.cl"
+#include "include/batch_headers/bf16_utils.cl"
 
 // Check alignment restrictions for using block writes on output.
 #define USE_BLOCK_WRITE ((OUTPUT_TYPE_SIZE * OUTPUT_FEATURE_PITCH) & 0xF == 0)
@@ -19,7 +20,7 @@
 #define BLOCK_READ(ptr, offset) CAT(DT_INPUT_BLOCK_READ, SUBGROUP_BLOCK_SIZE)(ptr, offset)
 #define BLOCK_WRITE(ptr, offset, val) CAT(DT_OUTPUT_BLOCK_WRITE, SUBGROUP_BLOCK_SIZE)(ptr, offset, val)
 #define ACC_TYPE MAKE_VECTOR_TYPE(ACCUMULATOR_TYPE, SUBGROUP_BLOCK_SIZE)
-#define TO_ACC_TYPE(x) CAT(convert_, ACC_TYPE)(x)
+#define TO_ACC_TYPE(x) TO_ACCUMULATOR_VECTOR_TYPE(x, SUBGROUP_BLOCK_SIZE)
 #define OUTPUT_VEC_TYPE MAKE_VECTOR_TYPE(OUTPUT_TYPE, SUBGROUP_BLOCK_SIZE)
 #endif
 
@@ -124,7 +125,7 @@ KERNEL(rms_gpu_bfyx_opt)(
 
     if (in_data_idx == 0) {
         rms = slm_buf[0] / data_size;
-        slm_buf[0] = native_powr(sqrt(rms + TO_ACCUMULATOR_TYPE(EPSILON)), -1);
+        slm_buf[0] = native_powr(sqrt(rms + EPSILON), -1);
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl
@@ -3,6 +3,7 @@
 //
 
 #include "include/fetch_utils.cl"
+#include "include/batch_headers/bf16_utils.cl"
 
 #if NORMALIZE_BATCH
     #define NORM_SIZE INPUT0_BATCH_NUM
@@ -55,7 +56,7 @@ KERNEL(rms_gpu_ref)(
             }
 
             rms /= NORM_SIZE;
-            rms = pow(sqrt(rms + TO_ACCUMULATOR_TYPE(EPSILON)), -1);
+            rms = pow(sqrt(rms + EPSILON), -1);
 
             for (uint n = 0; n < NORM_SIZE; n++) {
                 NORM_INDEX = n;
@@ -63,9 +64,9 @@ KERNEL(rms_gpu_ref)(
                 const uint output_idx = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, 0, z, y, x);
 #if ELEMENTWISE_AFFINE
                 const uint gamma_idx = INPUT1_OFFSET + (INPUT1_LENGTH == 1 ? 0 : n);
-                OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]) * TO_OUTPUT_TYPE(gamma[gamma_idx]);
+                OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms * TO_ACCUMULATOR_TYPE(input[input_idx]) * TO_ACCUMULATOR_TYPE(gamma[gamma_idx]));
 #else
-                OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms) * TO_OUTPUT_TYPE(input[input_idx]);
+                OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms * TO_ACCUMULATOR_TYPE(input[input_idx]));
 #endif
                 #if HAS_FUSED_OPS
                     FUSED_OPS;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp
@@ -33,6 +33,13 @@ JitConstants RMSKernelBase::GetJitConstants(const rms_params& params, RMSKernelB
     });
     jit.Merge(MakeTypeJitConstants(GetAccumulatorType(params), "ACCUMULATOR"));
 
+    if (params.inputs[0].GetDType() == Datatype::BF16) {
+        jit.RemoveConstant("TO_ACCUMULATOR_TYPE(v)");
+        jit.AddConstant(MakeJitConstant("TO_ACCUMULATOR_TYPE(v)", "_convert_as_bfloat16_float(v)"));
+        jit.RemoveConstant("TO_ACCUMULATOR_VECTOR_TYPE(v, size)");
+        jit.AddConstant(MakeJitConstant("TO_ACCUMULATOR_VECTOR_TYPE(v, size)", "CONVERT_AS_BFLOAT16_FLOAT(v, size)"));
+    }
+
     return jit;
 }
 
@@ -128,6 +135,7 @@ Datatype RMSKernelBase::GetAccumulatorType(const rms_params& params) const {
     switch (input_dt) {
         case Datatype::F32:
         case Datatype::F16:
+        case Datatype::BF16:
             return Datatype::F32;
         case Datatype::INT8: return Datatype::INT32;
         case Datatype::UINT8: return Datatype::INT32;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
@@ -27,8 +27,10 @@ static std::pair<size_t, size_t> get_item_num_and_lws(const rms_params params, s
 ParamsKey RMSKernelBfyxOpt::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableInputLayout(DataLayout::bfzyx);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.cpp
@@ -10,8 +10,10 @@ namespace kernel_selector {
 ParamsKey RMSKernelRef::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::F16);
+    k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::BF16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableInputLayout(DataLayout::bfzyx);

--- a/src/plugins/intel_gpu/tests/unit/fusions/rms_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/rms_fusion_test.cpp
@@ -72,6 +72,11 @@ public:
 #define CASE_RMS_F16_2      { 2, 16, 8, 8 },    { 1, 1, 1, 8 },     { 2, 16, 8, 8 },    data_types::f16, data_types::f32, format::bfyx
 #define CASE_RMS_3D_F16_1   { 1, 16, 8, 8, 8 }, { 1, 1, 1, 1, 8 },  { 1, 16, 8, 8, 8 }, data_types::f16, data_types::f32, format::bfzyx
 #define CASE_RMS_3D_F16_2   { 2, 16, 8, 8, 8 }, { 1, 1, 1, 1, 8 },  { 2, 16, 8, 8, 8 }, data_types::f16, data_types::f32, format::bfzyx
+#define CASE_RMS_BF16_1     { 1, 16, 8, 8 },    { 1, 1, 1, 8 },     { 1, 16, 8, 8 },    data_types::bf16, data_types::f32, format::bfyx
+#define CASE_RMS_BF16_2     { 2, 16, 8, 8 },    { 1, 1, 1, 8 },     { 2, 16, 8, 8 },    data_types::bf16, data_types::f32, format::bfyx
+#define CASE_RMS_3D_BF16_1  { 1, 16, 8, 8, 8 }, { 1, 1, 1, 1, 8 },  { 1, 16, 8, 8, 8 }, data_types::bf16, data_types::f32, format::bfzyx
+#define CASE_RMS_3D_BF16_2  { 2, 16, 8, 8, 8 }, { 1, 1, 1, 1, 8 },  { 2, 16, 8, 8, 8 }, data_types::bf16, data_types::f32, format::bfzyx
+#define CASE_RMS_BF16_LARGE { 1, 4, 1, 2048 },  { 1, 1, 1, 2048 },  { 1, 4, 1, 2048 },  data_types::bf16, data_types::f32, format::bfyx
 
 class rms_activation : public RMSFusingTest {};
 TEST_P(rms_activation, basic) {
@@ -97,6 +102,11 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, rms_activation, ::testing::ValuesIn(std::v
     rms_test_params{ CASE_RMS_F16_2, 3, 3, 4 },
     rms_test_params{ CASE_RMS_3D_F16_1, 3, 3, 4 },
     rms_test_params{ CASE_RMS_3D_F16_2, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_BF16_1, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_BF16_2, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_3D_BF16_1, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_3D_BF16_2, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_BF16_LARGE, 3, 3, 4 },
 }));
 
 class rms_eltwise : public RMSFusingTest {};
@@ -124,6 +134,11 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, rms_eltwise, ::testing::ValuesIn(std::vect
     rms_test_params{ CASE_RMS_F16_2, 3, 3, 4 },
     rms_test_params{ CASE_RMS_3D_F16_1, 3, 3, 4 },
     rms_test_params{ CASE_RMS_3D_F16_2, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_BF16_1, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_BF16_2, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_3D_BF16_1, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_3D_BF16_2, 3, 3, 4 },
+    rms_test_params{ CASE_RMS_BF16_LARGE, 3, 3, 4 },
 }));
 
 class rms_reorder : public RMSFusingTest {};

--- a/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
@@ -801,3 +801,125 @@ TEST(rms_gpu_test, in_place_crop_rms_spatial_split) {
         ASSERT_NEAR(out1[i], ref1[i], 1e-4f) << "Branch 1 mismatch at index=" << i;
     }
 }
+
+// ============================================================================
+// BF16 RMS: reference is computed in FP32 via rms_ref<ov::bfloat16> (reuses the
+// generic template). GPU BF16 output is compared with relative tolerance to
+// account for native_rsqrt approximation in the opt kernel.
+// ============================================================================
+static void run_rms_bf16(const std::string& kernel_name, const ov::PartialShape& in_shape,
+                         bool with_gamma, bool dynamic, float epsilon = 1e-5f,
+                         float in_min = 7.f, float in_max = 100.f,
+                         float abs_floor = 0.01f, float rel_tol = 0.02f) {
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory({in_shape, data_types::bf16, format::bfyx});
+    // Rank-3 input [1, C, W] normalizes over the last dim W; gamma covers W elements.
+    const size_t W = in_shape[in_shape.size() - 1].get_length();
+    memory::ptr gamma = nullptr;
+    if (with_gamma)
+        gamma = engine.allocate_memory({ov::PartialShape{1, static_cast<int64_t>(W)}, data_types::bf16, format::bfyx});
+    auto output_ref = engine.allocate_memory({in_shape, data_types::bf16, format::bfyx});
+
+    std::mt19937 rnd_gen;
+    auto fill_uniform = [&](memory::ptr mem, float lo, float hi) {
+        std::uniform_real_distribution<float> dist(lo, hi);
+        cldnn::mem_lock<ov::bfloat16> ptr(mem, get_test_stream());
+        for (auto it = ptr.begin(); it != ptr.end(); ++it)
+            *it = ov::bfloat16(dist(rnd_gen));
+    };
+    fill_uniform(input, in_min, in_max);
+    if (with_gamma)
+        fill_uniform(gamma, 0.5f, 1.5f);
+
+    rms_ref<ov::bfloat16>(input, gamma, output_ref, epsilon);
+
+    topology topology;
+    auto input_layout_dyn = layout{ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension::dynamic()},
+                                   data_types::bf16, format::bfyx};
+    topology.add(input_layout("input", dynamic ? input_layout_dyn : input->get_layout()));
+    if (with_gamma) {
+        topology.add(input_layout("gamma", gamma->get_layout()));
+        topology.add(rms("rms", input_info("input"), input_info("gamma"), epsilon));
+    } else {
+        topology.add(rms("rms", input_info("input"), epsilon));
+    }
+
+    ExecutionConfig config = get_test_default_config(engine);
+    if (dynamic)
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    ov::intel_gpu::ImplForcingMap forced{
+        {"rms", ov::intel_gpu::ImplementationDesc{format::bfyx, kernel_name}},
+    };
+    config.set_property(ov::intel_gpu::force_implementations(forced));
+
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+    if (with_gamma)
+        network.set_input_data("gamma", gamma);
+
+    if (dynamic) {
+        auto inst = network.get_primitive("rms");
+        ASSERT_TRUE(inst->get_impl() != nullptr);
+        ASSERT_TRUE(inst->get_impl()->is_dynamic());
+    }
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "rms");
+
+    auto output = outputs.begin()->second.get_memory();
+    cldnn::mem_lock<ov::bfloat16> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> output_ref_ptr(output_ref, get_test_stream());
+
+    // BF16 has ~7 mantissa bits; relative tolerance accounts for native_rsqrt.
+    for (size_t i = 0; i < output_ref->count(); ++i) {
+        float gpu_val = static_cast<float>(output_ptr[i]);
+        float ref_val = static_cast<float>(output_ref_ptr[i]);
+        float diff = std::abs(gpu_val - ref_val);
+        float tolerance = std::max(abs_floor, std::abs(ref_val) * rel_tol);
+        ASSERT_LE(diff, tolerance) << "Mismatch at i=" << i
+            << " gpu=" << gpu_val << " ref=" << ref_val << " diff=" << diff;
+    }
+}
+
+// BF16 RMS on the ref kernel, small rank-3 shape, with gamma
+TEST(rms_gpu_test, rms_test_bf16_bfyx_ref) {
+    run_rms_bf16("rms_gpu_ref", ov::PartialShape{1, 2, 6}, /*with_gamma=*/true, /*dynamic=*/false);
+}
+
+// BF16 RMS on the ref kernel, small rank-3 shape, without gamma
+TEST(rms_gpu_test, rms_test_bf16_without_gamma_ref) {
+    run_rms_bf16("rms_gpu_ref", ov::PartialShape{1, 2, 6}, /*with_gamma=*/false, /*dynamic=*/false);
+}
+
+// BF16 RMS on the opt kernel, 16-wide (subgroup-aligned), with gamma
+TEST(rms_gpu_test, rms_test_bf16_bfyx_opt) {
+    run_rms_bf16("rms_gpu_bfyx_opt", ov::PartialShape{1, 2, 16}, /*with_gamma=*/true, /*dynamic=*/false);
+}
+
+// BF16 RMS on the opt kernel, 18-wide (leftovers path), with gamma
+TEST(rms_gpu_test, rms_test_bf16_bfyx_opt_leftovers) {
+    run_rms_bf16("rms_gpu_bfyx_opt", ov::PartialShape{1, 2, 18}, /*with_gamma=*/true, /*dynamic=*/false);
+}
+
+// BF16 RMS on the opt kernel, 16-wide, without gamma
+TEST(rms_gpu_test, rms_test_bf16_without_gamma_opt) {
+    run_rms_bf16("rms_gpu_bfyx_opt", ov::PartialShape{1, 2, 16}, /*with_gamma=*/false, /*dynamic=*/false);
+}
+
+// BF16 RMS, dynamic shape 4096-wide (auto kernel selection), with gamma
+TEST(rms_gpu_test, rms_test_bf16_bfyx_opt_dyn) {
+    run_rms_bf16("rms_gpu_bfyx_opt", ov::PartialShape{2, 1, 4096}, /*with_gamma=*/true, /*dynamic=*/true);
+}
+
+// BF16 RMS, dynamic shape 3083-wide (unaligned leftovers), with gamma
+TEST(rms_gpu_test, rms_test_bf16_bfyx_opt_unaligned_dyn) {
+    run_rms_bf16("rms_gpu_bfyx_opt", ov::PartialShape{2, 1, 3083}, /*with_gamma=*/true, /*dynamic=*/true);
+}
+
+TEST(rms_gpu_test, rms_test_bf16_bfyx_opt_near_zero) {
+    run_rms_bf16("rms_gpu_bfyx_opt", ov::PartialShape{1, 1, 4096}, /*with_gamma=*/true, /*dynamic=*/false,
+                 /*epsilon=*/1e-5f, /*in_min=*/0.001f, /*in_max=*/0.003f,
+                 /*abs_floor=*/0.01f, /*rel_tol=*/0.05f);
+}


### PR DESCRIPTION
Enable BF16 for the RMS OCL implementation and the ref/opt kernels. BF16 data is decoded into the FP32 compute domain (via the standard DECODE_INPUT0/1_COMPUTE_TYPE mechanism) so the RMS reduction, scaling, and epsilon are computed in FP32 rather than on raw BF16 bit patterns.

Add BF16 unit tests for both kernels, including a near-zero case that guards the epsilon term in the rsqrt.

### Tickets:
 - [CVS-192281](https://jira.devtools.intel.com/browse/CVS-192281)

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
