### PR TITLE
Replace ISA string blob check with precision capability flags

### DIFF
--- a/src/plugins/intel_cpu/src/compiled_model.cpp
+++ b/src/plugins/intel_cpu/src/compiled_model.cpp
@@ -87,7 +87,7 @@ CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
       m_loaded_from_cache(loaded_from_cache),
       m_sub_memory_manager(std::move(sub_memory_manager)) {
     m_mutex = std::make_shared<std::mutex>();
-    m_runtime_requirements = build_runtime_requirements();
+    m_runtime_requirements = build_runtime_requirements(m_cfg.inferencePrecision);
     const auto& core = m_plugin->get_core();
     OPENVINO_ASSERT(core, "Unable to get API version. Core is unavailable");
 

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -810,7 +810,7 @@ static void validate_runtime_requirements(const char* base_ptr, size_t total_byt
     offset += static_cast<size_t>(reqs_size);
     OPENVINO_ASSERT(is_runtime_requirements_compatible(runtime_requirements),
                     "[CPU] Cannot import compiled blob: it was built for a different runtime "
-                    "configuration (OpenVINO version/isa mismatch) and cannot be executed on "
+                    "configuration (OpenVINO version/precision mismatch) and cannot be executed on "
                     "this device.\n"
                     "  blob:    ",
                     runtime_requirements,

--- a/src/plugins/intel_cpu/src/utils/graph_serializer/serializer.cpp
+++ b/src/plugins/intel_cpu/src/utils/graph_serializer/serializer.cpp
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <string>
 
-#include "cpu/platform.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
@@ -24,6 +23,7 @@
 #include "openvino/pass/serialize.hpp"
 #include "openvino/xml_util/constant_writer.hpp"
 #include "openvino/xml_util/xml_serialize_util.hpp"
+#include "utils/precision_support.h"
 
 namespace ov::intel_cpu {
 
@@ -182,16 +182,53 @@ std::unique_ptr<util::XmlSerializer> ModelSerializer::make_serializer(pugi::xml_
                                            m_weightless_mode);
 }
 
-std::string build_runtime_requirements() {
+std::string build_runtime_requirements(ov::element::Type inference_precision) {
+    bool needs_bf16 = false;
+    bool needs_f16 = false;
+
+    if (inference_precision == ov::element::bf16) {
+        needs_bf16 = true;
+    } else if (inference_precision == ov::element::f16) {
+        needs_f16 = true;
+    } else if (inference_precision == ov::element::dynamic) {
+        // dynamic: precision chosen at runtime; record hardware capabilities
+        needs_bf16 = hasHardwareSupport(ov::element::bf16);
+        needs_f16 = hasHardwareSupport(ov::element::f16);
+    }
+    // f32: no special hardware required, needs_bf16/f16 stay false
+
     std::ostringstream ss;
     ss << "meta=1.0"
        << ";ov=" << OPENVINO_VERSION_MAJOR << "." << OPENVINO_VERSION_MINOR << "." << OPENVINO_VERSION_PATCH
-       << ";isa=" << dnnl::impl::cpu::platform::get_isa_info();
+       << ";bf16=" << (needs_bf16 ? 1 : 0)
+       << ";f16=" << (needs_f16 ? 1 : 0);
     return ss.str();
 }
 
 bool is_runtime_requirements_compatible(const std::string& requirements) {
-    return requirements == build_runtime_requirements();
+    auto get_field = [&](const std::string& key) -> std::string {
+        const std::string prefix = key + "=";
+        auto pos = requirements.find(prefix);
+        if (pos == std::string::npos)
+            return "";
+        pos += prefix.size();
+        auto end = requirements.find(';', pos);
+        return requirements.substr(pos, end == std::string::npos ? end : end - pos);
+    };
+
+    const std::string expected_ov = std::to_string(OPENVINO_VERSION_MAJOR) + "." +
+                                    std::to_string(OPENVINO_VERSION_MINOR) + "." +
+                                    std::to_string(OPENVINO_VERSION_PATCH);
+    if (get_field("ov") != expected_ov)
+        return false;
+
+    if (get_field("bf16") == "1" && !hasHardwareSupport(ov::element::bf16))
+        return false;
+
+    if (get_field("f16") == "1" && !hasHardwareSupport(ov::element::f16))
+        return false;
+
+    return true;
 }
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/graph_serializer/serializer.hpp
+++ b/src/plugins/intel_cpu/src/utils/graph_serializer/serializer.hpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "openvino/core/model.hpp"
+#include "openvino/core/type/element_type.hpp"
 #include "openvino/pass/serialize.hpp"
 
 namespace ov::intel_cpu {
@@ -37,9 +38,14 @@ private:
 };
 
 static constexpr uint64_t runtime_requirements_magic = 0x4F564350555F5252ULL;  // "OVCPU_RR" in ASCII
-static constexpr uint32_t runtime_requirements_version = 1;
+static constexpr uint32_t runtime_requirements_version = 2;
 static constexpr uint64_t runtime_requirements_max_size = 4096;
-std::string build_runtime_requirements();
+// inference_precision controls what precision flags are stored:
+//   f32      -> bf16=0;f16=0 (no special hardware needed, compatible everywhere)
+//   bf16     -> bf16=1;f16=0
+//   f16      -> bf16=0;f16=1
+//   dynamic  -> hardware capabilities (conservative: store what the machine can use)
+std::string build_runtime_requirements(ov::element::Type inference_precision = ov::element::dynamic);
 bool is_runtime_requirements_compatible(const std::string& requirements);
 
 }  // namespace ov::intel_cpu


### PR DESCRIPTION
The runtime requirements stored in a compiled blob previously encoded the host machine's full ISA string and compatibility was verified via exact string match. Blobs compiled on a higher-ISA machine with fp32 precision were rejected on lower-ISA machines even when no precision incompatibility existed.

Replace the ISA string with bf16/f16 precision flags derived from the actual inference precision used at compile time. An fp32 blob stores bf16=0;f16=0 and is accepted on any machine. A bf16 or f16 blob stores the corresponding flag and is rejected on hardware without that precision support.

Bump runtime_requirements_version to 2 to invalidate existing ISA-string blobs, ensuring they fail fast with a clear version mismatch error rather than bypassing the precision check silently.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *CVS-193206*

### AI Assistance:
 - *AI assistance used: yes*
