### PR TITLE
[NPUW] Add a separate GatheredPositionIdsMatcher in AddPositionIdsParam

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/add_position_ids_param.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/add_position_ids_param.cpp
@@ -31,6 +31,16 @@ void set_node_name(std::shared_ptr<ov::Node> node, const std::string& name) {
     node->get_output_tensor(0).set_names({name});
 }
 
+// Creates a fresh `position_ids` [batch, seq] parameter plus a batch-squeezed [seq] view of it.
+std::pair<std::shared_ptr<ov::op::v0::Parameter>, std::shared_ptr<ov::op::v0::Squeeze>> make_position_ids() {
+    auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1, -1});
+    set_node_name(position_ids, "position_ids");
+    auto position_ids_squeezed =
+        std::make_shared<ov::op::v0::Squeeze>(position_ids,
+                                              ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0}));
+    return {position_ids, position_ids_squeezed};
+}
+
 // TODO: Consolidate with similar pattern in prepare_embedding_model.cpp
 class HardcodedPositionIdsMatcher : public ov::pass::MultiMatcher {
 public:
@@ -71,103 +81,101 @@ public:
         auto cos = opp::wrap_type<ov::op::v0::Cos>(concat);
         auto sin = opp::wrap_type<ov::op::v0::Sin>(concat);
 
-        // Gather-based (cache-table) RoPE. Instead of computing cos/sin, ONNX GroupQueryAttention-style exports
-        // precompute cos/sin cache tables and index into them with the position ids. The `position_ids` therefore
-        // drives a Gather rather than a Cos/Sin, and the branch has no MatMul/Transpose/Concat at all:
-        //
-        // Range -> [Convert] -> Unsqueeze -> [Add(past_len)] -> Squeeze -> [Maximum] -> [Minimum] --> Gather (cos)
-        //                                                                                         --> Gather (sin)
-        //
-        // The Maximum/Minimum pair is a clip of the absolute position into the cache bounds; both the
-        // clip and the past-length Add are optional across exports.
-        auto g_range = opp::wrap_type<ov::op::v4::Range>();
-        auto g_convert = opp::optional<ov::op::v0::Convert>({g_range->output(0)});
-        auto g_unsqueeze = opp::wrap_type<ov::op::v0::Unsqueeze>({g_convert, opp::any_input()});
-        auto g_add = opp::optional<ov::op::v1::Add>({g_unsqueeze->output(0), opp::any_input()});
-        auto g_squeeze = opp::wrap_type<ov::op::v0::Squeeze>({g_add, opp::any_input()});
-        auto g_clip_max = opp::optional<ov::op::v1::Maximum>({g_squeeze->output(0), opp::any_input()});
-        auto g_clip_min = opp::optional<ov::op::v1::Minimum>({g_clip_max->output(0), opp::any_input()});
-        // A single Gather root matches both the cos-cache and sin-cache lookups (identical structure);
-        // they share the same `g_squeeze`, so one `position_ids` parameter is created regardless.
-        auto g_gather = opp::wrap_type<ov::op::v8::Gather>({opp::any_input(), g_clip_min, opp::any_input()});
+        ov::pass::MultiMatcher::Callback callback = [=, &new_params](const auto& m) {
+            // NOTE: Range that mimics `position_ids` is consumed by RoPE operation as well as by Causal Mask creation
+            //       (LessEqual operation) and Gated Short Convolution Block's ScattedNDUpdate operation.
+            //       For static shapes case, it is not right to use actual `position_ids` for the second argument of
+            //       LessEqual operation (=Q range), because causal triangular mask will only allow positions from
+            //       the left till the real current positions in the sequence (inclusively), while our current items
+            //       are lied at the right end of the static `input_ids` after a window of padding.
+            //       Thus, the Range is preserved for Causal Mask creation, while added `position_ids` parameter is
+            //       used only for RoPE and ScatterNDUpdate in Gated Short Convolution Block.
+            auto& pattern_to_output = m.at(cos).front();
 
-        // Creates a fresh `position_ids` [batch, seq] parameter plus a batch-squeezed [seq] view of it.
-        auto make_position_ids = []() {
-            auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1, -1});
-            set_node_name(position_ids, "position_ids");
-            auto position_ids_squeezed = std::make_shared<ov::op::v0::Squeeze>(
-                position_ids,
-                ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0}));
-            return std::make_pair(position_ids, position_ids_squeezed);
+            auto range_node = pattern_to_output.at(range).get_node_shared_ptr();
+            // Point of branching:
+            auto unsqueeze1_node = pattern_to_output.at(unsqueeze1).get_node_shared_ptr();
+            auto convert_node = pattern_to_output.at(convert).get_node_shared_ptr();
+
+            // Create `position_ids` parameter
+            auto [position_ids, position_ids_squeezed] = make_position_ids();
+
+            // Create new Unsqueeze node for point of branching
+            auto unsqueeze1_node_copy =
+                unsqueeze1_node->clone_with_new_inputs({position_ids, unsqueeze1_node->input_value(1)});
+            convert_node->input(0).replace_source_output(unsqueeze1_node_copy->output(0));
+
+            // FIXME: For Gated Short Convolution Block, there is ScatterNDUpdate that also consumes generated
+            // positions.
+            //        It seems to right to use the newly created `position_ids` for it as well, however, real tests show
+            //        no difference against usage of hardcoded QRange: both are similarly accurate.
+            OPENVINO_ASSERT(range_node->get_output_size() == 1, "Range node should have exactly one output");
+            auto range_consumers = range_node->get_output_target_inputs(0);
+            for (auto&& consumer : range_consumers) {
+                // Only the Clamp path is rewired: the Range is preserved for Causal Mask creation,
+                // and newer models have no Clamp to begin with.
+                if (consumer.get_node()->get_type_name() == std::string("Clamp")) {
+                    consumer.replace_source_output(position_ids_squeezed->output(0));
+                }
+            }
+
+            new_params.push_back(position_ids);
+            return true;
         };
+
+        register_patterns({sin, cos}, std::move(callback));
+    }
+};
+
+// Gather-based (cache-table) RoPE. Instead of computing cos/sin, ONNX GroupQueryAttention-style exports
+// precompute cos/sin cache tables and index into them with the position ids. The `position_ids` therefore
+// drives a Gather rather than a Cos/Sin, and the branch has no MatMul/Transpose/Concat at all:
+//
+// Range -> [Convert] -> Unsqueeze -> [Add(past_len)] -> Squeeze -> [Maximum] -> [Minimum] --> Gather (cos)
+//                                                                                         --> Gather (sin)
+//
+// The Maximum/Minimum pair is a clip of the absolute position into the cache bounds; both the
+// clip and the past-length Add are optional across exports.
+class GatheredPositionIdsMatcher : public ov::pass::MultiMatcher {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("ov::npuw::GatheredPositionIdsMatcher");
+    explicit GatheredPositionIdsMatcher(ov::ParameterVector& new_params) {
+        auto range = opp::wrap_type<ov::op::v4::Range>();
+        auto convert = opp::optional<ov::op::v0::Convert>({range->output(0)});
+        auto unsqueeze = opp::wrap_type<ov::op::v0::Unsqueeze>({convert, opp::any_input()});
+        auto add = opp::optional<ov::op::v1::Add>({unsqueeze->output(0), opp::any_input()});
+        auto squeeze = opp::wrap_type<ov::op::v0::Squeeze>({add, opp::any_input()});
+        auto clip_max = opp::optional<ov::op::v1::Maximum>({squeeze->output(0), opp::any_input()});
+        auto clip_min = opp::optional<ov::op::v1::Minimum>({clip_max->output(0), opp::any_input()});
+        // A single Gather root matches both the cos-cache and sin-cache lookups (identical structure);
+        // they share the same `squeeze`, so one `position_ids` parameter is created regardless.
+        auto gather = opp::wrap_type<ov::op::v8::Gather>({opp::any_input(), clip_min, opp::any_input()});
 
         ov::pass::MultiMatcher::Callback callback = [=, &new_params](const auto& m) {
-            if (m.count(cos)) {
-                // NOTE: Range that mimics `position_ids` is consumed by RoPE operation as well as by Causal Mask
-                //       creation (LessEqual operation) and Gated Short Convolution Block's ScattedNDUpdate operation.
-                //       For static shapes case, it is not right to use actual `position_ids` for the second argument of
-                //       LessEqual operation (=Q range), because causal triangular mask will only allow positions from
-                //       the left till the real current positions in the sequence (inclusively), while our current items
-                //       are lied at the right end of the static `input_ids` after a window of padding.
-                //       Thus, the Range is preserved for Causal Mask creation, while added `position_ids` parameter is
-                //       used only for RoPE and ScatterNDUpdate in Gated Short Convolution Block.
-                auto& pattern_to_output = m.at(cos).front();
-
-                auto range_node = pattern_to_output.at(range).get_node_shared_ptr();
-                // Point of branching:
-                auto unsqueeze1_node = pattern_to_output.at(unsqueeze1).get_node_shared_ptr();
-                auto convert_node = pattern_to_output.at(convert).get_node_shared_ptr();
-
-                // Create `position_ids` parameter
-                auto [position_ids, position_ids_squeezed] = make_position_ids();
-
-                // Create new Unsqueeze node for point of branching
-                auto unsqueeze1_node_copy =
-                    unsqueeze1_node->clone_with_new_inputs({position_ids, unsqueeze1_node->input_value(1)});
-                convert_node->input(0).replace_source_output(unsqueeze1_node_copy->output(0));
-
-                // FIXME: For Gated Short Convolution Block, there is ScatterNDUpdate that also consumes generated
-                // positions.
-                //        It seems to right to use the newly created `position_ids` for it as well, however, real tests
-                //        show no difference against usage of hardcoded QRange: both are similarly accurate.
-                OPENVINO_ASSERT(range_node->get_output_size() == 1, "Range node should have exactly one output");
-                auto range_consumers = range_node->get_output_target_inputs(0);
-                for (auto&& consumer : range_consumers) {
-                    // Only the Clamp path is rewired: the Range is preserved for Causal Mask creation,
-                    // and newer models have no Clamp to begin with.
-                    if (consumer.get_node()->get_type_name() == std::string("Clamp")) {
-                        consumer.replace_source_output(position_ids_squeezed->output(0));
-                    }
+            // The cos-cache and sin-cache Gathers share the same position-producing `Squeeze`; some exports
+            // may also repeat it per layer. All of them carry the same logical positions, so create a single
+            // `position_ids` parameter and rewire every distinct `Squeeze` to it. Dedupe by the matched Squeeze
+            // node to avoid double-rewiring (and to avoid emitting colliding same-named parameters).
+            //
+            // The gathered index is 1-D [seq]; squeeze the batch dim off `position_ids` to match. This
+            // bypasses the hardcoded Range/Add(past_len) while preserving the downstream clip and Gathers.
+            std::unordered_set<ov::Node*> handled_squeezes;
+            auto [position_ids, position_ids_squeezed] = make_position_ids();
+            for (auto&& match : m.at(gather)) {
+                auto squeeze_node = match.at(squeeze).get_node_shared_ptr();
+                if (!handled_squeezes.insert(squeeze_node.get()).second) {
+                    continue;
                 }
-
-                new_params.push_back(position_ids);
-            } else if (m.count(g_gather)) {
-                // The cos-cache and sin-cache Gathers share the same position-producing `Squeeze`; some exports
-                // may also repeat it per layer. All of them carry the same logical positions, so create a single
-                // `position_ids` parameter and rewire every distinct `Squeeze` to it. Dedupe by the matched Squeeze
-                // node to avoid double-rewiring (and to avoid emitting colliding same-named parameters).
-                //
-                // The gathered index is 1-D [seq]; squeeze the batch dim off `position_ids` to match. This
-                // bypasses the hardcoded Range/Add(past_len) while preserving the downstream clip and Gathers.
-                std::unordered_set<ov::Node*> handled_squeezes;
-                auto [position_ids, position_ids_squeezed] = make_position_ids();
-                for (auto&& match : m.at(g_gather)) {
-                    auto squeeze_node = match.at(g_squeeze).get_node_shared_ptr();
-                    if (!handled_squeezes.insert(squeeze_node.get()).second) {
-                        continue;
-                    }
-                    OPENVINO_ASSERT(squeeze_node->get_output_size() == 1,
-                                    "Squeeze node should have exactly one output");
-                    for (auto&& consumer : squeeze_node->get_output_target_inputs(0)) {
-                        consumer.replace_source_output(position_ids_squeezed->output(0));
-                    }
+                OPENVINO_ASSERT(squeeze_node->get_output_size() == 1, "Squeeze node should have exactly one output");
+                for (auto&& consumer : squeeze_node->get_output_target_inputs(0)) {
+                    consumer.replace_source_output(position_ids_squeezed->output(0));
                 }
-
-                new_params.push_back(position_ids);
             }
+
+            new_params.push_back(position_ids);
         };
 
-        register_patterns({sin, cos, g_gather}, std::move(callback));
+        register_patterns({gather}, std::move(callback));
     }
 };
 
@@ -178,10 +186,20 @@ public:
 
 bool ov::npuw::AddPositionIdsParam::run_on_model(const std::shared_ptr<ov::Model>& model) {
     ov::ParameterVector new_parameters;
-    ov::pass::Manager manager("add-position-ids-param");
-    manager.set_per_pass_validation(false);
-    manager.register_pass<HardcodedPositionIdsMatcher>(new_parameters);
-    manager.run_passes(model);
+    {
+        ov::pass::Manager manager("add-position-ids-param");
+        manager.set_per_pass_validation(false);
+        manager.register_pass<HardcodedPositionIdsMatcher>(new_parameters);
+        manager.run_passes(model);
+    }
+    if (new_parameters.empty()) {
+        // The Cos/Sin- and Gather-based RoPE flavors are mutually exclusive within a model: run the
+        // Gather matcher only if the former didn't fire, so a single `position_ids` is ever introduced.
+        ov::pass::Manager manager("add-position-ids-param-gathered");
+        manager.set_per_pass_validation(false);
+        manager.register_pass<GatheredPositionIdsMatcher>(new_parameters);
+        manager.run_passes(model);
+    }
 
     model->add_parameters(new_parameters);
     model->validate_nodes_and_infer_types();

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/add_position_ids_param.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/add_position_ids_param.cpp
@@ -4,6 +4,8 @@
 
 #include "add_position_ids_param.hpp"
 
+#include <unordered_set>
+
 #include "openvino/op/ops.hpp"
 #include "openvino/openvino.hpp"
 #include "openvino/pass/manager.hpp"
@@ -69,53 +71,102 @@ public:
         auto cos = opp::wrap_type<ov::op::v0::Cos>(concat);
         auto sin = opp::wrap_type<ov::op::v0::Sin>(concat);
 
-        ov::pass::MultiMatcher::Callback callback = [=, &new_params](const auto& m) {
-            // NOTE: Range that mimics `position_ids` is consumed by RoPE operation as well as by Causal Mask creation
-            //       (LessEqual operation) and Gated Short Convolution Block's ScattedNDUpdate operation.
-            //       For static shapes case, it is not right to use actual `position_ids` for the second argument of
-            //       LessEqual operation (=Q range), because causal triangular mask will only allow positions from
-            //       the left till the real current positions in the sequence (inclusively), while our current items
-            //       are lied at the right end of the static `input_ids` after a window of padding.
-            //       Thus, the Range is preserved for Causal Mask creation, while added `position_ids` parameter is
-            //       used only for RoPE and ScatterNDUpdate in Gated Short Convolution Block.
-            auto& pattern_to_output = m.at(cos).front();
+        // Gather-based (cache-table) RoPE. Instead of computing cos/sin, ONNX GroupQueryAttention-style exports
+        // precompute cos/sin cache tables and index into them with the position ids. The `position_ids` therefore
+        // drives a Gather rather than a Cos/Sin, and the branch has no MatMul/Transpose/Concat at all:
+        //
+        // Range -> [Convert] -> Unsqueeze -> [Add(past_len)] -> Squeeze -> [Maximum] -> [Minimum] --> Gather (cos)
+        //                                                                                         --> Gather (sin)
+        //
+        // The Maximum/Minimum pair is a clip of the absolute position into the cache bounds; both the
+        // clip and the past-length Add are optional across exports.
+        auto g_range = opp::wrap_type<ov::op::v4::Range>();
+        auto g_convert = opp::optional<ov::op::v0::Convert>({g_range->output(0)});
+        auto g_unsqueeze = opp::wrap_type<ov::op::v0::Unsqueeze>({g_convert, opp::any_input()});
+        auto g_add = opp::optional<ov::op::v1::Add>({g_unsqueeze->output(0), opp::any_input()});
+        auto g_squeeze = opp::wrap_type<ov::op::v0::Squeeze>({g_add, opp::any_input()});
+        auto g_clip_max = opp::optional<ov::op::v1::Maximum>({g_squeeze->output(0), opp::any_input()});
+        auto g_clip_min = opp::optional<ov::op::v1::Minimum>({g_clip_max->output(0), opp::any_input()});
+        // A single Gather root matches both the cos-cache and sin-cache lookups (identical structure);
+        // they share the same `g_squeeze`, so one `position_ids` parameter is created regardless.
+        auto g_gather = opp::wrap_type<ov::op::v8::Gather>({opp::any_input(), g_clip_min, opp::any_input()});
 
-            auto range_node = pattern_to_output.at(range).get_node_shared_ptr();
-            // Point of branching:
-            auto unsqueeze1_node = pattern_to_output.at(unsqueeze1).get_node_shared_ptr();
-            auto convert_node = pattern_to_output.at(convert).get_node_shared_ptr();
-
-            // Create `position_ids` parameter
+        // Creates a fresh `position_ids` [batch, seq] parameter plus a batch-squeezed [seq] view of it.
+        auto make_position_ids = []() {
             auto position_ids = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{-1, -1});
             set_node_name(position_ids, "position_ids");
-
-            // Create new Unsqueeze node for point of branching
-            auto unsqueeze1_node_copy =
-                unsqueeze1_node->clone_with_new_inputs({position_ids, unsqueeze1_node->input_value(1)});
-            convert_node->input(0).replace_source_output(unsqueeze1_node_copy->output(0));
-
-            // FIXME: For Gated Short Convolution Block, there is ScatterNDUpdate that also consumes generated
-            // positions.
-            //        It seems to right to use the newly created `position_ids` for it as well, however, real tests show
-            //        no difference against usage of hardcoded QRange: both are similarly accurate.
             auto position_ids_squeezed = std::make_shared<ov::op::v0::Squeeze>(
                 position_ids,
                 ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0}));
-            OPENVINO_ASSERT(range_node->get_output_size() == 1, "Range node should have exactly one output");
-            auto range_consumers = range_node->get_output_target_inputs(0);
-            for (auto&& consumer : range_consumers) {
-                // Only the Clamp path is rewired: the Range is preserved for Causal Mask creation,
-                // and newer models have no Clamp to begin with.
-                if (consumer.get_node()->get_type_name() == std::string("Clamp")) {
-                    consumer.replace_source_output(position_ids_squeezed->output(0));
-                }
-            }
-
-            new_params.push_back(position_ids);
-            return true;
+            return std::make_pair(position_ids, position_ids_squeezed);
         };
 
-        register_patterns({sin, cos}, std::move(callback));
+        ov::pass::MultiMatcher::Callback callback = [=, &new_params](const auto& m) {
+            if (m.count(cos)) {
+                // NOTE: Range that mimics `position_ids` is consumed by RoPE operation as well as by Causal Mask
+                //       creation (LessEqual operation) and Gated Short Convolution Block's ScattedNDUpdate operation.
+                //       For static shapes case, it is not right to use actual `position_ids` for the second argument of
+                //       LessEqual operation (=Q range), because causal triangular mask will only allow positions from
+                //       the left till the real current positions in the sequence (inclusively), while our current items
+                //       are lied at the right end of the static `input_ids` after a window of padding.
+                //       Thus, the Range is preserved for Causal Mask creation, while added `position_ids` parameter is
+                //       used only for RoPE and ScatterNDUpdate in Gated Short Convolution Block.
+                auto& pattern_to_output = m.at(cos).front();
+
+                auto range_node = pattern_to_output.at(range).get_node_shared_ptr();
+                // Point of branching:
+                auto unsqueeze1_node = pattern_to_output.at(unsqueeze1).get_node_shared_ptr();
+                auto convert_node = pattern_to_output.at(convert).get_node_shared_ptr();
+
+                // Create `position_ids` parameter
+                auto [position_ids, position_ids_squeezed] = make_position_ids();
+
+                // Create new Unsqueeze node for point of branching
+                auto unsqueeze1_node_copy =
+                    unsqueeze1_node->clone_with_new_inputs({position_ids, unsqueeze1_node->input_value(1)});
+                convert_node->input(0).replace_source_output(unsqueeze1_node_copy->output(0));
+
+                // FIXME: For Gated Short Convolution Block, there is ScatterNDUpdate that also consumes generated
+                // positions.
+                //        It seems to right to use the newly created `position_ids` for it as well, however, real tests
+                //        show no difference against usage of hardcoded QRange: both are similarly accurate.
+                OPENVINO_ASSERT(range_node->get_output_size() == 1, "Range node should have exactly one output");
+                auto range_consumers = range_node->get_output_target_inputs(0);
+                for (auto&& consumer : range_consumers) {
+                    // Only the Clamp path is rewired: the Range is preserved for Causal Mask creation,
+                    // and newer models have no Clamp to begin with.
+                    if (consumer.get_node()->get_type_name() == std::string("Clamp")) {
+                        consumer.replace_source_output(position_ids_squeezed->output(0));
+                    }
+                }
+
+                new_params.push_back(position_ids);
+            } else if (m.count(g_gather)) {
+                // The cos-cache and sin-cache Gathers share the same position-producing `Squeeze`; some exports
+                // may also repeat it per layer. All of them carry the same logical positions, so create a single
+                // `position_ids` parameter and rewire every distinct `Squeeze` to it. Dedupe by the matched Squeeze
+                // node to avoid double-rewiring (and to avoid emitting colliding same-named parameters).
+                //
+                // The gathered index is 1-D [seq]; squeeze the batch dim off `position_ids` to match. This
+                // bypasses the hardcoded Range/Add(past_len) while preserving the downstream clip and Gathers.
+                std::unordered_set<ov::Node*> handled_squeezes;
+                auto [position_ids, position_ids_squeezed] = make_position_ids();
+                for (auto&& match : m.at(g_gather)) {
+                    auto squeeze_node = match.at(g_squeeze).get_node_shared_ptr();
+                    if (!handled_squeezes.insert(squeeze_node.get()).second) {
+                        continue;
+                    }
+                    OPENVINO_ASSERT(squeeze_node->get_output_size() == 1, "Squeeze node should have exactly one output");
+                    for (auto&& consumer : squeeze_node->get_output_target_inputs(0)) {
+                        consumer.replace_source_output(position_ids_squeezed->output(0));
+                    }
+                }
+
+                new_params.push_back(position_ids);
+            }
+        };
+
+        register_patterns({sin, cos, g_gather}, std::move(callback));
     }
 };
 

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/add_position_ids_param.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/add_position_ids_param.cpp
@@ -156,7 +156,8 @@ public:
                     if (!handled_squeezes.insert(squeeze_node.get()).second) {
                         continue;
                     }
-                    OPENVINO_ASSERT(squeeze_node->get_output_size() == 1, "Squeeze node should have exactly one output");
+                    OPENVINO_ASSERT(squeeze_node->get_output_size() == 1,
+                                    "Squeeze node should have exactly one output");
                     for (auto&& consumer : squeeze_node->get_output_target_inputs(0)) {
                         consumer.replace_source_output(position_ids_squeezed->output(0));
                     }

--- a/src/plugins/intel_npu/tests/unit/npuw/pipeline_passes/add_position_ids_param_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pipeline_passes/add_position_ids_param_test.cpp
@@ -16,8 +16,11 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/cos.hpp"
+#include "openvino/op/gather.hpp"
 #include "openvino/op/less_eq.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/range.hpp"
 #include "openvino/op/result.hpp"
@@ -119,6 +122,85 @@ std::shared_ptr<ov::Model> build_model_with_lfm2_like_pattern(bool offset_positi
     return std::make_shared<ov::Model>(results, params, "model_with_lfm2_like_pattern");
 }
 
+// Gather-based (cache-table) RoPE, as in ONNX GroupQueryAttention-style exports. Instead of computing
+// cos/sin from inv_freq*positions, precomputed cos/sin cache tables are indexed with the positions:
+//
+//   Range -> [Convert] -> Unsqueeze -> [Add(past_len)] -> Squeeze -> [Maximum] -> [Minimum] --> Gather (cos)
+//                                                                                           --> Gather (sin)
+//
+// with_convert inserts the optional Convert right after Range; offset_positions inserts the optional
+// past-length Add; with_clip inserts the optional Maximum/Minimum clip of the position into cache bounds.
+// The cos and sin Gathers share the same position-producing Squeeze, matching the real export.
+std::shared_ptr<ov::Model> build_model_with_gather_rope_pattern(bool with_convert = false,
+                                                                bool offset_positions = false,
+                                                                bool with_clip = true) {
+    // Range: start=0, stop=seq_len, step=1  (mimics position_ids generation)
+    const auto range_type = with_convert ? ov::element::i32 : ov::element::i64;
+    auto start = ov::op::v0::Constant::create(range_type, ov::Shape{}, {0});
+    auto stop = ov::op::v0::Constant::create(range_type, ov::Shape{}, {128});
+    auto step = ov::op::v0::Constant::create(range_type, ov::Shape{}, {1});
+    auto range = std::make_shared<ov::op::v4::Range>(start, stop, step, range_type);
+    range->set_friendly_name("range");
+
+    ov::Output<ov::Node> positions = range->output(0);
+    if (with_convert) {
+        auto convert = std::make_shared<ov::op::v0::Convert>(positions, ov::element::i64);
+        convert->set_friendly_name("positions_convert");
+        positions = convert->output(0);
+    }
+
+    // Unsqueeze: add batch dim [seq_len] → [1, seq_len]
+    auto unsqueeze_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+    auto unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(positions, unsqueeze_axes);
+    unsqueeze->set_friendly_name("unsqueeze_batch");
+    ov::Output<ov::Node> seq = unsqueeze->output(0);
+
+    // transformers>=5.4: past length added after the Range
+    if (offset_positions) {
+        auto past_len = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {8});
+        auto offset_add = std::make_shared<ov::op::v1::Add>(seq, past_len);
+        offset_add->set_friendly_name("positions_offset_add");
+        seq = offset_add->output(0);
+    }
+
+    // Squeeze: drop batch dim [1, seq_len] → [seq_len] to feed the 1-D Gather index
+    auto squeeze_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+    auto squeeze = std::make_shared<ov::op::v0::Squeeze>(seq, squeeze_axes);
+    squeeze->set_friendly_name("positions_squeeze");
+    ov::Output<ov::Node> indices = squeeze->output(0);
+
+    // Optional clip of the absolute position into the cache bounds: Maximum(0) then Minimum(max_pos)
+    if (with_clip) {
+        auto lo = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+        auto clip_max = std::make_shared<ov::op::v1::Maximum>(indices, lo);
+        clip_max->set_friendly_name("clip_max");
+        auto hi = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {255});
+        auto clip_min = std::make_shared<ov::op::v1::Minimum>(clip_max, hi);
+        clip_min->set_friendly_name("clip_min");
+        indices = clip_min->output(0);
+    }
+
+    // Precomputed cos/sin cache tables [max_pos, head_dim], indexed by the (shared) position sequence.
+    auto gather_axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+    auto cos_cache =
+        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{256, 8}, std::vector<float>(256 * 8, 1.0f));
+    auto sin_cache =
+        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{256, 8}, std::vector<float>(256 * 8, 0.0f));
+    auto gather_cos = std::make_shared<ov::op::v8::Gather>(cos_cache, indices, gather_axis);
+    gather_cos->set_friendly_name("gather_cos");
+    auto gather_sin = std::make_shared<ov::op::v8::Gather>(sin_cache, indices, gather_axis);
+    gather_sin->set_friendly_name("gather_sin");
+
+    auto cos_result = std::make_shared<ov::op::v0::Result>(gather_cos);
+    cos_result->set_friendly_name("cos_result");
+    auto sin_result = std::make_shared<ov::op::v0::Result>(gather_sin);
+    sin_result->set_friendly_name("sin_result");
+
+    return std::make_shared<ov::Model>(ov::ResultVector{cos_result, sin_result},
+                                       ov::ParameterVector{},
+                                       "model_with_gather_rope_pattern");
+}
+
 bool has_parameter_named(const std::shared_ptr<ov::Model>& model, const std::string& name) {
     for (const auto& p : model->get_parameters()) {
         for (const auto& n : p->output(0).get_names()) {
@@ -130,6 +212,19 @@ bool has_parameter_named(const std::shared_ptr<ov::Model>& model, const std::str
     return false;
 }
 
+size_t count_parameters_named(const std::shared_ptr<ov::Model>& model, const std::string& name) {
+    size_t count = 0;
+    for (const auto& p : model->get_parameters()) {
+        for (const auto& n : p->output(0).get_names()) {
+            if (n == name) {
+                ++count;
+                break;
+            }
+        }
+    }
+    return count;
+}
+
 size_t count_ops_of_type(const std::shared_ptr<ov::Model>& model, const std::string& type_name) {
     size_t count = 0;
     for (const auto& op : model->get_ops()) {
@@ -138,6 +233,22 @@ size_t count_ops_of_type(const std::shared_ptr<ov::Model>& model, const std::str
         }
     }
     return count;
+}
+
+// Returns true if position_ids (through the new Squeeze and any preserved clip) feeds the given
+// Gather's index input (input 1). Walks back along the data input (input 0) of clip/squeeze nodes.
+bool gather_index_fed_by_position_ids(const std::shared_ptr<ov::Node>& gather) {
+    auto walk = gather->input_value(1).get_node_shared_ptr();
+    for (int depth = 0; depth < 6; ++depth) {
+        if (walk->get_type_name() == std::string("Parameter")) {
+            return walk->output(0).get_names().count("position_ids") > 0;
+        }
+        if (walk->get_input_size() == 0) {
+            break;
+        }
+        walk = walk->input_value(0).get_node_shared_ptr();
+    }
+    return false;
 }
 
 // ===================== TESTS =====================
@@ -392,5 +503,95 @@ TEST(AddPositionIdsParamTest, OffsetAddWithClampReplacesClampInput) {
         EXPECT_TRUE(squeeze_input->output(0).get_names().count("position_ids") > 0)
             << "Squeeze should be fed by position_ids parameter";
     }
+}
+
+// ===================== GATHER-BASED (CACHE-TABLE) RoPE TESTS =====================
+// ONNX GroupQueryAttention-style exports index precomputed cos/sin cache tables with the positions,
+// so the position sequence drives a Gather rather than a Cos/Sin. The pass must still synthesize a
+// position_ids parameter for these models.
+
+TEST(AddPositionIdsParamTest, GatherRopeAddsPositionIdsParameter) {
+    auto model = build_model_with_gather_rope_pattern();
+
+    EXPECT_FALSE(has_parameter_named(model, "position_ids"));
+    ASSERT_NO_THROW(ov::npuw::AddPositionIdsParam().run_on_model(model));
+    EXPECT_TRUE(has_parameter_named(model, "position_ids"));
+}
+
+// Both the cos-cache and sin-cache Gathers share one position-producing Squeeze, so exactly one
+// position_ids parameter must be created (dedup), not one per Gather.
+TEST(AddPositionIdsParamTest, GatherRopeCreatesSinglePositionIdsForCosAndSin) {
+    auto model = build_model_with_gather_rope_pattern();
+    ov::npuw::AddPositionIdsParam().run_on_model(model);
+
+    EXPECT_EQ(count_parameters_named(model, "position_ids"), 1u)
+        << "The shared cos/sin Gathers should yield exactly one position_ids parameter";
+}
+
+// After the pass, both Gathers must be indexed by position_ids (through the preserved clip), not by
+// the original Range/Squeeze chain.
+TEST(AddPositionIdsParamTest, GatherRopeGatherIndexUsesPositionIds) {
+    auto model = build_model_with_gather_rope_pattern();
+    ov::npuw::AddPositionIdsParam().run_on_model(model);
+
+    size_t gathers_checked = 0;
+    for (const auto& op : model->get_ops()) {
+        if (op->get_type_name() != std::string("Gather")) {
+            continue;
+        }
+        ++gathers_checked;
+        EXPECT_TRUE(gather_index_fed_by_position_ids(op))
+            << "Gather '" << op->get_friendly_name() << "' should be indexed by position_ids";
+    }
+    EXPECT_EQ(gathers_checked, 2u) << "Model should contain both the cos-cache and sin-cache Gathers";
+}
+
+// The optional Convert / Add(past_len) / clip nodes are all absent in some exports; the pass must
+// match through the bare Range -> Unsqueeze -> Squeeze -> Gather chain too.
+TEST(AddPositionIdsParamTest, GatherRopeMatchesWithoutOptionalNodes) {
+    auto model = build_model_with_gather_rope_pattern(false /*with_convert*/, false /*offset*/, false /*with_clip*/);
+
+    EXPECT_FALSE(has_parameter_named(model, "position_ids"));
+    ASSERT_NO_THROW(ov::npuw::AddPositionIdsParam().run_on_model(model));
+    EXPECT_TRUE(has_parameter_named(model, "position_ids"));
+    EXPECT_EQ(count_parameters_named(model, "position_ids"), 1u);
+
+    for (const auto& op : model->get_ops()) {
+        if (op->get_type_name() == std::string("Gather")) {
+            EXPECT_TRUE(gather_index_fed_by_position_ids(op))
+                << "Gather should be indexed by position_ids even without clip/convert/add";
+        }
+    }
+}
+
+// The optional Convert (after Range) and Add(past_len) must not prevent the match.
+TEST(AddPositionIdsParamTest, GatherRopeMatchesWithConvertAndOffsetAdd) {
+    auto model = build_model_with_gather_rope_pattern(true /*with_convert*/, true /*offset*/, true /*with_clip*/);
+
+    EXPECT_FALSE(has_parameter_named(model, "position_ids"));
+    ASSERT_NO_THROW(ov::npuw::AddPositionIdsParam().run_on_model(model));
+    EXPECT_TRUE(has_parameter_named(model, "position_ids"));
+    EXPECT_EQ(count_parameters_named(model, "position_ids"), 1u);
+
+    for (const auto& op : model->get_ops()) {
+        if (op->get_type_name() == std::string("Gather")) {
+            EXPECT_TRUE(gather_index_fed_by_position_ids(op))
+                << "Gather should be indexed by position_ids through the optional Convert/Add";
+        }
+    }
+}
+
+// Reapplying the pass to an already-transformed Gather-RoPE model must be a no-op.
+TEST(AddPositionIdsParamTest, GatherRopeReapplyDoesNotModifyGraph) {
+    auto model = build_model_with_gather_rope_pattern();
+    ov::npuw::AddPositionIdsParam().run_on_model(model);
+
+    const size_t params_after_first = model->get_parameters().size();
+    const size_t ops_after_first = model->get_ops().size();
+
+    ov::npuw::AddPositionIdsParam().run_on_model(model);
+
+    EXPECT_EQ(model->get_parameters().size(), params_after_first) << "Second pass should not add duplicate parameters";
+    EXPECT_EQ(model->get_ops().size(), ops_after_first) << "Second pass should not add duplicate operations";
 }
 }  // namespace


### PR DESCRIPTION
### Details:
`AddPositionIdsParam` synthesizes a `position_ids` parameter for models whose position sequence is hardcoded as a `Range`, so that NPUW can drive RoPE with real positions. Until now it only matched the style that computes cos/sin via `MatMul -> Transpose -> Concat -> Cos/Sin`. However, ONNX GroupQueryAttention-style exports instead precompute cos/sin cache tables and index into them with the position ids, so the position sequence drives a `Gather` rather than a `Cos/Sin.

This PR adds a second, independent matcher — `GatheredPositionIdsMatcher` — rooted at that `Gather`, so these exports also get a synthesized `position_ids` parameter. The `Convert`, the past-length `Add`, and the `Maximum`/`Minimum` clip (into the cache bounds) are all optional across exports and are matched as such.

Since the cos-cache and sin-cache `Gather`s share the same position-producing `Squeeze`, a single `position_ids` parameter is created and rewired into every distinct `Squeeze` (deduped), avoiding colliding same-named parameters.

This PR also adds tests for the new matcher.

### Tickets:
 - CVS-193208
