### PR TITLE
[Coverity Enterprise] Explicit null dereferenced in TF FE component

### DIFF
--- a/src/frontends/tensorflow/src/graph_iterator_meta.hpp
+++ b/src/frontends/tensorflow/src/graph_iterator_meta.hpp
@@ -25,12 +25,11 @@ class GraphIteratorMeta : public GraphIteratorProto {
     std::shared_ptr<std::map<std::string, std::string>> m_outputs_map;
     HashTableKeysValuesMap m_hash_table_keys_map;
     HashTableKeysValuesMap m_hash_table_values_map;
-    bool m_mmap_enabled;
 
 public:
     GraphIteratorMeta(const std::filesystem::path& path, const bool mmap_enabled)
         : m_metagraph_def(std::make_shared<::tensorflow::MetaGraphDef>()),
-          m_mmap_enabled(mmap_enabled) {
+          m_variables_index(std::make_shared<VariablesIndex>(mmap_enabled)) {
         this->read_meta(path);
     }
 
@@ -80,7 +79,6 @@ private:
 
         auto varIndexPath = get_variables_index_name(model_path);
         if (ov::util::file_exists(varIndexPath)) {
-            m_variables_index = std::make_shared<VariablesIndex>(m_mmap_enabled);
             std::ifstream vi_stream{varIndexPath, std::ifstream::in | std::ifstream::binary};
             FRONT_END_GENERAL_CHECK(vi_stream && vi_stream.is_open(), "MetaGraph's variable index file does not exist");
             FRONT_END_GENERAL_CHECK(m_variables_index->read_variables(vi_stream, model_path, false),

--- a/src/frontends/tensorflow/src/graph_iterator_saved_model.hpp
+++ b/src/frontends/tensorflow/src/graph_iterator_saved_model.hpp
@@ -181,7 +181,7 @@ private:
         // Update variables map using information by resolving AssignVariableOp graph nodes
         std::map<std::string, std::string> var_map;
         VariablesIndex::map_assignvariable(m_graph_def, var_map, m_hash_table_keys_map, m_hash_table_values_map);
-        if (var_map.size() > 0 && m_variables_index.get() != nullptr) {
+        if (m_variables_index && !m_variables_index->empty()) {
             for (auto var : var_map) {
                 m_variables_index->map_variable(var.first, var.second);
             }

--- a/src/frontends/tensorflow/src/op/var_handle.cpp
+++ b/src/frontends/tensorflow/src/op/var_handle.cpp
@@ -94,7 +94,7 @@ OutputVector translate_varhandle_op(const NodeContext& node) {
     std::shared_ptr<Node> const_node;
     if (ov_type == element::dynamic) {
         const_node = std::make_shared<UnsupportedConstant>();
-    } else if (var_index.get() == nullptr) {
+    } else if (!var_index || var_index->empty()) {
         auto ov_shape = node.get_attribute<ov::PartialShape>("shape").get_shape();
         const_node =
             std::make_shared<frontend::tensorflow::Variable>(node.get_name(), ov_shape, ov_type, node.get_decoder());

--- a/src/frontends/tensorflow/src/variables_index.hpp
+++ b/src/frontends/tensorflow/src/variables_index.hpp
@@ -42,7 +42,7 @@ class VariablesIndex {
     bool m_mmap_enabled = false;
 
 public:
-    VariablesIndex(bool mmap_enabled = false) : m_mmap_enabled(mmap_enabled) {}
+    explicit VariablesIndex(bool mmap_enabled = false) : m_mmap_enabled(mmap_enabled) {}
     /// \brief Returns mmap_enabled state.
     /// \returns True if mmap is enabled, false otherwise
     bool is_mmap_enabled(void) const {
@@ -54,6 +54,12 @@ public:
     /// \param is_saved_model Flag shows variables index is a part of Saved Model format
     /// \returns Returns true in case of everything loads successfully, false otherwise
     bool read_variables(std::ifstream& vi_stream, const std::filesystem::path& path, const bool is_saved_model = true);
+
+    /// \brief Tells whether no *.index file was provided or present (no variables were read).
+    /// \returns True if the variables index holds no entries, false otherwise
+    bool empty() const {
+        return m_variables_index.empty();
+    }
 
     /// \brief Returns data and size of data of stored variable
     /// \param name Name of variable

--- a/src/frontends/tensorflow/tests/convert_tricky_models.cpp
+++ b/src/frontends/tensorflow/tests/convert_tricky_models.cpp
@@ -4,6 +4,7 @@
 
 #include <functional>
 
+#include "common_test_utils/test_assertions.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "conversion_with_reference.hpp"
 #include "gtest/gtest.h"
@@ -580,6 +581,20 @@ TEST_F(FrontEndConversionWithReferenceTestsF, MetaGraphCutIdentity) {
 TEST_F(FrontEndConversionWithReferenceTestsF, MetaGraphMMAPCompare) {
     { model = convert_model("metagraph_variables/graph.meta"); }
     { model_ref = convert_model("metagraph_variables/graph.meta", nullptr, {}, {}, {}, {}, {}, true); }
+}
+
+TEST(TensorFlowMetaGraphTest, MetaGraphWithoutVariablesIndex) {
+    // Regression test: loading a MetaGraph (*.meta) that contains RestoreV2 -> AssignVariableOp
+    // nodes but has no variables index (*.index) file next to it must not crash (previously the
+    // variables index was dereferenced while null during load).
+    FrontEndManager fem;
+    auto front_end = fem.load_by_framework(TF_FE);
+    ASSERT_NE(front_end, nullptr);
+    auto model_filename = FrontEndTestUtils::make_model_path(std::string(TEST_TENSORFLOW_MODELS_DIRNAME) +
+                                                             "metagraph_no_index/graph.meta");
+    ov::frontend::InputModel::Ptr input_model;
+    OV_ASSERT_NO_THROW(input_model = front_end->load(model_filename));
+    ASSERT_NE(input_model, nullptr);
 }
 
 TEST_F(FrontEndConversionWithReferenceTestsF, SplitInFunction) {

--- a/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_metagraph_no_index.py
+++ b/src/frontends/tensorflow/tests/test_models/gen_scripts/generate_metagraph_no_index.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import tensorflow as tf
+
+# Build a MetaGraph that contains RestoreV2 -> AssignVariableOp nodes (so a
+# non-empty variables map is resolved during loading), but export only the
+# ".meta" file without saving a checkpoint. This way no variables index
+# (".index") file is produced next to the model, reproducing a MetaGraph
+# without a variables index.
+tf.compat.v1.reset_default_graph()
+with tf.compat.v1.Session() as sess:
+    z_value = [[2., 2., 1.], [1., 1., 2.]]
+    x_value = [[1., 2., 3.], [3., 2., 1.]]
+
+    # Main computation depends only on a placeholder and a constant, so it can
+    # be converted without any restored variable values.
+    tf_y = tf.compat.v1.placeholder(dtype=tf.float32, shape=[2, 3], name='y')
+    tf_z = tf.constant(z_value)
+    tf.add(tf_y, tf_z, name="AddOperation")
+
+    # A resource variable with RestoreV2 -> AssignVariableOp nodes. These are not
+    # connected to the model output but still populate the variables map.
+    tf_x = tf.Variable(x_value)
+    sess.run(tf.compat.v1.global_variables_initializer())
+    var_handle = tf.compat.v1.get_default_graph().get_tensor_by_name("Variable:0")
+    prefix = tf.constant("no_such_checkpoint")
+    restorev2 = tf.raw_ops.RestoreV2(prefix=prefix, tensor_names=["Variable"],
+                                     shape_and_slices=[""], dtypes=[tf.float32],
+                                     name="save/RestoreV2/Direct")
+    tf.compat.v1.raw_ops.AssignVariableOp(resource=var_handle, value=restorev2[0])
+
+    os.makedirs(os.path.join(sys.argv[1], "metagraph_no_index"))
+    # Export only the MetaGraph (*.meta) without saving a checkpoint, so no
+    # variables index (*.index) file is produced next to the model.
+    tf.compat.v1.train.export_meta_graph(
+        filename=os.path.join(sys.argv[1], "metagraph_no_index", "graph.meta"))


### PR DESCRIPTION
### Details:
 - Fixing the issue by ensuring, that the "GraphIteratorMeta::m_variables_index" is not being dereferenced, when null

### Tickets:
 - *CVS-193094*

### AI Assistance:
 - *AI assistance used: yes*
 - *How: tests generation*

