### PR TITLE
[OV JS]  Fix uncaught exception in JS API

### DIFF
--- a/src/bindings/js/node/include/tensor_impl.hpp
+++ b/src/bindings/js/node/include/tensor_impl.hpp
@@ -29,10 +29,10 @@ public:
     struct CleanupContext {
         explicit CleanupContext(Napi::Reference<Napi::TypedArray>* typed_array_ref) : ref(typed_array_ref) {}
 
-        void release_owner();
-        void release_tsfn();
-        void remove_cleanup_hook();
-        static void cleanup_hook(napi_async_cleanup_hook_handle handle, void* data);
+        void release_owner() noexcept;
+        void release_tsfn() noexcept;
+        void remove_cleanup_hook() noexcept;
+        static void cleanup_hook(napi_async_cleanup_hook_handle handle, void* data) noexcept;
 
         std::atomic<uint32_t> owners{2};
         std::atomic<bool> tsfn_released{false};

--- a/src/bindings/js/node/src/tensor_impl.cpp
+++ b/src/bindings/js/node/src/tensor_impl.cpp
@@ -4,6 +4,8 @@
 
 #include "node/include/tensor_impl.hpp"
 
+#include <cassert>
+
 #include "openvino/core/except.hpp"
 #include "openvino/runtime/tensor.hpp"
 
@@ -11,31 +13,30 @@ namespace ov {
 namespace js {
 
 // Drops one native owner of the shared cleanup state and deletes it on the last release.
-void TensorImpl::CleanupContext::release_owner() {
+void TensorImpl::CleanupContext::release_owner() noexcept {
     if (owners.fetch_sub(1) == 1) {
         delete this;
     }
 }
 
 // Releases the TSFN exactly once because both destructor and env cleanup may race here.
-void TensorImpl::CleanupContext::release_tsfn() {
+void TensorImpl::CleanupContext::release_tsfn() noexcept {
     if (!tsfn_released.exchange(true)) {
         const auto status = tsfn.Release();
-        OPENVINO_ASSERT(status == napi_ok || status == napi_closing,
-                        "TensorImpl: failed to release ThreadSafeFunction.");
+        assert((status == napi_ok) && "TensorImpl: TSFN release failed");
+        static_cast<void>(status);
     }
 }
 
 // Unregisters the async cleanup hook exactly once to avoid double removal during shutdown.
-void TensorImpl::CleanupContext::remove_cleanup_hook() {
+void TensorImpl::CleanupContext::remove_cleanup_hook() noexcept {
     if (cleanup_handle != nullptr && !cleanup_handle_removed.exchange(true)) {
-        const auto status = napi_remove_async_cleanup_hook(cleanup_handle);
-        OPENVINO_ASSERT(status == napi_ok, "TensorImpl: failed to remove async cleanup hook.");
+        napi_remove_async_cleanup_hook(cleanup_handle);
     }
 }
 
 // Handles Node environment teardown by forcing TSFN shutdown through the cleanup hook path.
-void TensorImpl::CleanupContext::cleanup_hook(napi_async_cleanup_hook_handle handle, void* data) {
+void TensorImpl::CleanupContext::cleanup_hook(napi_async_cleanup_hook_handle handle, void* data) noexcept {
     auto* cleanup_ctx = static_cast<TensorImpl::CleanupContext*>(data);
     cleanup_ctx->cleanup_handle = handle;
     cleanup_ctx->release_tsfn();

--- a/src/bindings/js/node/src/tensor_impl.cpp
+++ b/src/bindings/js/node/src/tensor_impl.cpp
@@ -22,9 +22,8 @@ void TensorImpl::CleanupContext::release_owner() noexcept {
 // Releases the TSFN exactly once because both destructor and env cleanup may race here.
 void TensorImpl::CleanupContext::release_tsfn() noexcept {
     if (!tsfn_released.exchange(true)) {
-        const auto status = tsfn.Release();
+        [[maybe_unused]] const auto status = tsfn.Release();
         assert((status == napi_ok) && "TensorImpl: TSFN release failed");
-        static_cast<void>(status);
     }
 }
 


### PR DESCRIPTION
### Details:
 - `~TensorImpl()` is implicitly `noexcept`. It calls `release_tsfn()` and `remove_cleanup_hook()`, both of which used `OPENVINO_ASSERT`.  Throwing from a `noexcept` function -> `std::terminate()`
 - Remove `OPENVINO_ASSERT` from `napi_remove_async_cleanup_hook()` - both invalid cases are handled (null handle and race on deleting the handle)
- Remove  `OPENVINO_ASSERT` and add `assert()` from `release_tsfn()`. Keep a debug-only `assert()` in case of changes to the std::atomic<> guard, `initialThreadCount` or `Aquire/Abort` use. 
- Mark the four teardown helpers `noexcept` (`release_owner`, `release_tsfn`,
  `remove_cleanup_hook`, `cleanup_hook`)
- `ThreadSafeFunction::Release()`  returns `napi_ok` or `napi_invalid_arg`  [see here](https://github.com/nodejs/node/blob/main/src/node_api.cc#L280)

### Tickets:
 - [CVS-192439](https://jira.devtools.intel.com/browse/CVS-192439)

### AI Assistance:
 - *AI assistance used: yes, analysis *
