### PR TITLE
[GPU] Add BF16 support to RoPE kernel

### DIFF
--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -536,6 +536,9 @@ bool can_eliminate_eltwise_node(const std::shared_ptr<Node>& eltwise,
     case element::f16:
         actual_const = reinterpret_cast<const ov::float16*>(data_ptr)[0];
         break;
+    case element::bf16:
+        actual_const = reinterpret_cast<const ov::bfloat16*>(data_ptr)[0];
+        break;
     case element::i32:
         actual_const = static_cast<float>(reinterpret_cast<const int32_t*>(data_ptr)[0]);
         break;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cl
@@ -3,6 +3,7 @@
 //
 
 #include "include/fetch_utils.cl"
+#include "include/batch_headers/bf16_utils.cl"
 
 #define INPUT_VEC_TYPE  MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_SIZE)
 #define OUTPUT_VEC_TYPE MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE)
@@ -119,6 +120,39 @@
                        input1[15],                 \
                        input2[15]);
 
+// BF16 (ushort) vector unpack: decode one ushort16 -> float16 (CONVERT_AS_BFLOAT16_FLOAT),
+// then take even (pair real) / odd (pair imag) lanes as float8.
+#define UNPACK_BF16_VEC_1(outputv, input1) \
+    do { float16 _bf16u1 = CONVERT_AS_BFLOAT16_FLOAT(input1, 16); \
+         outputv = (float8)(_bf16u1[0], _bf16u1[2], _bf16u1[4], _bf16u1[6], _bf16u1[8], _bf16u1[10], _bf16u1[12], _bf16u1[14]); } while (0)
+#define UNPACK_BF16_VEC_2(outputv, input1) \
+    do { float16 _bf16u2 = CONVERT_AS_BFLOAT16_FLOAT(input1, 16); \
+         outputv = (float8)(_bf16u2[1], _bf16u2[3], _bf16u2[5], _bf16u2[7], _bf16u2[9], _bf16u2[11], _bf16u2[13], _bf16u2[15]); } while (0)
+
+// BF16 two-vector unpack for 16 complex pairs (32 elements): even/odd lanes across both vectors.
+#define UNPACK_BF1616_VEC_1(outputv, input1, input2) \
+    do { float16 _bf16a1 = CONVERT_AS_BFLOAT16_FLOAT(input1, 16); \
+         float16 _bf16b1 = CONVERT_AS_BFLOAT16_FLOAT(input2, 16); \
+         outputv = (float16)(_bf16a1[0], _bf16a1[2], _bf16a1[4], _bf16a1[6], _bf16a1[8], _bf16a1[10], _bf16a1[12], _bf16a1[14], \
+                             _bf16b1[0], _bf16b1[2], _bf16b1[4], _bf16b1[6], _bf16b1[8], _bf16b1[10], _bf16b1[12], _bf16b1[14]); } while (0)
+#define UNPACK_BF1616_VEC_2(outputv, input1, input2) \
+    do { float16 _bf16a2 = CONVERT_AS_BFLOAT16_FLOAT(input1, 16); \
+         float16 _bf16b2 = CONVERT_AS_BFLOAT16_FLOAT(input2, 16); \
+         outputv = (float16)(_bf16a2[1], _bf16a2[3], _bf16a2[5], _bf16a2[7], _bf16a2[9], _bf16a2[11], _bf16a2[13], _bf16a2[15], \
+                             _bf16b2[1], _bf16b2[3], _bf16b2[5], _bf16b2[7], _bf16b2[9], _bf16b2[11], _bf16b2[13], _bf16b2[15]); } while (0)
+
+// BF16 pack: interleave 8 real/imag pairs and encode float16 -> ushort16.
+#define PACK_BF1616_VEC_1(outputv, input1, input2) \
+    do { float16 _bf16p1 = (float16)(input1[0], input2[0], input1[1], input2[1], input1[2], input2[2], \
+                                     input1[3], input2[3], input1[4], input2[4], input1[5], input2[5], \
+                                     input1[6], input2[6], input1[7], input2[7]); \
+         outputv = CONVERT_BFLOAT16_AS_USHORT(_bf16p1, 16); } while (0)
+#define PACK_BF1616_VEC_2(outputv, input1, input2) \
+    do { float16 _bf16p2 = (float16)(input1[8], input2[8], input1[9], input2[9], input1[10], input2[10], \
+                                     input1[11], input2[11], input1[12], input2[12], input1[13], input2[13], \
+                                     input1[14], input2[14], input1[15], input2[15]); \
+         outputv = CONVERT_BFLOAT16_AS_USHORT(_bf16p2, 16); } while (0)
+
 #ifdef CHATGLM
 KERNEL(rope_opt)(
     OPTIONAL_SHAPE_INFO_ARG const __global INPUT0_TYPE* input,
@@ -164,15 +198,15 @@ KERNEL(rope_opt)(
 
 #if VEC_SIZE == 1
     #ifdef USE_ROPE_CACHE
-    float cosv = convert_float(cos_sin[cos_sin_idx + r]);
-    float sinv = convert_float(cos_sin[cos_sin_idx + r + 1]);
+    float cosv = DECODE_INPUT1_COMPUTE_TYPE(cos_sin[cos_sin_idx + r]);
+    float sinv = DECODE_INPUT1_COMPUTE_TYPE(cos_sin[cos_sin_idx + r + 1]);
     #else
-    float cosv = convert_float(cos[cos_sin_idx + cos_sin_r]);
-    float sinv = convert_float(sin[cos_sin_idx + cos_sin_r]);
+    float cosv = DECODE_INPUT1_COMPUTE_TYPE(cos[cos_sin_idx + cos_sin_r]);
+    float sinv = DECODE_INPUT2_COMPUTE_TYPE(sin[cos_sin_idx + cos_sin_r]);
     #endif
 
-    float in1 = convert_float(input[input_idx + r]);
-    float in2 = convert_float(input[input_idx + r + 1]);
+    float in1 = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + r]);
+    float in2 = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + r + 1]);
 
     output[output_idx + r] = TO_OUTPUT_TYPE(cosv * in1 - sinv * in2);
     output[output_idx + r + 1] = TO_OUTPUT_TYPE(sinv * in1 + cosv * in2);
@@ -217,18 +251,33 @@ KERNEL(rope_opt)(
     unroll_for(int i = 0; i < 2; i += 1) {
         INPUT_VEC_TYPE inv = *(INPUT_VEC_TYPE*)(input + input_idx + r + i * VEC_SIZE);
         float8 in1, in2;
+        #if INPUT0_IS_BF16
+        UNPACK_BF16_VEC_1(in1, inv);
+        UNPACK_BF16_VEC_2(in2, inv);
+        #else
         UNPACK_HALF_VEC_1(in1, inv);
         UNPACK_HALF_VEC_2(in2, inv);
+        #endif
     #ifdef USE_ROPE_CACHE
         INPUT_VEC_TYPE cossinv = *(INPUT_VEC_TYPE*)(cos_sin + cos_sin_idx + r + i * VEC_SIZE);
         float8 cosv, sinv;
+        #if INPUT0_IS_BF16
+        UNPACK_BF16_VEC_1(cosv, cossinv);
+        UNPACK_BF16_VEC_2(sinv, cossinv);
+        #else
         UNPACK_HALF_VEC_1(cosv, cossinv);
         UNPACK_HALF_VEC_2(sinv, cossinv);
+        #endif
     #else
         MAKE_VECTOR_TYPE(INPUT0_TYPE, 8) cosvv = *(MAKE_VECTOR_TYPE(INPUT0_TYPE, 8)*)(cos + cos_sin_idx + cos_sin_r + i * 8);
         MAKE_VECTOR_TYPE(INPUT0_TYPE, 8) sinvv = *(MAKE_VECTOR_TYPE(INPUT0_TYPE, 8)*)(sin + cos_sin_idx + cos_sin_r + i * 8);
+        #if INPUT0_IS_BF16
+        float8 cosv = CONVERT_AS_BFLOAT16_FLOAT(cosvv, 8);
+        float8 sinv = CONVERT_AS_BFLOAT16_FLOAT(sinvv, 8);
+        #else
         float8 cosv = convert_float8(cosvv);
         float8 sinv = convert_float8(sinvv);
+        #endif
     #endif
         float8 out1 = cosv * in1 - sinv * in2;
         float8 out2 = sinv * in1 + cosv * in2;
@@ -298,13 +347,13 @@ KERNEL(rope_opt)(
     uint output_idx = OUTPUT_GET_INDEX(b, p, h, 0);
 
 #if VEC_SIZE == 1
-    INPUT0_TYPE in1 = input[input_idx + r];
-    INPUT0_TYPE in2 = input[input_idx + HALF_ROTARY_NDIMS + r];
+    float in1 = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + r]);
+    float in2 = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + HALF_ROTARY_NDIMS + r]);
 
-    output[output_idx + r] = cos[cos_idx + r] * in1 - sin[sin_idx + r] * in2;
+    output[output_idx + r] = TO_OUTPUT_TYPE(DECODE_INPUT1_COMPUTE_TYPE(cos[cos_idx + r]) * in1 - DECODE_INPUT2_COMPUTE_TYPE(sin[sin_idx + r]) * in2);
 
     output[output_idx + HALF_ROTARY_NDIMS + r] =
-        cos[cos_idx + HALF_ROTARY_NDIMS + r] * in2 + sin[sin_idx + HALF_ROTARY_NDIMS + r] * in1;
+        TO_OUTPUT_TYPE(DECODE_INPUT1_COMPUTE_TYPE(cos[cos_idx + HALF_ROTARY_NDIMS + r]) * in2 + DECODE_INPUT2_COMPUTE_TYPE(sin[sin_idx + HALF_ROTARY_NDIMS + r]) * in1);
 #else
     INPUT_VEC_TYPE in1 = *(INPUT_VEC_TYPE*)(input + input_idx + r);
     INPUT_VEC_TYPE in2 = *(INPUT_VEC_TYPE*)(input + input_idx + HALF_ROTARY_NDIMS + r);
@@ -313,11 +362,26 @@ KERNEL(rope_opt)(
     INPUT_VEC_TYPE sin1 = *(INPUT_VEC_TYPE*)(sin + sin_idx + r);
     INPUT_VEC_TYPE sin2 = *(INPUT_VEC_TYPE*)(sin + sin_idx + HALF_ROTARY_NDIMS + r);
 
+    #if INPUT0_IS_BF16
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) din1 = CONVERT_AS_BFLOAT16_FLOAT(in1, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) din2 = CONVERT_AS_BFLOAT16_FLOAT(in2, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) dcos1 = CONVERT_AS_BFLOAT16_FLOAT(cos1, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) dcos2 = CONVERT_AS_BFLOAT16_FLOAT(cos2, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) dsin1 = CONVERT_AS_BFLOAT16_FLOAT(sin1, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) dsin2 = CONVERT_AS_BFLOAT16_FLOAT(sin2, VEC_SIZE);
+
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) out1 = dcos1 * din1 - dsin1 * din2;
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) out2 = dcos2 * din2 + dsin2 * din1;
+
+    *(INPUT_VEC_TYPE*)(output + output_idx + r) = CONVERT_BFLOAT16_AS_USHORT(out1, VEC_SIZE);
+    *(INPUT_VEC_TYPE*)(output + output_idx + HALF_ROTARY_NDIMS + r) = CONVERT_BFLOAT16_AS_USHORT(out2, VEC_SIZE);
+    #else
     OUTPUT_VEC_TYPE out1 = cos1 * in1 - sin1 * in2;
     OUTPUT_VEC_TYPE out2 = cos2 * in2 + sin2 * in1;
 
     *(OUTPUT_VEC_TYPE*)(output + output_idx + r) = out1;
     *(OUTPUT_VEC_TYPE*)(output + output_idx + HALF_ROTARY_NDIMS + r) = out2;
+    #endif
 #endif
 }
 #endif
@@ -412,13 +476,17 @@ uint cos_sin_p = p;
     uint output_idx = OUTPUT_GET_INDEX(b, h, p, 0);
 
 #if VEC_SIZE == 1
-    ACCUMULATOR_TYPE in1 = TO_ACCUMULATOR_TYPE(input[input_idx + r]);
-    ACCUMULATOR_TYPE in2 = TO_ACCUMULATOR_TYPE(input[input_idx + HALF_ROTARY_NDIMS + r]);
+    ACCUMULATOR_TYPE in1 = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + r]);
+    ACCUMULATOR_TYPE in2 = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + HALF_ROTARY_NDIMS + r]);
 
-    ACCUMULATOR_TYPE res = cos[cos_idx + r] * in1 - sin[sin_idx + r] * in2;
+    ACCUMULATOR_TYPE cosv = DECODE_INPUT1_COMPUTE_TYPE(cos[cos_idx + r]);
+    ACCUMULATOR_TYPE sinv = DECODE_INPUT2_COMPUTE_TYPE(sin[sin_idx + r]);
+    ACCUMULATOR_TYPE res = cosv * in1 - sinv * in2;
     output[output_idx + r] = TO_OUTPUT_TYPE(res);
 
-    res = cos[cos_idx + COS_SIN_TABLE_OFFSET + r] * in2 + sin[sin_idx + COS_SIN_TABLE_OFFSET + r] * in1;
+    cosv = DECODE_INPUT1_COMPUTE_TYPE(cos[cos_idx + COS_SIN_TABLE_OFFSET + r]);
+    sinv = DECODE_INPUT2_COMPUTE_TYPE(sin[sin_idx + COS_SIN_TABLE_OFFSET + r]);
+    res = cosv * in2 + sinv * in1;
     output[output_idx + HALF_ROTARY_NDIMS + r] = TO_OUTPUT_TYPE(res);
 #else
     INPUT_VEC_TYPE in1 = *(INPUT_VEC_TYPE*)(input + input_idx + r);
@@ -428,11 +496,26 @@ uint cos_sin_p = p;
     INPUT_VEC_TYPE sin1 = *(INPUT_VEC_TYPE*)(sin + sin_idx + r);
     INPUT_VEC_TYPE sin2 = *(INPUT_VEC_TYPE*)(sin + sin_idx + COS_SIN_TABLE_OFFSET + r);
 
+    #if INPUT0_IS_BF16
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) din1 = CONVERT_AS_BFLOAT16_FLOAT(in1, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) din2 = CONVERT_AS_BFLOAT16_FLOAT(in2, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) dcos1 = CONVERT_AS_BFLOAT16_FLOAT(cos1, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) dcos2 = CONVERT_AS_BFLOAT16_FLOAT(cos2, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) dsin1 = CONVERT_AS_BFLOAT16_FLOAT(sin1, VEC_SIZE);
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) dsin2 = CONVERT_AS_BFLOAT16_FLOAT(sin2, VEC_SIZE);
+
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) out1 = dcos1 * din1 - dsin1 * din2;
+    MAKE_VECTOR_TYPE(float, VEC_SIZE) out2 = dcos2 * din2 + dsin2 * din1;
+
+    *(INPUT_VEC_TYPE*)(output + output_idx + r) = CONVERT_BFLOAT16_AS_USHORT(out1, VEC_SIZE);
+    *(INPUT_VEC_TYPE*)(output + output_idx + HALF_ROTARY_NDIMS + r) = CONVERT_BFLOAT16_AS_USHORT(out2, VEC_SIZE);
+    #else
     OUTPUT_VEC_TYPE out1 = cos1 * in1 - sin1 * in2;
     OUTPUT_VEC_TYPE out2 = cos2 * in2 + sin2 * in1;
 
     *(OUTPUT_VEC_TYPE*)(output + output_idx + r) = out1;
     *(OUTPUT_VEC_TYPE*)(output + output_idx + HALF_ROTARY_NDIMS + r) = out2;
+    #endif
 #endif
 
 }
@@ -475,11 +558,11 @@ KERNEL(rope_opt)(
     uint output_idx = OUTPUT_GET_INDEX(b, h, p, 0);
 
 #if VEC_SIZE == 1
-    INPUT0_TYPE in1 = input[input_idx + r];
-    INPUT0_TYPE in2 = input[input_idx + r + 1];
+    float in1 = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + r]);
+    float in2 = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + r + 1]);
 
-    output[output_idx + r] = cos[cos_idx + r] * in1 - sin[sin_idx + r] * in2;
-    output[output_idx + r + 1] = cos[cos_idx + r + 1] * in2 + sin[sin_idx + r + 1] * in1;
+    output[output_idx + r] = TO_OUTPUT_TYPE(DECODE_INPUT1_COMPUTE_TYPE(cos[cos_idx + r]) * in1 - DECODE_INPUT2_COMPUTE_TYPE(sin[sin_idx + r]) * in2);
+    output[output_idx + r + 1] = TO_OUTPUT_TYPE(DECODE_INPUT1_COMPUTE_TYPE(cos[cos_idx + r + 1]) * in2 + DECODE_INPUT2_COMPUTE_TYPE(sin[sin_idx + r + 1]) * in1);
 #elif VEC_SIZE == 8
     INPUT_VEC_TYPE inv1 = *(INPUT_VEC_TYPE*)(input + input_idx + r);
     INPUT_VEC_TYPE inv2 = *(INPUT_VEC_TYPE*)(input + input_idx + r + VEC_SIZE);
@@ -511,6 +594,25 @@ KERNEL(rope_opt)(
     INPUT_VEC_TYPE cosv2 = *(INPUT_VEC_TYPE*)(cos + cos_idx + r + VEC_SIZE);
     INPUT_VEC_TYPE sinv2 = *(INPUT_VEC_TYPE*)(sin + sin_idx + r + VEC_SIZE);
 
+    #if INPUT0_IS_BF16
+    float16 in1, in2, cos1, sin1, cos2, sin2;
+    UNPACK_BF1616_VEC_1(in1, inv1, inv2);
+    UNPACK_BF1616_VEC_2(in2, inv1, inv2);
+    UNPACK_BF1616_VEC_1(cos1, cosv1, cosv2);
+    UNPACK_BF1616_VEC_2(cos2, cosv1, cosv2);
+    UNPACK_BF1616_VEC_1(sin1, sinv1, sinv2);
+    UNPACK_BF1616_VEC_2(sin2, sinv1, sinv2);
+
+    float16 out1 = cos1 * in1 - sin1 * in2;
+    float16 out2 = sin2 * in1 + cos2 * in2;
+
+    INPUT_VEC_TYPE outputv1, outputv2;
+    PACK_BF1616_VEC_1(outputv1, out1, out2);
+    PACK_BF1616_VEC_2(outputv2, out1, out2);
+
+    *(INPUT_VEC_TYPE*)(output + output_idx + r) = outputv1;
+    *(INPUT_VEC_TYPE*)(output + output_idx + r + VEC_SIZE) = outputv2;
+    #else
     INPUT_VEC_TYPE in1, in2, cos1, sin1, cos2, sin2;
     UNPACK_HALF16_VEC_1(in1, inv1, inv2);
     UNPACK_HALF16_VEC_2(in2, inv1, inv2);
@@ -528,6 +630,7 @@ KERNEL(rope_opt)(
 
     *(half16*)(output + output_idx + r) = outputv1;
     *(half16*)(output + output_idx + r + VEC_SIZE) = outputv2;
+    #endif
 #endif
 }
 #endif
@@ -566,11 +669,11 @@ KERNEL(rope_opt)(
 
 #if VEC_SIZE == 1
     // Scalar processing: process one complex pair at a time
-    INPUT0_TYPE in_real = input[input_idx + r];      // real part
-    INPUT0_TYPE in_imag = input[input_idx + r + 1];  // imaginary part
+    float in_real = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + r]);      // real part
+    float in_imag = DECODE_INPUT0_COMPUTE_TYPE(input[input_idx + r + 1]);  // imaginary part
 
-    INPUT1_TYPE cos_val = cos[cos_idx + r];
-    INPUT2_TYPE sin_val = sin[sin_idx + r];
+    float cos_val = DECODE_INPUT1_COMPUTE_TYPE(cos[cos_idx + r]);
+    float sin_val = DECODE_INPUT2_COMPUTE_TYPE(sin[sin_idx + r]);
 
     // Complex rotation: (real + i*imag) * (cos + i*sin)
     // out_real = real * cos - imag * sin
@@ -615,6 +718,25 @@ KERNEL(rope_opt)(
     INPUT_VEC_TYPE cosv2 = *(INPUT_VEC_TYPE*)(cos + cos_idx + r + VEC_SIZE);
     INPUT_VEC_TYPE sinv2 = *(INPUT_VEC_TYPE*)(sin + sin_idx + r + VEC_SIZE);
 
+    #if INPUT0_IS_BF16
+    float16 in_real, in_imag, cos_val, sin_val, cos_val2, sin_val2;
+    UNPACK_BF1616_VEC_1(in_real, inv1, inv2);
+    UNPACK_BF1616_VEC_2(in_imag, inv1, inv2);
+    UNPACK_BF1616_VEC_1(cos_val, cosv1, cosv2);
+    UNPACK_BF1616_VEC_2(cos_val2, cosv1, cosv2);
+    UNPACK_BF1616_VEC_1(sin_val, sinv1, sinv2);
+    UNPACK_BF1616_VEC_2(sin_val2, sinv1, sinv2);
+
+    float16 out_real = cos_val * in_real - sin_val * in_imag;
+    float16 out_imag = sin_val2 * in_real + cos_val2 * in_imag;
+
+    INPUT_VEC_TYPE outputv1, outputv2;
+    PACK_BF1616_VEC_1(outputv1, out_real, out_imag);
+    PACK_BF1616_VEC_2(outputv2, out_real, out_imag);
+
+    *(INPUT_VEC_TYPE*)(output + output_idx + r) = outputv1;
+    *(INPUT_VEC_TYPE*)(output + output_idx + r + VEC_SIZE) = outputv2;
+    #else
     INPUT_VEC_TYPE in_real, in_imag, cos_val, sin_val, cos_val2, sin_val2;
     UNPACK_HALF16_VEC_1(in_real, inv1, inv2);
     UNPACK_HALF16_VEC_2(in_imag, inv1, inv2);
@@ -632,6 +754,7 @@ KERNEL(rope_opt)(
 
     *(half16*)(output + output_idx + r) = outputv1;
     *(half16*)(output + output_idx + r + VEC_SIZE) = outputv2;
+    #endif
 #endif
 }
 #endif

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cpp
@@ -20,8 +20,6 @@ size_t get_vec_size(const RuntimeParams& params) {
     size_t vec_size = 1;
     switch (input.data_type) {
     case ov::element::f16:
-        vec_size = 16;
-        break;
     case ov::element::bf16:
         vec_size = 16;
         break;
@@ -118,17 +116,6 @@ protected:
             jit.add(make_type_jit_constants("ACCUMULATOR", params.get_input_layout(0).data_type));
         }
 
-        // Use the standard BF16 decode flags (same names and semantics as
-        // kernel_selector's MakeTypeJitConstants, kernel_selector/jitter.cpp):
-        // BF16 -> proper BF16->float decode, other types -> identity.
-        const auto decode_flag = [](ov::element::Type dt) -> std::string {
-            return dt == ov::element::bf16 ? "_convert_as_bfloat16_float(v)" : "(v)";
-        };
-        jit.make("DECODE_INPUT0_COMPUTE_TYPE(v)", decode_flag(params.get_input_layout(0).data_type));
-        jit.make("DECODE_INPUT1_COMPUTE_TYPE(v)", decode_flag(params.get_input_layout(1).data_type));
-        if (params.input_layouts.size() > 2) {
-            jit.make("DECODE_INPUT2_COMPUTE_TYPE(v)", decode_flag(params.get_input_layout(2).data_type));
-        }
         return jit;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cpp
@@ -22,6 +22,9 @@ size_t get_vec_size(const RuntimeParams& params) {
     case ov::element::f16:
         vec_size = 16;
         break;
+    case ov::element::bf16:
+        vec_size = 16;
+        break;
     case ov::element::f32:
         vec_size = 8;
         break;
@@ -107,10 +110,24 @@ protected:
             }
         }
         jit.make("VEC_SIZE", get_vec_size(params));
-        if (params.get_input_layout(0).data_type != params.get_input_layout(1).data_type) {
+        if (in_l.data_type == ov::element::bf16) {
+            jit.add(make_type_jit_constants("ACCUMULATOR", ov::element::f32));
+        } else if (params.get_input_layout(0).data_type != params.get_input_layout(1).data_type) {
             jit.add(make_type_jit_constants("ACCUMULATOR", params.get_input_layout(1).data_type));
         } else {
             jit.add(make_type_jit_constants("ACCUMULATOR", params.get_input_layout(0).data_type));
+        }
+
+        // Use the standard BF16 decode flags (same names and semantics as
+        // kernel_selector's MakeTypeJitConstants, kernel_selector/jitter.cpp):
+        // BF16 -> proper BF16->float decode, other types -> identity.
+        const auto decode_flag = [](ov::element::Type dt) -> std::string {
+            return dt == ov::element::bf16 ? "_convert_as_bfloat16_float(v)" : "(v)";
+        };
+        jit.make("DECODE_INPUT0_COMPUTE_TYPE(v)", decode_flag(params.get_input_layout(0).data_type));
+        jit.make("DECODE_INPUT1_COMPUTE_TYPE(v)", decode_flag(params.get_input_layout(1).data_type));
+        if (params.input_layouts.size() > 2) {
+            jit.make("DECODE_INPUT2_COMPUTE_TYPE(v)", decode_flag(params.get_input_layout(2).data_type));
         }
         return jit;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.hpp
@@ -26,6 +26,7 @@ struct RopeOpt : public ImplementationManager {
         static constexpr std::array supported_types = {
             ov::element::f32,
             ov::element::f16,
+            ov::element::bf16,
         };
 
         const auto& in0_layout = node.get_input_layout(0);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
@@ -165,6 +165,7 @@ JitConstants make_type_jit_constants(const std::string& name, const ov::element:
     std::string abs_func = "dynamic";
     std::string type_size = "dynamic";
     bool is_fp = false;
+    bool is_bf16 = false;
     switch (value) {
     case ov::element::i8:
         type = "char";
@@ -304,6 +305,7 @@ JitConstants make_type_jit_constants(const std::string& name, const ov::element:
         to_type_sat = "_convert_bfloat16_as_ushort(v)";
         type_size = "2";
         is_fp = false;
+        is_bf16 = true;
         break;
     case ov::element::f32:
         type = "float";
@@ -401,6 +403,7 @@ JitConstants make_type_jit_constants(const std::string& name, const ov::element:
         make_jit_constant(name + "_ABS_FUNC", abs_func),
         make_jit_constant(name + "_TYPE_SIZE", type_size),
         make_jit_constant(name + "_IS_FP", is_fp),
+        make_jit_constant(name + "_IS_BF16", is_bf16),
     };
 }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
@@ -164,6 +164,10 @@ JitConstants make_type_jit_constants(const std::string& name, const ov::element:
     std::string min_func = "dynamic";
     std::string abs_func = "dynamic";
     std::string type_size = "dynamic";
+    std::string compute_type;
+    std::string to_compute_type;
+    std::string decode_compute_type;
+    std::string decode_compute_vector_type;
     bool is_fp = false;
     bool is_bf16 = false;
     switch (value) {
@@ -303,6 +307,10 @@ JitConstants make_type_jit_constants(const std::string& name, const ov::element:
         val_zero = "(ushort) 0";
         to_type = "_convert_bfloat16_as_ushort(v)";
         to_type_sat = "_convert_bfloat16_as_ushort(v)";
+        compute_type = "float";
+        to_compute_type = "convert_float(v)";
+        decode_compute_type = "_convert_as_bfloat16_float(v)";
+        decode_compute_vector_type = "CONVERT_AS_BFLOAT16_FLOAT(v, size)";
         type_size = "2";
         is_fp = false;
         is_bf16 = true;
@@ -389,6 +397,15 @@ JitConstants make_type_jit_constants(const std::string& name, const ov::element:
         OPENVINO_THROW("[GPU] Jitter: unsupported data type: ", value);
     }
 
+    if (compute_type.empty())
+        compute_type = type;
+    if (to_compute_type.empty())
+        to_compute_type = to_type;
+    if (decode_compute_type.empty())
+        decode_compute_type = "(v)";
+    if (decode_compute_vector_type.empty())
+        decode_compute_vector_type = "(v)";
+
     return {
         make_jit_constant(name + "_TYPE", type),
         make_jit_constant(name + "_VAL_MAX", max_val),
@@ -404,6 +421,10 @@ JitConstants make_type_jit_constants(const std::string& name, const ov::element:
         make_jit_constant(name + "_TYPE_SIZE", type_size),
         make_jit_constant(name + "_IS_FP", is_fp),
         make_jit_constant(name + "_IS_BF16", is_bf16),
+        make_jit_constant(name + "_COMPUTE_TYPE", compute_type),
+        make_jit_constant("TO_" + name + "_COMPUTE_TYPE(v)", to_compute_type),
+        make_jit_constant("DECODE_" + name + "_COMPUTE_TYPE(v)", decode_compute_type),
+        make_jit_constant("DECODE_" + name + "_COMPUTE_VECTOR_TYPE(v, size)", decode_compute_vector_type),
     };
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1460,6 +1460,7 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
     std::string to_vector_type = "undefined";
     std::string to_vector_type_sat = "undefined";
     bool is_fp;
+    bool is_bf16 = false;
     switch (dataType) {
         case Datatype::INT8:
             type = "char";
@@ -1641,6 +1642,7 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             abs_func = "fabs";
             type_size = "2";
             is_fp = true;
+            is_bf16 = true;
             break;
         case Datatype::F4E2M1:
             type = "fp4e2m1_t";
@@ -1734,6 +1736,7 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
         MakeJitConstant(macroName + "_ABS_FUNC", abs_func),
         MakeJitConstant(macroName + "_TYPE_SIZE", type_size),
         MakeJitConstant(macroName + "_IS_FP", is_fp),
+        MakeJitConstant(macroName + "_IS_BF16", is_bf16),
         MakeJitConstant(macroName + "_COMPUTE_TYPE", compute_type),
         MakeJitConstant("TO_" + macroName + "_COMPUTE_TYPE(v)", to_compute_type),
         MakeJitConstant("DECODE_" + macroName + "_COMPUTE_TYPE(v)", decode_compute_type),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/rope_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/rope_gpu_test.cpp
@@ -1,0 +1,521 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include <intel_gpu/primitives/input_layout.hpp>
+#include <intel_gpu/primitives/rope.hpp>
+
+using namespace cldnn;
+using namespace ::tests;
+
+// ============================================================================
+// BF16/F16 RoPE reference (RotateHalf mode). For BF16 the kernel runs the
+// VEC_SIZE==1 path with DECODE_INPUT0_COMPUTE_TYPE decode; for F16 it may run the
+// vectorized path, but the math is the same half-rotation.
+// Input layout [batch, head, seq, head_size] bfyx (or [batch, seq, head, head_size]
+// when input_trans0213). Cos/Sin tables [1, 1, seq, head_size].
+// Rotate pairs (i, i + rotary_ndims/2):
+//   out[i]        = cos[p, i]        * in[i]        - sin[p, i]        * in[i + half]
+//   out[i + half] = cos[p, i + half] * in[i + half] + sin[p, i + half] * in[i]
+// (default COS_SIN_TABLE_OFFSET == rotary_ndims/2). Computed in FP32.
+// ============================================================================
+static void rope_ref(const memory::ptr input, const memory::ptr cos, const memory::ptr sin,
+                     memory::ptr output, size_t batch, size_t head_cnt, size_t seq,
+                     size_t head_size, size_t rotary_ndims, bool input_trans0213) {
+    const size_t half = rotary_ndims / 2;
+
+    cldnn::mem_lock<ov::bfloat16> src_bf16(input, get_test_stream());
+    cldnn::mem_lock<ov::float16> src_f16(input, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> cosv_bf16(cos, get_test_stream());
+    cldnn::mem_lock<ov::float16> cosv_f16(cos, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> sinv_bf16(sin, get_test_stream());
+    cldnn::mem_lock<ov::float16> sinv_f16(sin, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> dst_bf16(output, get_test_stream());
+    cldnn::mem_lock<ov::float16> dst_f16(output, get_test_stream());
+
+    auto read_src = [&](size_t i) -> float {
+        if (input->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(src_bf16[i]);
+        else
+            return static_cast<float>(src_f16[i]);
+    };
+    auto read_cos = [&](size_t i) -> float {
+        if (cos->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(cosv_bf16[i]);
+        else
+            return static_cast<float>(cosv_f16[i]);
+    };
+    auto read_sin = [&](size_t i) -> float {
+        if (sin->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(sinv_bf16[i]);
+        else
+            return static_cast<float>(sinv_f16[i]);
+    };
+    auto write_dst = [&](size_t i, float v) {
+        if (output->get_layout().data_type == data_types::bf16)
+            dst_bf16[i] = ov::bfloat16(v);
+        else
+            dst_f16[i] = ov::float16(v);
+    };
+
+    auto out_off = [&](size_t b, size_t h, size_t p, size_t x) {
+        return b * head_cnt * seq * head_size + h * seq * head_size + p * head_size + x;
+    };
+    auto cos_off = [&](size_t p, size_t x) { return p * head_size + x; };
+
+    for (size_t b = 0; b < batch; ++b) {
+        for (size_t h = 0; h < head_cnt; ++h) {
+            for (size_t p = 0; p < seq; ++p) {
+                size_t base_out = out_off(b, h, p, 0);
+                size_t base_in;
+                if (input_trans0213) {
+                    // input [batch, seq, head, head_size] bfyx: b=b, f=seq, y=head, x=head_size
+                    base_in = b * seq * head_cnt * head_size + p * head_cnt * head_size + h * head_size;
+                } else {
+                    base_in = base_out;
+                }
+                for (size_t i = 0; i < half; ++i) {
+                    float in1 = read_src(base_in + i);
+                    float in2 = read_src(base_in + half + i);
+                    float c1 = read_cos(cos_off(p, i));
+                    float s1 = read_sin(cos_off(p, i));
+                    float c2 = read_cos(cos_off(p, half + i));
+                    float s2 = read_sin(cos_off(p, half + i));
+                    write_dst(base_out + i, c1 * in1 - s1 * in2);
+                    write_dst(base_out + half + i, c2 * in2 + s2 * in1);
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// BF16/F16 RoPE reference (interleaved mode, config.is_interleaved). Cos/Sin are
+// per-element tables with the same layout as input/output
+// [batch, head, seq, head_size] bfyx. Rotate adjacent pairs (i, i + 1):
+//   out[i]   = cos[i]   * in[i]   - sin[i]   * in[i + 1]
+//   out[i+1] = cos[i+1] * in[i+1] + sin[i+1] * in[i]
+// Elements at/above rotary_ndims are copied as-is. Computed in FP32.
+// ============================================================================
+static void rope_interleaved_ref(const memory::ptr input, const memory::ptr cos, const memory::ptr sin,
+                                 memory::ptr output, size_t batch, size_t head_cnt, size_t seq,
+                                 size_t head_size, size_t rotary_ndims) {
+    cldnn::mem_lock<ov::bfloat16> src_bf16(input, get_test_stream());
+    cldnn::mem_lock<ov::float16> src_f16(input, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> cosv_bf16(cos, get_test_stream());
+    cldnn::mem_lock<ov::float16> cosv_f16(cos, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> sinv_bf16(sin, get_test_stream());
+    cldnn::mem_lock<ov::float16> sinv_f16(sin, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> dst_bf16(output, get_test_stream());
+    cldnn::mem_lock<ov::float16> dst_f16(output, get_test_stream());
+
+    auto read_src = [&](size_t i) -> float {
+        if (input->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(src_bf16[i]);
+        else
+            return static_cast<float>(src_f16[i]);
+    };
+    auto read_cos = [&](size_t i) -> float {
+        if (cos->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(cosv_bf16[i]);
+        else
+            return static_cast<float>(cosv_f16[i]);
+    };
+    auto read_sin = [&](size_t i) -> float {
+        if (sin->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(sinv_bf16[i]);
+        else
+            return static_cast<float>(sinv_f16[i]);
+    };
+    auto write_dst = [&](size_t i, float v) {
+        if (output->get_layout().data_type == data_types::bf16)
+            dst_bf16[i] = ov::bfloat16(v);
+        else
+            dst_f16[i] = ov::float16(v);
+    };
+
+    for (size_t b = 0; b < batch; ++b) {
+        for (size_t h = 0; h < head_cnt; ++h) {
+            for (size_t p = 0; p < seq; ++p) {
+                const size_t base = b * head_cnt * seq * head_size + h * seq * head_size + p * head_size;
+                for (size_t i = 0; i < rotary_ndims; i += 2) {
+                    float in1 = read_src(base + i);
+                    float in2 = read_src(base + i + 1);
+                    write_dst(base + i, read_cos(base + i) * in1 - read_sin(base + i) * in2);
+                    write_dst(base + i + 1, read_cos(base + i + 1) * in2 + read_sin(base + i + 1) * in1);
+                }
+                for (size_t i = rotary_ndims; i < head_size; ++i) {
+                    write_dst(base + i, read_src(base + i));
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// BF16/F16 RoPE reference (QWEN per-head mode, config.is_qwen). Input
+// [batch, seq, head_cnt*head_size] bfyx, per-head cos/sin tables
+// [batch, seq, head, head_size], output [batch, seq, head, head_size].
+// Same half-offset rotation as RotateHalf, but the tables are indexed per head:
+//   out[h][r]        = cos[h][r]        * in[h][r]        - sin[h][r]        * in[h][r + half]
+//   out[h][r + half] = cos[h][r + half] * in[h][r + half] + sin[h][r + half] * in[h][r]
+// Elements at/above rotary_ndims are copied as-is. Computed in FP32.
+// ============================================================================
+static void rope_qwen_ref(const memory::ptr input, const memory::ptr cos, const memory::ptr sin,
+                          memory::ptr output, size_t batch, size_t head_cnt, size_t seq,
+                          size_t head_size, size_t rotary_ndims) {
+    const size_t half = rotary_ndims / 2;
+
+    cldnn::mem_lock<ov::bfloat16> src_bf16(input, get_test_stream());
+    cldnn::mem_lock<ov::float16> src_f16(input, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> cosv_bf16(cos, get_test_stream());
+    cldnn::mem_lock<ov::float16> cosv_f16(cos, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> sinv_bf16(sin, get_test_stream());
+    cldnn::mem_lock<ov::float16> sinv_f16(sin, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> dst_bf16(output, get_test_stream());
+    cldnn::mem_lock<ov::float16> dst_f16(output, get_test_stream());
+
+    auto read_src = [&](size_t i) -> float {
+        if (input->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(src_bf16[i]);
+        else
+            return static_cast<float>(src_f16[i]);
+    };
+    auto read_cos = [&](size_t i) -> float {
+        if (cos->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(cosv_bf16[i]);
+        else
+            return static_cast<float>(cosv_f16[i]);
+    };
+    auto read_sin = [&](size_t i) -> float {
+        if (sin->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(sinv_bf16[i]);
+        else
+            return static_cast<float>(sinv_f16[i]);
+    };
+    auto write_dst = [&](size_t i, float v) {
+        if (output->get_layout().data_type == data_types::bf16)
+            dst_bf16[i] = ov::bfloat16(v);
+        else
+            dst_f16[i] = ov::float16(v);
+    };
+
+    for (size_t b = 0; b < batch; ++b) {
+        for (size_t p = 0; p < seq; ++p) {
+            for (size_t h = 0; h < head_cnt; ++h) {
+                // input row, table row and output row share the same linear base
+                const size_t base = b * seq * head_cnt * head_size + p * head_cnt * head_size + h * head_size;
+                for (size_t i = 0; i < half; ++i) {
+                    float in1 = read_src(base + i);
+                    float in2 = read_src(base + half + i);
+                    float c1 = read_cos(base + i);
+                    float s1 = read_sin(base + i);
+                    float c2 = read_cos(base + half + i);
+                    float s2 = read_sin(base + half + i);
+                    write_dst(base + i, c1 * in1 - s1 * in2);
+                    write_dst(base + half + i, c2 * in2 + s2 * in1);
+                }
+                for (size_t i = rotary_ndims; i < head_size; ++i) {
+                    write_dst(base + i, read_src(base + i));
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// BF16/F16 RoPE reference (ChatGLM mode, config.is_chatglm). Input
+// [seq, batch, head_cnt*head_size] bfyx, output [seq, batch, head, head_size].
+// Rotate adjacent pairs (r, r+1):
+//   cache:     interleaved cos_sin table [seq, batch, 1, rotary_ndims]
+//              (cos at even, sin at odd indices)
+//   non-cache: per-pair cos/sin tables [seq, batch, 1, rotary_ndims/2]
+//   out[r]   = cos * in[r]   - sin * in[r+1]
+//   out[r+1] = sin * in[r]   + cos * in[r+1]
+// Computed in FP32.
+// ============================================================================
+static void rope_chatglm_ref(const memory::ptr input, const memory::ptr cos, const memory::ptr sin,
+                             memory::ptr output, size_t batch, size_t seq, size_t head_cnt,
+                             size_t head_size, size_t rotary_ndims, bool use_rope_cache) {
+    const size_t half = rotary_ndims / 2;
+
+    cldnn::mem_lock<ov::bfloat16> src_bf16(input, get_test_stream());
+    cldnn::mem_lock<ov::float16> src_f16(input, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> cosv_bf16(cos, get_test_stream());
+    cldnn::mem_lock<ov::float16> cosv_f16(cos, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> sinv_bf16(sin, get_test_stream());
+    cldnn::mem_lock<ov::float16> sinv_f16(sin, get_test_stream());
+    cldnn::mem_lock<ov::bfloat16> dst_bf16(output, get_test_stream());
+    cldnn::mem_lock<ov::float16> dst_f16(output, get_test_stream());
+
+    auto read_src = [&](size_t i) -> float {
+        if (input->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(src_bf16[i]);
+        else
+            return static_cast<float>(src_f16[i]);
+    };
+    auto read_cos = [&](size_t i) -> float {
+        if (cos->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(cosv_bf16[i]);
+        else
+            return static_cast<float>(cosv_f16[i]);
+    };
+    auto read_sin = [&](size_t i) -> float {
+        if (sin->get_layout().data_type == data_types::bf16)
+            return static_cast<float>(sinv_bf16[i]);
+        else
+            return static_cast<float>(sinv_f16[i]);
+    };
+    auto write_dst = [&](size_t i, float v) {
+        if (output->get_layout().data_type == data_types::bf16)
+            dst_bf16[i] = ov::bfloat16(v);
+        else
+            dst_f16[i] = ov::float16(v);
+    };
+
+    for (size_t p = 0; p < seq; ++p) {
+        for (size_t b = 0; b < batch; ++b) {
+            for (size_t h = 0; h < head_cnt; ++h) {
+                // input and output rows share the same linear base
+                const size_t base = p * batch * head_cnt * head_size + b * head_cnt * head_size + h * head_size;
+                for (size_t rf = 0; rf < half; ++rf) {
+                    const size_t r = rf * 2;
+                    float in1 = read_src(base + r);
+                    float in2 = read_src(base + r + 1);
+                    float c, s;
+                    if (use_rope_cache) {
+                        // interleaved table: cos at even, sin at odd
+                        const size_t tb = p * batch * rotary_ndims + b * rotary_ndims;
+                        c = read_cos(tb + r);
+                        s = read_cos(tb + r + 1);
+                    } else {
+                        // per-pair tables
+                        const size_t tb = p * batch * half + b * half;
+                        c = read_cos(tb + rf);
+                        s = read_sin(tb + rf);
+                    }
+                    write_dst(base + r, c * in1 - s * in2);
+                    write_dst(base + r + 1, s * in1 + c * in2);
+                }
+            }
+        }
+    }
+}
+
+enum class rope_variant { rotate_half, interleaved, qwen_per_head, chatglm };
+
+static void run_rope(data_types dt, const ov::PartialShape& in_shape, size_t head_cnt, size_t head_size,
+                     bool input_trans0213, bool dynamic,
+                     rope_variant variant = rope_variant::rotate_half,
+                     bool use_rope_cache = false) {
+    auto& engine = get_test_engine();
+    size_t batch = in_shape[0].get_length();
+    size_t seq;
+    if (variant == rope_variant::chatglm) {
+        // chatglm input is [seq, batch, head_cnt*head_size] (seq is the leading dim)
+        seq = in_shape[0].get_length();
+        batch = in_shape[1].get_length();
+    } else if (variant == rope_variant::qwen_per_head || input_trans0213) {
+        seq = in_shape[1].get_length();
+    } else {
+        seq = in_shape[2].get_length();
+    }
+    const size_t rotary_ndims = head_size;  // All tests cover full head_size
+
+    // Variant-specific cos/sin table and output shapes (bfyx)
+    ov::PartialShape cos_shape;
+    ov::PartialShape out_shape;
+    if (variant == rope_variant::chatglm) {
+        // non-cache: per-pair cos/sin [seq, batch, 1, rotary_ndims/2]
+        // cache: interleaved cos_sin [seq, batch, 1, rotary_ndims]
+        cos_shape = ov::PartialShape{static_cast<int64_t>(seq), static_cast<int64_t>(batch), 1,
+                                     static_cast<int64_t>(use_rope_cache ? rotary_ndims : rotary_ndims / 2)};
+        out_shape = ov::PartialShape{static_cast<int64_t>(seq), static_cast<int64_t>(batch),
+                                     static_cast<int64_t>(head_cnt), static_cast<int64_t>(head_size)};
+    } else if (variant == rope_variant::qwen_per_head) {
+        // input [batch, seq, head_cnt*head_size] -> per-head tables [batch, seq, head, head_size]
+        cos_shape = ov::PartialShape{static_cast<int64_t>(batch), static_cast<int64_t>(seq),
+                                     static_cast<int64_t>(head_cnt), static_cast<int64_t>(head_size)};
+        out_shape = cos_shape;
+    } else if (variant == rope_variant::interleaved) {
+        // per-element tables with the same layout as the input
+        cos_shape = in_shape;
+        out_shape = in_shape;
+    } else {
+        cos_shape = ov::PartialShape{1, 1, static_cast<int64_t>(seq), static_cast<int64_t>(head_size)};
+        // output is [batch, head, seq, head_size] (transpose swaps input dims 1&2)
+        out_shape = input_trans0213
+            ? ov::PartialShape{static_cast<int64_t>(batch), static_cast<int64_t>(head_cnt),
+                               static_cast<int64_t>(seq), static_cast<int64_t>(head_size)}
+            : in_shape;
+    }
+
+    auto input = engine.allocate_memory({in_shape, dt, format::bfyx});
+    auto cos = engine.allocate_memory({cos_shape, dt, format::bfyx});
+    auto sin = engine.allocate_memory({cos_shape, dt, format::bfyx});
+    auto output_ref = engine.allocate_memory({out_shape, dt, format::bfyx});
+
+    if (dt == data_types::bf16) {
+        tests::set_random_values<ov::bfloat16>(input, true, 7, 4);
+        tests::set_random_values<ov::bfloat16>(cos, true, 7, 1);
+        tests::set_random_values<ov::bfloat16>(sin, true, 7, 1);
+    } else {
+        tests::set_random_values<ov::float16>(input, true, 10, 4);
+        tests::set_random_values<ov::float16>(cos, true, 10, 1);
+        tests::set_random_values<ov::float16>(sin, true, 10, 1);
+    }
+
+    if (variant == rope_variant::interleaved) {
+        rope_interleaved_ref(input, cos, sin, output_ref, batch, head_cnt, seq, head_size, rotary_ndims);
+    } else if (variant == rope_variant::qwen_per_head) {
+        rope_qwen_ref(input, cos, sin, output_ref, batch, head_cnt, seq, head_size, rotary_ndims);
+    } else if (variant == rope_variant::chatglm) {
+        rope_chatglm_ref(input, cos, sin, output_ref, batch, seq, head_cnt, head_size, rotary_ndims, use_rope_cache);
+    } else {
+        rope_ref(input, cos, sin, output_ref, batch, head_cnt, seq, head_size, rotary_ndims, input_trans0213);
+    }
+
+    ov::op::internal::RoPE::Config config;
+    config.head_cnt = head_cnt;
+    config.head_size = head_size;
+    config.rotary_ndims = rotary_ndims;
+    config.input_trans0213 = input_trans0213 && variant == rope_variant::rotate_half;
+    config.is_interleaved = variant == rope_variant::interleaved;
+    config.is_qwen = variant == rope_variant::qwen_per_head;
+    config.is_chatglm = variant == rope_variant::chatglm;
+    config.use_rope_cache = use_rope_cache;
+
+    topology topology;
+    auto in_lay = dynamic
+        ? layout{ov::PartialShape{ov::Dimension::dynamic(), ov::Dimension::dynamic(),
+                                  ov::Dimension::dynamic(), ov::Dimension::dynamic()},
+                 dt, format::bfyx}
+        : input->get_layout();
+    topology.add(input_layout("input", in_lay));
+    if (variant == rope_variant::chatglm && use_rope_cache) {
+        topology.add(input_layout("cos_sin", cos->get_layout()));
+        topology.add(rope("rope", {input_info("input"), input_info("cos_sin")}, config));
+    } else {
+        topology.add(input_layout("cos", cos->get_layout()));
+        topology.add(input_layout("sin", sin->get_layout()));
+        topology.add(rope("rope", {input_info("input"), input_info("cos"), input_info("sin")}, config));
+    }
+
+    ExecutionConfig cfg = get_test_default_config(engine);
+    if (dynamic)
+        cfg.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, cfg);
+    network.set_input_data("input", input);
+    if (variant == rope_variant::chatglm && use_rope_cache) {
+        network.set_input_data("cos_sin", cos);
+    } else {
+        network.set_input_data("cos", cos);
+        network.set_input_data("sin", sin);
+    }
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "rope");
+
+    auto output = outputs.at("rope").get_memory();
+    ASSERT_EQ(output->get_layout().get_shape(), out_shape.get_shape());
+
+    auto compare = [&](auto&& read_gpu) {
+        cldnn::mem_lock<ov::bfloat16> ref_bf16(output_ref, get_test_stream());
+        cldnn::mem_lock<ov::float16> ref_f16(output_ref, get_test_stream());
+        // BF16 ~7 mantissa bits, F16 ~10; F16 accumulates in half on GPU
+        float abs_floor = 0.02f;
+        float rel_tol = (dt == data_types::bf16) ? 0.02f : 0.04f;
+        for (size_t i = 0; i < output_ref->count(); ++i) {
+            float gpu_val = read_gpu(i);
+            float ref_val = (dt == data_types::bf16) ? static_cast<float>(ref_bf16[i])
+                                                     : static_cast<float>(ref_f16[i]);
+            float diff = std::abs(gpu_val - ref_val);
+            float tolerance = std::max(abs_floor, std::abs(ref_val) * rel_tol);
+            ASSERT_LE(diff, tolerance) << "Mismatch at i=" << i
+                << " gpu=" << gpu_val << " ref=" << ref_val << " diff=" << diff;
+        }
+    };
+
+    if (dt == data_types::bf16) {
+        cldnn::mem_lock<ov::bfloat16> out_ptr(output, get_test_stream());
+        compare([&](size_t i) { return static_cast<float>(out_ptr[i]); });
+    } else {
+        cldnn::mem_lock<ov::float16> out_ptr(output, get_test_stream());
+        compare([&](size_t i) { return static_cast<float>(out_ptr[i]); });
+    }
+}
+
+class rope_gpu_test : public ::testing::TestWithParam<data_types> {};
+
+static std::string rope_test_name(testing::TestParamInfo<data_types> info) {
+    return info.param == data_types::bf16 ? "bf16" : "f16";
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, rope_gpu_test,
+                         ::testing::Values(data_types::bf16, data_types::f16),
+                         rope_test_name);
+
+// RoPE basic RotateHalf, 2 batches x 2 heads x 4 positions x 8 dims
+TEST_P(rope_gpu_test, rope_basic) {
+    run_rope(GetParam(), ov::PartialShape{2, 2, 4, 8}, 2, 8, false, false);
+}
+
+// RoPE input_trans0213 (input [b, seq, head, HS], output [b, head, seq, HS])
+TEST_P(rope_gpu_test, rope_transpose_input) {
+    run_rope(GetParam(), ov::PartialShape{2, 4, 2, 8}, 2, 8, true, false);
+}
+
+// RoPE larger realistic shape (8 heads, 16 positions, 64 dims) - exercises the F16
+// vectorized (VEC_SIZE=16) kernel path
+TEST_P(rope_gpu_test, rope_large) {
+    run_rope(GetParam(), ov::PartialShape{1, 8, 16, 64}, 8, 64, false, false);
+}
+
+// RoPE dynamic shape (seq is dynamic)
+TEST_P(rope_gpu_test, rope_dynamic) {
+    run_rope(GetParam(), ov::PartialShape{1, 2, 4, 8}, 2, 8, false, true);
+}
+
+// RoPE interleaved variant (per-element cos/sin tables), small head - VEC_SIZE=1 path
+TEST_P(rope_gpu_test, rope_interleaved) {
+    run_rope(GetParam(), ov::PartialShape{2, 2, 4, 8}, 2, 8, false, false, rope_variant::interleaved);
+}
+
+// RoPE interleaved variant, 8 heads x 16 positions x 64 dims - VEC_SIZE=16 path
+TEST_P(rope_gpu_test, rope_interleaved_large) {
+    run_rope(GetParam(), ov::PartialShape{1, 8, 16, 64}, 8, 64, false, false, rope_variant::interleaved);
+}
+
+// RoPE QWEN per-head variant (input [b, seq, H*HS], per-head cos/sin tables), small head - VEC_SIZE=1 path
+TEST_P(rope_gpu_test, rope_qwen) {
+    run_rope(GetParam(), ov::PartialShape{2, 4, 16}, 2, 8, false, false, rope_variant::qwen_per_head);
+}
+
+// RoPE QWEN per-head variant, 8 heads x 16 positions x 64 dims - VEC_SIZE=16 path
+TEST_P(rope_gpu_test, rope_qwen_large) {
+    run_rope(GetParam(), ov::PartialShape{1, 16, 512}, 8, 64, false, false, rope_variant::qwen_per_head);
+}
+
+// RoPE ChatGLM variant (non-cache per-pair cos/sin, input [seq, batch, H*HS]), small head - VEC_SIZE=1
+TEST_P(rope_gpu_test, rope_chatglm) {
+    run_rope(GetParam(), ov::PartialShape{4, 2, 16}, 2, 8, false, false, rope_variant::chatglm);
+}
+
+// RoPE ChatGLM variant, 8 heads x 64 dims - VEC_SIZE=16 path (UNPACK_BF16_VEC, scalar
+// TO_OUTPUT_TYPE write loop, non-cache ushort8 cos/sin read)
+TEST_P(rope_gpu_test, rope_chatglm_large) {
+    run_rope(GetParam(), ov::PartialShape{16, 1, 512}, 8, 64, false, false, rope_variant::chatglm);
+}
+
+// RoPE ChatGLM variant with use_rope_cache (interleaved cos_sin table, 2 inputs), small head - VEC_SIZE=1
+TEST_P(rope_gpu_test, rope_chatglm_cache) {
+    run_rope(GetParam(), ov::PartialShape{4, 2, 16}, 2, 8, false, false, rope_variant::chatglm, true);
+}
+
+// RoPE ChatGLM variant with use_rope_cache, 8 heads x 64 dims - VEC_SIZE=16 path
+TEST_P(rope_gpu_test, rope_chatglm_cache_large) {
+    run_rope(GetParam(), ov::PartialShape{16, 1, 512}, 8, 64, false, false, rope_variant::chatglm, true);
+}


### PR DESCRIPTION
Enable BF16 in the rope_opt OCL implementation and the RoPE fusion utility (fuse_rotary_positional_embeddings: allow BF16 in the fused embedding path).

Fix rope accuracy for BF16:
- Decode inputs with the standard DECODE_INPUT0/1/2_COMPUTE_TYPE flags (same names and semantics as kernel_selector's MakeTypeJitConstants: BF16 -> proper BF16->float decode, other types -> identity), registered per input data type in rope_opt.cpp. Scalar (VEC_SIZE=1) paths of all variants (RotateHalf / QWEN / Interleaved / LTX_VIDEO) use these; bf16_utils.cl is included for the conversion helpers.
- VEC_SIZE=16 is the default for BF16 (same as F16). Vectorized paths decode ushort vectors via CONVERT_AS_BFLOAT16_FLOAT, compute in FP32 and re-encode with CONVERT_BFLOAT16_AS_USHORT (UNPACK_BF16_VEC / UNPACK_BF1616_VEC / PACK_BF1616_VEC macros), selected per-input via the new INPUT0_IS_BF16 JIT flag. ACCUMULATOR_TYPE stays float.

### Tickets:
 - [CVS-192281](https://jira.devtools.intel.com/browse/CVS-192281)

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
