### PR TITLE
[NPU] Rename DMA-BUF System Heap references to DMA-BUF file descriptor

### DIFF
--- a/docs/articles_en/assets/snippets/npu_remote_objects_creation.cpp
+++ b/docs/articles_en/assets/snippets/npu_remote_objects_creation.cpp
@@ -59,16 +59,9 @@ int main() {
 
     {
         //! [wrap_dmabuf_fd]
-        int32_t fd_heap = 0;  // create the DMA-BUF System Heap file descriptor
+        int dma_buf_fd = 0;
         ov::intel_npu::MemType memory_type = ov::intel_npu::MemType::SHARED_BUF;
-        auto remote_tensor = npu_context.create_tensor(in_element_type, in_shape, fd_heap, memory_type);
-        //! [wrap_dmabuf_fd]
-    }
-
-    {
-        //! [wrap_dmabuf_fd]
-        ov::intel_npu::FileDescriptor file_descriptor{"file_path.bin", 0};  // create the FileDescriptor
-        auto remote_tensor = npu_context.create_tensor(in_element_type, in_shape, file_descriptor);
+        auto remote_tensor = npu_context.create_tensor(in_element_type, in_shape, dma_buf_fd, memory_type);
         //! [wrap_dmabuf_fd]
     }
 

--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device/remote-tensor-api-npu-plugin.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device/remote-tensor-api-npu-plugin.rst
@@ -5,12 +5,12 @@ Remote Tensor API of NPU Plugin
 .. meta::
    :description: The Remote Tensor API of NPU plugin in OpenVINO™ supports
                  interoperability with existing native APIs, such as
-                 NT handle, or DMA-BUF System Heap, and provides mechanisms
+                 NT handle, or DMA-BUF file descriptor, and provides mechanisms
                  for mapping files into memory for efficient data access.
 
 The NPU plugin supports memory sharing between OpenVINO and native APIs such as OpenCL, Vulkan, or DirectX 12.
 It implements the ``ov::RemoteContext`` and ``ov::RemoteTensor`` interfaces, providing mechanisms for efficient memory sharing.
-On Windows, the plugin exports an NT handle; on Linux, it uses a DMA-BUF System Heap. You can share this memory by
+On Windows, the plugin exports an NT handle; on Linux, it uses a DMA-BUF file descriptor. You can share this memory by
 passing the pointer as the ``shared_buffer`` member to the ``remote_tensor(..., shared_buffer)`` create function.
 Another option is to import memory by mapping a file into memory or by using a CPU virtual address allocation. These methods
 help avoid memory copy overhead when plugging OpenVINO inference into an existing NPU pipeline.
@@ -95,7 +95,7 @@ For more details, see the code snippets below:
                :language: cpp
                :fragment: [wrap_nt_handle]
 
-         .. tab-item:: DMA-BUF System Heap file descriptor
+         .. tab-item:: DMA-BUF file descriptor
             :sync: dma-buf
 
             .. doxygensnippet:: docs/articles_en/assets/snippets/npu_remote_objects_creation.cpp

--- a/src/inference/include/openvino/runtime/intel_npu/level_zero/level_zero.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/level_zero/level_zero.hpp
@@ -125,7 +125,7 @@ public:
     }
 
     /**
-     * @brief This function is used to obtain remote tensor object from user-supplied DMA-BUF System Heap object
+     * @brief This function is used to obtain remote tensor object from user-supplied DMA-BUF file descriptor object
      * @param type Tensor element type
      * @param shape Tensor shape
      * @param fd A int object that should be wrapped by a remote tensor


### PR DESCRIPTION
### Details:
 - Correct misleading terminology in NPU remote tensor documentation and code sample, replacing "DMA-BUF System Heap" with "DMA-BUF file descriptor" to accurately reflect the underlying mechanism. Also removes an unrelated/duplicate FileDescriptor snippet block that reused the same doc fragment name, since it did not belong to this topic.

### Tickets:
- 

### AI Assistance:
 - *AI assistance used: no*
