### PR TITLE
[GHA] Fix Files Size and OVC workflow concurrency

### DIFF
--- a/.github/workflows/files_size.yml
+++ b/.github/workflows/files_size.yml
@@ -1,5 +1,5 @@
 name: Files Size
-on: [push, pull_request]
+on: [pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ovc.yml
+++ b/.github/workflows/ovc.yml
@@ -19,7 +19,8 @@ on:
       - ready_for_review
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # github.ref is not unique in post-commit
+  group: ${{ github.event_name == 'push' && github.run_id || github.ref }}-ovc
   cancel-in-progress: true
 
 permissions: read-all


### PR DESCRIPTION
### Details:
 - Remove `push` trigger from the Files Size workflow so the check runs on pull requests only; post-merge runs on `master` were cancelling in-flight PR jobs via shared concurrency groups.
 - Update OVC workflow concurrency to use per-run grouping on `push` events (same pattern as `windows_vs2022_release`), avoiding post-commit cancellations on the same ref.

### Tickets:
 - CVS-176295

### AI Assistance:
 - AI assistance used: yes
 - Cursor agent applied the workflow changes from JIRA comment on CVS-176295; human requested commit, push, and PR creation.