### PR TITLE
[NPUW]Fixed issues with Pyramid + Block-KV.

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/attention.hpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 #include "logging.hpp"  // NPUW_ASSERT
@@ -36,10 +37,18 @@ struct Attention {
     ov::Shape _mask_shape;
 
     // Per-variant KV block parameter indices.
-    // Ordered by Concat input order: [block_0_idx, ..., block_{M-1}_idx] in this variant's model.
-    // Empty in the non-block (contiguous KV) case.
-    std::vector<size_t> past_key_block_variant_param_indices;
-    std::vector<size_t> past_value_block_variant_param_indices;
+    // Ordered by Concat input order: [block_0_idx, ..., block_{M-1}_idx] in this variant's model
+    // (i.e. LOCAL indices — see global_to_local_param_idx below). Empty in the non-block
+    // (contiguous KV) case.
+    std::vector<size_t> past_key_block_local_param_indices;
+    std::vector<size_t> past_value_block_local_param_indices;
+
+    // Block mode only: global (original/full model) parameter index → this variant's LOCAL
+    // parameter index, for every parameter retained by this variant (mask, KV blocks, and
+    // everything else). Surplus KV block Parameters are removed per variant, which shifts
+    // every subsequent Parameter's index, so a direct lookup is required. Empty in
+    // contiguous mode (variants never drop parameters there).
+    std::unordered_map<size_t, size_t> global_to_local_param_idx;
 
     std::size_t query_len() const {
         // Put the mask's innermost dimension dynamic

--- a/src/plugins/intel_npu/src/plugin/npuw/attn/attn_subgraph.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/attn/attn_subgraph.cpp
@@ -579,8 +579,11 @@ ov::npuw::v1::subgraphs::RuntimeBehaviorFactory make_runtime_factory() {
                             get_behavior_io(state, ctx.subgraph_idx, get_param_base(ctx, ctx.real_subgraph_idx), 0u);
                         ensure_pyramid_selector(ctx, state);
                         const auto pyramid_id = state.pyramid_selector->pyramid_id();
-                        const std::size_t info_mask_idx = pyramid->mask_idx_at(pyramid_id);
-                        const bool is_mask = (input_idx == info_mask_idx);
+                        // Compare against the *global* (original model) mask index, not the
+                        // per-variant local one: block-mode variants may have dropped surplus
+                        // KV block parameters, shifting local indices relative to input_idx
+                        // (which is always a global/original-model index here).
+                        const bool is_mask = (input_idx == pyramid->global_mask_idx);
                         const auto& iport = compiled_model->inputs()[input_idx];
                         if (pyramid->is_block_mode()) {
                             // Block KV mode: bind block tensors directly to variant ports;
@@ -590,29 +593,25 @@ ov::npuw::v1::subgraphs::RuntimeBehaviorFactory make_runtime_factory() {
                                             pyramid_attention::Selector::Case::PREFILL &&
                                         "Pyramid block KV cache is only supported in PREFILL. "
                                         "For GENERATE use NPUW_LLM_GENERATE_PYRAMID=YES.");
-                            auto try_bind_block = [&](const std::unordered_map<size_t, size_t>& port_map) -> bool {
-                                auto it = port_map.find(input_idx);
-                                if (it == port_map.end()) {
-                                    return false;  // Not a block KV input.
-                                }
-                                // It is a block KV input. Check if this variant has a port for it.
-                                // std::numeric_limits<size_t>::max() means no port (e.g. model[0]).
-                                if (it->second == std::numeric_limits<size_t>::max()) {
-                                    return true;  // Consume silently — no set_tensor needed.
-                                }
-                                const auto& block_iport = pyramid->_compiled_models[pyramid_id]->inputs()[it->second];
-                                ctx.target_request->set_tensor(block_iport, tensor);
-                                return true;
-                            };
-                            if (try_bind_block(pyramid->key_block_port_map_at(pyramid_id)) ||
-                                try_bind_block(pyramid->val_block_port_map_at(pyramid_id))) {
-                                return true;  // Block KV input handled.
-                            }
-                            // Not a block KV input: mask is deferred to prologue(), others bind directly.
-                            if (is_mask) {
+                            // Single global->variant parameter port map covers mask, retained KV
+                            // blocks, and everything else (surplus KV block parameters may have
+                            // been dropped for this variant, shifting indices). A dropped KV block
+                            // simply has no entry here — distinguish that from "not a block input
+                            // at all" via is_key/value_block_global_idx().
+                            const auto& param_port_map = pyramid->param_port_map_at(pyramid_id);
+                            auto it = param_port_map.find(input_idx);
+                            if (it == param_port_map.end()) {
+                                NPUW_ASSERT((pyramid->is_key_block_global_idx(input_idx) ||
+                                             pyramid->is_value_block_global_idx(input_idx)) &&
+                                            "Pyramid block-mode variant is missing a parameter port mapping "
+                                            "for a non-block input; process_pyramid_model must populate "
+                                            "global_to_local_param_idx for every retained parameter");
+                                // Known KV block, but dropped for this variant — consume silently.
+                            } else if (is_mask) {
                                 io.inputs.at(input_idx) = tensor;
                             } else {
-                                ctx.target_request->set_tensor(iport, tensor);
+                                const auto& pyramid_iport = pyramid->_compiled_models[pyramid_id]->inputs()[it->second];
+                                ctx.target_request->set_tensor(pyramid_iport, tensor);
                             }
                         } else {
                             // Contiguous KV mode: look up whether input_idx is a KV param
@@ -809,10 +808,15 @@ ov::npuw::v1::subgraphs::RuntimeBehaviorFactory make_runtime_factory() {
                 case BehaviorKind::Pyramid:
                     if (const auto* pyramid = ov::npuw::attn::get_compiled_pyramid(pipeline.context)) {
                         const auto pyramid_id = state.pyramid_selector->pyramid_id();
-                        const std::size_t dyn_mask_idx = pyramid->mask_idx_at(pyramid_id);
+                        const std::size_t mask_idx_local = pyramid->mask_idx_local_at(pyramid_id);
                         const std::size_t dyn_query_size = pyramid->query_size_at(pyramid_id);
-                        auto mask_iport = pyramid->_compiled_models[pyramid_id]->inputs().at(dyn_mask_idx);
-                        const auto& graph_mask = io.inputs.at(dyn_mask_idx);
+                        auto mask_iport = pyramid->_compiled_models[pyramid_id]->inputs()[mask_idx_local];
+                        // io.inputs is indexed by the *global* (original model) input_idx — the same
+                        // index bind_function_input used when it deferred the mask tensor via
+                        // io.inputs.at(input_idx) = tensor. mask_idx_local above is the variant-LOCAL
+                        // port index and must NOT be used here (block-mode variants may have dropped
+                        // surplus KV block parameters, so local != global in general).
+                        const auto& graph_mask = io.inputs.at(pyramid->global_mask_idx);
                         const auto this_case = state.pyramid_selector->this_case();
                         const auto present_len = dyn_query_size;
                         const auto& dst = ctx.target_request->get_tensor(mask_iport);

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -145,6 +145,40 @@ std::optional<ov::npuw::function::Attention> create_attention_from_model(
     return attention;
 }
 
+// Node identity -> global (original model) parameter index, captured right after
+// Model::clone() and before any Parameters are removed from the clone. ov::Model::clone()
+// preserves parameter order 1:1 with the source model, so at that point
+// snapshot->get_parameters()[i] is exactly the clone of original_model->get_parameters()[i].
+using ClonedParamGlobalIdx = std::unordered_map<ov::Node*, size_t>;
+
+static ClonedParamGlobalIdx snapshot_cloned_param_global_idx(const std::shared_ptr<ov::Model>& freshly_cloned_model) {
+    ClonedParamGlobalIdx result;
+    const auto& params = freshly_cloned_model->get_parameters();
+    result.reserve(params.size());
+    for (size_t i = 0; i < params.size(); ++i) {
+        result[params[i].get()] = i;
+    }
+    return result;
+}
+
+// Build global (original model) parameter index -> this variant's LOCAL parameter index, for
+// every parameter this variant retained. Matches by node identity (via the snapshot taken right
+// after cloning) rather than friendly_name, since a variant may have dropped some Parameters
+// (shifting LOCAL indices) and friendly_name is not guaranteed unique.
+static std::unordered_map<size_t, size_t> build_global_to_local_param_idx(
+    const std::shared_ptr<ov::Model>& cloned_model,
+    const ClonedParamGlobalIdx& cloned_param_global_idx) {
+    std::unordered_map<size_t, size_t> global_to_local;
+    const auto& local_params = cloned_model->get_parameters();
+    for (size_t local_idx = 0; local_idx < local_params.size(); ++local_idx) {
+        auto it = cloned_param_global_idx.find(local_params[local_idx].get());
+        if (it != cloned_param_global_idx.end()) {
+            global_to_local[it->second] = local_idx;
+        }
+    }
+    return global_to_local;
+}
+
 // Collect past KV block parameter indices from a Concat node in Concat input order.
 // All inputs except the last (present_key/value) are past block params.
 // SplitKVCacheIntoBlocks may insert a Convert between each block Parameter and the Concat.
@@ -229,9 +263,6 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
                                                         const std::map<std::string, size_t>& past_key_sequence_dims,
                                                         const std::map<std::string, size_t>& past_value_sequence_dims,
                                                         bool is_block_split) {
-    // Clone the original model for modification
-    auto cloned_model = original_model->clone();
-
     // Calculate dimensions for this model
     size_t current_context_length = 0u;
     size_t current_past_length = 0u;
@@ -267,7 +298,14 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
     //   model[1]  -> Concat([block_0, present_key])  (1 past block)
     //   model[idx]-> Concat([block_0..block_{idx-1}, present_key])
     // -------------------------------------------------------------------------
+    // Clone once up front: both the block-split and non-block paths below need their own
+    // modifiable copy of the original model. Model::clone() preserves parameter order 1:1 with
+    // the source model, so snapshot the identity -> global-index correspondence right away,
+    // before shrink_concat_inputs() below removes any surplus block Parameters.
+    auto cloned_model = original_model->clone();
     if (is_block_split) {
+        const auto cloned_param_global_idx = snapshot_cloned_param_global_idx(cloned_model);
+
         const size_t num_blocks_needed = model_idx;  // model[idx] needs exactly idx past blocks
 
         // Lambda: shrink one Concat (key or value) to keep only num_blocks_needed past inputs.
@@ -383,10 +421,11 @@ std::optional<PyramidModelResult> process_pyramid_model(const std::shared_ptr<ov
         ov::npuw::function::Attention block_attention;
         block_attention._mask = mask_param;
         block_attention._mask_shape = mask_param->get_shape();
-        collect_concat_block_indices(cloned_model, shrunk_key, block_attention.past_key_block_variant_param_indices);
-        collect_concat_block_indices(cloned_model,
-                                     shrunk_value,
-                                     block_attention.past_value_block_variant_param_indices);
+        collect_concat_block_indices(cloned_model, shrunk_key, block_attention.past_key_block_local_param_indices);
+        collect_concat_block_indices(cloned_model, shrunk_value, block_attention.past_value_block_local_param_indices);
+
+        block_attention.global_to_local_param_idx =
+            build_global_to_local_param_idx(cloned_model, cloned_param_global_idx);
 
         LOG_INFO("Block-mode pyramid model[" << model_idx << "] ready: " << num_blocks_needed
                                              << " past block(s), context=" << current_context_length);
@@ -564,10 +603,52 @@ std::optional<PyramidValidationResult> validate_and_setup_pyramid_attention(cons
         std::vector<size_t> full_key_indices, full_val_indices;
         collect_concat_block_indices(model, pattern_nodes.past_key_concat_node, full_key_indices);
         collect_concat_block_indices(model, pattern_nodes.past_value_concat_node, full_val_indices);
+
+        // Total past KV length already cached = sum of each block's sequence-axis size.
+        // Needed by process_pyramid_model's GENERATE-case formula
+        // (output_len = full_context_length - query_length - full_past_kv_length); leaving
+        // this at 0 makes output_len (and thus current_context_length) too large for every
+        // pyramid model, mis-sizing the tile models fed to the device.
+        auto sum_block_kv_length = [&](const std::shared_ptr<ov::Node>& concat_node,
+                                       const std::vector<size_t>& block_indices) -> size_t {
+            auto concat_op = std::dynamic_pointer_cast<ov::op::v0::Concat>(concat_node);
+            if (!concat_op) {
+                return 0u;
+            }
+            const auto& out_shape = concat_op->get_output_partial_shape(0);
+            const auto axis = ov::util::try_normalize_axis(concat_op->get_axis(), out_shape.rank(), *concat_op);
+            const auto& params = model->get_parameters();
+            size_t total = 0u;
+            for (auto idx : block_indices) {
+                total += params[idx]->get_shape()[static_cast<size_t>(axis)];
+            }
+            return total;
+        };
+        const size_t key_past_kv_length = sum_block_kv_length(pattern_nodes.past_key_concat_node, full_key_indices);
+        const size_t value_past_kv_length = sum_block_kv_length(pattern_nodes.past_value_concat_node, full_val_indices);
+        if (key_past_kv_length != value_past_kv_length) {
+            LOG_WARN("Inconsistent past KV lengths across blocks: key=" << key_past_kv_length
+                                                                        << ", value=" << value_past_kv_length);
+            return std::nullopt;
+        }
+
+        // Global (original/full model) index of the mask parameter. Needed because pyramid
+        // variant models may drop surplus block parameters, shifting all subsequent parameter
+        // indices — the mask's LOCAL index within a variant model is generally NOT the same as
+        // its GLOBAL index here, so callers must compare against this global index instead.
+        auto mask_param = ov::npuw::util::find_mask_parameter(pattern_nodes.add_node);
+        if (!mask_param) {
+            LOG_WARN("Could not find mask parameter in original model for block-split pyramid attention");
+            return std::nullopt;
+        }
+        const size_t global_mask_idx = static_cast<size_t>(model->get_parameter_index(mask_param));
+
         return PyramidValidationBlockResult{query_length,
                                             full_context_length,
+                                            key_past_kv_length,
                                             std::move(full_key_indices),
-                                            std::move(full_val_indices)};
+                                            std::move(full_val_indices),
+                                            global_mask_idx};
     }
 
     // Pre-analyze original model to find sequence dimensions for past key/value parameters
@@ -668,6 +749,7 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
     bool is_block_split = false;
     std::vector<size_t> block_key_global_indices;
     std::vector<size_t> block_val_global_indices;
+    size_t global_mask_idx = 0;
 
     std::visit(
         [&](auto&& result) {
@@ -681,9 +763,11 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
                 is_left_aligned = result.data_left_aligned;
             } else {
                 static_assert(std::is_same_v<T, PyramidValidationBlockResult>);
+                full_past_kv_length = result.past_kv_length;
                 is_block_split = true;
                 block_key_global_indices = result.past_key_block_global_param_indices;
                 block_val_global_indices = result.past_value_block_global_param_indices;
+                global_mask_idx = result.global_mask_idx;
             }
         },
         *validation_result);
@@ -722,8 +806,14 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
             // The info structs (PyramidAttentionContiguousInfo / PyramidAttentionBlockInfo) can copy them without
             // re-scanning the graph.
             if (is_block_split) {
-                last_attention->past_key_block_variant_param_indices = block_key_global_indices;
-                last_attention->past_value_block_variant_param_indices = block_val_global_indices;
+                last_attention->past_key_block_local_param_indices = block_key_global_indices;
+                last_attention->past_value_block_local_param_indices = block_val_global_indices;
+                // The last model IS the original model: every global parameter index maps to
+                // itself (no parameters were ever dropped for this variant).
+                const auto& params = model->get_parameters();
+                for (size_t i = 0; i < params.size(); ++i) {
+                    last_attention->global_to_local_param_idx[i] = i;
+                }
             }
 
             pyramid_attentions.push_back(std::move(*last_attention));
@@ -760,6 +850,7 @@ std::optional<PyramidAttention> PyramidAttention::from(const std::shared_ptr<ov:
     // Block indices are empty in contiguous mode; assigned unconditionally for simplicity.
     pyramid_attention.past_key_block_global_param_indices = std::move(block_key_global_indices);
     pyramid_attention.past_value_block_global_param_indices = std::move(block_val_global_indices);
+    pyramid_attention.global_mask_idx = global_mask_idx;
 
     LOG_INFO("Returning pyramid attention with " << pyramid_models.size() << " models");
     LOG_INFO("  Query length: " << pyramid_attention._query_length);
@@ -784,10 +875,10 @@ const std::unordered_set<size_t>& PyramidAttentionContiguous::key_block_port_set
 const std::unordered_set<size_t>& PyramidAttentionContiguous::val_block_port_set_at(size_t) const {
     return s_empty_port_set;
 }
-const std::unordered_map<size_t, size_t>& PyramidAttentionContiguous::key_block_port_map_at(size_t) const {
-    return s_empty_port_map;
-}
-const std::unordered_map<size_t, size_t>& PyramidAttentionContiguous::val_block_port_map_at(size_t) const {
+
+const std::unordered_map<size_t, size_t>& PyramidAttentionContiguous::param_port_map_at(size_t) const {
+    // Contiguous variants share the exact same parameter set/order as the main model, so no
+    // global->local remapping is ever needed.
     return s_empty_port_map;
 }
 
@@ -828,9 +919,9 @@ void PyramidAttentionContiguous::validate_port_indices() const {
         }
         const auto inputs_size = _compiled_models[i]->inputs().size();
         const auto& info = _attention_infos[i];
-        if (info.mask_idx >= inputs_size) {
-            OPENVINO_THROW("NPU NPUW: pyramid attention mask_idx (",
-                           info.mask_idx,
+        if (info.mask_idx_local >= inputs_size) {
+            OPENVINO_THROW("NPU NPUW: pyramid attention mask_idx_local (",
+                           info.mask_idx_local,
                            ") out of bounds for model ",
                            i,
                            " with ",
@@ -903,9 +994,9 @@ void PyramidAttentionBlock::validate_port_indices() const {
         }
         const auto inputs_size = _compiled_models[i]->inputs().size();
         const auto& info = _attention_infos[i];
-        if (info.mask_idx >= inputs_size) {
-            OPENVINO_THROW("NPU NPUW: pyramid attention mask_idx (",
-                           info.mask_idx,
+        if (info.mask_idx_local >= inputs_size) {
+            OPENVINO_THROW("NPU NPUW: pyramid attention mask_idx_local (",
+                           info.mask_idx_local,
                            ") out of bounds for model ",
                            i,
                            " with ",
@@ -945,12 +1036,16 @@ std::shared_ptr<PyramidAttention> PyramidAttention::make(const function::Pyramid
             for (const auto& input : func_attn._inputs) {
                 info.params.push_back({static_cast<std::size_t>(model->get_parameter_index(input.param)), input.dim});
             }
-            info.mask_idx = static_cast<std::size_t>(model->get_parameter_index(func_attn._mask));
+            info.mask_idx_local = static_cast<std::size_t>(model->get_parameter_index(func_attn._mask));
             info.query_size = func_attn.query_len();
             info.context_length = func_attn.context_len();
             obj->_context_lengths.push_back(info.context_length);
             obj->_attention_infos.push_back(std::move(info));
         }
+        // Contiguous mode never drops parameters, so LOCAL index == GLOBAL index; any
+        // variant's mask_idx_local is valid as the shared global_mask_idx.
+        NPUW_ASSERT(!obj->_attention_infos.empty());
+        obj->global_mask_idx = obj->_attention_infos.back().mask_idx_local;
         LOG_INFO("compiled::PyramidAttentionContiguous metadata extracted");
         return obj;
     } else {
@@ -960,34 +1055,32 @@ std::shared_ptr<PyramidAttention> PyramidAttention::make(const function::Pyramid
         obj->_models_to_compile = func_pyramid._models;
         obj->past_key_block_global_param_indices = gk;
         obj->past_value_block_global_param_indices = gv;
+        obj->_key_block_global_set = std::unordered_set<size_t>(gk.begin(), gk.end());
+        obj->_value_block_global_set = std::unordered_set<size_t>(gv.begin(), gv.end());
+        obj->global_mask_idx = func_pyramid.global_mask_idx;
         obj->_attention_infos.reserve(num_models);
         obj->_context_lengths.reserve(num_models);
 
-        constexpr size_t NO_PORT = std::numeric_limits<size_t>::max();
         for (size_t i = 0; i < num_models; ++i) {
             const auto& func_attn = func_pyramid._attentions[i];
             const auto& model = func_pyramid._models[i];
             PyramidAttentionBlockInfo info;
-            info.mask_idx = static_cast<std::size_t>(model->get_parameter_index(func_attn._mask));
+            info.mask_idx_local = static_cast<std::size_t>(model->get_parameter_index(func_attn._mask));
             info.query_size = func_attn.query_len();
             info.context_length = func_attn.context_len();
+            // Covers every retained parameter (mask, retained KV blocks, everything else).
+            // A dropped KV block simply has no entry here; see
+            // PyramidAttention::is_key_block_global_idx()/is_value_block_global_idx().
+            info.param_port_map = func_attn.global_to_local_param_idx;
+            const auto& vk = func_attn.past_key_block_local_param_indices;
+            const auto& vv = func_attn.past_value_block_local_param_indices;
+            for (size_t m = 0; m < vk.size(); ++m) {
+                info.past_key_block_port_set.insert(vk[m]);
+            }
+            for (size_t m = 0; m < vv.size(); ++m) {
+                info.past_value_block_port_set.insert(vv[m]);
+            }
 
-            const auto& vk = func_attn.past_key_block_variant_param_indices;
-            const auto& vv = func_attn.past_value_block_variant_param_indices;
-            for (size_t m = 0; m < gk.size(); ++m) {
-                const size_t port = (m < vk.size()) ? vk[m] : NO_PORT;
-                info.past_key_block_port_map[gk[m]] = port;
-                if (port != NO_PORT) {
-                    info.past_key_block_port_set.insert(port);
-                }
-            }
-            for (size_t m = 0; m < gv.size(); ++m) {
-                const size_t port = (m < vv.size()) ? vv[m] : NO_PORT;
-                info.past_value_block_port_map[gv[m]] = port;
-                if (port != NO_PORT) {
-                    info.past_value_block_port_set.insert(port);
-                }
-            }
             obj->_context_lengths.push_back(info.context_length);
             obj->_attention_infos.push_back(std::move(info));
         }

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.hpp
@@ -48,10 +48,16 @@ struct PyramidValidationContiguousResult {
 struct PyramidValidationBlockResult {
     size_t query_length = 0;
     size_t full_context_length = 0;
+    // Total past KV length already cached across all N blocks (sum of each block's
+    // sequence-axis size), analogous to PyramidValidationContiguousResult::past_kv_length.
+    size_t past_kv_length = 0;
     // Parameter indices for all N past-key/value blocks in the full (original) model,
     // in Concat input order (block_0 … block_{N-1}).
     std::vector<size_t> past_key_block_global_param_indices;
     std::vector<size_t> past_value_block_global_param_indices;
+    // Global (original/full model) parameter index of the attention mask. Same across all
+    // pyramid variants (the mask parameter is never dropped, only reshaped).
+    size_t global_mask_idx = 0;
 
     bool is_valid() const {
         return query_length > 0 && full_context_length > 0 && full_context_length >= query_length &&
@@ -109,6 +115,11 @@ struct PyramidAttention {
     std::vector<size_t> past_key_block_global_param_indices;
     std::vector<size_t> past_value_block_global_param_indices;
 
+    // Global (original/full model) parameter index of the attention mask. Same across all
+    // pyramid variants (the mask parameter is never dropped, only reshaped). Populated by
+    // from() in both contiguous and block modes.
+    size_t global_mask_idx = 0;
+
     // Validation helpers
     bool is_valid() const {
         return !_models.empty() && _models.size() == _attentions.size() && _query_length > 0 &&
@@ -135,7 +146,7 @@ struct PyramidAttentionContiguousInfo {
         std::size_t dim;
     };
 
-    std::size_t mask_idx = 0u;
+    std::size_t mask_idx_local = 0u;
     std::size_t query_size = 0u;
     std::size_t context_length = 0u;
 
@@ -146,22 +157,37 @@ struct PyramidAttentionContiguousInfo {
 // Per-variant compiled metadata for block-split KV cache mode
 // (after SplitKVCacheIntoBlocks has been applied).
 // Populated by compiled::PyramidAttention constructor when block indices are present.
+//
+// Index-space convention (applies to every field below): all *keys* / bare indices are in
+// the GLOBAL (canonical/main model) index space — the same space as bind_function_input's
+// input_idx — because that's the only index space callers ever have on hand. Only the
+// *values* used to actually call set_tensor() on this variant's compiled model (map values,
+// mask_idx_local) are in this variant's own LOCAL (shifted-by-removed-blocks) index space.
 struct PyramidAttentionBlockInfo {
-    std::size_t mask_idx = 0u;
+    // LOCAL (this variant's) mask port index — an index into this variant's own compiled
+    // model, NOT the global index. Compare against PyramidAttention::global_mask_idx, never
+    // against a caller-supplied global input_idx.
+    std::size_t mask_idx_local = 0u;
     std::size_t query_size = 0u;
     std::size_t context_length = 0u;
 
-    // Precomputed direct lookup: global KV block param index → this variant's port index.
-    // std::numeric_limits<size_t>::max() means this variant has no port for that block
-    // (e.g. model[0] has 0 past blocks; model[i] has no port for blocks > i).
-    // Enables O(1) binding in bind_function_input.
-    std::unordered_map<size_t, size_t> past_key_block_port_map;
-    std::unordered_map<size_t, size_t> past_value_block_port_map;
-
-    // Precomputed set of this variant's KV block port indices.
+    // Precomputed set of this variant's LOCAL KV block port indices.
     // Used by ensure_pyramid_requests to identify block ports during request setup.
     std::unordered_set<size_t> past_key_block_port_set;
     std::unordered_set<size_t> past_value_block_port_set;
+
+    // GLOBAL input index → this variant's LOCAL input index, for ALL retained parameters
+    // (mask, KV blocks, and everything else). Built from
+    // function::Attention::global_to_local_param_idx. Required because surplus KV block
+    // Parameters are removed per variant, which shifts the index of every remaining
+    // Parameter — unlike contiguous mode, where all variants keep the same parameter
+    // order/count as the main model and indices can be reused as-is.
+    //
+    // A GLOBAL KV block index that this variant dropped has NO entry here (rather than an
+    // explicit sentinel): callers must first check PyramidAttention::is_key_block_global_idx()
+    // / is_value_block_global_idx() to tell "dropped block" apart from "not a block at all"
+    // when a lookup misses. Enables O(1) binding in bind_function_input.
+    std::unordered_map<size_t, size_t> param_port_map;
 };
 
 // Per-variant compiled metadata: exactly one of contiguous or block mode is active.
@@ -190,30 +216,50 @@ struct PyramidAttention {
     /// Temporary storage for models pending compilation; cleared by set_compiled_models().
     std::vector<std::shared_ptr<ov::Model>> _models_to_compile;
 
+    // GLOBAL (original/full model) parameter index of the attention mask. Identical across
+    // all pyramid variants (contiguous: LOCAL index equals GLOBAL index since no parameters
+    // are ever dropped; block: propagated from function::PyramidAttention::global_mask_idx).
+    // Use this — never mask_idx_local_at() — when comparing against a caller-supplied global
+    // input_idx.
+    std::size_t global_mask_idx = 0u;
+
     virtual ~PyramidAttention() = default;
 
     // Type discriminator
     virtual bool is_block_mode() const = 0;
 
-    // Shared per-variant accessors
-    virtual std::size_t mask_idx_at(size_t pyramid_id) const = 0;
+    // Shared per-variant accessors. Returns the LOCAL (this variant's) mask index — do not
+    // compare it against a global input_idx; use global_mask_idx for that.
+    virtual std::size_t mask_idx_local_at(size_t pyramid_id) const = 0;
     virtual std::size_t query_size_at(size_t pyramid_id) const = 0;
 
     // Block-mode accessors (contiguous subclass returns empty containers / zero)
     // Contiguous subclass returns empty containers / zero for all of these.
     virtual const std::unordered_set<size_t>& key_block_port_set_at(size_t pyramid_id) const = 0;
     virtual const std::unordered_set<size_t>& val_block_port_set_at(size_t pyramid_id) const = 0;
-    virtual const std::unordered_map<size_t, size_t>& key_block_port_map_at(size_t pyramid_id) const = 0;
-    virtual const std::unordered_map<size_t, size_t>& val_block_port_map_at(size_t pyramid_id) const = 0;
     virtual size_t num_key_blocks_global() const = 0;
     virtual size_t key_block_global_at(size_t block_idx) const = 0;
     virtual size_t val_block_global_at(size_t block_idx) const = 0;
+
+    // Block-mode only: true if 'idx' (a GLOBAL parameter index) is one of the KV block
+    // Parameters in the full/original model — regardless of whether this specific variant
+    // still has a port for it. Used to distinguish "this variant dropped a known KV block"
+    // (param_port_map_at() has no entry, but this returns true) from "input isn't a KV block
+    // at all" (both would return false/miss). Contiguous subclass always returns false.
+    virtual bool is_key_block_global_idx(size_t idx) const = 0;
+    virtual bool is_value_block_global_idx(size_t idx) const = 0;
 
     // Contiguous-mode KV param lookup
     // Returns the sequence dimension for input_idx in pyramid variant pyramid_id,
     // or nullopt when input_idx is not a KV param in that variant.
     // Block subclass always returns nullopt.
     virtual std::optional<std::size_t> kv_param_dim(size_t pyramid_id, size_t input_idx) const = 0;
+
+    // Block-mode only: GLOBAL input index → this variant's LOCAL parameter port index, for
+    // ALL parameters (see PyramidAttentionBlockInfo::param_port_map). Contiguous subclass
+    // returns an empty map — its variants share the exact same parameter set/order as the
+    // main model, so input_idx is already a valid LOCAL index and this lookup is unnecessary.
+    virtual const std::unordered_map<size_t, size_t>& param_port_map_at(size_t pyramid_id) const = 0;
 
     // Strides setup helper
     // Appends enable_strides_for input names for pyramid model 0 to 'out'.
@@ -248,16 +294,14 @@ struct PyramidAttentionContiguous final : PyramidAttention {
     bool is_block_mode() const override {
         return false;
     }
-    std::size_t mask_idx_at(size_t id) const override {
-        return _attention_infos[id].mask_idx;
+    std::size_t mask_idx_local_at(size_t id) const override {
+        return _attention_infos[id].mask_idx_local;
     }
     std::size_t query_size_at(size_t id) const override {
         return _attention_infos[id].query_size;
     }
     const std::unordered_set<size_t>& key_block_port_set_at(size_t) const override;
     const std::unordered_set<size_t>& val_block_port_set_at(size_t) const override;
-    const std::unordered_map<size_t, size_t>& key_block_port_map_at(size_t) const override;
-    const std::unordered_map<size_t, size_t>& val_block_port_map_at(size_t) const override;
     size_t num_key_blocks_global() const override {
         return 0u;
     }
@@ -267,7 +311,14 @@ struct PyramidAttentionContiguous final : PyramidAttention {
     size_t val_block_global_at(size_t) const override {
         return 0u;
     }
+    bool is_key_block_global_idx(size_t) const override {
+        return false;
+    }
+    bool is_value_block_global_idx(size_t) const override {
+        return false;
+    }
     std::optional<std::size_t> kv_param_dim(size_t pyramid_id, size_t input_idx) const override;
+    const std::unordered_map<size_t, size_t>& param_port_map_at(size_t) const override;
     void collect_strided_input_names(const ov::Model& model, std::string& out) const override;
     void validate_port_indices() const override;
 };
@@ -278,12 +329,15 @@ struct PyramidAttentionBlock final : PyramidAttention {
     /// Global (full-model) KV block parameter indices (block_0 … block_{N-1}).
     std::vector<size_t> past_key_block_global_param_indices;
     std::vector<size_t> past_value_block_global_param_indices;
+    /// O(1) membership views over the vectors above, for is_key/value_block_global_idx().
+    std::unordered_set<size_t> _key_block_global_set;
+    std::unordered_set<size_t> _value_block_global_set;
 
     bool is_block_mode() const override {
         return true;
     }
-    std::size_t mask_idx_at(size_t id) const override {
-        return _attention_infos[id].mask_idx;
+    std::size_t mask_idx_local_at(size_t id) const override {
+        return _attention_infos[id].mask_idx_local;
     }
     std::size_t query_size_at(size_t id) const override {
         return _attention_infos[id].query_size;
@@ -294,12 +348,6 @@ struct PyramidAttentionBlock final : PyramidAttention {
     const std::unordered_set<size_t>& val_block_port_set_at(size_t id) const override {
         return _attention_infos[id].past_value_block_port_set;
     }
-    const std::unordered_map<size_t, size_t>& key_block_port_map_at(size_t id) const override {
-        return _attention_infos[id].past_key_block_port_map;
-    }
-    const std::unordered_map<size_t, size_t>& val_block_port_map_at(size_t id) const override {
-        return _attention_infos[id].past_value_block_port_map;
-    }
     size_t num_key_blocks_global() const override {
         return past_key_block_global_param_indices.size();
     }
@@ -309,8 +357,17 @@ struct PyramidAttentionBlock final : PyramidAttention {
     size_t val_block_global_at(size_t i) const override {
         return past_value_block_global_param_indices[i];
     }
+    bool is_key_block_global_idx(size_t idx) const override {
+        return _key_block_global_set.count(idx) != 0;
+    }
+    bool is_value_block_global_idx(size_t idx) const override {
+        return _value_block_global_set.count(idx) != 0;
+    }
     std::optional<std::size_t> kv_param_dim(size_t, size_t) const override {
         return std::nullopt;
+    }
+    const std::unordered_map<size_t, size_t>& param_port_map_at(size_t id) const override {
+        return _attention_infos[id].param_port_map;
     }
     void collect_strided_input_names(const ov::Model&, std::string&) const override {}  // no-op
     void validate_port_indices() const override;

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.cpp
@@ -81,12 +81,14 @@ void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::Attention::Par
 }
 
 void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionContiguous& var) {
-    stream & var.query_size & var.full_context_size & var._context_lengths & var._attention_infos;
+    stream & var.query_size & var.full_context_size & var._context_lengths & var._attention_infos &
+        var.global_mask_idx & var._data_left_aligned;
 }
 
 void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionBlock& var) {
     stream & var.query_size & var.full_context_size & var._context_lengths & var._attention_infos &
-        var.past_key_block_global_param_indices & var.past_value_block_global_param_indices;
+        var.past_key_block_global_param_indices & var.past_value_block_global_param_indices & var.global_mask_idx &
+        var._data_left_aligned;
 }
 
 void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::PyramidAttention& var) {
@@ -108,12 +110,18 @@ std::shared_ptr<ov::npuw::compiled::PyramidAttention> ov::npuw::orc::make_pyrami
         NPUW_ASSERT(tag == 1u && "Unknown PyramidAttention serialization tag");
         auto obj = std::make_shared<ov::npuw::compiled::PyramidAttentionBlock>();
         serialize(stream, *obj);
+        // Rebuild the O(1) membership sets — not serialized directly, derived from the
+        // (serialized) ordered global block index vectors.
+        obj->_key_block_global_set = std::unordered_set<size_t>(obj->past_key_block_global_param_indices.begin(),
+                                                                obj->past_key_block_global_param_indices.end());
+        obj->_value_block_global_set = std::unordered_set<size_t>(obj->past_value_block_global_param_indices.begin(),
+                                                                  obj->past_value_block_global_param_indices.end());
         return obj;
     }
 }
 
 void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionContiguousInfo& var) {
-    stream & var.params & var.mask_idx & var.query_size & var.context_length;
+    stream & var.params & var.mask_idx_local & var.query_size & var.context_length;
 }
 
 void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionContiguousInfo::Param& var) {
@@ -121,8 +129,8 @@ void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::PyramidAttenti
 }
 
 void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::PyramidAttentionBlockInfo& var) {
-    stream & var.mask_idx & var.query_size & var.context_length & var.past_key_block_port_map &
-        var.past_value_block_port_map & var.past_key_block_port_set & var.past_value_block_port_set;
+    stream & var.mask_idx_local & var.query_size & var.context_length & var.param_port_map &
+        var.past_key_block_port_set & var.past_value_block_port_set;
 }
 
 void ov::npuw::orc::serialize(Stream& stream, ov::npuw::compiled::HostFlashAttention& var) {

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -52,7 +52,7 @@ const constexpr ov::npuw::s11n::IndicatorType NPUW_GQA_COMPILED_MODEL_INDICATOR 
 const constexpr ov::npuw::s11n::IndicatorType NPUW_FLUX2_COMPILED_MODEL_INDICATOR =
     {char{0x46}, char{0x4c}, char{0x32}, char{0x43}, char{0x4d}, char{0x4f}};
 
-const constexpr char* NPUW_SERIALIZATION_VERSION = "0.30";
+const constexpr char* NPUW_SERIALIZATION_VERSION = "0.31";
 
 // Forward declaration
 namespace intel_npu {

--- a/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_test.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "pyramid_attention.hpp"
+
 #include <gtest/gtest.h>
 
 #include <map>
@@ -11,6 +13,8 @@
 #include <vector>
 
 #include "attn/attn_subgraph.hpp"
+#include "npuw_transformations/convert_kvcache_to_precision.hpp"
+#include "npuw_transformations/split_kvcache_into_blocks.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
@@ -19,11 +23,9 @@
 #include "openvino/op/result.hpp"
 #include "openvino/op/softmax.hpp"
 #include "openvino/openvino.hpp"
-#include "npuw_transformations/convert_kvcache_to_precision.hpp"
-#include "npuw_transformations/split_kvcache_into_blocks.hpp"
-#include "pyramid_attention.hpp"
 #include "serialization.hpp"
 #include "util.hpp"
+#include "v1/subgraph_pipeline.hpp"
 
 namespace {
 
@@ -124,9 +126,8 @@ const ov::npuw::function::PyramidValidationBlockResult& get_block_result(
     return std::get<ov::npuw::function::PyramidValidationBlockResult>(validation);
 }
 // Helper function to apply SplitKVCacheIntoBlocks transformation
-std::shared_ptr<ov::Model> apply_split_kvcache_into_blocks(
-    const std::shared_ptr<ov::Model>& model,
-    uint32_t block_size = 32) {
+std::shared_ptr<ov::Model> apply_split_kvcache_into_blocks(const std::shared_ptr<ov::Model>& model,
+                                                           uint32_t block_size = 32) {
     auto cloned = model->clone();
     // Use v_transposed=false to match test model structure where both key and value use axis 2
     ov::npuw::pass::SplitKVCacheIntoBlocks(block_size, false).run_on_model(cloned);
@@ -142,7 +143,7 @@ TEST(PyramidAttentionTest, ValidateSucceedsOnValidAttentionModel) {
 
     auto result = ov::npuw::function::validate_and_setup_pyramid_attention(model);
     ASSERT_TRUE(result.has_value());
-    
+
     const auto& contiguous = get_contiguous_result(*result);
     EXPECT_TRUE(contiguous.is_valid());
     EXPECT_EQ(contiguous.query_length, 1u);
@@ -162,18 +163,19 @@ TEST(PyramidAttentionTest, ValidateExtractsCorrectSequenceDimForSingleLayer) {
 
     ASSERT_TRUE(result.has_value()) << "Validation failed for single-layer model";
     const auto& contiguous = get_contiguous_result(*result);
-    
+
     // Concat axis is 2 (sequence dim)
     auto key_it = contiguous.past_key_sequence_dims.find("past_key_values.0.key");
-    EXPECT_NE(key_it, contiguous.past_key_sequence_dims.end()) 
+    EXPECT_NE(key_it, contiguous.past_key_sequence_dims.end())
         << "Key 'past_key_values.0.key' not found. Map has " << contiguous.past_key_sequence_dims.size() << " entries.";
     if (key_it != contiguous.past_key_sequence_dims.end()) {
         EXPECT_EQ(key_it->second, 2u);
     }
-    
+
     auto val_it = contiguous.past_value_sequence_dims.find("past_key_values.0.value");
     EXPECT_NE(val_it, contiguous.past_value_sequence_dims.end())
-        << "Key 'past_key_values.0.value' not found. Map has " << contiguous.past_value_sequence_dims.size() << " entries.";
+        << "Key 'past_key_values.0.value' not found. Map has " << contiguous.past_value_sequence_dims.size()
+        << " entries.";
     if (val_it != contiguous.past_value_sequence_dims.end()) {
         EXPECT_EQ(val_it->second, 2u);
     }
@@ -183,16 +185,16 @@ TEST(PyramidAttentionTest, DebugRegexPatternMatching) {
     // Verify that our regex patterns match expected parameter names
     EXPECT_TRUE(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.0.key").has_value());
     EXPECT_EQ(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.0.key").value(), 0);
-    
+
     EXPECT_TRUE(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.1.key").has_value());
     EXPECT_EQ(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.1.key").value(), 1);
-    
+
     EXPECT_TRUE(ov::npuw::util::isPastKeyValuesValueContiguous("past_key_values.0.value").has_value());
     EXPECT_EQ(ov::npuw::util::isPastKeyValuesValueContiguous("past_key_values.0.value").value(), 0);
-    
+
     EXPECT_TRUE(ov::npuw::util::isPastKeyValuesValueContiguous("past_key_values.1.value").has_value());
     EXPECT_EQ(ov::npuw::util::isPastKeyValuesValueContiguous("past_key_values.1.value").value(), 1);
-    
+
     // Should NOT match
     EXPECT_FALSE(ov::npuw::util::isPastKeyValuesKeyContiguous("query.0").has_value());
     EXPECT_FALSE(ov::npuw::util::isPastKeyValuesKeyContiguous("past_key_values.0.key_block_0").has_value());
@@ -557,8 +559,7 @@ TEST(PyramidAttentionTest, ProcessPyramidModelAfterI8KVCacheConversion) {
                                                             contiguous.past_key_sequence_dims,
                                                             contiguous.past_value_sequence_dims);
 
-    ASSERT_TRUE(result.has_value())
-        << "process_pyramid_model should succeed after i8 KV cache conversion";
+    ASSERT_TRUE(result.has_value()) << "process_pyramid_model should succeed after i8 KV cache conversion";
 }
 
 TEST(PyramidAttentionTest, ProcessPyramidModelI8IncludesDQParamsInAttentionInputs) {
@@ -669,15 +670,17 @@ TEST(PyramidAttentionTest, DebugBlockModeTransformation) {
         const auto& name = param->get_friendly_name();
         if (name.find("_block_") != std::string::npos) {
             block_params++;
-            if (name.find("_block_0") != std::string::npos) found_block_0 = true;
-            if (name.find("_block_tail") != std::string::npos) found_block_tail = true;
+            if (name.find("_block_0") != std::string::npos)
+                found_block_0 = true;
+            if (name.find("_block_tail") != std::string::npos)
+                found_block_tail = true;
         }
     }
-    
+
     EXPECT_TRUE(found_block_0) << "Block 0 parameters not found after split";
     EXPECT_TRUE(found_block_tail) << "Block tail parameters not found after split";
     EXPECT_GE(block_params, 4u) << "Expected at least 4 block params (2 keys + 2 values), got " << block_params;
-    
+
     // Verify that original contiguous parameters were removed
     for (const auto& param : block_model->get_parameters()) {
         const auto& name = param->get_friendly_name();
@@ -698,7 +701,7 @@ TEST(PyramidAttentionTest, ValidateSucceedsOnBlockModeModel) {
 
     // After block split, model should validate and return PyramidValidationBlockResult
     auto result = ov::npuw::function::validate_and_setup_pyramid_attention(block_model);
-    
+
     ASSERT_TRUE(result.has_value());
     const auto& block_result = get_block_result(*result);
     EXPECT_TRUE(block_result.is_valid());
@@ -718,6 +721,58 @@ TEST(PyramidAttentionTest, ValidateExtractsCorrectBlockIndicesForSingleLayer) {
     const auto& block_result = get_block_result(*result);
     EXPECT_EQ(block_result.past_key_block_global_param_indices.size(), 1u);
     EXPECT_EQ(block_result.past_value_block_global_param_indices.size(), 1u);
+}
+
+// Regression test using real production values (query=1024, past_kv=3072, step=1024,
+// 4 models): a regression to full_past_kv_length=0 would make every context length below
+// wrong (too large), mis-sizing the tile models fed to the device.
+TEST(PyramidAttentionTest, ProcessBlockModeMatchesReportedProductionScenario) {
+    AttentionModelConfig cfg;
+    cfg.query_len = 1024;
+    cfg.past_len = 3072;
+    auto model = build_isolated_attention_model(cfg);
+
+    const uint32_t kv_step = 1024;
+    auto block_model = apply_split_kvcache_into_blocks(model, kv_step);
+
+    auto validation = ov::npuw::function::validate_and_setup_pyramid_attention(block_model);
+    ASSERT_TRUE(validation.has_value());
+    const auto& block_result = get_block_result(*validation);
+    ASSERT_EQ(block_result.past_key_block_global_param_indices.size(), 3u);
+    ASSERT_EQ(block_result.past_value_block_global_param_indices.size(), 3u);
+    EXPECT_EQ(block_result.query_length, 1024u);
+    EXPECT_EQ(block_result.full_context_length, 4096u);
+    EXPECT_EQ(block_result.past_kv_length, 3072u);
+
+    const size_t pyramid_step = 1024;
+    const size_t num_models = block_result.full_context_length / pyramid_step;
+    ASSERT_EQ(num_models, 4u);
+
+    const std::vector<size_t> expected_context_lengths = {1024u, 2048u, 3072u};
+    for (size_t model_idx = 0; model_idx < num_models - 1; ++model_idx) {
+        auto result = ov::npuw::function::process_pyramid_model(block_model,
+                                                                model_idx,
+                                                                pyramid_step,
+                                                                block_result.query_length,
+                                                                block_result.past_kv_length,
+                                                                block_result.full_context_length,
+                                                                {},
+                                                                {},
+                                                                true);
+        ASSERT_TRUE(result.has_value()) << "Failed to process pyramid model " << model_idx;
+        EXPECT_EQ(result->attention.context_len(), expected_context_lengths[model_idx])
+            << "Unexpected context length for model " << model_idx;
+    }
+
+    // End-to-end check: PyramidAttention::from() must reproduce the same context lengths.
+    auto pyramid = ov::npuw::function::PyramidAttention::from(block_model);
+    ASSERT_TRUE(pyramid.has_value());
+    ASSERT_EQ(pyramid->num_models(), num_models);
+    for (size_t model_idx = 0; model_idx < num_models - 1; ++model_idx) {
+        EXPECT_EQ(pyramid->_attentions[model_idx].context_len(), expected_context_lengths[model_idx])
+            << "Unexpected context length for model " << model_idx;
+    }
+    EXPECT_EQ(pyramid->_attentions.back().context_len(), block_result.full_context_length);
 }
 
 TEST(PyramidAttentionTest, ProcessPyramidModelSucceedsForBlockModePrefillCase) {
@@ -958,7 +1013,7 @@ TEST(PyramidAttentionTest, ValidPortIndicesPassValidation) {
     src.full_context_size = 64;
     src._context_lengths = {64};
     ov::npuw::compiled::PyramidAttentionContiguousInfo info;
-    info.mask_idx = 2;
+    info.mask_idx_local = 2;
     info.params = {{1, 0}};
     src._attention_infos = {info};
 
@@ -982,7 +1037,7 @@ TEST(PyramidAttentionTest, MalformedSerializedPyramidStateIsRejectedOnDeserializ
     src->full_context_size = 64;
     src->_context_lengths = {64};
     ContigInfo info;
-    info.mask_idx = 0xFF;
+    info.mask_idx_local = 0xFF;
     src->_attention_infos = {info};
     src->_compiled_models = {stub_model};
 
@@ -1017,7 +1072,7 @@ TEST(PyramidAttentionTest, ZeroModelPyramidStateIsRejectedOnDeserialize) {
     src.full_context_size = 64;
     src._context_lengths = {64};
     ContigInfo info;
-    info.mask_idx = 0;
+    info.mask_idx_local = 0;
     src._attention_infos = {info};
 
     std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
@@ -1065,7 +1120,7 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.full_context_size = 64;
         src._context_lengths = {64};
         ContigInfo info;
-        info.mask_idx = 0xFF;
+        info.mask_idx_local = 0xFF;
         src._attention_infos = {info};
         expect_invalid_port_indices_rejected(src, 0u, {3}, "mask_idx out of range");
     }
@@ -1076,7 +1131,7 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.full_context_size = 64;
         src._context_lengths = {64};
         ContigInfo info;
-        info.mask_idx = 0;
+        info.mask_idx_local = 0;
         info.params = {{0xFFFFFFFF, 0}};
         src._attention_infos = {info};
         expect_invalid_port_indices_rejected(src, 0u, {3}, "param idx out of range");
@@ -1088,7 +1143,7 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.full_context_size = 64;
         src._context_lengths = {64};
         BlockInfo info;
-        info.mask_idx = 0xFF;
+        info.mask_idx_local = 0xFF;
         src._attention_infos = {info};
         expect_invalid_port_indices_rejected(src, 1u, {4}, "block mask idx out of range");
     }
@@ -1101,7 +1156,7 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.past_key_block_global_param_indices = {0, 1};
         src.past_value_block_global_param_indices = {0};
         BlockInfo info;
-        info.mask_idx = 0;
+        info.mask_idx_local = 0;
         src._attention_infos = {info};
         expect_invalid_port_indices_rejected(src, 1u, {4}, "block global key/value length mismatch");
     }
@@ -1114,7 +1169,7 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.past_key_block_global_param_indices = {7};
         src.past_value_block_global_param_indices = {0};
         BlockInfo info;
-        info.mask_idx = 0;
+        info.mask_idx_local = 0;
         src._attention_infos = {info};
         expect_invalid_port_indices_rejected(src, 1u, {4}, "block key global idx out of range");
     }
@@ -1127,7 +1182,7 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.past_key_block_global_param_indices = {0};
         src.past_value_block_global_param_indices = {7};
         BlockInfo info;
-        info.mask_idx = 0;
+        info.mask_idx_local = 0;
         src._attention_infos = {info};
         expect_invalid_port_indices_rejected(src, 1u, {4}, "block value global idx out of range");
     }
@@ -1140,7 +1195,7 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.past_key_block_global_param_indices = {0};
         src.past_value_block_global_param_indices = {0};
         BlockInfo info;
-        info.mask_idx = 0;
+        info.mask_idx_local = 0;
         src._attention_infos = {info};
 
         auto pyramid = import_pyramid_from_stream(src, 1u);
@@ -1157,7 +1212,7 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.full_context_size = 64;
         src._context_lengths = {64};
         ContigInfo info;
-        info.mask_idx = 0;
+        info.mask_idx_local = 0;
         src._attention_infos = {info};
         // Model count mismatches the serialized attention info count.
         auto pyramid = import_pyramid_from_stream(src, 0u);

--- a/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
@@ -261,11 +261,13 @@ void expect_pyramid_attention_equal(const ov::npuw::compiled::PyramidAttentionCo
     EXPECT_EQ(expected.query_size, actual.query_size);
     EXPECT_EQ(expected.full_context_size, actual.full_context_size);
     EXPECT_EQ(expected._context_lengths, actual._context_lengths);
+    EXPECT_EQ(expected.global_mask_idx, actual.global_mask_idx);
+    EXPECT_EQ(expected._data_left_aligned, actual._data_left_aligned);
     ASSERT_EQ(expected._attention_infos.size(), actual._attention_infos.size());
     for (std::size_t i = 0; i < expected._attention_infos.size(); ++i) {
         const auto& lhs = expected._attention_infos[i];
         const auto& rhs = actual._attention_infos[i];
-        EXPECT_EQ(lhs.mask_idx, rhs.mask_idx);
+        EXPECT_EQ(lhs.mask_idx_local, rhs.mask_idx_local);
         EXPECT_EQ(lhs.query_size, rhs.query_size);
         EXPECT_EQ(lhs.context_length, rhs.context_length);
         EXPECT_EQ(lhs.params.size(), rhs.params.size());
@@ -283,15 +285,16 @@ void expect_pyramid_attention_equal(const ov::npuw::compiled::PyramidAttentionBl
     EXPECT_EQ(expected._context_lengths, actual._context_lengths);
     EXPECT_EQ(expected.past_key_block_global_param_indices, actual.past_key_block_global_param_indices);
     EXPECT_EQ(expected.past_value_block_global_param_indices, actual.past_value_block_global_param_indices);
+    EXPECT_EQ(expected.global_mask_idx, actual.global_mask_idx);
+    EXPECT_EQ(expected._data_left_aligned, actual._data_left_aligned);
     ASSERT_EQ(expected._attention_infos.size(), actual._attention_infos.size());
     for (std::size_t i = 0; i < expected._attention_infos.size(); ++i) {
         const auto& lhs = expected._attention_infos[i];
         const auto& rhs = actual._attention_infos[i];
-        EXPECT_EQ(lhs.mask_idx, rhs.mask_idx);
+        EXPECT_EQ(lhs.mask_idx_local, rhs.mask_idx_local);
         EXPECT_EQ(lhs.query_size, rhs.query_size);
         EXPECT_EQ(lhs.context_length, rhs.context_length);
-        EXPECT_EQ(lhs.past_key_block_port_map, rhs.past_key_block_port_map);
-        EXPECT_EQ(lhs.past_value_block_port_map, rhs.past_value_block_port_map);
+        EXPECT_EQ(lhs.param_port_map, rhs.param_port_map);
         EXPECT_EQ(lhs.past_key_block_port_set, rhs.past_key_block_port_set);
         EXPECT_EQ(lhs.past_value_block_port_set, rhs.past_value_block_port_set);
     }
@@ -718,16 +721,18 @@ TEST(SerializationTest, OVTypes_PyramidAttention) {
     var.query_size = 16;
     var.full_context_size = 128;
     var._context_lengths = {16, 32, 64, 128};
+    var.global_mask_idx = 4;
+    var._data_left_aligned = true;
 
     ov::npuw::compiled::PyramidAttentionContiguousInfo info1;
     info1.params = {{0, 2}, {1, 3}};
-    info1.mask_idx = 4;
+    info1.mask_idx_local = 4;
     info1.query_size = 16;
     info1.context_length = 32;
 
     ov::npuw::compiled::PyramidAttentionContiguousInfo info2;
     info2.params = {{2, 1}};
-    info2.mask_idx = 5;
+    info2.mask_idx_local = 5;
     info2.query_size = 16;
     info2.context_length = 64;
 
@@ -752,28 +757,22 @@ TEST(SerializationTest, OVTypes_PyramidAttention_BlockMode) {
     var._context_lengths = {16, 32, 64, 128};
     var.past_key_block_global_param_indices = {10, 11, 12};
     var.past_value_block_global_param_indices = {20, 21, 22};
+    var.global_mask_idx = 4;
+    var._data_left_aligned = true;
 
     ov::npuw::compiled::PyramidAttentionBlockInfo info1;
-    info1.mask_idx = 4;
+    info1.mask_idx_local = 4;
     info1.query_size = 16;
     info1.context_length = 32;
-    info1.past_key_block_port_map = {{10, std::numeric_limits<size_t>::max()},
-                                     {11, std::numeric_limits<size_t>::max()},
-                                     {12, std::numeric_limits<size_t>::max()}};
-    info1.past_value_block_port_map = {{20, std::numeric_limits<size_t>::max()},
-                                       {21, std::numeric_limits<size_t>::max()},
-                                       {22, std::numeric_limits<size_t>::max()}};
+    // This variant dropped all KV blocks — no entries for global indices 10/11/12/20/21/22.
+    info1.param_port_map = {{4, 4}};
 
     ov::npuw::compiled::PyramidAttentionBlockInfo info2;
-    info2.mask_idx = 5;
+    info2.mask_idx_local = 5;
     info2.query_size = 16;
     info2.context_length = 64;
-    info2.past_key_block_port_map = {{10, 0},
-                                     {11, std::numeric_limits<size_t>::max()},
-                                     {12, std::numeric_limits<size_t>::max()}};
-    info2.past_value_block_port_map = {{20, 1},
-                                       {21, std::numeric_limits<size_t>::max()},
-                                       {22, std::numeric_limits<size_t>::max()}};
+    // This variant retained one K block (global 10 -> local 0) and one V block (global 20 -> local 1).
+    info2.param_port_map = {{4, 5}, {10, 0}, {20, 1}};
     info2.past_key_block_port_set = {0};
     info2.past_value_block_port_set = {1};
 
@@ -787,6 +786,49 @@ TEST(SerializationTest, OVTypes_PyramidAttention_BlockMode) {
     read(ss, res);
 
     expect_pyramid_attention_equal(var, res);
+}
+
+// make_pyramid_from_stream() rebuilds _key_block_global_set / _value_block_global_set from the
+// (serialized) ordered global block index vectors rather than serializing them directly. Exercise
+// that exact factory path (tag + orc::serialize/make_pyramid_from_stream), which the round-trip
+// test above bypasses, and verify the rebuilt sets answer is_key_block_global_idx() /
+// is_value_block_global_idx() correctly.
+TEST(SerializationTest, OVTypes_PyramidAttention_BlockMode_RebuildsGlobalBlockSets) {
+    using namespace ov::npuw::s11n;
+
+    ov::npuw::compiled::PyramidAttentionBlock var;
+    var.query_size = 16;
+    var.full_context_size = 128;
+    var._context_lengths = {16, 32, 64, 128};
+    var.past_key_block_global_param_indices = {10, 11, 12};
+    var.past_value_block_global_param_indices = {20, 21, 22};
+    var.global_mask_idx = 4;
+    var._data_left_aligned = true;
+
+    std::stringstream ss;
+    {
+        auto stream_io = Stream::writer(ss);
+        ov::npuw::orc::serialize(stream_io, static_cast<ov::npuw::compiled::PyramidAttention&>(var));
+    }
+
+    std::shared_ptr<ov::npuw::compiled::PyramidAttention> res;
+    {
+        auto stream_io = Stream::reader(ss);
+        res = ov::npuw::orc::make_pyramid_from_stream(stream_io, /*tag=*/1u);
+    }
+
+    ASSERT_TRUE(res);
+    ASSERT_TRUE(res->is_block_mode());
+    EXPECT_TRUE(res->is_key_block_global_idx(10));
+    EXPECT_TRUE(res->is_key_block_global_idx(11));
+    EXPECT_TRUE(res->is_key_block_global_idx(12));
+    EXPECT_FALSE(res->is_key_block_global_idx(20));  // 20 is a value block, not a key block
+    EXPECT_TRUE(res->is_value_block_global_idx(20));
+    EXPECT_TRUE(res->is_value_block_global_idx(21));
+    EXPECT_TRUE(res->is_value_block_global_idx(22));
+    EXPECT_FALSE(res->is_value_block_global_idx(10));  // 10 is a key block, not a value block
+    EXPECT_FALSE(res->is_key_block_global_idx(999));
+    EXPECT_FALSE(res->is_value_block_global_idx(999));
 }
 
 TEST(SerializationTest, OVTypes_HostFlashAttention) {
@@ -1021,14 +1063,14 @@ TEST(SerializationTest, OVTypes_Tensor_weightless_mmap_oob_overflow) {
     // reads it (serialize_weightless, is_weightless branch):
     //   size, is_initialized, is_weightless, type_str, shape, byte_size, offset
     std::stringstream ss;
-    write(ss, std::size_t(1));    // one tensor in the vector
-    write(ss, true);              // is_initialized
-    write(ss, true);              // is_weightless
-    write(ss, std::string("u8"));  // element type -> 1 byte / element
-    write(ss, ov::Shape{4});      // destination tensor: 4 bytes only
+    write(ss, std::size_t(1));                         // one tensor in the vector
+    write(ss, true);                                   // is_initialized
+    write(ss, true);                                   // is_weightless
+    write(ss, std::string("u8"));                      // element type -> 1 byte / element
+    write(ss, ov::Shape{4});                           // destination tensor: 4 bytes only
     const std::size_t attacker_byte_size = 64 * 1024;  // >> dest (4) and >> weights file (8)
-    write(ss, attacker_byte_size);  // byte_size  (attacker-controlled, unchecked)
-    write(ss, std::size_t(0));    // offset      (attacker-controlled, unchecked)
+    write(ss, attacker_byte_size);                     // byte_size  (attacker-controlled, unchecked)
+    write(ss, std::size_t(0));                         // offset      (attacker-controlled, unchecked)
 
     // Tiny backing "weights" file: only 8 bytes get mmapped.
     std::filesystem::path file_path = ov::test::utils::generateTestFilePrefix() + "_npuw_oob_weights.bin";


### PR DESCRIPTION
### Details:
Partial changes in https://github.com/openvinotoolkit/openvino/pull/37609

**Bug 1 fix: populate past_kv_length in block mode**
**Problem**: In block-split KV cache (pyramid attention) mode, PyramidValidationBlockResult::past_kv_length was never computed (left at 0). This value feeds process_pyramid_model's formula and we will always create 1 pyramid variant with the maximum history size.

**Fix**: Added sum_block_kv_length() helper that sums each retained past-KV block's sequence-axis size (via the block Concat node's axis + parameter shapes) for both key and value blocks, validates key/value totals match (bails out with a warning if inconsistent), and threads the result into PyramidValidationBlockResult::past_kv_length → PyramidAttention::from().

**Bug 2 fix: build global→variant parameter mapping**
**Problem**: Block-mode pyramid attention variants can drop surplus KV-block Parameters, which shifts the index of every remaining parameter in that variant's compiled sub-model (LOCAL index ≠ GLOBAL/original-model index). There was no reliable, complete GLOBAL→LOCAL mapping for all parameters (only partial per-KV-block maps existed), and the mask index (mask_idx) was ambiguously used as both a global and local index, causing incorrect input binding in bind_function_input.

**Fix**:
1. Renamed mask_idx → mask_idx_local everywhere (contiguous & block info structs) to make clear it's variant-local; added global_mask_idx on PyramidValidationBlockResult and on compiled::PyramidAttention base struct as the single source of truth for the mask's GLOBAL index, populated in both contiguous (LOCAL == GLOBAL, no drops) and block modes.
2. Added PyramidAttentionBlockInfo::param_port_map (GLOBAL input idx → this variant's LOCAL port idx, for all parameters, not just KV blocks), built from a new function::Attention::global_to_local_param_idx, and populated for the "last model" (full/undropped variant) by mapping every global index to itself.
3. Added param_port_map_at() virtual accessor (block mode returns the real map; contiguous mode returns an empty map since no remapping is ever needed).
4. Renamed past_key/value_block_variant_param_indices → past_key/value_block_local_param_indices for clarity.
5. Updated serialization.cpp field names accordingly (mask_idx → mask_idx_local).

**Validation**:
https://cje-ir-prod01.devtools.intel.com/sai-npu-experience/job/Staging/job/xiong/job/Validate/93/Validation_20report/

Phi3 accuracy issue clarify:
https://jira.devtools.intel.com/browse/EISW-231454?focusedId=30640122&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-30640122


### Tickets:
 - *[EISW-231454](https://jira.devtools.intel.com/browse/EISW-231454)*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
