### PR TITLE
[GPU] Enable sdpa_micro in PA MIXED stage with token_type_ids

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1382,11 +1382,15 @@ public:
         return false;
     }
 
+    // MIXED may use micro SDPA regardless of token_type_ids: bidirectional masking is implemented
+    // only in the PREFILL kernels, and in MIXED neither micro SDPA nor paged_attention_opt.cl consumes token_type_ids.
+    // TODO: implement bidirectional attention for MIXED with token_type_ids
     bool can_use_micro_sdpa_for(const kernel_impl_params& params, const PagedAttentionStage& stage) const {
-        if (!supports_micro_sdpa(params) || !valid_micro_stage(stage))
-            return false;
-        const auto desc = params.typed_desc<paged_attention>();
-        return !desc->has_token_type_ids || stage == PagedAttentionStage::PREFILL;
+        const auto can_use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(stage);
+        GPU_DEBUG_TRACE_DETAIL << "can_use_micro_sdpa_for: stage = " << static_cast<size_t>(stage)
+                               << ", token_type_ids = " << params.get_input_layout(PagedAttentionInputIdx::TOKEN_TYPE_IDS).to_short_string()
+                               << ", can_use_micro_sdpa = " << can_use_micro_sdpa << std::endl;
+        return can_use_micro_sdpa;
     }
 
     bool supports_micro_sdpa(const kernel_impl_params& params) const {

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/update_shape_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/update_shape_test.cpp
@@ -353,7 +353,7 @@ TEST(update_shape_test, max_context_len_shapeof_subgraph) {
     ASSERT_EQ(broadcast_shape, ov::Shape{8});
 }
 
-TEST(update_shape_test, paged_attention_mixed_stage_token_type_ids_disables_micro_layout) {
+TEST(update_shape_test, paged_attention_mixed_stage_token_type_ids_buffer_layout) {
     tests::random_generator rg(GET_SUITE_NAME);
     auto& engine = get_test_engine();
 
@@ -570,6 +570,10 @@ TEST(update_shape_test, paged_attention_mixed_stage_token_type_ids_disables_micr
 
     auto pa_inst = network.get_primitive("paged_attention");
     const auto& intermediate_mems = pa_inst->get_intermediates_memories();
-    ASSERT_EQ(intermediate_mems.size(), 7u);
+
+    // Allocation-time and execution-time micro/non-micro decisions must agree; a mismatch shows up
+    // as the wrong buffer count. token_type_ids no longer forces the non-micro path in MIXED.
+    const bool micro_layout = engine.get_device_info().supports_immad;
+    ASSERT_EQ(intermediate_mems.size(), micro_layout ? 4u : 7u);
 }
 }  // update_shape_test

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_token_type_gpu_test.cpp
@@ -151,4 +151,122 @@ INSTANTIATE_TEST_SUITE_P(smoke_paged_attention_token_type_micro_sdpa_prefill,
                          paged_attention_token_type_micro_sdpa_prefill_test,
                          ::testing::ValuesIn(make_micro_sdpa_prefill_test_params()),
                          get_micro_sdpa_prefill_test_name);
+
+// Micro SDPA in the MIXED stage while token_type_ids is present. MIXED used to fall back to
+// paged_attention_opt__multi_tokens, which carries no token_type_ids handling of its own, so the
+// fallback only ever cost performance.
+//
+// The PREFILL golden data is replayed as a chunked prefill:
+//
+//            |<----- past_len ----->|<---- num_tokens ---->|
+//     k, v   | preloaded into cache | passed as input      |
+//     q      | -                    | passed as input      |
+//     golden | -                    | compared             |
+//
+// past_len is picked so the query chunk holds text tokens only. A bidirectional pair needs both the
+// query and the key to be image tokens, so a text-only chunk is masked purely causally - which is
+// what both MIXED kernels produce, neither of them implementing token_type_ids.
+class paged_attention_token_type_micro_sdpa_mixed_test : public paged_attention_token_type_test {
+public:
+    void apply_mixed_test_data(PagedAttentionManager& pam, const paged_attention_token_type_test_params& p, const test::TestData& data) {
+        ASSERT_EQ(p.subsequences.size(), 1);
+
+        const size_t past_len = static_cast<size_t>(p.subsequences[0].past_len);
+        const size_t num_tokens = static_cast<size_t>(p.subsequences[0].num_tokens);
+        const size_t seq_len = data.tokenTypes.size();
+        const size_t hidden_dim = static_cast<size_t>(p.num_heads) * static_cast<size_t>(p.k_head_size);
+
+        ASSERT_GT(past_len, 0u);
+        ASSERT_EQ(past_len + num_tokens, seq_len);
+        ASSERT_EQ(data.qData.size(), seq_len * hidden_dim);
+        ASSERT_EQ(data.kData.size(), seq_len * hidden_dim);
+        ASSERT_EQ(data.vData.size(), seq_len * hidden_dim);
+        ASSERT_EQ(data.expectedOutput.size(), seq_len * hidden_dim);
+
+        // Key/Value cover the whole sequence: PagedAttentionManager copies the leading past_len
+        // tokens into the KV cache and submits the rest through the key/value inputs.
+        pam.key_data = {to_float16(data.kData)};
+        pam.value_data = {to_float16(data.vData)};
+
+        // Query only covers the scheduled chunk.
+        const auto query_data = to_float16(data.qData);
+        pam.query_data = {std::vector<ov::float16>(query_data.begin() + past_len * hidden_dim, query_data.end())};
+
+        pam.token_type_ids.assign(data.tokenTypes.begin(), data.tokenTypes.end());
+    }
+};
+
+TEST_P(paged_attention_token_type_micro_sdpa_mixed_test, mixed_stage) {
+    const auto& device_info = tests::get_test_engine().get_device_info();
+    if (!device_info.supports_immad || device_info.arch < cldnn::gpu_arch::xe_hpg)
+        GTEST_SKIP() << "Micro SDPA requires DPAS/XMX support";
+    if (device_info.arch == cldnn::gpu_arch::xe3p)
+        GTEST_SKIP() << "Micro SDPA is disabled on xe3p";
+
+    auto p = GetParam();
+
+    ASSERT_TRUE(this->pam.has_value());
+    auto& pam = *this->pam;
+
+    apply_mixed_test_data(pam, p, p.token_type_test_data);
+    auto result = run_gpu_inference(pam, p);
+
+    auto pa_inst = result.network->get_primitive("paged_attention");
+    ASSERT_NE(pa_inst, nullptr);
+    auto* impl = pa_inst->get_impl();
+    ASSERT_NE(impl, nullptr);
+    const auto kernel_entries = impl->get_kernels_dump_info(*pa_inst->get_impl_params()).get_entries();
+    EXPECT_NE(kernel_entries.find("sdpa_micro"), std::string::npos) << "Expected micro SDPA kernel for MIXED with token_type_ids, got: " << kernel_entries;
+    EXPECT_EQ(kernel_entries.find("paged_attention_opt__multi_tokens"), std::string::npos) << "MIXED fell back to the partition kernel: " << kernel_entries;
+
+    // The golden data covers the whole sequence, but only the scheduled chunk is produced here.
+    const size_t hidden_dim = static_cast<size_t>(p.num_heads) * static_cast<size_t>(p.v_head_size);
+    const size_t cached_values = static_cast<size_t>(p.subsequences[0].past_len) * hidden_dim;
+    const auto& golden_output = p.token_type_test_data.expectedOutput;
+    const std::vector<float> expected_output(golden_output.begin() + cached_values, golden_output.end());
+
+    cldnn::memory::ptr output_data_mem = result.outputs.at("output_data").get_memory();
+    compare_token_type_output(output_data_mem, expected_output);
+}
+
+// Picks a split that leaves only text tokens in the scheduled chunk, and returns 0 when no usable
+// split exists - either every token is an image token, or the tail would be short enough to be
+// classified as GENERATE instead of MIXED.
+static int find_text_only_mixed_split(const test::TestData& data) {
+    const int seq_len = static_cast<int>(data.tokenTypes.size());
+    int last_image_token = -1;
+    for (int i = 0; i < seq_len; i++) {
+        if (data.tokenTypes[i] == 1)
+            last_image_token = i;
+    }
+
+    const int past_len = std::max(last_image_token + 1, seq_len / 2);
+    const bool usable = past_len > 0 && seq_len - past_len >= 2;
+    return usable ? past_len : 0;
+}
+
+static std::vector<paged_attention_token_type_test_params> make_micro_sdpa_mixed_test_params() {
+    std::vector<paged_attention_token_type_test_params> params;
+    for (const auto& data : test::PagedAttentionTokenTypeTestData::GetTestData()) {
+        const int past_len = find_text_only_mixed_split(data);
+        if (past_len == 0)
+            continue;
+
+        auto p = make_token_type_test_param(data, ENABLE_FA_V2);
+        p.subsequences = {{static_cast<int>(data.tokenTypes.size()) - past_len, past_len}};
+        params.push_back(p);
+    }
+    return params;
+}
+
+static std::string get_micro_sdpa_mixed_test_name(const testing::TestParamInfo<paged_attention_token_type_test_params>& obj) {
+    const auto& p = obj.param;
+    return p.token_type_test_data.name + "_SW" + std::to_string(p.sliding_window_size) + "_Past" + std::to_string(p.subsequences[0].past_len) +
+           "_MicroSDPA_Mixed";
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_paged_attention_token_type_micro_sdpa_mixed,
+                         paged_attention_token_type_micro_sdpa_mixed_test,
+                         ::testing::ValuesIn(make_micro_sdpa_mixed_test_params()),
+                         get_micro_sdpa_mixed_test_name);
 #endif


### PR DESCRIPTION
[GPU] Enable micro SDPA for the PagedAttention MIXED stage with token_type_ids

### Description of the issue(symptom, root-cause, how it was resolved)

- **Symptom.** When a long prompt is split into chunks, prefill takes far longer than running the same prompt in one chunk, but only for models that have a `token_type_ids` input. The slowdown stays the same no matter how many chunks we use, so chunking itself is not the problem.
- **Root cause.** `can_use_micro_sdpa_for()` did not allow micro SDPA in the MIXED stage when `token_type_ids` was present. The idea was that the other kernel handles the bidirectional mask, but it does not: `paged_attention_opt.cl` never reads `token_type_ids`. So both kernels give the same mask in MIXED, and the fallback only made things slower - it skips the sliding-window shortcut and allocates buffers sized by `max_context_len`.
- **Resolution.** Remove the `token_type_ids` check and decide by stage only. PREFILL and GENERATE work as before. MIXED still has no bidirectional masking, but that was already the case and is tracked separately.
- Before removing the check, we confirmed micro SDPA supports attention sinks, `qq_bias` and rotated blocks. The other cases are already blocked by `supports_micro_sdpa()`.

#### Results

On PTLH with a 60K-token prompt and `max_num_batched_tokens` = 256, chunked prefill latency drops
from about 2,000 s to about 100 s.

Measured with [#37575](https://github.com/openvinotoolkit/openvino/pull/37575) applied on top, which speeds up the full-attention layers (head size 512). This PR covers the remaining layers, which run in the MIXED stage from the second chunk onward.

#### The code and line that caused this issue (if it is not changed directly)

- `intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp` -
  `PagedAttentionOptImpl::can_use_micro_sdpa_for()`, the `!desc->has_token_type_ids || stage == PREFILL`
  expression. Introduced as an all-stage block in #34601 and relaxed to PREFILL-only in #36737, which
  implemented bidirectional masking for the prefill path.
- `intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl` - the kernel that gate fell back to. It
  has no `token_type_ids` handling, which is what makes the gate's premise incorrect.
- `intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl` - `window_k_begin` for
  `IS_PAGED_ATTENTION && !IS_PREFILL`, the sliding-window skip that the fallback was bypassing.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)

`cb_run.py`:

```python
import sys, time, openvino_genai

model, device, mnbt = sys.argv[1], sys.argv[2], int(sys.argv[3])

cfg = openvino_genai.SchedulerConfig()
cfg.cache_size = 0
cfg.enable_prefix_caching = True
cfg.max_num_batched_tokens = mnbt

pipe = openvino_genai.ContinuousBatchingPipeline(model, cfg, device)
prompt = "hi " * 60000  # 60,001 tokens once tokenized

# The handle has to stay alive: dropping it cancels the request and every later step() is a no-op.
handle = pipe.add_request(request_id=0, prompt=prompt,
                          generation_config=openvino_genai.GenerationConfig(max_new_tokens=5))

total = 0.0
while pipe.has_non_finished_requests():
    t0 = time.perf_counter()
    pipe.step()
    dt = time.perf_counter() - t0
    total += dt
    print(f"  step {dt:7.3f}s  total {total:8.1f}s", flush=True)
```

```
$ MODEL=<gemma-4-26b-a4b-it>/OV_FP16-4BIT_DEFAULT

$ python cb_run.py $MODEL GPU 99999      # single chunk, PREFILL only - reference
$ python cb_run.py $MODEL GPU 256        # 235 chunks, MIXED - reproduces the issue
```

Any `max_num_batched_tokens` below the prompt length reproduces it; the penalty is flat across
chunk sizes. Which kernel runs in MIXED can be confirmed either from the kernel dump
(`paged_attention_opt__multi_tokens` before, `sdpa_micro__generate` after) or from the per-step
timings, which grow linearly with context before the fix and flatten out after it.

#### Problematic graph

- Not a graph transformation issue; the graph is unchanged by this PR.
- Relevant graph property: the model has 30 PagedAttention nodes, 25 of which take
  `token_type_ids` (input 25) from a dynamically shaped `Convert [?,?]`, while the other 5 take a
  `Constant [0]`. `has_token_type_ids` is set from that dynamic shape at compile time, so the 25
  dynamic ones were gated out of micro SDPA in MIXED regardless of whether the prompt actually
  contained image tokens - a text-only prompt paid the same 24×.

#### Checklist

- [x] Is it a proper fix? (not a workaround)
  - The gate is removed because its premise was wrong, not bypassed; bidirectional masking keeps
    running in the PREFILL kernels that implement it.
- [x] Did you include test case for this fix, if necessary?
  - Added `paged_attention_token_type_micro_sdpa_mixed_test`, which replays the PREFILL golden data
    as a chunked prefill and asserts micro SDPA runs in MIXED with the output still matching.
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
  - `paged_attention_token_type_micro_sdpa_prefill_test` (PREFILL only, extended into the new test),
    `paged_attention_u4_mixed_micro_test` and the MIXED cases in `paged_attention_gpu_test.cpp`.

### Tickets:
- **192880**