### PR TITLE
[CPU] Add allocation-failure diagnostics for scratchpad/tensor memory

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -164,7 +164,19 @@ void Memory::create(MemoryDescPtr desc, const void* data, bool pads_zeroing) {
     if (nullptr != data) {
         m_blockHandle->setExtBuff(const_cast<void*>(data), memSize);
     } else {
-        m_blockHandle->resize(memSize);
+        try {
+            m_blockHandle->resize(memSize);
+        } catch (const std::exception& e) {
+            // rethrow with the descriptor context, the raw size alone doesn't tell which tensor requested it
+            OPENVINO_THROW("Memory allocation of ",
+                           memSize,
+                           " bytes failed for a tensor with shape ",
+                           m_pMemDesc->getShape().toString(),
+                           ", precision ",
+                           m_pMemDesc->getPrecision(),
+                           ": ",
+                           e.what());
+        }
     }
 }
 

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -828,7 +828,17 @@ protected:
 
     MemoryPtr getScratchPadMem(const MemoryDescPtr& desc) {
         if (!scratchpadMem || !scratchpadMem->getDesc().isCompatible(*desc)) {
-            scratchpadMem = context->getScratchPad()->createScratchPadMem(desc);
+            try {
+                scratchpadMem = context->getScratchPad()->createScratchPadMem(desc);
+            } catch (const std::exception& e) {
+                // scratchpad size is computed by the selected oneDNN primitive, name/type pinpoints which node/primitive asked for it
+                OPENVINO_THROW("Scratchpad allocation failed for node '",
+                               getName(),
+                               "' of type ",
+                               getTypeStr(),
+                               ": ",
+                               e.what());
+            }
         }
         return scratchpadMem;
     }


### PR DESCRIPTION
Include tensor shape/precision and node name/type in the exception message when memory allocation fails, to help diagnose unexpectedly large allocation requests (e.g. PTL platform-specific issue).

### Details:
 - `Memory::create()` now catches `MemoryBlockWithReuse::resize()` failures and rethrows with the tensor's shape and precision included, so the raw byte count can be tied to the descriptor that requested it.
 - `Node::getScratchPadMem()` now catches `createScratchPadMem()` failures and rethrows with the requesting node's name and type, since scratchpad size is computed per-primitive and can vary by selected implementation/ISA.
 - No functional/behavioral changes on the success path; only the error message on allocation failure is enriched.
 - Confirmed the failure reproduces with a minimal `compile_model()`-only script on the affected PTL machine (unmodified official `openvino` wheel), ruling out `accuracy_checker`/dataset pipeline as a factor — same `Failed to allocate 131550175360 bytes of memory` error at `cpu_memory.cpp:257`.
 - With `ONEDNN_VERBOSE=2` set, no oneDNN verbose output was produced before the crash, indicating the failure occurs during CPU-plugin graph compilation/size computation, before any oneDNN primitive is created or executed.

### Tickets:
 - *ticket-id*

### AI Assistance:
 - AI assistance used: yes
 - GitHub Copilot (agent mode) was used to locate the allocation failure site (`cpu_memory.cpp:257`, `Check 'ptr' failed`) and the scratchpad allocation path (`node.h::getScratchPadMem`), and to draft the try/catch diagnostic wrappers. Human validation: reviewed the diff manually for correctness of the exception message construction (confirmed `Shape::toString()` and `element::Type` stream operators exist and `OPENVINO_THROW` is available in both files); reproduced the original failure on the target PTL hardware with an unmodified minimal script to confirm it's isolated from `accuracy_checker`. A build with this patch on the PTL machine to confirm the enriched error message is still pending.