### PR TITLE
[NPU] Remove skipped test and avoid automatic HostCompile for dynamic batch model

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -384,7 +384,11 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
         const auto isDynamicHostCompilePort = [&hasFiniteUpperBounds](const auto& port) {
             const auto& shape = port.get_partial_shape();
             const auto rank = shape.rank();
-            return shape.is_dynamic() && rank.is_static() && rank.get_length() == 4 && hasFiniteUpperBounds(port);
+
+            // Keep batch static: ConvertBatchedLayerTo1N and AdjustScaleShiftForDWConv do not support dynamic
+            // shapes in their AffineReshape and Reshape operations, respectively.
+            return shape.is_dynamic() && rank.is_static() && rank.get_length() == 4 && shape[0].is_static() &&
+                   hasFiniteUpperBounds(port);
         };
 
         const auto& modelInputs = model->inputs();

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -385,8 +385,8 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
             const auto& shape = port.get_partial_shape();
             const auto rank = shape.rank();
 
-            // Keep batch static: ConvertBatchedLayerTo1N and AdjustScaleShiftForDWConv do not support dynamic
-            // shapes in their AffineReshape and Reshape operations, respectively.
+            // Keep batch static to avoid failures in ConvertBatchedLayerTo1N and AdjustScaleShiftForDWConv,
+            // because reshape operations in these passes do not support dynamic batch shapes.
             return shape.is_dynamic() && rank.is_static() && rank.get_length() == 4 && shape[0].is_static() &&
                    hasFiniteUpperBounds(port);
         };

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -373,38 +373,4 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- C#191823 -->
-    <skip_config>
-        <message>HostCompile cannot compile the dynamic Add model because AdjustScaleShiftForDWConv requires static Reshape shapes.</message>
-        <enable_rules>
-            <device>4000</device>
-            <device>5010</device>
-        </enable_rules>
-        <filters>
-            <filter>.*DynamicBatchingTests.DynamicCheckMultipleBatchingRun0.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchingTests.DynamicCheckMultipleBatchingRunsSeq.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.DynamicSetInputRemoteTensorsMultipleInfer.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.DynamicSetInputRemoteTensorsDynamicBatchInflation.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.DynamicSetInputRemoteTensorsDynamicBatchDeflation.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.SetInputRemoteSingleBatchedTensorSingleInfer.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.SetInputRemoteSingleBatchedTensorSingleInferWithExportImport.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.SetInputRemoteSingleBatchedTensorDynamicBatchInflation.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.SetInputRemoteSingleBatchedTensorDynamicBatchInflationWithExportImport.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.SetInputRemoteSingleBatchedTensorDynamicBatchDeflation.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*DynamicBatchedTensorsRunTests.DynamicSetInputDifferentTensorsMultipleInfer.*NPU_BATCH_MODE_PLUGIN.*</filter>
-            <filter>.*RoiTensorsTestsRun.RunStridedTensorWithDynamicBoundedBatching.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>HostCompile cannot compile the dynamic MaxPool model because ConvertBatchedLayerTo1N requires static AffineReshape shapes.</message>
-        <enable_rules>
-            <device>4000</device>
-            <device>5010</device>
-        </enable_rules>
-        <filters>
-            <filter>.*InferWithDefaultHostCompileTests.CompileDynamicModelWithNoHostCompileMode.*model=MaxPool_NCHW_DynBatch.*</filter>
-        </filters>
-    </skip_config>
-
 </skip_configs>


### PR DESCRIPTION
### Details:
 - Require a static batch dimension when automatically selecting HostCompile_Interpreter for bounded dynamic 4D models.
Dynamic batch can trigger current compiler reshape limitations in ConvertBatchedLayerTo1N and AdjustScaleShiftForDWConv. With this restriction, affected models use the regular batch handling path instead of automatic HostCompile.
 - Removed the corresponding NPU4000/NPU5010 test skips.

### Tickets:
 - *CVS-191823*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
