### PR TITLE
Do not link onnx_proto alongside onnx (fixes SIGABRT in shared builds)

### DIFF
--- a/src/frontends/onnx/onnx_common/CMakeLists.txt
+++ b/src/frontends/onnx/onnx_common/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(${TARGET_NAME}
 
 target_link_libraries(${TARGET_NAME} PRIVATE openvino::runtime openvino::util)
 
-ov_link_system_libraries(${TARGET_NAME} PUBLIC onnx_proto onnx)
+ov_link_system_libraries(${TARGET_NAME} PUBLIC onnx)
 
 ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
 

--- a/src/frontends/onnx/tests/CMakeLists.txt
+++ b/src/frontends/onnx/tests/CMakeLists.txt
@@ -183,7 +183,7 @@ add_custom_command(TARGET ov_onnx_frontend_tests POST_BUILD
 add_dependencies(ov_onnx_frontend_tests test_model_zoo)
 
 # Working with ModelProto
-ov_link_system_libraries(ov_onnx_frontend_tests PUBLIC onnx_proto onnx)
+ov_link_system_libraries(ov_onnx_frontend_tests PUBLIC onnx)
 
 add_subdirectory(standalone_build)
 add_dependencies(ov_onnx_frontend_tests onnx_fe_standalone_build_test)


### PR DESCRIPTION
### Details:
 - Link only `onnx` (dropping the redundant `onnx_proto`) in `openvino_onnx_common` and in `ov_onnx_frontend_tests`.
 - Upstream ONNX builds the core library as `add_library(onnx $<TARGET_OBJECTS:onnx_proto>)`, so `libonnx` already contains every object file of `libonnx_proto` and does *not* link it. With `BUILD_SHARED_LIBS=ON` this yields two independent shared libraries that each run the static initializer registering `onnx/onnx-ml.proto`. Loading both into one process aborts inside `ABSL_CHECK`

### Tickets:

closes #36093 

### AI Assistance:
 - AI assistance used: no