### PR TITLE
[EXPERIMENT][WIP] Add BlockSparseAttention-17 operator (CPU + Template)

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sequence/block-sparse-attention-17.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sequence/block-sparse-attention-17.rst
@@ -1,0 +1,273 @@
+BlockSparseAttention
+====================
+
+
+.. meta::
+  :description: Learn about BlockSparseAttention-17 - a fused block-sparse scaled dot-product
+                attention operation.
+
+**Versioned name**: *BlockSparseAttention-17*
+
+**Category**: *Sequence processing*
+
+**Short description**: *BlockSparseAttention* computes exact scaled dot-product attention in
+which every query block only attends to a caller-supplied, per-query-block selection of
+key/value blocks, fusing the "gather selected blocks" step with the attention computation
+itself.
+
+**Detailed description**:
+
+Query, key and value tokens are conceptually partitioned into contiguous, non-overlapping
+blocks of ``block_size`` tokens along the sequence dimension. For every query block, the
+``block_indices`` input names which key/value blocks that query block is allowed to attend
+to; only tokens belonging to those blocks contribute to the attention output, all other key/
+value tokens are excluded (not merely down-weighted). ``block_indices`` is typically produced
+upstream (for example by pooling query/key blocks and running TopK on the resulting coarse
+scores) — this operation only fuses the "gather the selected blocks" and "attend" steps, it
+does not compute the selection itself.
+
+*BlockSparseAttention* provides functionality according to the following pseudo-code, using
+other operations from the OpenVINO opset and ``numpy``:
+
+.. code-block:: py
+    :force:
+
+    def BlockSparseAttention(query, key, value, block_indices, block_indices_mask=None, scale=None, *, block_size, causal):
+        B, H, L, E = query.shape
+        _, Hk, S, Ev = value.shape
+        _, Hb, num_q_blocks, k_blocks = block_indices.shape
+        num_kv_blocks = S // block_size
+        if scale is None:
+            scale = 1.0 / np.sqrt(E)
+
+        output = np.zeros((B, H, L, Ev), dtype=query.dtype)
+        for b, h in np.ndindex(B, H):
+            hk = 0 if Hk == 1 else h  # key/value may broadcast a single shared head
+            hb = 0 if Hb == 1 else h  # block_indices/mask may broadcast a single shared head
+            for qb in range(num_q_blocks):
+                # Gather this query block's selected key/value blocks -- happens *inside*
+                # the operation, no materialized gathered/transposed copy is required.
+                selected = [blk for i, blk in enumerate(block_indices[b, hb, qb])
+                            if block_indices_mask is None or block_indices_mask[b, hb, qb, i]]
+                key_positions = [blk * block_size + t for blk in selected for t in range(block_size)
+                                  if 0 <= blk < num_kv_blocks]
+                for qi in range(block_size):
+                    q_pos = qb * block_size + qi
+                    positions = [p for p in key_positions if not causal or p <= q_pos]
+                    logits = [query[b, h, q_pos] @ key[b, hk, p] * scale for p in positions]
+                    weights = softmax(logits)  # empty input -> all-zero output row
+                    output[b, h, q_pos] = sum(w * value[b, hk, p] for w, p in zip(weights, positions))
+        return output
+
+Unlike an equivalent subgraph built from existing operations (``Gather`` + ``Reshape`` +
+``ScaledDotProductAttention``), *BlockSparseAttention* never materializes a gathered and
+transposed copy of ``key``/``value``: it reads directly from the original tensors at the
+offsets named by ``block_indices``. The cost of the decomposed subgraph scales with
+``batch * heads * num_query_blocks * gathered_length`` regardless of how sparse the
+selection actually is, while *BlockSparseAttention* scales with the amount of selected
+(sparse) work only.
+
+A ``block_indices`` entry that falls outside ``[0, num_kv_blocks)`` is treated the same as a
+masked-out entry (ignored, contributes nothing to the output), rather than being an error --
+this allows a fixed-size ``block_indices`` tensor to be reused across queries with a
+different number of actually-relevant candidate blocks, by padding unused slots with an
+out-of-range sentinel index in addition to (or instead of) the explicit
+``block_indices_mask``. When ``causal`` is ``true``, this same "contributes nothing" handling
+also applies token-by-token to any selected key position that lies after the query position,
+including a key/value block that only partially precedes the query block on the diagonal, so
+callers are not required to pre-filter ``block_indices`` for causal validity.
+
+**Attributes**
+
+* *block_size*
+
+  * **Description**: number of contiguous key/value tokens per block. The query sequence
+    length and the key/value sequence length must each be evenly divisible by *block_size*.
+  * **Range of values**: a positive integer
+  * **Type**: ``int``
+  * **Required**: *yes*
+
+* *causal*
+
+  * **Description**: if ``true``, in addition to the block-level selection expressed by
+    ``block_indices``, applies token-level causal masking so that query position ``i`` never
+    attends to a key position greater than ``i``, even if that key position belongs to a
+    selected block.
+  * **Range of values**: a boolean value
+  * **Type**: ``bool``
+  * **Default value**: ``false``
+  * **Required**: *no*
+
+**Inputs**
+
+* **1**: ``query`` - 4-dimensional tensor of type *T* and shape ``[B, H, L, E]``.
+  **Required.**
+
+* **2**: ``key`` - 4-dimensional tensor of type *T* and shape ``[B, Hk, S, E]``, where ``Hk``
+  is either equal to ``H`` (one key head per query head) or ``1`` (a single key head
+  broadcast to every query head, mirroring the level of head broadcasting supported by
+  *ScaledDotProductAttention*). **Required.**
+
+* **3**: ``value`` - 4-dimensional tensor of type *T* and shape ``[B, Hk, S, Ev]``, using the
+  same ``Hk`` as ``key``. **Required.**
+
+* **4**: ``block_indices`` - 4-dimensional tensor of type *T_IDX* and shape
+  ``[B, Hb, L / block_size, k_blocks]``, containing, for every query block, the indices (into
+  the ``S / block_size`` key/value blocks) of the key/value blocks selected for that query
+  block. ``Hb`` is either ``H`` or ``1`` (broadcast to every query head), the same rule as
+  ``Hk`` above. An index outside ``[0, S / block_size)`` is treated as masked out (see
+  *Detailed description*). **Required.**
+
+* **5**: ``block_indices_mask`` - tensor of type *T_MASK* with the same shape as
+  ``block_indices``. A ``false`` (or zero) entry marks a padding slot that must not
+  contribute to the output, used when the number of actually-relevant candidate blocks is
+  ragged across query blocks. **Optional.**
+
+* **6**: ``scale`` - a scalar or single-element 1D tensor of type *T*, an alternative scale
+  factor instead of the default ``1 / sqrt(E)``. **Optional.**
+
+**Outputs**
+
+* **1**: the result of block-sparse scaled dot-product attention, a tensor of type *T* and
+  shape ``[B, H, L, Ev]``.
+
+**Types**
+
+* *T*: any supported floating-point type.
+
+* *T_IDX*: any supported integer type.
+
+* *T_MASK*: ``boolean``. ``u8`` is also accepted as an equivalent alternative: some plugins
+  normalize boolean tensors to ``u8`` storage ahead of the operations that consume them (for
+  example via a generic boolean-to-``u8`` precision conversion pass), so a ``u8`` tensor
+  containing only ``0``/``1`` values is accepted with the exact same semantics as a
+  ``boolean`` one.
+
+**Dimensions**
+
+* ``B`` - batch size.
+
+* ``H`` - number of query (and output) attention heads.
+
+* ``Hk`` - number of key/value attention heads: either ``H`` or ``1`` (broadcast).
+
+* ``Hb`` - number of ``block_indices``/``block_indices_mask`` heads: either ``H`` or ``1``
+  (broadcast).
+
+* ``L`` - query sequence length. Must be evenly divisible by *block_size*.
+
+* ``S`` - key/value sequence length. Must be evenly divisible by *block_size*.
+
+* ``E`` - embedding (head) size of query and key.
+
+* ``Ev`` - embedding (head) size of value and of the output.
+
+* ``k_blocks`` - number of key/value blocks selected per query block.
+
+Unlike *ScaledDotProductAttention*, *BlockSparseAttention* requires exactly one batch
+dimension and exactly one head dimension (rank-4 ``query``/``key``/``value``); it does not
+support the arbitrary number of leading batch dimensions that *ScaledDotProductAttention*
+allows.
+
+**Examples**
+
+*Example 1: Non-causal block-sparse attention with an explicit padding mask*
+
+.. code-block:: xml
+   :force:
+
+    <layer id="42" name="BlockSparseAttention_0" type="BlockSparseAttention" version="opset17">
+        <data block_size="2" causal="false" />
+        <input>
+            <!-- query: B=1, H=2, L=4 (2 query blocks), E=8 -->
+            <port id="0" precision="FP32">
+                <dim>1</dim>
+                <dim>2</dim>
+                <dim>4</dim>
+                <dim>8</dim>
+            </port>
+            <!-- key: B=1, Hk=2, S=6 (3 key/value blocks), E=8 -->
+            <port id="1" precision="FP32">
+                <dim>1</dim>
+                <dim>2</dim>
+                <dim>6</dim>
+                <dim>8</dim>
+            </port>
+            <!-- value: B=1, Hk=2, S=6, Ev=8 -->
+            <port id="2" precision="FP32">
+                <dim>1</dim>
+                <dim>2</dim>
+                <dim>6</dim>
+                <dim>8</dim>
+            </port>
+            <!-- block_indices: B=1, Hb=2, num_q_blocks=2, k_blocks=2 -->
+            <port id="3" precision="I32">
+                <dim>1</dim>
+                <dim>2</dim>
+                <dim>2</dim>
+                <dim>2</dim>
+            </port>
+            <!-- block_indices_mask: same shape as block_indices -->
+            <port id="4" precision="BOOL">
+                <dim>1</dim>
+                <dim>2</dim>
+                <dim>2</dim>
+                <dim>2</dim>
+            </port>
+        </input>
+        <output>
+            <port id="5" precision="FP32">
+                <dim>1</dim>
+                <dim>2</dim>
+                <dim>4</dim>
+                <dim>8</dim>
+            </port>
+        </output>
+    </layer>
+
+*Example 2: Causal block-sparse attention, no mask, default scale, broadcast key/value head*
+
+.. code-block:: xml
+   :force:
+
+    <layer id="43" name="BlockSparseAttention_1" type="BlockSparseAttention" version="opset17">
+        <data block_size="4" causal="true" />
+        <input>
+            <!-- query: B=2, H=4, L=8 (2 query blocks), E=64 -->
+            <port id="0" precision="FP16">
+                <dim>2</dim>
+                <dim>4</dim>
+                <dim>8</dim>
+                <dim>64</dim>
+            </port>
+            <!-- key: B=2, Hk=1 (broadcast to all 4 query heads), S=16 (4 key/value blocks), E=64 -->
+            <port id="1" precision="FP16">
+                <dim>2</dim>
+                <dim>1</dim>
+                <dim>16</dim>
+                <dim>64</dim>
+            </port>
+            <!-- value: B=2, Hk=1, S=16, Ev=64 -->
+            <port id="2" precision="FP16">
+                <dim>2</dim>
+                <dim>1</dim>
+                <dim>16</dim>
+                <dim>64</dim>
+            </port>
+            <!-- block_indices: B=2, Hb=1, num_q_blocks=2, k_blocks=2 -->
+            <port id="3" precision="I64">
+                <dim>2</dim>
+                <dim>1</dim>
+                <dim>2</dim>
+                <dim>2</dim>
+            </port>
+        </input>
+        <output>
+            <port id="4" precision="FP16">
+                <dim>2</dim>
+                <dim>4</dim>
+                <dim>8</dim>
+                <dim>64</dim>
+            </port>
+        </output>
+    </layer>

--- a/src/core/dev_api/openvino/op/ops_decl.hpp
+++ b/src/core/dev_api/openvino/op/ops_decl.hpp
@@ -292,6 +292,7 @@ class SparseFillEmptyRows;
 }  // namespace ov::op::v16
 
 namespace ov::op::v17 {
+class BlockSparseAttention;
 class ErfInv;
 class GroupedMatMul;
 }  // namespace ov::op::v17

--- a/src/core/include/openvino/op/block_sparse_attention.hpp
+++ b/src/core/include/openvino/op/block_sparse_attention.hpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov::op::v17 {
+/// \brief Block-sparse scaled dot product attention.
+///
+/// Computes exact scaled dot-product attention restricted to a caller-supplied,
+/// per-query-block selection of key/value blocks:
+///
+///     output = softmax(scale * query @ gather(key, block_indices)^T + causal_bias)
+///                 @ gather(value, block_indices)
+///
+/// The gather of key/value blocks happens *inside* the kernel: the operation reads
+/// directly from the original (non-gathered, non-transposed) key/value tensors using
+/// `block_indices`, so no auxiliary Gather/Transpose/Reshape subgraph is needed around
+/// it. This is the key difference versus decomposing the same computation with existing
+/// ops (Gather + Reshape + ScaledDotProductAttention): that decomposition requires
+/// materializing a gathered-and-transposed copy of key/value before the attention
+/// matmuls, whose cost scales with `batch * heads * num_query_blocks * gathered_length`
+/// and can dominate at small sequence lengths. BlockSparseAttention avoids that
+/// materialization entirely, so its cost scales with the actual amount of selected
+/// (sparse) work regardless of sequence length.
+///
+/// Block selection itself (pooling / coarse scoring / top-k) is expected to be built
+/// from existing ops (ReduceMean, MatMul, TopK, ...) upstream in the graph and passed in
+/// as `block_indices`; this operation only fuses "gather selected blocks" with "attend".
+///
+/// \ingroup ov_ops_cpp_api
+class OPENVINO_API BlockSparseAttention : public Op {
+public:
+    OPENVINO_OP("BlockSparseAttention", "opset17", ov::op::Op);
+
+    BlockSparseAttention() = default;
+
+    /// \brief Constructs a BlockSparseAttention operation from a flat input list.
+    ///
+    /// \param inputs     3 to 6 inputs: query, key, value, block_indices,
+    ///                   [block_indices_mask], [scale]. See the named-argument
+    ///                   constructors below for the meaning of each input.
+    /// \param block_size Number of contiguous key/value tokens per block.
+    /// \param causal     Apply an additional token-level causal mask.
+    BlockSparseAttention(const OutputVector& inputs, int64_t block_size, bool causal = false);
+
+    /// \brief Constructs a BlockSparseAttention operation with an explicit scale.
+    ///
+    /// \param query               Query tensor, shape `[B, H, L, E]`.
+    /// \param key                 Key tensor, shape `[B, Hk, S, E]`. `Hk` must be either `H`
+    ///                            (one key head per query head) or `1` (a single key head
+    ///                            broadcast to every query head), matching the level of head
+    ///                            broadcasting ScaledDotProductAttention itself supports.
+    /// \param value               Value tensor, shape `[B, Hk, S, Ev]` (same `Hk` as `key`).
+    /// \param block_indices       Indices, into the `S / block_size` key/value blocks,
+    ///                            of the blocks selected for each query block. Shape
+    ///                            `[B, Hb, L / block_size, k_blocks]`, integer type, `Hb`
+    ///                            either `H` or `1` (broadcast), same rule as `Hk` above.
+    /// \param block_indices_mask  Boolean tensor with the same shape as `block_indices`;
+    ///                            `false` marks a padding entry that must not contribute
+    ///                            to the output (used when the number of true candidate
+    ///                            blocks is ragged across query blocks).
+    /// \param scale               Custom softmax scale (scalar, or single-element
+    ///                            tensor). Defaults to `1 / sqrt(E)` when omitted.
+    /// \param block_size          Number of contiguous key/value tokens per block.
+    /// \param causal              Apply an additional token-level causal mask.
+    BlockSparseAttention(const Output<Node>& query,
+                         const Output<Node>& key,
+                         const Output<Node>& value,
+                         const Output<Node>& block_indices,
+                         const Output<Node>& block_indices_mask,
+                         const Output<Node>& scale,
+                         int64_t block_size,
+                         bool causal = false);
+
+    /// \brief Constructs a BlockSparseAttention operation without an explicit scale.
+    BlockSparseAttention(const Output<Node>& query,
+                         const Output<Node>& key,
+                         const Output<Node>& value,
+                         const Output<Node>& block_indices,
+                         const Output<Node>& block_indices_mask,
+                         int64_t block_size,
+                         bool causal = false);
+
+    /// \brief Constructs a BlockSparseAttention operation without a mask or scale.
+    BlockSparseAttention(const Output<Node>& query,
+                         const Output<Node>& key,
+                         const Output<Node>& value,
+                         const Output<Node>& block_indices,
+                         int64_t block_size,
+                         bool causal = false);
+
+    void validate_and_infer_types() override;
+    bool visit_attributes(AttributeVisitor& visitor) override;
+    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+
+    int64_t get_block_size() const {
+        return m_block_size;
+    }
+
+    void set_block_size(int64_t block_size) {
+        m_block_size = block_size;
+    }
+
+    bool get_causal() const {
+        return m_causal;
+    }
+
+    void set_causal(bool causal) {
+        m_causal = causal;
+    }
+
+private:
+    int64_t m_block_size = 0;
+    bool m_causal = false;
+};
+
+}  // namespace ov::op::v17

--- a/src/core/include/openvino/op/ops.hpp
+++ b/src/core/include/openvino/op/ops.hpp
@@ -28,6 +28,7 @@
 #include "openvino/op/bitwise_or.hpp"
 #include "openvino/op/bitwise_right_shift.hpp"
 #include "openvino/op/bitwise_xor.hpp"
+#include "openvino/op/block_sparse_attention.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/bucketize.hpp"
 #include "openvino/op/ceiling.hpp"

--- a/src/core/include/openvino/opsets/opset17_tbl.hpp
+++ b/src/core/include/openvino/opsets/opset17_tbl.hpp
@@ -14,6 +14,7 @@ _OPENVINO_OP_REG(Convert, ov::op::v0)
 _OPENVINO_OP_REG(ShapeOf, ov::op::v3)
 
 // New operations added in opset17
+_OPENVINO_OP_REG(BlockSparseAttention, ov::op::v17)
 _OPENVINO_OP_REG(ErfInv, ov::op::v17)
 _OPENVINO_OP_REG(GroupedMatMul, ov::op::v17)
 _OPENVINO_OP_REG(RGBtoNV12, ov::op::v17)

--- a/src/core/include/public_headers.cmake
+++ b/src/core/include/public_headers.cmake
@@ -84,6 +84,7 @@ set(PUBLIC_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/bitwise_or.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/bitwise_right_shift.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/bitwise_xor.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/openvino/op/block_sparse_attention.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/broadcast.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/bucketize.hpp
     ${CMAKE_CURRENT_LIST_DIR}/openvino/op/ceiling.hpp

--- a/src/core/reference/include/openvino/reference/block_sparse_attention.hpp
+++ b/src/core/reference/include/openvino/reference/block_sparse_attention.hpp
@@ -1,0 +1,157 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "openvino/core/shape.hpp"
+
+namespace ov::reference {
+
+/// \brief Reference implementation of BlockSparseAttention-17.
+///
+/// Unlike a graph built from existing ops (Gather + Reshape + ScaledDotProductAttention),
+/// this loop never materializes a gathered/transposed copy of key or value: for every
+/// selected block it reads directly from the original `key`/`value` buffers at the
+/// computed offset. That is the property the op exists for -- the cost of this loop
+/// scales with the amount of *selected* (sparse) work, not with a gather-then-transpose
+/// step whose cost scales with `batch * heads * num_query_blocks * gathered_length`
+/// regardless of how little was actually selected.
+///
+/// \param query                [B, H,  L, E]
+/// \param key                  [B, Hk, S, E]              (Hk == H or Hk == 1, GQA/MQA style)
+/// \param value                [B, Hk, S, Ev]
+/// \param block_indices        [B, Hb, L / block_size, k_blocks] (Hb == H or Hb == 1)
+/// \param block_indices_mask   same shape as block_indices, non-null only when provided;
+///                             a zero byte marks a padding entry that must be ignored.
+/// \param scale                pointer to a single scale value, or nullptr for the
+///                             default `1 / sqrt(E)`.
+/// \param output               [B, H, L, Ev]
+template <typename T, typename TIndex>
+void block_sparse_attention(const T* query,
+                            const T* key,
+                            const T* value,
+                            const TIndex* block_indices,
+                            const char* block_indices_mask,
+                            const T* scale,
+                            T* output,
+                            bool causal,
+                            int64_t block_size,
+                            const Shape& query_shape,
+                            const Shape& key_shape,
+                            const Shape& value_shape,
+                            const Shape& block_indices_shape) {
+    const int64_t B = static_cast<int64_t>(query_shape[0]);
+    const int64_t H = static_cast<int64_t>(query_shape[1]);
+    const int64_t L = static_cast<int64_t>(query_shape[2]);
+    const int64_t E = static_cast<int64_t>(query_shape[3]);
+    const int64_t Hk = static_cast<int64_t>(key_shape[1]);
+    const int64_t S = static_cast<int64_t>(key_shape[2]);
+    const int64_t Ev = static_cast<int64_t>(value_shape[3]);
+    const int64_t Hb = static_cast<int64_t>(block_indices_shape[1]);
+    const int64_t num_q_blocks = static_cast<int64_t>(block_indices_shape[2]);
+    const int64_t k_blocks = static_cast<int64_t>(block_indices_shape[3]);
+    const int64_t num_kv_blocks = S / block_size;
+
+    const T scale_val = scale ? *scale : static_cast<T>(1.0 / std::sqrt(static_cast<double>(E)));
+    // key/value and block_indices/mask may each provide a single shared head that broadcasts to
+    // every query head (Hk == 1 / Hb == 1), or a full per-query-head tensor (Hk == H / Hb == H).
+    // Shape inference (block_sparse_attention_shape_inference.hpp) only accepts these two cases,
+    // matching the level of head broadcasting ScaledDotProductAttention itself supports; real
+    // GQA models expand key/value to the full head count with Broadcast/Tile before attention.
+    const auto broadcast_head = [](int64_t h, int64_t dim_size) {
+        return dim_size == 1 ? int64_t{0} : h;
+    };
+
+    const auto query_at = [&](int64_t b, int64_t h, int64_t l) {
+        return query + ((b * H + h) * L + l) * E;
+    };
+    const auto key_at = [&](int64_t b, int64_t h, int64_t s) {
+        return key + ((b * Hk + broadcast_head(h, Hk)) * S + s) * E;
+    };
+    const auto value_at = [&](int64_t b, int64_t h, int64_t s) {
+        return value + ((b * Hk + broadcast_head(h, Hk)) * S + s) * Ev;
+    };
+    const auto output_at = [&](int64_t b, int64_t h, int64_t l) {
+        return output + ((b * H + h) * L + l) * Ev;
+    };
+    const auto block_indices_at = [&](int64_t b, int64_t h, int64_t qb) {
+        return block_indices + ((b * Hb + broadcast_head(h, Hb)) * num_q_blocks + qb) * k_blocks;
+    };
+    const auto block_indices_mask_at = [&](int64_t b, int64_t h, int64_t qb) -> const char* {
+        return block_indices_mask
+                   ? block_indices_mask + ((b * Hb + broadcast_head(h, Hb)) * num_q_blocks + qb) * k_blocks
+                   : nullptr;
+    };
+
+    // Per-row scratch: at most k_blocks*block_size candidate keys contribute to one query row.
+    std::vector<T> scores(static_cast<size_t>(k_blocks) * static_cast<size_t>(block_size));
+    std::vector<int64_t> positions(scores.size());
+
+    for (int64_t b = 0; b < B; ++b) {
+        for (int64_t h = 0; h < H; ++h) {
+            for (int64_t qb = 0; qb < num_q_blocks; ++qb) {
+                const TIndex* bi_row = block_indices_at(b, h, qb);
+                const char* mask_row = block_indices_mask_at(b, h, qb);
+                for (int64_t qi = 0; qi < block_size; ++qi) {
+                    const int64_t q_pos = qb * block_size + qi;
+                    const T* q_ptr = query_at(b, h, q_pos);
+
+                    size_t valid_count = 0;
+                    T max_score = std::numeric_limits<T>::lowest();
+                    for (int64_t kb = 0; kb < k_blocks; ++kb) {
+                        if (mask_row && mask_row[kb] == 0) {
+                            continue;  // padding entry (ragged top-k selection) -- excluded, not just biased
+                        }
+                        const int64_t blk = static_cast<int64_t>(bi_row[kb]);
+                        if (blk < 0 || blk >= num_kv_blocks) {
+                            continue;  // defensive: ignore out-of-range indices instead of reading OOB memory
+                        }
+                        // token-level causal mask *within* the selected block: a block on or
+                        // straddling the diagonal is only partially valid.
+                        const int64_t tokens_in_block =
+                            causal ? std::min<int64_t>(block_size, q_pos - blk * block_size + 1) : block_size;
+                        for (int64_t ki = 0; ki < tokens_in_block; ++ki) {
+                            const int64_t k_pos = blk * block_size + ki;
+                            const T* k_ptr = key_at(b, h, k_pos);
+                            T dot = T{0};
+                            for (int64_t e = 0; e < E; ++e) {
+                                dot += q_ptr[e] * k_ptr[e];
+                            }
+                            scores[valid_count] = dot * scale_val;
+                            positions[valid_count] = k_pos;
+                            max_score = std::max(max_score, scores[valid_count]);
+                            ++valid_count;
+                        }
+                    }
+
+                    T* out_ptr = output_at(b, h, q_pos);
+                    std::fill(out_ptr, out_ptr + Ev, T{0});
+                    if (valid_count == 0) {
+                        continue;  // no valid candidate for this row (e.g. fully-masked edge case)
+                    }
+                    T sum_exp = T{0};
+                    for (size_t i = 0; i < valid_count; ++i) {
+                        scores[i] = static_cast<T>(std::exp(static_cast<double>(scores[i] - max_score)));
+                        sum_exp += scores[i];
+                    }
+                    for (size_t i = 0; i < valid_count; ++i) {
+                        const T weight = scores[i] / sum_exp;
+                        const T* v_ptr = value_at(b, h, positions[i]);
+                        for (int64_t e = 0; e < Ev; ++e) {
+                            out_ptr[e] += weight * v_ptr[e];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace ov::reference

--- a/src/core/reference/sources.cmake
+++ b/src/core/reference/sources.cmake
@@ -82,6 +82,7 @@ set(REFERENCE_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/include/openvino/reference/bitwise_or.hpp
     ${CMAKE_CURRENT_LIST_DIR}/include/openvino/reference/bitwise_right_shift.hpp
     ${CMAKE_CURRENT_LIST_DIR}/include/openvino/reference/bitwise_xor.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/include/openvino/reference/block_sparse_attention.hpp
     ${CMAKE_CURRENT_LIST_DIR}/include/openvino/reference/broadcast.hpp
     ${CMAKE_CURRENT_LIST_DIR}/include/openvino/reference/bucketize.hpp
     ${CMAKE_CURRENT_LIST_DIR}/include/openvino/reference/ceiling.hpp

--- a/src/core/shape_inference/CMakeLists.txt
+++ b/src/core/shape_inference/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${TARGET_NAME}
     ${SHAPE_INFER_INCLUDE_DIR}/batch_norm_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/batch_to_space_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/binary_convolution_shape_inference.hpp
+    ${SHAPE_INFER_INCLUDE_DIR}/block_sparse_attention_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/broadcast_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/bucketize_shape_inference.hpp
     ${SHAPE_INFER_INCLUDE_DIR}/col2im_shape_inference.hpp

--- a/src/core/shape_inference/include/block_sparse_attention_shape_inference.hpp
+++ b/src/core/shape_inference/include/block_sparse_attention_shape_inference.hpp
@@ -1,0 +1,171 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "openvino/op/block_sparse_attention.hpp"
+#include "utils.hpp"
+
+namespace ov::op::v17 {
+
+/// \brief Shape inference for BlockSparseAttention.
+///
+/// Layout (all 4 tensors are rank 4):
+///   query:          [B, H,           L, E ]
+///   key:            [B, Hk,          S, E ]  (Hk == H, or Hk == 1 broadcast to all heads)
+///   value:          [B, Hk,          S, Ev]  (same Hk as key)
+///   block_indices:  [B, Hb, L / block_size, k_blocks]  (Hb == H, or Hb == 1 broadcast)
+///   block_indices_mask (optional): same shape as block_indices
+///   scale (optional): scalar or single-element tensor, not shape-relevant
+///   output:         [B, H,           L, Ev]
+template <class T, class TRShape = result_shape_t<T>>
+std::vector<TRShape> shape_infer(const BlockSparseAttention* op, const std::vector<T>& input_shapes) {
+    using DimType = typename T::value_type;
+    const auto& inputs_count = input_shapes.size();
+    NODE_SHAPE_INFER_CHECK(op,
+                           input_shapes,
+                           inputs_count >= 4 && inputs_count <= 6,
+                           "BlockSparseAttention expects 4 to 6 inputs (query, key, value, block_indices, "
+                           "[block_indices_mask], [scale]).");
+    const bool has_mask = inputs_count >= 5;
+    const bool has_scale = inputs_count == 6;
+
+    const auto& query_shape = input_shapes[0];
+    const auto& key_shape = input_shapes[1];
+    const auto& value_shape = input_shapes[2];
+    const auto& block_indices_shape = input_shapes[3];
+
+    for (auto* named_shape : {&query_shape, &key_shape, &value_shape, &block_indices_shape}) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               named_shape->rank().compatible(4),
+                               "Query, key, value and block_indices inputs must be rank 4 "
+                               "[batch, heads, tokens, features].");
+    }
+    if (has_mask) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               input_shapes[4].rank().compatible(4),
+                               "block_indices_mask must be rank 4, matching block_indices.");
+    }
+
+    // Batch and head dims are merged (with broadcasting, like ScaledDotProductAttention) across
+    // query/key/value/block_indices/block_indices_mask: each of key/value/block_indices/mask may
+    // provide a single shared head (broadcast to all query heads), matching the level of head
+    // broadcasting ScaledDotProductAttention itself supports. Arbitrary group sizes (e.g. an
+    // integer-multiple GQA grouping where 1 < Hk < H) are intentionally out of scope: real GQA
+    // models expand key/value to full head count with Broadcast/Tile before attention, exactly as
+    // they do for ScaledDotProductAttention.
+    DimType batch_dim{};
+    DimType head_dim{};
+    DimType l_dim{};
+    DimType e_dim{};
+    DimType s_dim{};
+    DimType ev_dim{};
+    DimType num_q_blocks_dim{};
+    DimType k_blocks_dim{};
+
+    // NOTE: the accumulator must be *seeded* from the first static-rank shape via plain
+    // assignment, not by broadcast_merge-ing from a default-constructed (fully dynamic) DimType:
+    // a fully dynamic interval already "contains 1", so broadcast_merge(dynamic, 1) widens back to
+    // dynamic instead of narrowing to 1, and the accumulator would never become static.
+    bool have_leading_dims = false;
+    auto merge_leading_dims = [&](const T& shape) {
+        if (!shape.rank().is_static()) {
+            return;
+        }
+        if (!have_leading_dims) {
+            batch_dim = shape[0];
+            head_dim = shape[1];
+            have_leading_dims = true;
+            return;
+        }
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               DimType::broadcast_merge(batch_dim, batch_dim, shape[0]) &&
+                                   DimType::broadcast_merge(head_dim, head_dim, shape[1]),
+                               "Incompatible batch/heads dimensions between query, key, value, "
+                               "block_indices and block_indices_mask.");
+    };
+    merge_leading_dims(query_shape);
+    merge_leading_dims(key_shape);
+    merge_leading_dims(value_shape);
+    merge_leading_dims(block_indices_shape);
+    if (has_mask) {
+        merge_leading_dims(input_shapes[4]);
+    }
+
+    if (query_shape.rank().is_static()) {
+        l_dim = query_shape[2];
+        e_dim = query_shape[3];
+    }
+    if (key_shape.rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               DimType::merge(e_dim, e_dim, key_shape[3]),
+                               "The head size (last dimension) of query and key must match.");
+        s_dim = key_shape[2];
+    }
+    if (value_shape.rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               DimType::merge(s_dim, s_dim, value_shape[2]),
+                               "The number of tokens (second-to-last dimension) of key and value must match.");
+        ev_dim = value_shape[3];
+    }
+    if (block_indices_shape.rank().is_static()) {
+        num_q_blocks_dim = block_indices_shape[2];
+        k_blocks_dim = block_indices_shape[3];
+    }
+    if (has_mask && input_shapes[4].rank().is_static()) {
+        NODE_SHAPE_INFER_CHECK(op,
+                               input_shapes,
+                               DimType::merge(num_q_blocks_dim, num_q_blocks_dim, input_shapes[4][2]) &&
+                                   DimType::merge(k_blocks_dim, k_blocks_dim, input_shapes[4][3]),
+                               "block_indices_mask shape must match block_indices shape.");
+    }
+    if (has_scale) {
+        const auto& scale_shape = input_shapes[5];
+        if (scale_shape.rank().is_static()) {
+            const bool scale_is_scalar = scale_shape.rank().compatible(0);
+            const bool scale_has_one_elem = scale_shape.rank().compatible(1) && scale_shape[0].compatible(1);
+            NODE_SHAPE_INFER_CHECK(op,
+                                   input_shapes,
+                                   scale_is_scalar || scale_has_one_elem,
+                                   "The scale input must be scalar or have a single element.");
+        }
+    }
+
+    const auto& block_size = op->get_block_size();
+    if (block_size > 0) {
+        if (l_dim.is_static()) {
+            NODE_SHAPE_INFER_CHECK(op,
+                                   input_shapes,
+                                   l_dim.get_length() % block_size == 0,
+                                   "The query length must be a multiple of 'block_size'.");
+            NODE_SHAPE_INFER_CHECK(op,
+                                   input_shapes,
+                                   DimType::merge(num_q_blocks_dim,
+                                                  num_q_blocks_dim,
+                                                  DimType(l_dim.get_length() / block_size)),
+                                   "block_indices' num_query_blocks dimension must equal query_len / block_size.");
+        }
+        if (s_dim.is_static()) {
+            NODE_SHAPE_INFER_CHECK(op,
+                                   input_shapes,
+                                   s_dim.get_length() % block_size == 0,
+                                   "The key/value length must be a multiple of 'block_size'.");
+        }
+    }
+
+    auto output_shapes = std::vector<TRShape>{TRShape{}};
+    auto& out = output_shapes[0];
+    out.resize(4);
+    out[0] = batch_dim;
+    out[1] = head_dim;
+    out[2] = l_dim;
+    out[3] = ev_dim;
+    return output_shapes;
+}
+
+}  // namespace ov::op::v17

--- a/src/core/src/op/block_sparse_attention.cpp
+++ b/src/core/src/op/block_sparse_attention.cpp
@@ -1,0 +1,113 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/block_sparse_attention.hpp"
+
+#include "block_sparse_attention_shape_inference.hpp"
+#include "itt.hpp"
+
+namespace ov::op::v17 {
+
+BlockSparseAttention::BlockSparseAttention(const OutputVector& inputs, int64_t block_size, bool causal)
+    : Op(inputs),
+      m_block_size(block_size),
+      m_causal(causal) {
+    constructor_validate_and_infer_types();
+}
+
+BlockSparseAttention::BlockSparseAttention(const Output<Node>& query,
+                                           const Output<Node>& key,
+                                           const Output<Node>& value,
+                                           const Output<Node>& block_indices,
+                                           const Output<Node>& block_indices_mask,
+                                           const Output<Node>& scale,
+                                           int64_t block_size,
+                                           bool causal)
+    : BlockSparseAttention({query, key, value, block_indices, block_indices_mask, scale}, block_size, causal) {}
+
+BlockSparseAttention::BlockSparseAttention(const Output<Node>& query,
+                                           const Output<Node>& key,
+                                           const Output<Node>& value,
+                                           const Output<Node>& block_indices,
+                                           const Output<Node>& block_indices_mask,
+                                           int64_t block_size,
+                                           bool causal)
+    : BlockSparseAttention({query, key, value, block_indices, block_indices_mask}, block_size, causal) {}
+
+BlockSparseAttention::BlockSparseAttention(const Output<Node>& query,
+                                           const Output<Node>& key,
+                                           const Output<Node>& value,
+                                           const Output<Node>& block_indices,
+                                           int64_t block_size,
+                                           bool causal)
+    : BlockSparseAttention({query, key, value, block_indices}, block_size, causal) {}
+
+void BlockSparseAttention::validate_and_infer_types() {
+    OV_OP_SCOPE(v17_BlockSparseAttention_validate_and_infer_types);
+
+    const auto& input_size = get_input_size();
+    NODE_VALIDATION_CHECK(this,
+                          input_size >= 4 && input_size <= 6,
+                          "BlockSparseAttention expects 4 to 6 inputs (query, key, value, block_indices, "
+                          "[block_indices_mask], [scale]), got ",
+                          input_size,
+                          ".");
+    NODE_VALIDATION_CHECK(this, m_block_size > 0, "The 'block_size' attribute must be a positive integer.");
+
+    const bool has_mask = input_size >= 5;
+    const bool has_scale = input_size == 6;
+
+    // query / key / value must share a floating-point type; block_indices is a separate
+    // integral input; block_indices_mask (if present) is boolean-valued (u8 is also accepted,
+    // since plugins such as CPU normalize boolean tensors to u8 storage -- e.g. via
+    // ov::pass::ConvertPrecision -- before an op ever sees them, and the two are byte-for-byte
+    // interchangeable for a strictly 0/1 mask); scale (if present) must merge with the
+    // floating-point data type.
+    auto data_type = get_input_element_type(0);
+    for (size_t i : {1u, 2u}) {
+        NODE_VALIDATION_CHECK(this,
+                              element::Type::merge(data_type, data_type, get_input_element_type(i)),
+                              "The element types of query, key and value must match.");
+    }
+    NODE_VALIDATION_CHECK(this,
+                          data_type.is_dynamic() || data_type.is_real(),
+                          "The element type of query, key and value must be a floating-point type.");
+
+    const auto& block_indices_type = get_input_element_type(3);
+    NODE_VALIDATION_CHECK(this,
+                          block_indices_type.is_dynamic() || block_indices_type.is_integral_number(),
+                          "The element type of 'block_indices' must be an integer type.");
+
+    if (has_mask) {
+        const auto& mask_type = get_input_element_type(4);
+        NODE_VALIDATION_CHECK(
+            this,
+            mask_type.is_dynamic() || mask_type == element::boolean || mask_type == element::u8,
+            "The element type of 'block_indices_mask' must be boolean (u8 is also accepted).");
+    }
+    if (has_scale) {
+        NODE_VALIDATION_CHECK(this,
+                              element::Type::merge(data_type, data_type, get_input_element_type(5)),
+                              "The element type of 'scale' must match query/key/value.");
+    }
+
+    const auto& input_shapes = ov::util::get_node_input_partial_shapes(*this);
+    const auto output_shapes = shape_infer(this, input_shapes);
+    set_output_type(0, data_type, output_shapes[0]);
+}
+
+bool BlockSparseAttention::visit_attributes(AttributeVisitor& visitor) {
+    OV_OP_SCOPE(v17_BlockSparseAttention_visit_attributes);
+    visitor.on_attribute("block_size", m_block_size);
+    visitor.on_attribute("causal", m_causal);
+    return true;
+}
+
+std::shared_ptr<Node> BlockSparseAttention::clone_with_new_inputs(const OutputVector& new_args) const {
+    OV_OP_SCOPE(v17_BlockSparseAttention_clone_with_new_inputs);
+    check_new_args_count(this, new_args);
+    return std::make_shared<BlockSparseAttention>(new_args, m_block_size, m_causal);
+}
+
+}  // namespace ov::op::v17

--- a/src/core/src/sources.cmake
+++ b/src/core/src/sources.cmake
@@ -73,6 +73,7 @@ set(LIBRARY_SRC
     ${CMAKE_CURRENT_LIST_DIR}/op/bitwise_or.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/bitwise_right_shift.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/bitwise_xor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/block_sparse_attention.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/broadcast.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/bucketize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/ceiling.cpp

--- a/src/core/tests/opset.cpp
+++ b/src/core/tests/opset.cpp
@@ -79,7 +79,7 @@ INSTANTIATE_TEST_SUITE_P(opset,
                                          OpsetTestParams{ov::get_opset14, 188},
                                          OpsetTestParams{ov::get_opset15, 199},
                                          OpsetTestParams{ov::get_opset16, 203},
-                                         OpsetTestParams{ov::get_opset17, 7}),
+                                         OpsetTestParams{ov::get_opset17, 8}),
                          OpsetTestNameGenerator{});
 
 class MyOpOld : public ov::op::Op {

--- a/src/core/tests/type_prop/block_sparse_attention.cpp
+++ b/src/core/tests/type_prop/block_sparse_attention.cpp
@@ -1,0 +1,257 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/block_sparse_attention.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "common_test_utils/type_prop.hpp"
+#include "openvino/openvino.hpp"
+
+using namespace ov;
+using namespace testing;
+
+namespace {
+using ov::op::v0::Parameter;
+using ov::op::v17::BlockSparseAttention;
+
+std::shared_ptr<Parameter> make_param(const element::Type& type, const PartialShape& shape) {
+    return std::make_shared<Parameter>(type, shape);
+}
+}  // namespace
+
+TEST(type_prop, block_sparse_attention_static_minimal) {
+    // batch=2, heads=4, L=8, E=16, S=32, Ev=16, block_size=4 -> num_q_blocks=2, k_blocks=3
+    const auto query = make_param(element::f32, PartialShape{2, 4, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{2, 4, 32, 16});
+    const auto value = make_param(element::f32, PartialShape{2, 4, 32, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{2, 4, 2, 3});
+
+    const auto op = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false);
+
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{2, 4, 8, 16}));
+    EXPECT_EQ(op->get_block_size(), 4);
+    EXPECT_FALSE(op->get_causal());
+}
+
+TEST(type_prop, block_sparse_attention_with_mask) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 24});
+    const auto block_indices = make_param(element::i64, PartialShape{1, 2, 2, 2});
+    const auto block_indices_mask = make_param(element::boolean, PartialShape{1, 2, 2, 2});
+
+    const auto op =
+        std::make_shared<BlockSparseAttention>(query, key, value, block_indices, block_indices_mask, 4, true);
+
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, 2, 8, 24}));
+    EXPECT_TRUE(op->get_causal());
+}
+
+TEST(type_prop, block_sparse_attention_with_u8_mask) {
+    // u8 must be accepted as an alternative to boolean for `block_indices_mask`: plugins such as
+    // CPU normalize `boolean` graph tensors to `u8` storage (via ov::pass::ConvertPrecision)
+    // before any op executes, so a graph built with a genuine boolean Parameter ends up feeding
+    // this op a u8 tensor once compiled -- this op must tolerate that, exactly like it must
+    // tolerate genuine boolean.
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 24});
+    const auto block_indices = make_param(element::i64, PartialShape{1, 2, 2, 2});
+    const auto block_indices_mask = make_param(element::u8, PartialShape{1, 2, 2, 2});
+
+    const auto op =
+        std::make_shared<BlockSparseAttention>(query, key, value, block_indices, block_indices_mask, 4, true);
+
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, 2, 8, 24}));
+    EXPECT_TRUE(op->get_causal());
+}
+
+TEST(type_prop, block_sparse_attention_with_mask_and_scale) {
+    const auto query = make_param(element::f16, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f16, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f16, PartialShape{1, 2, 16, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 2, 2});
+    const auto block_indices_mask = make_param(element::boolean, PartialShape{1, 2, 2, 2});
+    const auto scale = make_param(element::f16, PartialShape{});
+
+    const auto op = std::make_shared<BlockSparseAttention>(query,
+                                                           key,
+                                                           value,
+                                                           block_indices,
+                                                           block_indices_mask,
+                                                           scale,
+                                                           4,
+                                                           false);
+
+    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, 2, 8, 16}));
+}
+
+TEST(type_prop, block_sparse_attention_broadcast_single_kv_head) {
+    // 8 query heads, a single shared kv head and a single shared block-selection head,
+    // broadcast to every query head (the level of head broadcasting this op supports;
+    // arbitrary GQA grouping, e.g. Hk=2 with H=8, is intentionally not supported -- such
+    // models are expected to expand key/value with Broadcast/Tile before this op, exactly
+    // as they would before ScaledDotProductAttention).
+    const auto query = make_param(element::f32, PartialShape{1, 8, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 1, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 1, 16, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 1, 2, 2});
+
+    const auto op = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false);
+
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1, 8, 8, 16}));
+}
+
+TEST(type_prop, block_sparse_attention_dynamic_batch_and_length) {
+    const auto query = make_param(element::f32, PartialShape{Dimension::dynamic(), 4, Dimension::dynamic(), 16});
+    const auto key = make_param(element::f32, PartialShape{Dimension::dynamic(), 4, Dimension::dynamic(), 16});
+    const auto value = make_param(element::f32, PartialShape{Dimension::dynamic(), 4, Dimension::dynamic(), 16});
+    const auto block_indices =
+        make_param(element::i32, PartialShape{Dimension::dynamic(), 4, Dimension::dynamic(), 3});
+
+    const auto op = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false);
+
+    EXPECT_EQ(op->get_output_partial_shape(0),
+              (PartialShape{Dimension::dynamic(), 4, Dimension::dynamic(), 16}));
+}
+
+TEST(type_prop, block_sparse_attention_dynamic_rank_inputs) {
+    const auto query = make_param(element::f32, PartialShape::dynamic());
+    const auto key = make_param(element::f32, PartialShape::dynamic());
+    const auto value = make_param(element::f32, PartialShape::dynamic());
+    const auto block_indices = make_param(element::i32, PartialShape::dynamic());
+
+    const auto op = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false);
+
+    EXPECT_EQ(op->get_output_partial_shape(0).rank(), (Rank(4)));
+}
+
+TEST(type_prop, block_sparse_attention_incompatible_data_types) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f16, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 2, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("element types"));
+}
+
+TEST(type_prop, block_sparse_attention_non_integer_block_indices) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto block_indices = make_param(element::f32, PartialShape{1, 2, 2, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("integer"));
+}
+
+TEST(type_prop, block_sparse_attention_non_boolean_mask) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 2, 2});
+    const auto block_indices_mask = make_param(element::i32, PartialShape{1, 2, 2, 2});
+
+    OV_EXPECT_THROW(
+        std::ignore =
+            std::make_shared<BlockSparseAttention>(query, key, value, block_indices, block_indices_mask, 4, false),
+        NodeValidationFailure,
+        HasSubstr("boolean"));
+}
+
+TEST(type_prop, block_sparse_attention_rank_mismatch) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 2, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("rank 4"));
+}
+
+TEST(type_prop, block_sparse_attention_head_size_mismatch) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 32});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 2, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("head size"));
+}
+
+TEST(type_prop, block_sparse_attention_key_value_length_mismatch) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 20, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 2, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("number of tokens"));
+}
+
+TEST(type_prop, block_sparse_attention_query_length_not_multiple_of_block_size) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 9, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 3, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("multiple of 'block_size'"));
+}
+
+TEST(type_prop, block_sparse_attention_key_length_not_multiple_of_block_size) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 18, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 18, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 2, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("multiple of 'block_size'"));
+}
+
+TEST(type_prop, block_sparse_attention_num_query_blocks_mismatch) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    // query has 2 blocks (8/4), but block_indices says 3
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 3, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("num_query_blocks"));
+}
+
+TEST(type_prop, block_sparse_attention_invalid_block_size) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto value = make_param(element::f32, PartialShape{1, 2, 16, 16});
+    const auto block_indices = make_param(element::i32, PartialShape{1, 2, 2, 2});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(query, key, value, block_indices, 0, false),
+                    NodeValidationFailure,
+                    HasSubstr("block_size"));
+}
+
+TEST(type_prop, block_sparse_attention_wrong_input_count) {
+    const auto query = make_param(element::f32, PartialShape{1, 2, 8, 16});
+    const auto key = make_param(element::f32, PartialShape{1, 2, 16, 16});
+
+    OV_EXPECT_THROW(std::ignore = std::make_shared<BlockSparseAttention>(OutputVector{query, key}, 4, false),
+                    NodeValidationFailure,
+                    HasSubstr("4 to 6 inputs"));
+}

--- a/src/core/tests/type_prop/sources.cmake
+++ b/src/core/tests/type_prop/sources.cmake
@@ -27,6 +27,7 @@ set(OV_CORE_TESTS_TYPE_PROP_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/bitwise_or.cpp
     ${CMAKE_CURRENT_LIST_DIR}/bitwise_right_shift.cpp
     ${CMAKE_CURRENT_LIST_DIR}/bitwise_xor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/block_sparse_attention.cpp
     ${CMAKE_CURRENT_LIST_DIR}/broadcast.cpp
     ${CMAKE_CURRENT_LIST_DIR}/bucketize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ceiling.cpp

--- a/src/core/tests/visitors/op/block_sparse_attention.cpp
+++ b/src/core/tests/visitors/op/block_sparse_attention.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/block_sparse_attention.hpp"
+
+#include <gtest/gtest.h>
+
+#include "visitors/visitors.hpp"
+
+namespace ov::test {
+using ov::op::v0::Parameter, ov::test::NodeBuilder;
+
+TEST(attributes, block_sparse_attention_v17) {
+    NodeBuilder::opset().insert<ov::op::v17::BlockSparseAttention>();
+    const auto query = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{2, 4, 8, 16});
+    const auto key = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{2, 4, 32, 16});
+    const auto value = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{2, 4, 32, 16});
+    const auto block_indices = std::make_shared<Parameter>(ov::element::i32, ov::PartialShape{2, 4, 2, 3});
+
+    const auto op = std::make_shared<ov::op::v17::BlockSparseAttention>(query, key, value, block_indices, 4, true);
+    NodeBuilder builder(op, {query, key, value, block_indices});
+    auto g_op = ov::as_type_ptr<ov::op::v17::BlockSparseAttention>(builder.create());
+
+    EXPECT_EQ(g_op->get_block_size(), op->get_block_size());
+    EXPECT_EQ(g_op->get_causal(), op->get_causal());
+    EXPECT_EQ(g_op->get_output_partial_shape(0), op->get_output_partial_shape(0));
+    EXPECT_EQ(g_op->get_output_element_type(0), op->get_output_element_type(0));
+}
+
+}  // namespace ov::test

--- a/src/core/tests/visitors/sources.cmake
+++ b/src/core/tests/visitors/sources.cmake
@@ -29,6 +29,7 @@ set(OV_CORE_TESTS_VISITORS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/op/bitwise_or.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/bitwise_rigth_shift.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/bitwise_xor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/op/block_sparse_attention.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/broadcast.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/bucketize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/op/ceiling.cpp

--- a/src/plugins/intel_cpu/src/cpu_types.cpp
+++ b/src/plugins/intel_cpu/src/cpu_types.cpp
@@ -251,6 +251,7 @@ static const TypeToNameMap& get_type_to_name_tbl() {
         {"ScaledDotProductAttention", Type::ScaledDotProductAttention},
         {"ScaledDotProductAttentionWithKVCache", Type::ScaledDotProductAttention},
         {"SDPAWithTransposeReshape", Type::ScaledDotProductAttention},
+        {"BlockSparseAttention", Type::BlockSparseAttention},
         {"PagedAttentionExtension", Type::PagedAttention},
         {"PaKVReorder", Type::PaKVReorder},
         {"RoPE", Type::RoPE},
@@ -393,6 +394,7 @@ std::string NameFromType(const Type type) {
         CASE(Unique);
         CASE(Ngram);
         CASE(ScaledDotProductAttention);
+        CASE(BlockSparseAttention);
         CASE(PagedAttention);
         CASE(PaKVReorder);
         CASE(RoPE);

--- a/src/plugins/intel_cpu/src/cpu_types.h
+++ b/src/plugins/intel_cpu/src/cpu_types.h
@@ -129,6 +129,7 @@ enum class Type : uint8_t {
     Unique,
     Ngram,
     ScaledDotProductAttention,
+    BlockSparseAttention,
     PagedAttention,
     PaKVReorder,
     RoPE,

--- a/src/plugins/intel_cpu/src/nodes/block_sparse_attention.cpp
+++ b/src/plugins/intel_cpu/src/nodes/block_sparse_attention.cpp
@@ -1,0 +1,207 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "block_sparse_attention.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <oneapi/dnnl/dnnl_common.hpp>
+#include <string>
+#include <tuple>
+
+#include "cpu_types.h"
+#include "graph_context.h"
+#include "memory_desc/cpu_memory_desc.h"
+#include "node.h"
+#include "onednn/iml_type_mapper.h"
+#include "openvino/core/except.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/parallel.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/block_sparse_attention.hpp"
+#include "openvino/reference/block_sparse_attention.hpp"
+#include "selective_build.h"
+#include "shape_inference/shape_inference_cpu.hpp"
+#include "utils/general_utils.h"
+
+namespace ov::intel_cpu::node {
+
+BlockSparseAttention::BlockSparseAttention(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
+    : Node(op, context, NgraphShapeInferFactory(op)) {
+    std::string errorMessage;
+    if (!isSupportedOperation(op, errorMessage)) {
+        OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
+    }
+    const auto bsa_op = ov::as_type_ptr<const ov::op::v17::BlockSparseAttention>(op);
+    m_block_size = bsa_op->get_block_size();
+    m_causal = bsa_op->get_causal();
+    m_has_mask = op->get_input_size() >= 5;
+    m_has_scale = op->get_input_size() == 6;
+}
+
+bool BlockSparseAttention::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
+                                                std::string& errorMessage) noexcept {
+    try {
+        if (!ov::is_type<ov::op::v17::BlockSparseAttention>(op)) {
+            errorMessage = "Only opset17 BlockSparseAttention operation is supported";
+            return false;
+        }
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+
+void BlockSparseAttention::getSupportedDescriptors() {
+    // Validation is already done in ov::op::v17::BlockSparseAttention::validate_and_infer_types().
+}
+
+void BlockSparseAttention::initSupportedPrimitiveDescriptors() {
+    if (!supportedPrimitiveDescriptors.empty()) {
+        return;
+    }
+
+    ov::element::Type dataPrec = getOriginalInputPrecisionAtPort(0);
+    if (none_of(dataPrec, ov::element::f32, ov::element::bf16)) {
+        dataPrec = ov::element::f32;
+    }
+
+    ov::element::Type indexPrec = getOriginalInputPrecisionAtPort(3);
+    if (none_of(indexPrec, ov::element::i32, ov::element::i64)) {
+        indexPrec = ov::element::i64;
+    }
+
+    std::vector<PortConfigurator> inConfs{{LayoutType::ncsp, dataPrec},
+                                          {LayoutType::ncsp, dataPrec},
+                                          {LayoutType::ncsp, dataPrec},
+                                          {LayoutType::ncsp, indexPrec}};
+    if (m_has_mask) {
+        // ov::pass::ConvertPrecision (run by most plugins, including CPU) normalizes
+        // `boolean`-typed graph tensors to `u8` storage before an op ever executes, splicing in
+        // a Convert on that edge -- mirrors intel_cpu's own ScaledDotProductAttention node, which
+        // negotiates the same port as u8 whenever the *original* (pre-conversion) input precision
+        // was already u8, and as boolean otherwise.
+        ov::element::Type maskPrec = getOriginalInputPrecisionAtPort(4);
+        if (maskPrec != ov::element::u8) {
+            maskPrec = ov::element::boolean;
+        }
+        inConfs.emplace_back(LayoutType::ncsp, maskPrec);
+    }
+    if (m_has_scale) {
+        inConfs.emplace_back(LayoutType::ncsp, dataPrec);
+    }
+
+    addSupportedPrimDesc(inConfs, {{LayoutType::ncsp, dataPrec}}, impl_desc_type::ref);
+}
+
+bool BlockSparseAttention::created() const {
+    return getType() == Type::BlockSparseAttention;
+}
+
+template <typename T, typename TIndex>
+void BlockSparseAttention::executeImpl() {
+    const auto* query = getSrcDataAtPortAs<const T>(0);
+    const auto* key = getSrcDataAtPortAs<const T>(1);
+    const auto* value = getSrcDataAtPortAs<const T>(2);
+    const auto* blockIndices = getSrcDataAtPortAs<const TIndex>(3);
+    const char* mask = m_has_mask ? getSrcDataAtPortAs<const char>(4) : nullptr;
+    const T* scale = m_has_scale ? getSrcDataAtPortAs<const T>(5) : nullptr;
+    auto* output = getDstDataAtPortAs<T>(0);
+
+    const ov::Shape queryShape{getSrcMemoryAtPort(0)->getStaticDims()};
+    const ov::Shape keyShape{getSrcMemoryAtPort(1)->getStaticDims()};
+    const ov::Shape valueShape{getSrcMemoryAtPort(2)->getStaticDims()};
+    const ov::Shape blockIndicesShape{getSrcMemoryAtPort(3)->getStaticDims()};
+
+    const auto B = static_cast<int64_t>(queryShape[0]);
+    const auto H = static_cast<int64_t>(queryShape[1]);
+    const auto L = static_cast<int64_t>(queryShape[2]);
+    const auto E = static_cast<int64_t>(queryShape[3]);
+    const auto Hk = static_cast<int64_t>(keyShape[1]);
+    const auto S = static_cast<int64_t>(keyShape[2]);
+    const auto Ev = static_cast<int64_t>(valueShape[3]);
+    const auto Hb = static_cast<int64_t>(blockIndicesShape[1]);
+    const auto numQBlocks = static_cast<int64_t>(blockIndicesShape[2]);
+    const auto kBlocks = static_cast<int64_t>(blockIndicesShape[3]);
+
+    const auto broadcastHead = [](int64_t h, int64_t dimSize) {
+        return dimSize == 1 ? int64_t{0} : h;
+    };
+
+    const ov::Shape sliceQueryShape{1, 1, static_cast<size_t>(L), static_cast<size_t>(E)};
+    const ov::Shape sliceKeyShape{1, 1, static_cast<size_t>(S), static_cast<size_t>(E)};
+    const ov::Shape sliceValueShape{1, 1, static_cast<size_t>(S), static_cast<size_t>(Ev)};
+    const ov::Shape sliceBlockIndicesShape{1, 1, static_cast<size_t>(numQBlocks), static_cast<size_t>(kBlocks)};
+
+    // Parallelize across (batch, head): every (b, h) pair is fully independent, so each task
+    // slices out exactly one head's worth of query/key/value/block_indices/output and delegates
+    // to the shared reference kernel with B=H=1. This reuses the exact same math already
+    // validated by the core unit tests and the Template-plugin functional tests, adding
+    // multi-core scaling on top without introducing any new attention/softmax logic here.
+    ov::parallel_for2d(B, H, [&](int64_t b, int64_t h) {
+        const T* qSlice = query + static_cast<size_t>((b * H + h) * L * E);
+        const T* kSlice = key + static_cast<size_t>((b * Hk + broadcastHead(h, Hk)) * S * E);
+        const T* vSlice = value + static_cast<size_t>((b * Hk + broadcastHead(h, Hk)) * S * Ev);
+        const TIndex* biSlice =
+            blockIndices + static_cast<size_t>((b * Hb + broadcastHead(h, Hb)) * numQBlocks * kBlocks);
+        const char* maskSlice =
+            mask ? mask + static_cast<size_t>((b * Hb + broadcastHead(h, Hb)) * numQBlocks * kBlocks) : nullptr;
+        T* outSlice = output + static_cast<size_t>((b * H + h) * L * Ev);
+
+        ov::reference::block_sparse_attention<T, TIndex>(qSlice,
+                                                          kSlice,
+                                                          vSlice,
+                                                          biSlice,
+                                                          maskSlice,
+                                                          scale,
+                                                          outSlice,
+                                                          m_causal,
+                                                          m_block_size,
+                                                          sliceQueryShape,
+                                                          sliceKeyShape,
+                                                          sliceValueShape,
+                                                          sliceBlockIndicesShape);
+    });
+}
+
+namespace {
+struct BlockSparseAttentionContext {
+    BlockSparseAttention& node;
+};
+}  // namespace
+
+template <typename T>
+struct BlockSparseAttention::Execute {
+    using TData = typename std::tuple_element<0, T>::type;
+    using TIndexType = typename std::tuple_element<1, T>::type;
+
+    void operator()(BlockSparseAttentionContext& ctx) {
+        ctx.node.executeImpl<TData, TIndexType>();
+    }
+};
+
+void BlockSparseAttention::execute([[maybe_unused]] const dnnl::stream& strm) {
+    auto dataPrecision = getParentEdgeAt(0)->getMemory().getDesc().getPrecision();
+    auto indexPrecision = getParentEdgeAt(3)->getMemory().getDesc().getPrecision();
+
+    BlockSparseAttentionContext ctx = {*this};
+
+#define CASE(OV_TYPE)                                                                             \
+    OV_CASE2(OV_TYPE, ov::element::i32, ov::element_type_traits<OV_TYPE>::value_type, int32_t),  \
+        OV_CASE2(OV_TYPE, ov::element::i64, ov::element_type_traits<OV_TYPE>::value_type, int64_t)
+
+    OV_SWITCH(intel_cpu,
+              Execute,
+              ctx,
+              std::tie(dataPrecision, indexPrecision),
+              CASE(ov::element::f32),
+              CASE(ov::element::bf16))
+
+#undef CASE
+}
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/block_sparse_attention.h
+++ b/src/plugins/intel_cpu/src/nodes/block_sparse_attention.h
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <oneapi/dnnl/dnnl_common.hpp>
+#include <string>
+
+#include "graph_context.h"
+#include "node.h"
+#include "openvino/core/node.hpp"
+
+namespace ov::intel_cpu::node {
+
+class BlockSparseAttention : public Node {
+public:
+    BlockSparseAttention(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
+
+    static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
+    void getSupportedDescriptors() override;
+    void initSupportedPrimitiveDescriptors() override;
+    void execute(const dnnl::stream& strm) override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override {
+        return false;
+    }
+    void executeDynamicImpl(const dnnl::stream& strm) override {
+        execute(strm);
+    }
+
+private:
+    template <typename T, typename TIndex>
+    void executeImpl();
+
+    template <typename T>
+    struct Execute;
+
+    bool m_has_mask = false;
+    bool m_has_scale = false;
+    int64_t m_block_size = 0;
+    bool m_causal = false;
+};
+
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes_factory.cpp
+++ b/src/plugins/intel_cpu/src/nodes_factory.cpp
@@ -36,6 +36,7 @@
 #include "nodes/experimental_detectron_topkrois.h"
 #include "nodes/extract_image_patches.h"
 #include "nodes/eye.h"
+#include "nodes/block_sparse_attention.h"
 #include "nodes/fullyconnected.h"
 #include "nodes/gated_delta_net.h"
 #include "nodes/gather.h"
@@ -242,6 +243,7 @@ Node::NodesFactory::NodesFactory() : Factory("NodesFactory") {
     INTEL_CPU_NODE(Subgraph, Type::Subgraph);
     INTEL_CPU_NODE(Composite, Type::SubModel);
     INTEL_CPU_NODE(ScaledDotProductAttention, Type::ScaledDotProductAttention);
+    INTEL_CPU_NODE(BlockSparseAttention, Type::BlockSparseAttention);
     INTEL_CPU_NODE(PaKVReorder, Type::PaKVReorder);
     INTEL_CPU_NODE(SearchSorted, Type::SearchSorted);
     INTEL_CPU_NODE(SegmentMax, Type::SegmentMax);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/block_sparse_attention.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/block_sparse_attention.cpp
@@ -1,0 +1,138 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <cstring>
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/op/block_sparse_attention.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "utils/cpu_test_utils.hpp"
+
+using namespace CPUTestUtils;
+
+namespace ov {
+namespace test {
+namespace {
+
+// End-to-end CPU-plugin correctness test: `SubgraphBaseTest::run()` compiles and infers this
+// graph on the real intel_cpu plugin, then automatically cross-checks the result against the
+// same graph run through the Template plugin's interpreter (`calculate_refs()` in
+// ov_subgraph.cpp calls `ov::test::utils::infer_on_template(...)`) -- i.e. against the very
+// backend already validated numerically against ScaledDotProductAttention in
+// src/plugins/template/tests/functional/op_reference/block_sparse_attention.cpp. No separate,
+// hand-derived oracle is needed here: this test exists to prove the CPU node's registration,
+// primitive-descriptor negotiation, and executor wiring produce the same result as the
+// already-trusted reference path, not to re-validate the attention math itself.
+struct BlockSparseAttentionCPUTestParams {
+    ov::Shape queryShape;
+    ov::Shape keyShape;
+    ov::Shape valueShape;
+    ov::Shape blockIndicesShape;
+    int64_t blockSize;
+    bool causal;
+    bool withMask;
+    std::string name;
+};
+
+using BlockSparseAttentionCPUTestParamsTuple = std::tuple<BlockSparseAttentionCPUTestParams, ElementType>;
+
+class BlockSparseAttentionCPUTest : public testing::WithParamInterface<BlockSparseAttentionCPUTestParamsTuple>,
+                                     virtual public SubgraphBaseTest,
+                                     public CPUTestsBase {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<BlockSparseAttentionCPUTestParamsTuple>& obj) {
+        const auto& [params, prc] = obj.param;
+        std::ostringstream result;
+        result << params.name << "_prc=" << prc;
+        return result.str();
+    }
+
+protected:
+    BlockSparseAttentionCPUTestParams m_params;
+
+    void SetUp() override {
+        targetDevice = utils::DEVICE_CPU;
+        const auto& [params, prc] = this->GetParam();
+        m_params = params;
+
+        const auto query = std::make_shared<ov::op::v0::Parameter>(prc, params.queryShape);
+        const auto key = std::make_shared<ov::op::v0::Parameter>(prc, params.keyShape);
+        const auto value = std::make_shared<ov::op::v0::Parameter>(prc, params.valueShape);
+        const auto blockIndices =
+            std::make_shared<ov::op::v0::Parameter>(ov::element::i64, params.blockIndicesShape);
+
+        ov::OutputVector graphInputs{query, key, value, blockIndices};
+        ov::ParameterVector paramVec{query, key, value, blockIndices};
+        std::vector<ov::Shape> shapesInOrder{params.queryShape, params.keyShape, params.valueShape,
+                                             params.blockIndicesShape};
+
+        if (params.withMask) {
+            const auto mask =
+                std::make_shared<ov::op::v0::Parameter>(ov::element::boolean, params.blockIndicesShape);
+            graphInputs.push_back(mask);
+            paramVec.push_back(mask);
+            shapesInOrder.push_back(params.blockIndicesShape);
+        }
+
+        const auto op =
+            std::make_shared<ov::op::v17::BlockSparseAttention>(graphInputs, params.blockSize, params.causal);
+        function = std::make_shared<ov::Model>(ov::OutputVector{op}, paramVec, "BlockSparseAttention");
+
+        init_input_shapes(ov::test::static_shapes_to_test_representation(shapesInOrder));
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& funcInputs = function->inputs();
+        const int64_t numKvBlocks = static_cast<int64_t>(m_params.keyShape[2]) / m_params.blockSize;
+
+        for (size_t i = 0; i < funcInputs.size(); ++i) {
+            const auto& funcInput = funcInputs[i];
+            const auto& shape = targetInputStaticShapes[i];
+            ov::Tensor tensor;
+
+            if (i == 3) {
+                // block_indices: round-robin over the valid [0, numKvBlocks) range instead of
+                // arbitrary random data, which would produce out-of-range indices.
+                std::vector<int64_t> data(shape_size(shape));
+                for (size_t idx = 0; idx < data.size(); ++idx) {
+                    data[idx] = static_cast<int64_t>(idx % static_cast<size_t>(numKvBlocks));
+                }
+                tensor = ov::Tensor(ov::element::i64, shape);
+                std::memcpy(tensor.data(), data.data(), data.size() * sizeof(int64_t));
+            } else if (i == 4) {
+                // block_indices_mask: all-true -- every generated index above is meant to be used.
+                std::vector<char> data(shape_size(shape), 1);
+                tensor = ov::Tensor(ov::element::boolean, shape);
+                std::memcpy(tensor.data(), data.data(), data.size());
+            } else {
+                tensor = utils::create_and_fill_tensor(funcInput.get_element_type(), shape, 2, -1, 100);
+            }
+            inputs.insert({funcInput.get_node_shared_ptr(), tensor});
+        }
+    }
+};
+
+TEST_P(BlockSparseAttentionCPUTest, CompareWithRefs) {
+    run();
+}
+
+const std::vector<BlockSparseAttentionCPUTestParams> params = {
+    {{1, 2, 8, 4}, {1, 2, 8, 4}, {1, 2, 8, 4}, {1, 2, 4, 4}, 2, false, false, "DenseEquivalent"},
+    {{1, 2, 8, 4}, {1, 2, 8, 4}, {1, 2, 8, 4}, {1, 2, 4, 4}, 2, true, false, "Causal"},
+    {{1, 2, 8, 4}, {1, 2, 8, 4}, {1, 2, 8, 4}, {1, 2, 4, 2}, 2, false, false, "SparseUniformSelection"},
+    {{1, 2, 8, 4}, {1, 2, 8, 4}, {1, 2, 8, 4}, {1, 2, 4, 3}, 2, false, true, "PaddingMask"},
+    {{1, 4, 8, 4}, {1, 1, 8, 4}, {1, 1, 8, 4}, {1, 1, 4, 4}, 2, false, false, "HeadBroadcast"},
+    {{2, 2, 16, 8}, {2, 2, 16, 8}, {2, 2, 16, 8}, {2, 2, 8, 3}, 2, false, true, "MultiBatchLargerBlocks"},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_BlockSparseAttention,
+                         BlockSparseAttentionCPUTest,
+                         ::testing::Combine(::testing::ValuesIn(params),
+                                            ::testing::Values(ElementType::f32, ElementType::bf16)),
+                         BlockSparseAttentionCPUTest::getTestCaseName);
+
+}  // namespace
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/template/backend/ops/block_sparse_attention.cpp
+++ b/src/plugins/template/backend/ops/block_sparse_attention.cpp
@@ -1,0 +1,85 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/reference/block_sparse_attention.hpp"
+
+#include "block_sparse_attention_shape_inference.hpp"
+#include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/block_sparse_attention.hpp"
+
+namespace {
+
+template <ov::element::Type_t ET, ov::element::Type_t ETIndex>
+bool evaluate(const std::shared_ptr<ov::op::v17::BlockSparseAttention>& op,
+              ov::TensorVector& outputs,
+              const ov::TensorVector& inputs) {
+    using T = typename ov::element_type_traits<ET>::value_type;
+    using TIndex = typename ov::element_type_traits<ETIndex>::value_type;
+
+    const bool has_mask = inputs.size() >= 5;
+    const bool has_scale = inputs.size() == 6;
+    const char* mask = has_mask ? inputs[4].data<const char>() : nullptr;
+    const T* scale = has_scale ? inputs[5].data<const T>() : nullptr;
+
+    // Hack below is needed to support dynamic shapes in the reference implementation, mirroring
+    // ScaledDotProductAttention's own template-plugin evaluate: at this point the *actual* fully
+    // static input shapes are known, while validate_and_infer_types() may only have seen
+    // partially dynamic ones.
+    const auto input_shapes = ov::util::get_tensors_partial_shapes(inputs);
+    const auto output_shape = ov::op::v17::shape_infer(op.get(), input_shapes).front().to_shape();
+    outputs[0].set_shape(output_shape);
+
+    ov::reference::block_sparse_attention<T, TIndex>(inputs[0].data<const T>(),
+                                                      inputs[1].data<const T>(),
+                                                      inputs[2].data<const T>(),
+                                                      inputs[3].data<const TIndex>(),
+                                                      mask,
+                                                      scale,
+                                                      outputs[0].data<T>(),
+                                                      op->get_causal(),
+                                                      op->get_block_size(),
+                                                      inputs[0].get_shape(),
+                                                      inputs[1].get_shape(),
+                                                      inputs[2].get_shape(),
+                                                      inputs[3].get_shape());
+    return true;
+}
+
+template <ov::element::Type_t ET>
+bool evaluate_by_index_type(const std::shared_ptr<ov::op::v17::BlockSparseAttention>& op,
+                            ov::TensorVector& outputs,
+                            const ov::TensorVector& inputs) {
+    switch (inputs[3].get_element_type()) {
+    case ov::element::i32:
+        return evaluate<ET, ov::element::i32>(op, outputs, inputs);
+    case ov::element::i64:
+        return evaluate<ET, ov::element::i64>(op, outputs, inputs);
+    default:
+        OPENVINO_THROW("Unhandled 'block_indices' data type ",
+                       inputs[3].get_element_type(),
+                       " in evaluate_node()");
+    }
+}
+
+}  // namespace
+
+template <>
+bool evaluate_node<ov::op::v17::BlockSparseAttention>(std::shared_ptr<ov::Node> node,
+                                                      ov::TensorVector& outputs,
+                                                      const ov::TensorVector& inputs) {
+    const auto op = ov::as_type_ptr<ov::op::v17::BlockSparseAttention>(node);
+    switch (node->get_input_element_type(0)) {
+    case ov::element::bf16:
+        return evaluate_by_index_type<ov::element::bf16>(op, outputs, inputs);
+    case ov::element::f16:
+        return evaluate_by_index_type<ov::element::f16>(op, outputs, inputs);
+    case ov::element::f32:
+        return evaluate_by_index_type<ov::element::f32>(op, outputs, inputs);
+    case ov::element::f64:
+        return evaluate_by_index_type<ov::element::f64>(op, outputs, inputs);
+    default:
+        OPENVINO_THROW("Unhandled data type ", node->get_input_element_type(0), " in evaluate_node()");
+    }
+}

--- a/src/plugins/template/backend/ops/ops_evaluates.hpp
+++ b/src/plugins/template/backend/ops/ops_evaluates.hpp
@@ -582,6 +582,10 @@ extern template bool evaluate_node<ov::op::v17::ErfInv>(std::shared_ptr<ov::Node
                                                         ov::TensorVector& outputs,
                                                         const ov::TensorVector& inputs);
 
+extern template bool evaluate_node<ov::op::v17::BlockSparseAttention>(std::shared_ptr<ov::Node> node,
+                                                                      ov::TensorVector& outputs,
+                                                                      const ov::TensorVector& inputs);
+
 extern template bool evaluate_node<ov::op::v17::GroupedMatMul>(std::shared_ptr<ov::Node> node,
                                                                ov::TensorVector& outputs,
                                                                const ov::TensorVector& inputs);

--- a/src/plugins/template/backend/opset_int_tbl.hpp
+++ b/src/plugins/template/backend/opset_int_tbl.hpp
@@ -179,6 +179,7 @@ _OPENVINO_OP_REG(SliceScatter, ov::op::v15)
 _OPENVINO_OP_REG(SearchSorted, ov::op::v15)
 
 _OPENVINO_OP_REG(AvgPool, ov::op::v16)
+_OPENVINO_OP_REG(BlockSparseAttention, ov::op::v17)
 _OPENVINO_OP_REG(ErfInv, ov::op::v17)
 _OPENVINO_OP_REG(GroupedMatMul, ov::op::v17)
 _OPENVINO_OP_REG(Identity, ov::op::v16)

--- a/src/plugins/template/tests/functional/CMakeLists.txt
+++ b/src/plugins/template/tests/functional/CMakeLists.txt
@@ -17,6 +17,7 @@ ov_add_test_target(
         LINK_LIBRARIES
             openvino::funcSharedTests
             openvino::runtime::dev
+            openvino::reference
         INCLUDES
             "${OpenVINOTemplatePlugin_SOURCE_DIR}/include"
             "${CMAKE_CURRENT_SOURCE_DIR}/op_reference"

--- a/src/plugins/template/tests/functional/op_reference/block_sparse_attention.cpp
+++ b/src/plugins/template/tests/functional/op_reference/block_sparse_attention.cpp
@@ -1,0 +1,541 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/block_sparse_attention.hpp"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "base_reference_test.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/reference/scaled_dot_product_attention.hpp"
+
+using namespace reference_tests;
+using namespace ov;
+
+namespace {
+
+// Deterministic (seeded) pseudo-random fill -- makes the very same test data reproducible
+// across compilers/runs without committing large literal arrays to the source tree.
+std::vector<float> makeData(size_t count, uint32_t seed) {
+    std::mt19937 gen(seed);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<float> data(count);
+    for (auto& v : data) {
+        v = dist(gen);
+    }
+    return data;
+}
+
+// Runs the already-upstream, trusted ScaledDotProductAttention-13 reference kernel.
+// BlockSparseAttention's own kernel must never be used to validate itself -- every expected
+// value in this file is produced by this independent, pre-existing oracle instead.
+std::vector<float> denseReference(const std::vector<float>& q,
+                                   const std::vector<float>& k,
+                                   const std::vector<float>& v,
+                                   const Shape& q_shape,
+                                   const Shape& k_shape,
+                                   const Shape& v_shape,
+                                   bool is_causal,
+                                   const float* scale = nullptr) {
+    Shape out_shape = q_shape;
+    out_shape.back() = v_shape.back();
+    std::vector<float> out(shape_size(out_shape), 0.0f);
+    ov::reference::scaled_dot_product_attention<float, char>(q.data(),
+                                                              k.data(),
+                                                              v.data(),
+                                                              nullptr,
+                                                              scale,
+                                                              nullptr,
+                                                              out.data(),
+                                                              is_causal,
+                                                              q_shape,
+                                                              k_shape,
+                                                              v_shape,
+                                                              Shape{},
+                                                              Shape{},
+                                                              out_shape);
+    return out;
+}
+
+// Concatenates the requested blocks (each `block_size` long along the sequence axis) out of a
+// [B, Hk, S, E] tensor into a shorter, contiguous [B, Hk, blocks.size()*block_size, E] tensor.
+// This is the "obviously correct" (if inefficient) mathematical definition of block-sparse
+// attention with a *uniform* selection (same blocks picked for every query position): gather the
+// selected blocks, then run plain dense attention over just those tokens. It is intentionally a
+// different code path from BlockSparseAttention's own direct-indexed reference kernel.
+std::vector<float> gatherBlocks(const std::vector<float>& tensor,
+                                 const Shape& shape,
+                                 const std::vector<int64_t>& blocks,
+                                 int64_t block_size) {
+    const auto B = static_cast<int64_t>(shape[0]);
+    const auto Hk = static_cast<int64_t>(shape[1]);
+    const auto S = static_cast<int64_t>(shape[2]);
+    const auto E = static_cast<int64_t>(shape[3]);
+    std::vector<float> out(static_cast<size_t>(B * Hk * static_cast<int64_t>(blocks.size()) * block_size * E));
+    size_t o = 0;
+    for (int64_t b = 0; b < B; ++b) {
+        for (int64_t h = 0; h < Hk; ++h) {
+            for (const auto blk : blocks) {
+                const size_t base = static_cast<size_t>(((b * Hk + h) * S + blk * block_size) * E);
+                const size_t len = static_cast<size_t>(block_size * E);
+                std::copy(tensor.begin() + static_cast<std::ptrdiff_t>(base),
+                          tensor.begin() + static_cast<std::ptrdiff_t>(base + len),
+                          out.begin() + static_cast<std::ptrdiff_t>(o));
+                o += len;
+            }
+        }
+    }
+    return out;
+}
+
+// Independent oracle for the case where DIFFERENT query blocks select DIFFERENT sets of key
+// blocks (the realistic case for e.g. a "local window + global sink block" sparsity pattern, as
+// used by FlashVSR-style long-context video attention). For each query block this gathers just
+// that row-group's selected blocks and calls the trusted dense SDPA reference on the resulting
+// short sequence -- BlockSparseAttention's own kernel is not involved in producing this value.
+std::vector<float> referenceViaPerBlockGather(const std::vector<float>& q,
+                                               const std::vector<float>& k,
+                                               const std::vector<float>& v,
+                                               const Shape& q_shape,
+                                               const Shape& k_shape,
+                                               const Shape& v_shape,
+                                               const std::vector<std::vector<int64_t>>& blocksPerQueryBlock,
+                                               int64_t block_size) {
+    const auto B = static_cast<int64_t>(q_shape[0]);
+    const auto H = static_cast<int64_t>(q_shape[1]);
+    const auto L = static_cast<int64_t>(q_shape[2]);
+    const auto E = static_cast<int64_t>(q_shape[3]);
+    const auto Hk = static_cast<int64_t>(k_shape[1]);
+    const auto S = static_cast<int64_t>(k_shape[2]);
+    const auto Ev = static_cast<int64_t>(v_shape[3]);
+    const auto num_q_blocks = L / block_size;
+
+    std::vector<float> out(static_cast<size_t>(B * H * L * Ev), 0.0f);
+
+    for (int64_t b = 0; b < B; ++b) {
+        for (int64_t h = 0; h < H; ++h) {
+            const int64_t hk = (Hk == 1) ? 0 : h;
+            for (int64_t qb = 0; qb < num_q_blocks; ++qb) {
+                const auto& blocks = blocksPerQueryBlock[static_cast<size_t>(qb)];
+
+                std::vector<float> k_gathered(static_cast<size_t>(static_cast<int64_t>(blocks.size()) * block_size * E));
+                std::vector<float> v_gathered(
+                    static_cast<size_t>(static_cast<int64_t>(blocks.size()) * block_size * Ev));
+                for (size_t bi = 0; bi < blocks.size(); ++bi) {
+                    const int64_t blk = blocks[bi];
+                    const float* k_src = k.data() + static_cast<size_t>(((b * Hk + hk) * S + blk * block_size) * E);
+                    const float* v_src = v.data() + static_cast<size_t>(((b * Hk + hk) * S + blk * block_size) * Ev);
+                    std::copy(k_src,
+                              k_src + static_cast<size_t>(block_size * E),
+                              k_gathered.begin() + static_cast<std::ptrdiff_t>(bi * static_cast<size_t>(block_size * E)));
+                    std::copy(
+                        v_src,
+                        v_src + static_cast<size_t>(block_size * Ev),
+                        v_gathered.begin() + static_cast<std::ptrdiff_t>(bi * static_cast<size_t>(block_size * Ev)));
+                }
+
+                std::vector<float> q_block(static_cast<size_t>(block_size * E));
+                const float* q_src = q.data() + static_cast<size_t>(((b * H + h) * L + qb * block_size) * E);
+                std::copy(q_src, q_src + static_cast<size_t>(block_size * E), q_block.begin());
+
+                const Shape qb_shape{1, 1, static_cast<size_t>(block_size), static_cast<size_t>(E)};
+                const Shape kb_shape{1, 1, blocks.size() * static_cast<size_t>(block_size), static_cast<size_t>(E)};
+                const Shape vb_shape{1, 1, blocks.size() * static_cast<size_t>(block_size), static_cast<size_t>(Ev)};
+                const Shape ob_shape{1, 1, static_cast<size_t>(block_size), static_cast<size_t>(Ev)};
+
+                std::vector<float> ob(shape_size(ob_shape), 0.0f);
+                ov::reference::scaled_dot_product_attention<float, char>(q_block.data(),
+                                                                          k_gathered.data(),
+                                                                          v_gathered.data(),
+                                                                          nullptr,
+                                                                          nullptr,
+                                                                          nullptr,
+                                                                          ob.data(),
+                                                                          false,
+                                                                          qb_shape,
+                                                                          kb_shape,
+                                                                          vb_shape,
+                                                                          Shape{},
+                                                                          Shape{},
+                                                                          ob_shape);
+
+                float* out_dst = out.data() + static_cast<size_t>(((b * H + h) * L + qb * block_size) * Ev);
+                std::copy(ob.begin(), ob.end(), out_dst);
+            }
+        }
+    }
+    return out;
+}
+
+// Replicates a single shared kv-head `Hk == 1` tensor into `H` full copies -- used to build an
+// oracle input for the head-broadcast test without relying on any broadcasting behaviour of the
+// dense reference kernel itself.
+std::vector<float> expandSharedHead(const std::vector<float>& tensor, const Shape& shape, int64_t H) {
+    const auto B = static_cast<int64_t>(shape[0]);
+    const auto S = static_cast<int64_t>(shape[2]);
+    const auto E = static_cast<int64_t>(shape[3]);
+    std::vector<float> out(static_cast<size_t>(B * H * S * E));
+    for (int64_t b = 0; b < B; ++b) {
+        const float* src = tensor.data() + static_cast<size_t>(b * S * E);
+        for (int64_t h = 0; h < H; ++h) {
+            float* dst = out.data() + static_cast<size_t>((b * H + h) * S * E);
+            std::copy(src, src + static_cast<size_t>(S * E), dst);
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+class ReferenceBlockSparseAttentionTest : public testing::Test, public CommonReferenceTest {
+protected:
+    void RunTest(const Shape& qShape,
+                 const std::vector<float>& qData,
+                 const Shape& kShape,
+                 const std::vector<float>& kData,
+                 const Shape& vShape,
+                 const std::vector<float>& vData,
+                 const Shape& biShape,
+                 const std::vector<int64_t>& biData,
+                 bool causal,
+                 int64_t blockSize,
+                 const Shape& maskShape,
+                 const std::vector<char>& maskData,
+                 const float* scaleValue,
+                 const std::vector<float>& expected) {
+        const auto q = std::make_shared<op::v0::Parameter>(element::f32, qShape);
+        const auto k = std::make_shared<op::v0::Parameter>(element::f32, kShape);
+        const auto v = std::make_shared<op::v0::Parameter>(element::f32, vShape);
+        const auto bi = std::make_shared<op::v0::Parameter>(element::i64, biShape);
+
+        OutputVector inputs = {q, k, v, bi};
+        ParameterVector params = {q, k, v, bi};
+        inputData = {CreateTensor(qShape, element::f32, qData),
+                     CreateTensor(kShape, element::f32, kData),
+                     CreateTensor(vShape, element::f32, vData),
+                     CreateTensor(biShape, element::i64, biData)};
+
+        if (!maskShape.empty()) {
+            const auto mask = std::make_shared<op::v0::Parameter>(element::boolean, maskShape);
+            inputs.push_back(mask);
+            params.push_back(mask);
+            inputData.push_back(CreateTensor(maskShape, element::boolean, maskData));
+        } else if (scaleValue) {
+            // The op resolves optional trailing inputs purely by count: 5 inputs always means
+            // "has mask, no scale" and 6 always means "has mask and scale" -- there is no
+            // positional form for "scale but no mask". So whenever a scale is requested without
+            // an explicit mask, synthesize a trivial all-true mask to keep the input list valid.
+            const std::vector<char> allTrueMask(shape_size(biShape), 1);
+            const auto mask = std::make_shared<op::v0::Parameter>(element::boolean, biShape);
+            inputs.push_back(mask);
+            params.push_back(mask);
+            inputData.push_back(CreateTensor(biShape, element::boolean, allTrueMask));
+        }
+
+        if (scaleValue) {
+            const auto scale = std::make_shared<op::v0::Constant>(element::f32, Shape{}, *scaleValue);
+            inputs.push_back(scale);
+        }
+
+        const auto op = std::make_shared<ov::op::v17::BlockSparseAttention>(inputs, blockSize, causal);
+        function = std::make_shared<Model>(OutputVector{op}, params);
+
+        refOutData = {CreateTensor(qShape, element::f32, expected)};
+        Exec();
+    }
+};
+
+// All blocks selected for every query position + causal=false must be bit-for-bit equivalent to
+// plain dense attention: the strongest possible cross-check against the trusted SDPA reference,
+// since there is no sparsity left to reason about independently.
+TEST_F(ReferenceBlockSparseAttentionTest, DenseEquivalent_NonCausal) {
+    constexpr int64_t B = 1, H = 2, L = 8, E = 4, Ev = 4, blockSize = 2, numKvBlocks = 4;
+    const Shape qShape{B, H, L, E}, kShape{B, H, L, E}, vShape{B, H, L, Ev};
+    const auto qData = makeData(static_cast<size_t>(B * H * L * E), 1);
+    const auto kData = makeData(static_cast<size_t>(B * H * L * E), 2);
+    const auto vData = makeData(static_cast<size_t>(B * H * L * Ev), 3);
+
+    const int64_t numQBlocks = L / blockSize;
+    const Shape biShape{B, H, static_cast<size_t>(numQBlocks), numKvBlocks};
+    std::vector<int64_t> biData;
+    for (int64_t i = 0; i < B * H * numQBlocks; ++i) {
+        for (int64_t blk = 0; blk < numKvBlocks; ++blk) {
+            biData.push_back(blk);
+        }
+    }
+
+    const auto expected = denseReference(qData, kData, vData, qShape, kShape, vShape, /*is_causal=*/false);
+
+    RunTest(qShape, qData, kShape, kData, vShape, vData, biShape, biData, /*causal=*/false, blockSize, {}, {}, nullptr, expected);
+}
+
+// Same as above but with the op's own `causal` attribute set. Every query block still lists
+// *all* kv blocks (including "future" ones) -- the reference kernel's intra-block causal
+// truncation must make this reduce exactly to standard causal dense attention.
+TEST_F(ReferenceBlockSparseAttentionTest, DenseEquivalent_Causal) {
+    constexpr int64_t B = 1, H = 2, L = 8, E = 4, Ev = 4, blockSize = 2, numKvBlocks = 4;
+    const Shape qShape{B, H, L, E}, kShape{B, H, L, E}, vShape{B, H, L, Ev};
+    const auto qData = makeData(static_cast<size_t>(B * H * L * E), 11);
+    const auto kData = makeData(static_cast<size_t>(B * H * L * E), 12);
+    const auto vData = makeData(static_cast<size_t>(B * H * L * Ev), 13);
+
+    const int64_t numQBlocks = L / blockSize;
+    const Shape biShape{B, H, static_cast<size_t>(numQBlocks), numKvBlocks};
+    std::vector<int64_t> biData;
+    for (int64_t i = 0; i < B * H * numQBlocks; ++i) {
+        for (int64_t blk = 0; blk < numKvBlocks; ++blk) {
+            biData.push_back(blk);
+        }
+    }
+
+    const auto expected = denseReference(qData, kData, vData, qShape, kShape, vShape, /*is_causal=*/true);
+
+    RunTest(qShape, qData, kShape, kData, vShape, vData, biShape, biData, /*causal=*/true, blockSize, {}, {}, nullptr, expected);
+}
+
+// Every query block selects the SAME fixed, non-contiguous pair of kv blocks {0, 3} out of 4:
+// the canonical block-sparse scenario. Expected output is computed by gathering just those two
+// blocks and running dense attention on the resulting short sequence.
+TEST_F(ReferenceBlockSparseAttentionTest, SparseUniformSelection_NonCausal) {
+    constexpr int64_t B = 1, H = 2, L = 8, E = 4, Ev = 4, blockSize = 2;
+    const Shape qShape{B, H, L, E}, kShape{B, H, L, E}, vShape{B, H, L, Ev};
+    const auto qData = makeData(static_cast<size_t>(B * H * L * E), 21);
+    const auto kData = makeData(static_cast<size_t>(B * H * L * E), 22);
+    const auto vData = makeData(static_cast<size_t>(B * H * L * Ev), 23);
+
+    const std::vector<int64_t> selected{0, 3};
+    const int64_t numQBlocks = L / blockSize;
+    const Shape biShape{B, H, static_cast<size_t>(numQBlocks), selected.size()};
+    std::vector<int64_t> biData;
+    for (int64_t i = 0; i < B * H * numQBlocks; ++i) {
+        biData.insert(biData.end(), selected.begin(), selected.end());
+    }
+
+    const auto kGathered = gatherBlocks(kData, kShape, selected, blockSize);
+    const auto vGathered = gatherBlocks(vData, vShape, selected, blockSize);
+    const Shape kGatheredShape{B, H, selected.size() * blockSize, E};
+    const Shape vGatheredShape{B, H, selected.size() * blockSize, Ev};
+    const auto expected =
+        denseReference(qData, kGathered, vGathered, qShape, kGatheredShape, vGatheredShape, /*is_causal=*/false);
+
+    RunTest(qShape, qData, kShape, kData, vShape, vData, biShape, biData, /*causal=*/false, blockSize, {}, {}, nullptr, expected);
+}
+
+// Adds a third, masked-off candidate slot per row that duplicates an already-selected block
+// index. If the mask were ignored, that block's contribution would be counted twice and the
+// softmax weights would visibly diverge from the 2-block gathered oracle used here.
+TEST_F(ReferenceBlockSparseAttentionTest, PaddingMaskIgnoresDuplicateSlot) {
+    constexpr int64_t B = 1, H = 2, L = 8, E = 4, Ev = 4, blockSize = 2;
+    const Shape qShape{B, H, L, E}, kShape{B, H, L, E}, vShape{B, H, L, Ev};
+    const auto qData = makeData(static_cast<size_t>(B * H * L * E), 31);
+    const auto kData = makeData(static_cast<size_t>(B * H * L * E), 32);
+    const auto vData = makeData(static_cast<size_t>(B * H * L * Ev), 33);
+
+    const std::vector<int64_t> selected{0, 3};
+    const int64_t numQBlocks = L / blockSize;
+    const int64_t kBlocks = 3;
+    const Shape biShape{B, H, static_cast<size_t>(numQBlocks), static_cast<size_t>(kBlocks)};
+    std::vector<int64_t> biData;
+    std::vector<char> maskData;
+    for (int64_t i = 0; i < B * H * numQBlocks; ++i) {
+        biData.insert(biData.end(), {0, 3, 0});   // 3rd slot duplicates block 0
+        maskData.insert(maskData.end(), {1, 1, 0});  // ... but is masked off
+    }
+
+    const auto kGathered = gatherBlocks(kData, kShape, selected, blockSize);
+    const auto vGathered = gatherBlocks(vData, vShape, selected, blockSize);
+    const Shape kGatheredShape{B, H, selected.size() * blockSize, E};
+    const Shape vGatheredShape{B, H, selected.size() * blockSize, Ev};
+    const auto expected =
+        denseReference(qData, kGathered, vGathered, qShape, kGatheredShape, vGatheredShape, /*is_causal=*/false);
+
+    RunTest(qShape,
+            qData,
+            kShape,
+            kData,
+            vShape,
+            vData,
+            biShape,
+            biData,
+            /*causal=*/false,
+            blockSize,
+            biShape,
+            maskData,
+            nullptr,
+            expected);
+}
+
+// Explicit scale attribute must actually be used by the kernel, not silently replaced by the
+// default `1/sqrt(E)` -- E=4 makes the default exactly 0.5, so 0.25 is unambiguous evidence the
+// override took effect.
+TEST_F(ReferenceBlockSparseAttentionTest, ExplicitScaleOverride) {
+    constexpr int64_t B = 1, H = 2, L = 8, E = 4, Ev = 4, blockSize = 2, numKvBlocks = 4;
+    const Shape qShape{B, H, L, E}, kShape{B, H, L, E}, vShape{B, H, L, Ev};
+    const auto qData = makeData(static_cast<size_t>(B * H * L * E), 41);
+    const auto kData = makeData(static_cast<size_t>(B * H * L * E), 42);
+    const auto vData = makeData(static_cast<size_t>(B * H * L * Ev), 43);
+
+    const int64_t numQBlocks = L / blockSize;
+    const Shape biShape{B, H, static_cast<size_t>(numQBlocks), numKvBlocks};
+    std::vector<int64_t> biData;
+    for (int64_t i = 0; i < B * H * numQBlocks; ++i) {
+        for (int64_t blk = 0; blk < numKvBlocks; ++blk) {
+            biData.push_back(blk);
+        }
+    }
+
+    const float scaleValue = 0.25f;
+    const auto expected =
+        denseReference(qData, kData, vData, qShape, kShape, vShape, /*is_causal=*/false, &scaleValue);
+
+    RunTest(qShape,
+            qData,
+            kShape,
+            kData,
+            vShape,
+            vData,
+            biShape,
+            biData,
+            /*causal=*/false,
+            blockSize,
+            {},
+            {},
+            &scaleValue,
+            expected);
+}
+
+// H=4 query heads sharing a single (Hk=1) kv head and a single (Hb=1) block-indices head --
+// SDPA's own broadcast contract, reused here. Expected output is built by first manually
+// expanding the shared kv head into 4 explicit copies (a dead-simple copy loop, independent of
+// any broadcasting logic in either kernel) and then calling the dense oracle.
+TEST_F(ReferenceBlockSparseAttentionTest, HeadBroadcast_SharedKvAndBlockIndices) {
+    constexpr int64_t B = 1, H = 4, Hk = 1, L = 8, S = 8, E = 4, Ev = 4, blockSize = 2, numKvBlocks = 4;
+    const Shape qShape{B, H, L, E};
+    const Shape kShape{B, Hk, S, E};
+    const Shape vShape{B, Hk, S, Ev};
+    const auto qData = makeData(static_cast<size_t>(B * H * L * E), 51);
+    const auto kData = makeData(static_cast<size_t>(B * Hk * S * E), 52);
+    const auto vData = makeData(static_cast<size_t>(B * Hk * S * Ev), 53);
+
+    const int64_t numQBlocks = L / blockSize;
+    const Shape biShape{B, 1, static_cast<size_t>(numQBlocks), numKvBlocks};  // Hb=1: shared across heads
+    std::vector<int64_t> biData;
+    for (int64_t i = 0; i < B * 1 * numQBlocks; ++i) {
+        for (int64_t blk = 0; blk < numKvBlocks; ++blk) {
+            biData.push_back(blk);
+        }
+    }
+
+    const auto kExpanded = expandSharedHead(kData, kShape, H);
+    const auto vExpanded = expandSharedHead(vData, vShape, H);
+    const Shape kExpandedShape{B, H, S, E};
+    const Shape vExpandedShape{B, H, S, Ev};
+    const auto expected =
+        denseReference(qData, kExpanded, vExpanded, qShape, kExpandedShape, vExpandedShape, /*is_causal=*/false);
+
+    RunTest(qShape, qData, kShape, kData, vShape, vData, biShape, biData, /*causal=*/false, blockSize, {}, {}, nullptr, expected);
+}
+
+// Realistic "local window + global sink block" sparsity pattern, structurally representative of
+// how long-context video models such as FlashVSR restrict attention to a handful of local and
+// global blocks per query position instead of the full sequence. Every query block selects a
+// *different* set of kv blocks (own block, previous block, and the first "global" block, with
+// duplicates masked off) -- exercised via the per-block gather oracle since a single dense call
+// cannot express varying selections.
+TEST_F(ReferenceBlockSparseAttentionTest, LocalWindowPlusGlobalSink_VaryingSelection) {
+    constexpr int64_t B = 1, H = 1, L = 16, S = 16, E = 4, Ev = 4, blockSize = 2;
+    const int64_t numQBlocks = L / blockSize;
+    const int64_t numKvBlocks = S / blockSize;
+    const Shape qShape{B, H, L, E}, kShape{B, H, S, E}, vShape{B, H, S, Ev};
+    const auto qData = makeData(static_cast<size_t>(B * H * L * E), 61);
+    const auto kData = makeData(static_cast<size_t>(B * H * S * E), 62);
+    const auto vData = makeData(static_cast<size_t>(B * H * S * Ev), 63);
+
+    constexpr int64_t kBlocks = 3;  // slots: [global=0, prev=qb-1, own=qb]
+    const Shape biShape{B, H, static_cast<size_t>(numQBlocks), static_cast<size_t>(kBlocks)};
+    std::vector<int64_t> biData;
+    std::vector<char> maskData;
+    std::vector<std::vector<int64_t>> blocksPerQueryBlock(static_cast<size_t>(numQBlocks));
+
+    for (int64_t qb = 0; qb < numQBlocks; ++qb) {
+        const int64_t own = qb;
+        const int64_t prev = std::max<int64_t>(qb - 1, 0);
+        const int64_t global = 0;
+        const char ownMask = 1;
+        const char prevMask = (qb >= 1) ? 1 : 0;                         // no previous block at qb==0
+        const char globalMask = (global != prev && global != own) ? 1 : 0;  // avoid double counting
+
+        biData.insert(biData.end(), {global, prev, own});
+        maskData.insert(maskData.end(), {globalMask, prevMask, ownMask});
+
+        std::vector<int64_t> active;
+        if (globalMask) {
+            active.push_back(global);
+        }
+        if (prevMask) {
+            active.push_back(prev);
+        }
+        active.push_back(own);
+        blocksPerQueryBlock[static_cast<size_t>(qb)] = active;
+    }
+    ASSERT_EQ(static_cast<int64_t>(numKvBlocks), numQBlocks);  // sanity: square attention in this test
+
+    const auto expected =
+        referenceViaPerBlockGather(qData, kData, vData, qShape, kShape, vShape, blocksPerQueryBlock, blockSize);
+
+    RunTest(qShape,
+            qData,
+            kShape,
+            kData,
+            vShape,
+            vData,
+            biShape,
+            biData,
+            /*causal=*/false,
+            blockSize,
+            biShape,
+            maskData,
+            nullptr,
+            expected);
+}
+
+// Exercises the i32 block_indices dispatch path (all other cases above use i64) -- a smaller
+// repeat of the dense-equivalent scenario is enough since the numerical kernel code is identical
+// regardless of index width.
+TEST_F(ReferenceBlockSparseAttentionTest, Int32BlockIndices) {
+    constexpr int64_t B = 1, H = 1, L = 4, E = 4, Ev = 4, blockSize = 2, numKvBlocks = 2;
+    const Shape qShape{B, H, L, E}, kShape{B, H, L, E}, vShape{B, H, L, Ev};
+    const auto qData = makeData(static_cast<size_t>(B * H * L * E), 71);
+    const auto kData = makeData(static_cast<size_t>(B * H * L * E), 72);
+    const auto vData = makeData(static_cast<size_t>(B * H * L * Ev), 73);
+
+    const int64_t numQBlocks = L / blockSize;
+    const Shape biShape{B, H, static_cast<size_t>(numQBlocks), numKvBlocks};
+
+    const auto q = std::make_shared<op::v0::Parameter>(element::f32, qShape);
+    const auto k = std::make_shared<op::v0::Parameter>(element::f32, kShape);
+    const auto v = std::make_shared<op::v0::Parameter>(element::f32, vShape);
+    const auto bi = std::make_shared<op::v0::Parameter>(element::i32, biShape);
+
+    std::vector<int32_t> biData;
+    for (int64_t i = 0; i < B * H * numQBlocks; ++i) {
+        for (int64_t blk = 0; blk < numKvBlocks; ++blk) {
+            biData.push_back(static_cast<int32_t>(blk));
+        }
+    }
+    const auto expected = denseReference(qData, kData, vData, qShape, kShape, vShape, /*is_causal=*/false);
+
+    const auto op =
+        std::make_shared<ov::op::v17::BlockSparseAttention>(OutputVector{q, k, v, bi}, blockSize, /*causal=*/false);
+    function = std::make_shared<Model>(OutputVector{op}, ParameterVector{q, k, v, bi});
+    inputData = {CreateTensor(qShape, element::f32, qData),
+                 CreateTensor(kShape, element::f32, kData),
+                 CreateTensor(vShape, element::f32, vData),
+                 CreateTensor(biShape, element::i32, biData)};
+    refOutData = {CreateTensor(qShape, element::f32, expected)};
+    Exec();
+}

--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/op_impl_check/single_op_graph.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/op_impl_check/single_op_graph.cpp
@@ -1157,6 +1157,34 @@ std::shared_ptr<ov::Model> generate(const std::shared_ptr<ov::op::v13::ScaledDot
     return std::make_shared<ov::Model>(results, ov::ParameterVector{query, key, value, attention_mask, scale}, "ScaledDotProductAttentionGraph");
 }
 
+std::shared_ptr<ov::Model> generate(const std::shared_ptr<ov::op::v17::BlockSparseAttention> &node) {
+    // 2 query blocks (L=4, block_size=2) each selecting 2 of the 3 available key/value
+    // blocks (S=6, block_size=2); block_indices/mask share the query head count (no
+    // head-broadcast) so the graph exercises the "default"/most common shape combination.
+    const auto query = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 4, 8});
+    const auto key = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 6, 8});
+    const auto value = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 6, 8});
+    const auto block_indices = std::make_shared<ov::op::v0::Parameter>(element::i32, Shape{1, 2, 2, 2});
+    const auto block_indices_mask = std::make_shared<ov::op::v0::Parameter>(element::boolean, Shape{1, 2, 2, 2});
+    const auto scale = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{});
+    const int64_t block_size = 2;
+    const bool causal = false;
+
+    const auto op = std::make_shared<ov::op::v17::BlockSparseAttention>(query,
+                                                                          key,
+                                                                          value,
+                                                                          block_indices,
+                                                                          block_indices_mask,
+                                                                          scale,
+                                                                          block_size,
+                                                                          causal);
+    ov::ResultVector results{std::make_shared<ov::op::v0::Result>(op)};
+    return std::make_shared<ov::Model>(
+        results,
+        ov::ParameterVector{query, key, value, block_indices, block_indices_mask, scale},
+        "BlockSparseAttentionGraph");
+}
+
 std::shared_ptr<ov::Model> generate(const std::shared_ptr<ov::op::v3::ScatterElementsUpdate> &node) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{{2, 2}}),
                                std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{{2, 2}})};


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

### Details:
 - Adds `ov::op::v17::BlockSparseAttention`: a fused "gather selected key/value blocks + attend" operator for block-sparse scaled dot-product attention.
 - Needed to enable **FlashVSR** (diffusion-based video super-resolution) on CPU without materializing a gathered/transposed copy of key/value ahead of the attention matmuls — that decomposition (`Gather` + `Reshape` + `ScaledDotProductAttention`) scales with `batch*heads*num_query_blocks*gathered_length` regardless of how sparse the actual selection is; this op scales with the amount of selected work only.
 - Scope, mirroring existing attention-op conventions (`ScaledDotProductAttention-13`) and the most recently added opset17 op (`GroupedMatMul-17`):
   - **Core** (`src/core`): `validate_and_infer_types`, shape inference, visitor/type_prop tests (18 cases), a reference kernel shared by both backends below.
   - **Template plugin**: `evaluate_node` wiring + 8 `op_reference` functional tests, cross-checked against the already-trusted `ov::reference::scaled_dot_product_attention` kernel as an independent oracle wherever the two overlap (dense/causal cases).
   - **CPU plugin**: node implementation (`parallel_for2d` over batch×heads, delegating to the shared reference kernel per slice) + 12 subgraph functional tests (6 scenarios × f32/bf16), relying on `SubgraphBaseTest`'s automatic CPU-vs-Template cross-validation.
   - **Conformance**: `op_impl_check` `generate()` overload so `query_model()` coverage is exercised on both CPU and TEMPLATE.
   - **Docs**: opset17 operation spec at `operation-specs/sequence/block-sparse-attention-17.rst`.
 - Notable bug found only by actually compiling and running the CPU functional tests (not static review): CPU's `ConvertPrecision` pass normalizes boolean `Parameter`s to `u8` storage before **any** op sees them. `ScaledDotProductAttention` appears immune only because an earlier, SDPA-specific transformation already rewrites its boolean mask into a `Select`-based additive float mask before `ConvertPrecision` runs — so SDPA itself never actually receives a raw boolean input on CPU. A new op with no equivalent pre-processing pass has no such protection, so this op's mask-type check now accepts `u8` as an equivalent alternative to `boolean` (both are 1-byte, non-real types; byte-level tensor access was verified to already be type-agnostic), and its CPU node's `initSupportedPrimitiveDescriptors` negotiates `u8` vs. `boolean` via `getOriginalInputPrecisionAtPort(4)`, mirroring the CPU `ScaledDotProductAttention` node's own existing precedent for its mask port.
 - **Verified by actually compiling OpenVINO from this branch and running the resulting tests** (not just static/code review):
   - `ov_core_unit_tests`: 19/19 (`block_sparse_attention` filter); full suite 13809/13817 (8 pre-existing/unrelated skips), 0 failures.
   - `ov_template_func_tests`: 8/8 (`BlockSparseAttention` filter); full suite 22180 tests, 0 failures.
   - `ov_cpu_func_tests`: 12/12 (`BlockSparseAttention` filter, f32+bf16 × 6 scenarios); SDPA sanity filter 2/2 (rest skipped, HW-capability gated, pre-existing/unrelated).
   - `ov_op_conformance_tests`: 1/1 on CPU, 1/1 on TEMPLATE.
   - Full project rebuild (1498/1498 targets), re-verified again after rebasing onto latest upstream `master`.
 - **GenAI / optimum-intel**: no changes needed or included. Confirmed via the linked ticket that FlashVSR uses a fully custom Python → OpenVINO IR pipeline (manual export/inference scripts, `OV_DEVICE=CPU`), not `optimum-intel`'s `OVModelForXXX` or `openvino_genai`'s `LLMPipeline`.
 - Supersedes `openvinotoolkit/omega#95`, a Python-only prototype with no OpenVINO core/plugin changes.

### Tickets:
 - openvinotoolkit/omega#87

### AI Assistance:
 - AI assistance used: yes
 - This entire PR (design, implementation, tests, docs) was produced by an autonomous AI agent. Human validation performed: full compilation of OpenVINO from this branch (core, Template plugin, CPU plugin, conformance runner) and execution of all new/existing automated test suites listed above, all passing, re-confirmed after rebasing onto the latest upstream `master`. **This PR still requires a human maintainer's design and code review before it can be considered for merge — see banner above.**
