### PR TITLE
[EXPERIMENT][WIP] [Transformations] Finalize PagedSelectiveSSM precision (CPU+GPU) in ConvertPagedAttnInputs

### DIFF
--- a/src/common/transformations/src/transformations/paged_attention/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/convert_pagedattn_inputs.cpp
@@ -14,6 +14,7 @@
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/op/paged_causal_conv1d.hpp"
 #include "openvino/op/paged_gated_delta_net.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/util/log.hpp"
 #include "transformations/rt_info/keep_const_precision.hpp"
@@ -35,7 +36,8 @@ ConvertPagedAttnInputs::ConvertPagedAttnInputs(const KVCacheConfig& config,
 
     auto result = pattern::wrap_type<ov::op::PagedAttentionExtension>() |
                   pattern::wrap_type<ov::op::internal::PagedCausalConv1D>() |
-                  pattern::wrap_type<ov::op::internal::PagedGatedDeltaNet>();
+                  pattern::wrap_type<ov::op::internal::PagedGatedDeltaNet>() |
+                  pattern::wrap_type<ov::op::internal::PagedSelectiveSSM>();
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
         const auto root = m.get_match_root();
         bool status = false;
@@ -167,6 +169,23 @@ ConvertPagedAttnInputs::ConvertPagedAttnInputs(const KVCacheConfig& config,
             gated_delta_state_table->set_element_type(gated_delta_cache_precision);
             enable_keep_const_precision(gated_delta_state_table);
             gated_delta_state_table->validate_and_infer_types();
+            return true;
+        }
+
+        if (const auto paged_ssm = ov::as_type_ptr<ov::op::internal::PagedSelectiveSSM>(root)) {
+            auto ssm_state_table = ov::as_type_ptr<v0::Parameter>(paged_ssm->get_input_node_shared_ptr(5));
+            if (!ssm_state_table) {
+                return false;
+            }
+
+            auto ssm_cache_precision = m_config.inferencePrecision;
+            if (m_update_precision_func) {
+                m_update_precision_func(ssm_cache_precision);
+            }
+
+            ssm_state_table->set_element_type(ssm_cache_precision);
+            enable_keep_const_precision(ssm_state_table);
+            ssm_state_table->validate_and_infer_types();
             return true;
         }
 

--- a/src/common/transformations/src/transformations/paged_attention/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/src/transformations/paged_attention/convert_pagedattn_inputs.cpp
@@ -11,6 +11,7 @@
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/op/paged_causal_conv1d.hpp"
 #include "openvino/op/paged_gated_delta_net.hpp"
@@ -186,6 +187,41 @@ ConvertPagedAttnInputs::ConvertPagedAttnInputs(const KVCacheConfig& config,
             ssm_state_table->set_element_type(ssm_cache_precision);
             enable_keep_const_precision(ssm_state_table);
             ssm_state_table->validate_and_infer_types();
+
+            // PagedSelectiveSSM requires inputs A, dt, B, x, C (ports 0..4) and
+            // recurrent_state_table (port 5) to share one common float element type
+            // (see PagedSelectiveSSM::validate_and_infer_types "float_types_merge" check).
+            // Port 5 is now pinned to ssm_cache_precision above, but ports 0..4 are produced
+            // by graph computations (often inside a per-layer Loop body) that may still be
+            // f32 when ssm_cache_precision differs (e.g. GPU inferencePrecision == f16).
+            // Align them explicitly here rather than relying on the generic ConvertPrecision
+            // pass, which does not reliably reach into Loop bodies for this op.
+            const auto original_data_type = paged_ssm->get_input_element_type(0);
+            for (size_t i = 0; i < 5; ++i) {
+                const auto& input_value = paged_ssm->input_value(i);
+                if (input_value.get_element_type() != ssm_cache_precision) {
+                    auto convert = std::make_shared<v0::Convert>(input_value, ssm_cache_precision);
+                    paged_ssm->input(i).replace_source_output(convert->output(0));
+                }
+            }
+            paged_ssm->validate_and_infer_types();
+
+            // Forcing ports 0..4 to ssm_cache_precision also shifts PagedSelectiveSSM's own
+            // output (0) to that precision. The rest of the model (e.g. the mamba mixer's
+            // skip-connection Add combining the SSM result with a separately computed x * D
+            // term) was built expecting the original data type, so leaking ssm_cache_precision
+            // to consumers outside this op would trade one precision mismatch for another.
+            // Restore the output to the original common data type so the SSM's numeric result
+            // stays consistent with the rest of the graph; only the internal computation (and
+            // the persisted recurrent_state_table) run at ssm_cache_precision.
+            if (original_data_type.is_static() && original_data_type != ssm_cache_precision) {
+                auto targets = paged_ssm->output(0).get_target_inputs();
+                auto output_convert = std::make_shared<v0::Convert>(paged_ssm->output(0), original_data_type);
+                output_convert->set_friendly_name(paged_ssm->get_friendly_name() + "/restore_precision");
+                for (auto& target : targets) {
+                    target.replace_source_output(output_convert->output(0));
+                }
+            }
             return true;
         }
 

--- a/src/common/transformations/tests/common_optimizations/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_pagedattn_inputs.cpp
@@ -11,6 +11,7 @@
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/op/paged_causal_conv1d.hpp"
 #include "openvino/op/paged_gated_delta_net.hpp"
+#include "openvino/op/paged_selective_ssm.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/runtime/properties.hpp"
@@ -531,6 +532,74 @@ TEST_F(ConvertPagedAttnInputsStateTableTest, ConvertPagedGatedDeltaNetPrecision)
     // Verify no Convert node between Parameter and PagedGatedDeltaNet
     EXPECT_TRUE(ov::is_type<v0::Parameter>(paged_gdn->get_input_node_shared_ptr(3)));
     EXPECT_EQ(gated_delta_state_table->get_element_type(), ov::element::f16);
+}
+
+TEST_F(ConvertPagedAttnInputsStateTableTest, ConvertPagedSelectiveSSMPrecision) {
+    auto A = std::make_shared<v0::Parameter>(element::f32, PartialShape{2});
+    auto dt = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2});
+    auto B = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 64});
+    auto x = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 64});
+    auto C = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 64});
+    auto ssm_state_table = std::make_shared<v0::Parameter>(element::dynamic, PartialShape{-1, 2, 64, 64});
+    ssm_state_table->set_friendly_name("selective_ssm_state_table.0");
+    enable_keep_const_precision(ssm_state_table);
+    auto subsequence_begins = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_indices = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_indices_begins = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto past_lens = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+
+    auto paged_ssm = std::make_shared<op::internal::PagedSelectiveSSM>(A,
+                                                                       dt,
+                                                                       B,
+                                                                       x,
+                                                                       C,
+                                                                       ssm_state_table,
+                                                                       subsequence_begins,
+                                                                       block_indices,
+                                                                       block_indices_begins,
+                                                                       past_lens,
+                                                                       cache_interval);
+    auto local_model = std::make_shared<Model>(OutputVector{paged_ssm},
+                                               ParameterVector{A,
+                                                               dt,
+                                                               B,
+                                                               x,
+                                                               C,
+                                                               ssm_state_table,
+                                                               subsequence_begins,
+                                                               block_indices,
+                                                               block_indices_begins,
+                                                               past_lens,
+                                                               cache_interval});
+
+    // Replicate GPU pipeline: clear keep_const_precision on all nodes
+    for (auto& node : local_model->get_ops()) {
+        ov::disable_keep_const_precision(node);
+    }
+
+    ov::pass::ConvertPagedAttnInputs::KVCacheConfig cacheConfig;
+    cacheConfig.inferencePrecision = ov::element::f16;
+
+    ov::pass::Manager local_manager;
+
+    precisions_map fp_convert_precision_map = {{ov::element::f64, ov::element::f32},
+                                               {ov::element::f32, ov::element::f16}};
+    type_to_fuse_map empty_fuse_map = {};
+    local_manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
+                                                            empty_fuse_map,
+                                                            /*keep_precision_sensitive_in_fp32*/ true,
+                                                            /*convert_input_output_precision*/ false,
+                                                            /*store_original_precision_as_rt_attribute*/ true);
+
+    auto update_paged_attention_shape_func =
+        [](const ov::element::Type&, const bool, const size_t, int64_t&, int64_t&) {};
+    local_manager.register_pass<ov::pass::ConvertPagedAttnInputs>(cacheConfig, update_paged_attention_shape_func);
+    local_manager.run_passes(local_model);
+
+    // Verify no Convert node between Parameter and PagedSelectiveSSM
+    EXPECT_TRUE(ov::is_type<v0::Parameter>(paged_ssm->get_input_node_shared_ptr(5)));
+    EXPECT_EQ(ssm_state_table->get_element_type(), ov::element::f16);
 }
 
 }  // namespace

--- a/src/common/transformations/tests/common_optimizations/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_pagedattn_inputs.cpp
@@ -8,6 +8,7 @@
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/op/convert.hpp"
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/op/paged_causal_conv1d.hpp"
 #include "openvino/op/paged_gated_delta_net.hpp"
@@ -600,6 +601,158 @@ TEST_F(ConvertPagedAttnInputsStateTableTest, ConvertPagedSelectiveSSMPrecision) 
     // Verify no Convert node between Parameter and PagedSelectiveSSM
     EXPECT_TRUE(ov::is_type<v0::Parameter>(paged_ssm->get_input_node_shared_ptr(5)));
     EXPECT_EQ(ssm_state_table->get_element_type(), ov::element::f16);
+}
+
+// Regression test for the GPU-only "PagedSelectiveSSM expects inputs A, dt, B, x, C and
+// recurrent_state_table to have the same element type" failure: A, dt, B, x, C (ports 0..4)
+// are produced by f32 subgraphs (e.g. left untouched by ConvertPrecision because they live
+// inside a Loop body) while recurrent_state_table (port 5) is already resolved to the
+// inference precision by ConvertPagedAttnInputs. Verify ConvertPagedAttnInputs inserts
+// explicit Converts to realign ports 0..4 so the op's port-precision-consistency invariant
+// holds, regardless of what ConvertPrecision did (or didn't do) upstream.
+TEST_F(ConvertPagedAttnInputsStateTableTest, ConvertPagedSelectiveSSMDataPortsPrecision) {
+    auto A = std::make_shared<v0::Parameter>(element::f32, PartialShape{2});
+    auto dt = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2});
+    auto B = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 64});
+    auto x = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 64});
+    auto C = std::make_shared<v0::Parameter>(element::f32, PartialShape{-1, 2, 64});
+    auto ssm_state_table = std::make_shared<v0::Parameter>(element::dynamic, PartialShape{-1, 2, 64, 64});
+    ssm_state_table->set_friendly_name("selective_ssm_state_table.0");
+    enable_keep_const_precision(ssm_state_table);
+    auto subsequence_begins = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_indices = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_indices_begins = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto past_lens = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+
+    auto paged_ssm = std::make_shared<op::internal::PagedSelectiveSSM>(A,
+                                                                       dt,
+                                                                       B,
+                                                                       x,
+                                                                       C,
+                                                                       ssm_state_table,
+                                                                       subsequence_begins,
+                                                                       block_indices,
+                                                                       block_indices_begins,
+                                                                       past_lens,
+                                                                       cache_interval);
+    auto local_model = std::make_shared<Model>(OutputVector{paged_ssm},
+                                               ParameterVector{A,
+                                                               dt,
+                                                               B,
+                                                               x,
+                                                               C,
+                                                               ssm_state_table,
+                                                               subsequence_begins,
+                                                               block_indices,
+                                                               block_indices_begins,
+                                                               past_lens,
+                                                               cache_interval});
+
+    for (auto& node : local_model->get_ops()) {
+        ov::disable_keep_const_precision(node);
+    }
+
+    ov::pass::ConvertPagedAttnInputs::KVCacheConfig cacheConfig;
+    cacheConfig.inferencePrecision = ov::element::f16;
+
+    ov::pass::Manager local_manager;
+    // Intentionally do NOT run ConvertPrecision: A, dt, B, x, C stay f32 to emulate the
+    // GPU scenario where those tensors are produced inside a Loop body and are not touched
+    // by the generic ConvertPrecision pass.
+    auto update_paged_attention_shape_func =
+        [](const ov::element::Type&, const bool, const size_t, int64_t&, int64_t&) {};
+    local_manager.register_pass<ov::pass::ConvertPagedAttnInputs>(cacheConfig, update_paged_attention_shape_func);
+    local_manager.run_passes(local_model);
+
+    // recurrent_state_table (port 5) is still resolved to the inference precision.
+    EXPECT_EQ(paged_ssm->get_input_element_type(5), ov::element::f16);
+
+    // Ports 0..4 (A, dt, B, x, C) must now be realigned to the same precision via explicit
+    // Converts, since their original producers (Parameters here) were left f32.
+    for (size_t i = 0; i < 5; ++i) {
+        EXPECT_TRUE(ov::is_type<v0::Convert>(paged_ssm->get_input_node_shared_ptr(i)))
+            << "Expected a Convert on PagedSelectiveSSM input " << i;
+        EXPECT_EQ(paged_ssm->get_input_element_type(i), ov::element::f16);
+    }
+
+    // The op-level port-precision-consistency invariant must hold after the transformation.
+    EXPECT_NO_THROW(paged_ssm->validate_and_infer_types());
+    EXPECT_EQ(paged_ssm->get_output_element_type(0), ov::element::f16);
+
+    // The op's own output runs at ssm_cache_precision (f16), but the rest of the graph
+    // (here: the model Result, standing in for e.g. a mamba mixer skip-connection Add) was
+    // built expecting the original f32 data type. A restoring Convert must be inserted so
+    // external consumers keep seeing f32, avoiding trading one precision mismatch for another.
+    const auto& result_input = local_model->get_results()[0]->input(0);
+    EXPECT_TRUE(ov::is_type<v0::Convert>(result_input.get_source_output().get_node_shared_ptr()));
+    EXPECT_EQ(result_input.get_source_output().get_element_type(), ov::element::f32);
+}
+
+// When ports 0..4 already match the resolved recurrent_state_table precision (as is
+// effectively the case on CPU, where ConvertPrecision aligns everything upstream), no
+// redundant Convert nodes should be inserted.
+TEST_F(ConvertPagedAttnInputsStateTableTest, ConvertPagedSelectiveSSMDataPortsPrecisionNoOpWhenAligned) {
+    auto A = std::make_shared<v0::Parameter>(element::f16, PartialShape{2});
+    auto dt = std::make_shared<v0::Parameter>(element::f16, PartialShape{-1, 2});
+    auto B = std::make_shared<v0::Parameter>(element::f16, PartialShape{-1, 2, 64});
+    auto x = std::make_shared<v0::Parameter>(element::f16, PartialShape{-1, 2, 64});
+    auto C = std::make_shared<v0::Parameter>(element::f16, PartialShape{-1, 2, 64});
+    auto ssm_state_table = std::make_shared<v0::Parameter>(element::dynamic, PartialShape{-1, 2, 64, 64});
+    ssm_state_table->set_friendly_name("selective_ssm_state_table.0");
+    enable_keep_const_precision(ssm_state_table);
+    auto subsequence_begins = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_indices = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto block_indices_begins = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto past_lens = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+    auto cache_interval = std::make_shared<v0::Parameter>(element::i32, PartialShape{-1});
+
+    auto paged_ssm = std::make_shared<op::internal::PagedSelectiveSSM>(A,
+                                                                       dt,
+                                                                       B,
+                                                                       x,
+                                                                       C,
+                                                                       ssm_state_table,
+                                                                       subsequence_begins,
+                                                                       block_indices,
+                                                                       block_indices_begins,
+                                                                       past_lens,
+                                                                       cache_interval);
+    auto local_model = std::make_shared<Model>(OutputVector{paged_ssm},
+                                               ParameterVector{A,
+                                                               dt,
+                                                               B,
+                                                               x,
+                                                               C,
+                                                               ssm_state_table,
+                                                               subsequence_begins,
+                                                               block_indices,
+                                                               block_indices_begins,
+                                                               past_lens,
+                                                               cache_interval});
+
+    for (auto& node : local_model->get_ops()) {
+        ov::disable_keep_const_precision(node);
+    }
+
+    ov::pass::ConvertPagedAttnInputs::KVCacheConfig cacheConfig;
+    cacheConfig.inferencePrecision = ov::element::f16;
+
+    ov::pass::Manager local_manager;
+    auto update_paged_attention_shape_func =
+        [](const ov::element::Type&, const bool, const size_t, int64_t&, int64_t&) {};
+    local_manager.register_pass<ov::pass::ConvertPagedAttnInputs>(cacheConfig, update_paged_attention_shape_func);
+    local_manager.run_passes(local_model);
+
+    for (size_t i = 0; i < 5; ++i) {
+        EXPECT_FALSE(ov::is_type<v0::Convert>(paged_ssm->get_input_node_shared_ptr(i)))
+            << "Did not expect a Convert on PagedSelectiveSSM input " << i << " when already aligned";
+    }
+
+    // Output must not be wrapped in a restoring Convert either, since it already matches
+    // ssm_cache_precision.
+    const auto& result_input = local_model->get_results()[0]->input(0);
+    EXPECT_FALSE(ov::is_type<v0::Convert>(result_input.get_source_output().get_node_shared_ptr()));
 }
 
 }  // namespace


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

### Details

`ConvertPagedAttnInputs` finalizes the concrete element type of the special
"paged state table" `Parameter`s that are created with `element::dynamic` by
the various paged-attention fusion passes (`PagedAttentionExtension` KV cache,
`PagedCausalConv1D` conv state table, `PagedGatedDeltaNet` gated-delta state
table). `PagedSelectiveSSM`'s `recurrent_state_table` (input port 5, created
by `PagedSelectiveSSMFusion`) was missing from this pass entirely: it wasn't
even included in the pattern this pass matches, so it was left at
`element::dynamic` all the way to plugin compilation.

This causes `ibm-granite/granite-4.0-h-small` (verified with the smaller,
architecturally-identical `ibm-granite/granite-4.0-h-micro` proxy, 36
Mamba2-SSM + 4 attention layers) to crash when run with the
PagedAttention/continuous-batching backend on CPU:

```
RuntimeError: Exception from src/inference/src/cpp/core.cpp:117:
Exception from src/inference/src/dev/plugin.cpp:54:
Check 'getOriginalInputPrecisionAtPort(port) == data_precision' failed at
src/plugins/intel_cpu/src/nodes/paged_selective_ssm.cpp:70:
PagedSelectiveSSM requires one data precision on ports 0..5.
```

### Fix (CPU, initial commit)

- Added `PagedSelectiveSSM` to the pattern matched by
  `ConvertPagedAttnInputs`.
- Added a callback branch resolving `recurrent_state_table` (input port 5)
  to `m_config.inferencePrecision`, mirroring the existing
  `PagedCausalConv1D` / `PagedGatedDeltaNet` branches exactly.
- Added `ConvertPagedSelectiveSSMPrecision` unit test, following the existing
  `ConvertPagedCausalConv1DInputsPrecision` / `ConvertPagedGatedDeltaNetPrecision`
  test structure.

### Fix (GPU, follow-up commit)

With the port-5 fix alone, GPU no longer hit the dynamic-type error, but
failed at model-compile time with a different error on both FP16 and FP32
IRs:

```
Check 'float_types_merge' failed at src/core/src/op/paged_selective_ssm.cpp:56:
...PagedSelectiveSSM expects inputs A, dt, B, x, C and recurrent_state_table
to have the same element type.
```

Root cause: on the GPU pipeline `recurrent_state_table` now correctly
resolves to f16 (GPU's `inferencePrecision`), but `A`/`dt`/`B`/`x`/`C`
(ports 0..4), computed inside the per-layer `Loop` body, remain f32 — the
GPU pipeline's `ConvertPrecision` (fp32→fp16) pass does not reach them there.

Follow-up commit adds, in the same `PagedSelectiveSSM` branch:
- Explicit `Convert` ops on ports 0..4 to the resolved `ssm_cache_precision`
  whenever their type doesn't already match (no-op on CPU, where they
  already match, verified by a new `...NoOpWhenAligned` test).
- A restoring `Convert` on the op's own output back to the *original*
  (pre-alignment) data type, since forcing ports 0..4 to
  `ssm_cache_precision` also shifts `PagedSelectiveSSM`'s output to that
  precision, and the rest of the model (e.g. the mamba mixer's `x * D`
  skip-connection `Add`) was built expecting the original type. This keeps
  the fix local to the op boundary instead of touching the general
  `ConvertPrecision` pass or `Loop`-body handling.
- Two new unit tests: `ConvertPagedSelectiveSSMDataPortsPrecision` (mismatched
  ports 0..4, emulating the GPU/Loop-body scenario) and
  `ConvertPagedSelectiveSSMDataPortsPrecisionNoOpWhenAligned` (already
  aligned, emulating CPU — must stay a no-op).

### Testing

- `ov_transformations_tests --gtest_filter="*SelectiveSSM*:*PagedAttnInputs*:*ConvertPagedCausalConv1D*:*ConvertPagedGatedDeltaNet*"`
  — 91 tests pass (including all 5 `ConvertPagedAttnInputsStateTableTest.*`
  tests and the existing `PagedSelectiveSSMFusion*` / `SDPAToPA_SelectiveSSM_*`
  suites).
- `ibm-granite/granite-4.0-h-micro` via `openvino.genai` `llm_bench`, PA
  backend:
  - **CPU**, FP32 IR: runs to completion, output unchanged (same MD5) before
    and after the GPU follow-up commit — no regression.
  - **GPU.0** (iGPU) and **GPU.1** (Arc Pro B60 dGPU), both FP16 and FP32
    IRs: previously failed to compile with the `float_types_merge` error;
    now compile and run to completion, producing output **identical (MD5)**
    across CPU, GPU.0, and GPU.1, and across FP16/FP32 IRs — e.g. "Quantum
    computing is a type of computing that uses the principles of quantum
    mechanics to perform calculations. Unlike classical...".

### Scope

This PR intentionally touches only
`src/common/transformations/src/transformations/paged_attention/convert_pagedattn_inputs.cpp`
and its test file. No other code, CI config, or unrelated refactors are
included.
