### PR TITLE
[AUTO] Add hybrid IPF ClientApi linking and telemetry integration

### DIFF
--- a/src/plugins/auto/CMakeLists.txt
+++ b/src/plugins/auto/CMakeLists.txt
@@ -45,16 +45,57 @@ endif()
 find_package(Threads REQUIRED)
 target_link_libraries(${TARGET_NAME} PRIVATE Threads::Threads)
 
-# Enable IPF support with the statically linked C API.
-# ClientApi_IMPORTS must remain undefined for static linking.
-if(TARGET openvino::ipf_client_api)
-    target_compile_definitions(${TARGET_NAME} PRIVATE OV_AUTO_ENABLE_IPF)
-    target_link_libraries(${TARGET_NAME} PRIVATE openvino::ipf_client_api)
+# Keep IPF's config-conditional libraries out of the version OBJECT library.
+# plugin.cpp does not use IPF symbols, and ov_add_version_defines() copies LINK_LIBRARIES.
+if(TARGET ${TARGET_NAME}_version)
+    get_target_property(_ov_auto_plugin_version_link_libs ${TARGET_NAME} LINK_LIBRARIES)
+endif()
+
+# Enable IPF support, statically linking ClientApiLib where its CRT already matches
+# OpenVINO's own (no mismatch, no DLL dependency), and falling back to the dynamically
+# delay-loaded ClientApi.dll only where it doesn't (currently: Debug, only while
+# ENABLE_IPF_DEBUG_WITH_RELEASE_CRT=ON forces ClientApi to the Release CRT).
+if(ENABLE_IPF_DEBUG_WITH_RELEASE_CRT)
+    set(_ipf_use_dynamic_genex "$<CONFIG:Debug>")
+else()
+    # A CRT-matching ClientApiProxy.dll is available for every config, so static linking
+    # works everywhere and dynamic delay-loading is never needed.
+    set(_ipf_use_dynamic_genex "$<BOOL:FALSE>")
+endif()
+
+if(TARGET openvino::ipf_client_api_static AND TARGET openvino::ipf_client_api_dynamic)
+    target_compile_definitions(${TARGET_NAME} PRIVATE
+        OV_AUTO_ENABLE_IPF
+        $<${_ipf_use_dynamic_genex}:ClientApi_IMPORTS>)
+    target_link_libraries(${TARGET_NAME} PRIVATE
+        $<${_ipf_use_dynamic_genex}:openvino::ipf_client_api_dynamic>
+        $<$<NOT:${_ipf_use_dynamic_genex}>:openvino::ipf_client_api_static>
+        $<${_ipf_use_dynamic_genex}:delayimp.lib>)
     target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
         $<TARGET_PROPERTY:nlohmann_json::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
-    message(STATUS "[AUTO] IPF support successfully enabled for ${TARGET_NAME}")
+
+    # Delay-load: a missing/incompatible ClientApi.dll must only disable IPF telemetry
+    # (handled gracefully at IpfCreate() call sites), not prevent the plugin itself
+    # from loading. Only meaningful in configs that actually link the dynamic target.
+    target_link_options(${TARGET_NAME} PRIVATE $<${_ipf_use_dynamic_genex}:/DELAYLOAD:ClientApi.dll>)
+
+    # Make ClientApi.dll available next to the plugin for in-tree/test runs only in the
+    # configs that dynamically link it; a no-op ("cmake -E true") elsewhere. Packaged
+    # installs are handled by the install(TARGETS ClientApi ...) rule in thirdparty/.
+    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E $<IF:${_ipf_use_dynamic_genex},copy_if_different,true>
+                "$<TARGET_FILE:ClientApi>" "$<TARGET_FILE_DIR:${TARGET_NAME}>")
+
+    message(STATUS "[AUTO] IPF support successfully enabled for ${TARGET_NAME} "
+                   "(Release: static; Debug: ${ENABLE_IPF_DEBUG_WITH_RELEASE_CRT})")
 else()
     message(STATUS "[AUTO] IPF support disabled")
+endif()
+
+# Restore the IPF-free libraries for the version OBJECT library.
+if(TARGET ${TARGET_NAME}_version)
+    set_property(TARGET ${TARGET_NAME}_version PROPERTY LINK_LIBRARIES
+        ${_ov_auto_plugin_version_link_libs})
 endif()
 
 ov_set_threading_interface_for(${TARGET_NAME})

--- a/src/plugins/auto/CMakeLists.txt
+++ b/src/plugins/auto/CMakeLists.txt
@@ -79,12 +79,11 @@ if(TARGET openvino::ipf_client_api_static AND TARGET openvino::ipf_client_api_dy
     # from loading. Only meaningful in configs that actually link the dynamic target.
     target_link_options(${TARGET_NAME} PRIVATE $<${_ipf_use_dynamic_genex}:/DELAYLOAD:ClientApi.dll>)
 
-    # Make ClientApi.dll available next to the plugin for in-tree/test runs only in the
-    # configs that dynamically link it; a no-op ("cmake -E true") elsewhere. Packaged
-    # installs are handled by the install(TARGETS ClientApi ...) rule in thirdparty/.
+    # Copy ClientApi.dll next to the plugin only in configs that link it dynamically;
+    # packaged installs are handled by the install(TARGETS ClientApi ...) rule in thirdparty/.
     add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E $<IF:${_ipf_use_dynamic_genex},copy_if_different,true>
-                "$<TARGET_FILE:ClientApi>" "$<TARGET_FILE_DIR:${TARGET_NAME}>")
+        COMMAND "$<${_ipf_use_dynamic_genex}:${CMAKE_COMMAND};-E;copy_if_different;$<TARGET_FILE:ClientApi>;$<TARGET_FILE_DIR:${TARGET_NAME}>>"
+        COMMAND_EXPAND_LISTS)
 
     message(STATUS "[AUTO] IPF support successfully enabled for ${TARGET_NAME} "
                    "(Release: static; Debug: ${ENABLE_IPF_DEBUG_WITH_RELEASE_CRT})")

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -729,12 +729,12 @@ DeviceInformation Plugin::select_device(const std::vector<DeviceInformation>& me
     std::list<DeviceInformation> valid_devices = get_valid_device(meta_devices, model_precision);
 
     if (!perf_curve_table.empty()) {
-        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %lu device curves",
-                       static_cast<unsigned long>(perf_curve_table.size()));
+        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %s device curves",
+                       std::to_string(perf_curve_table.size()).c_str());
         for (const auto& [device_key, curve] : perf_curve_table) {
-            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %lu points",
+            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %s points",
                           device_key.c_str(),
-                          static_cast<unsigned long>(curve.size()));
+                          std::to_string(curve.size()).c_str());
             for (const auto& [utilization, score] : curve) {
                 LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s]: utilization=%u, score=%lf",
                               device_key.c_str(),

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -729,11 +729,14 @@ DeviceInformation Plugin::select_device(const std::vector<DeviceInformation>& me
     std::list<DeviceInformation> valid_devices = get_valid_device(meta_devices, model_precision);
 
     if (!perf_curve_table.empty()) {
-        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %zu device curves", perf_curve_table.size());
+        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %lu device curves",
+                       static_cast<unsigned long>(perf_curve_table.size()));
         for (const auto& [device_key, curve] : perf_curve_table) {
-            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %zu points", device_key.c_str(), curve.size());
+            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %lu points",
+                          device_key.c_str(),
+                          static_cast<unsigned long>(curve.size()));
             for (const auto& [utilization, score] : curve) {
-                LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s]: utilization=%u, score=%f",
+                LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s]: utilization=%u, score=%lf",
                               device_key.c_str(),
                               utilization,
                               score);
@@ -945,7 +948,7 @@ std::list<DeviceInformation> Plugin::sort_device_by_perf_curve(
         }
         try {
             scores[i] = interpolate_perf_score(curve_it->second, utilization.value());
-            LOG_DEBUG_TAG("[%s] perf_curve_table: key=%s, utilization=%f, performance_score=%f",
+            LOG_DEBUG_TAG("[%s] perf_curve_table: key=%s, utilization=%lf, performance_score=%lf",
                           device.device_name.c_str(),
                           device_key.logical_key.c_str(),
                           utilization.value(),

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -21,7 +21,7 @@ namespace auto_plugin {
 namespace device_monitor {
 
 inline std::string get_log_tag() {
-    return "[IPF]";
+    return "IPF";
 }
 
 // IPF namespace/paths confirmed against the DttSampleEfApp sample (Demo.cpp / Constants.h) and

--- a/src/plugins/auto/tests/unit/CMakeLists.txt
+++ b/src/plugins/auto/tests/unit/CMakeLists.txt
@@ -28,11 +28,29 @@ ov_add_test_target(
 
 ov_add_version_defines(${OpenVINO_SOURCE_DIR}/src/plugins/auto/src/plugin.cpp ${TARGET_NAME})
 
-if(TARGET openvino::ipf_client_api)
-    target_compile_definitions(${TARGET_NAME} PRIVATE OV_AUTO_ENABLE_IPF)
-    target_link_libraries(${TARGET_NAME} PRIVATE openvino::ipf_client_api)
+# See src/plugins/auto/CMakeLists.txt for the per-config static/dynamic ClientApi choice.
+if(ENABLE_IPF_DEBUG_WITH_RELEASE_CRT)
+    set(_ipf_use_dynamic_genex "$<CONFIG:Debug>")
+else()
+    set(_ipf_use_dynamic_genex "$<BOOL:FALSE>")
+endif()
+
+if(TARGET openvino::ipf_client_api_static AND TARGET openvino::ipf_client_api_dynamic)
+    target_compile_definitions(${TARGET_NAME} PRIVATE
+        OV_AUTO_ENABLE_IPF
+        $<${_ipf_use_dynamic_genex}:ClientApi_IMPORTS>)
+    target_link_libraries(${TARGET_NAME} PRIVATE
+        $<${_ipf_use_dynamic_genex}:openvino::ipf_client_api_dynamic>
+        $<$<NOT:${_ipf_use_dynamic_genex}>:openvino::ipf_client_api_static>
+        $<${_ipf_use_dynamic_genex}:delayimp.lib>)
     target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
         $<TARGET_PROPERTY:nlohmann_json::nlohmann_json,INTERFACE_INCLUDE_DIRECTORIES>)
+
+    target_link_options(${TARGET_NAME} PRIVATE $<${_ipf_use_dynamic_genex}:/DELAYLOAD:ClientApi.dll>)
+
+    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E $<IF:${_ipf_use_dynamic_genex},copy_if_different,true>
+                "$<TARGET_FILE:ClientApi>" "$<TARGET_FILE_DIR:${TARGET_NAME}>")
 endif()
 
 ov_set_threading_interface_for(${TARGET_NAME})

--- a/src/plugins/auto/tests/unit/CMakeLists.txt
+++ b/src/plugins/auto/tests/unit/CMakeLists.txt
@@ -49,8 +49,8 @@ if(TARGET openvino::ipf_client_api_static AND TARGET openvino::ipf_client_api_dy
     target_link_options(${TARGET_NAME} PRIVATE $<${_ipf_use_dynamic_genex}:/DELAYLOAD:ClientApi.dll>)
 
     add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E $<IF:${_ipf_use_dynamic_genex},copy_if_different,true>
-                "$<TARGET_FILE:ClientApi>" "$<TARGET_FILE_DIR:${TARGET_NAME}>")
+        COMMAND "$<${_ipf_use_dynamic_genex}:${CMAKE_COMMAND};-E;copy_if_different;$<TARGET_FILE:ClientApi>;$<TARGET_FILE_DIR:${TARGET_NAME}>>"
+        COMMAND_EXPAND_LISTS)
 endif()
 
 ov_set_threading_interface_for(${TARGET_NAME})

--- a/src/plugins/auto/thirdparty/CMakeLists.txt
+++ b/src/plugins/auto/thirdparty/CMakeLists.txt
@@ -3,7 +3,8 @@
 #
 
 # Intel Platform Framework (IPF) telemetry client (MSVC only).
-# ClientApiLib is linked statically into openvino_auto_plugin.
+# ClientApi.dll is loaded dynamically (delay-loaded) by openvino_auto_plugin, so a
+# missing/incompatible ClientApi.dll only disables IPF telemetry, not the whole plugin.
 # IPF requires the dynamic CRT (/MD); static CRT toolchains disable IPF.
 
 set(_ipf_ef_dir "${CMAKE_CURRENT_SOURCE_DIR}/ipf/IPF_EF")
@@ -29,38 +30,70 @@ if(TARGET nlohmann_json::nlohmann_json OR TARGET nlohmann_json)
     set_property(GLOBAL PROPERTY _FetchContent_nlohmann_json_populated TRUE)
 endif()
 
-# Use the same configuration-specific dynamic CRT for ClientApiLib and the plugin.
+# The native ClientApiProxy.dll shipped by the IPF driver today is Release-only. IPF's
+# own runtime compatibility check (DllProxy::Open()) fails with ENOEXEC if ClientApi.dll
+# does not use the same CRT "debug-ness" as ClientApiProxy.dll, regardless of whether
+# OpenVINO itself is built Debug or Release.
+option(ENABLE_IPF_DEBUG_WITH_RELEASE_CRT
+       "Build IPF ClientApi.dll with the Release dynamic CRT (/MD) even in a Debug OpenVINO \
+build, matching the Release-only ClientApiProxy.dll currently shipped by the IPF driver. \
+Turn OFF once a CRT-matching (e.g. Debug) ClientApiProxy.dll is available, so ClientApi.dll \
+instead matches OpenVINO's own build configuration." ON)
+
+# Use the same configuration-specific dynamic CRT as the rest of OpenVINO.
 if(DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
     set(_ov_msvc_runtime "${CMAKE_MSVC_RUNTIME_LIBRARY}")
 else()
     set(_ov_msvc_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif()
 
+if(ENABLE_IPF_DEBUG_WITH_RELEASE_CRT)
+    set(_ipf_client_api_runtime "MultiThreadedDLL")
+else()
+    set(_ipf_client_api_runtime "${_ov_msvc_runtime}")
+endif()
+
 add_subdirectory("${_ipf_ef_dir}" "${CMAKE_CURRENT_BINARY_DIR}/ipf" EXCLUDE_FROM_ALL)
 
-if(NOT TARGET ClientApiLib)
-    message(STATUS "[AUTO] IPF: ClientApiLib target not produced by submodule, device utilization monitoring disabled")
+if(NOT TARGET ClientApi)
+    message(STATUS "[AUTO] IPF: ClientApi target not produced by submodule, device utilization monitoring disabled")
     return()
 endif()
 
-set_target_properties(ClientApiLib PROPERTIES EXPORT_NAME ipf_client_api
-                                              MSVC_RUNTIME_LIBRARY "${_ov_msvc_runtime}")
-add_library(openvino::ipf_client_api ALIAS ClientApiLib)
+# ClientApiC.h only applies dllexport/dllimport when ClientApi_EXPORTS/ClientApi_IMPORTS
+# is defined; the submodule itself defines neither, so without this the DLL would not
+# export IpfCreate/IpfDestroy/etc. at all.
+target_compile_definitions(ClientApi PRIVATE ClientApi_EXPORTS)
+set_target_properties(ClientApi PROPERTIES EXPORT_NAME ipf_client_api_dynamic
+                                            MSVC_RUNTIME_LIBRARY "${_ipf_client_api_runtime}")
+add_library(openvino::ipf_client_api_dynamic ALIAS ClientApi)
 
-# The submodule also defines the stand-alone ClientApi DLL, which OpenVINO does not ship.
-if(TARGET ClientApi)
-    set_target_properties(ClientApi PROPERTIES EXCLUDE_FROM_ALL TRUE
-                                               EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+# Use OpenVINO's per-config CRT for the static client; see auto/CMakeLists.txt for selection.
+if(TARGET ClientApiLib)
+    set_target_properties(ClientApiLib PROPERTIES EXCLUDE_FROM_ALL FALSE
+                                                  EXPORT_NAME ipf_client_api_static
+                                                  MSVC_RUNTIME_LIBRARY "${_ov_msvc_runtime}")
+    add_library(openvino::ipf_client_api_static ALIAS ClientApiLib)
+
+    # Keep the header-only nlohmann/json dependency out of the exported link interface.
+    get_target_property(_ipf_link_interface ClientApiLib INTERFACE_LINK_LIBRARIES)
+    if(_ipf_link_interface)
+        list(FILTER _ipf_link_interface EXCLUDE REGEX "^(\\$<LINK_ONLY:)?nlohmann_json(::nlohmann_json)?>?$")
+        set_property(TARGET ClientApiLib PROPERTY INTERFACE_LINK_LIBRARIES "${_ipf_link_interface}")
+    endif()
+
+    ov_install_static_lib(ClientApiLib ${OV_CPACK_COMP_CORE_DEV} ${OV_CPACK_COMP_CORE_DEV_EXCLUDE_ALL})
 endif()
 
-# Keep the header-only nlohmann/json dependency out of the exported link interface.
-get_target_property(_ipf_link_interface ClientApiLib INTERFACE_LINK_LIBRARIES)
-if(_ipf_link_interface)
-    list(FILTER _ipf_link_interface EXCLUDE REGEX "^(\\$<LINK_ONLY:)?nlohmann_json(::nlohmann_json)?>?$")
-    set_property(TARGET ClientApiLib PROPERTY INTERFACE_LINK_LIBRARIES "${_ipf_link_interface}")
+# Install ClientApi.dll only for configurations that delay-load it.
+if(ENABLE_IPF_DEBUG_WITH_RELEASE_CRT)
+    install(TARGETS ClientApi
+            RUNTIME DESTINATION ${OV_CPACK_PLUGINSDIR}
+            COMPONENT ${OV_CPACK_COMP_CORE}
+            CONFIGURATIONS Debug
+            ${OV_CPACK_COMP_CORE_EXCLUDE_ALL})
 endif()
 
-# Install ClientApiLib for static OpenVINO builds.
-ov_install_static_lib(ClientApiLib ${OV_CPACK_COMP_CORE_DEV} ${OV_CPACK_COMP_CORE_DEV_EXCLUDE_ALL})
-
-message(STATUS "[AUTO] IPF: successfully configured (ClientApiLib linked statically)")
+message(STATUS "[AUTO] IPF: successfully configured (Release: static ClientApiLib; "
+               "Debug: dynamic ClientApi.dll delay-loaded when ENABLE_IPF_DEBUG_WITH_RELEASE_CRT=ON, "
+               "else static ClientApiLib; ENABLE_IPF_DEBUG_WITH_RELEASE_CRT=${ENABLE_IPF_DEBUG_WITH_RELEASE_CRT})")


### PR DESCRIPTION
The current IPF driver only provides `ClientApiProxy.dll` with `Release CRT`, while IPF will validates that its CRT debug flag matches the one used by AUTO plugin. Therefore, to ensure combability when OpenVINO is built with Debug mode, this PR  builds `ClientApi.dll` with `Release CRT`.
### Details:
 - Use static ClientApiLib linking for Release and dynamic delay-loaded ClientApi.dll linking for Debug when the Release CRT compatibility option is enabled.
 -  Fix telemetry log formatting and tags, and keep the version object target free of config-conditional IPF libraries.

### Tickets:
 - CVS-193194

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
