### PR TITLE
[Docs][GPU] Fix C API property values in VA remote tensor snippet

### DIFF
--- a/docs/articles_en/assets/snippets/gpu/context_sharing_va_c.cpp
+++ b/docs/articles_en/assets/snippets/gpu/context_sharing_va_c.cpp
@@ -3,6 +3,8 @@
 //
 
 #ifdef ENABLE_LIBVA
+#include <stdio.h>
+
 #include <openvino/c/openvino.h>
 #include <openvino/c/gpu/gpu_plugin_properties.h>
 #include <openvino/runtime/intel_gpu/ocl/va.hpp>
@@ -97,6 +99,11 @@ int main() {
     //     ...
     //wrap decoder output into RemoteBlobs and set it as inference input
 
+    // the C API reads every non-handle property value with va_arg(..., char*),
+    // so numeric values such as the VASurfaceID and the plane index must be decimal strings
+    char surface_id[16];
+    snprintf(surface_id, sizeof(surface_id), "%u", (unsigned int)va_surface);
+
     ov_tensor_t* remote_tensor_y = NULL;
     ov_tensor_t* remote_tensor_uv = NULL;
     ov_remote_context_create_tensor(shared_va_context,
@@ -107,9 +114,9 @@ int main() {
                                     ov_property_key_intel_gpu_shared_mem_type,
                                     "VA_SURFACE",
                                     ov_property_key_intel_gpu_dev_object_handle,
-                                    va_surface,
+                                    surface_id,
                                     ov_property_key_intel_gpu_va_plane,
-                                    0);
+                                    "0");
     ov_remote_context_create_tensor(shared_va_context,
                                     U8,
                                     shape_uv,
@@ -118,9 +125,9 @@ int main() {
                                     ov_property_key_intel_gpu_shared_mem_type,
                                     "VA_SURFACE",
                                     ov_property_key_intel_gpu_dev_object_handle,
-                                    va_surface,
+                                    surface_id,
                                     ov_property_key_intel_gpu_va_plane,
-                                    1);
+                                    "1");
 
     ov_compiled_model_create_infer_request(compiled_model, &infer_request);
     ov_infer_request_set_tensor(infer_request, input_name_0, remote_tensor_y);

--- a/docs/articles_en/assets/snippets/gpu/context_sharing_va_c.cpp
+++ b/docs/articles_en/assets/snippets/gpu/context_sharing_va_c.cpp
@@ -101,7 +101,7 @@ int main() {
 
     // the C API reads every non-handle property value with va_arg(..., char*),
     // so numeric values such as the VASurfaceID and the plane index must be decimal strings
-    char surface_id[16];
+    char surface_id[21];
     snprintf(surface_id, sizeof(surface_id), "%u", (unsigned int)va_surface);
 
     ov_tensor_t* remote_tensor_y = NULL;

--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/gpu-device/remote-tensor-api-gpu-plugin.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/gpu-device/remote-tensor-api-gpu-plugin.rst
@@ -218,6 +218,19 @@ of the ``ov::RemoteContext`` sub-classes.
 object or request plugin to allocate specific device memory. There also provides C APIs to do the same things with C++ APIs.
 For more details, see the code snippets below:
 
+.. note::
+
+   In the C API, ``ov_core_create_context()`` and ``ov_remote_context_create_tensor()`` take property
+   values as variadic arguments and only handle-type properties are read as raw pointers:
+   ``ov_property_key_intel_gpu_ocl_context``, ``ov_property_key_intel_gpu_ocl_queue``,
+   ``ov_property_key_intel_gpu_va_device``, ``ov_property_key_intel_gpu_mem_handle``, and,
+   on Windows only, ``ov_property_key_intel_gpu_dev_object_handle`` (an ``ID3D11Resource*``).
+   Every other value is read with ``va_arg(..., char*)`` and must be passed as a null-terminated
+   string, including numeric ones such as ``ov_property_key_intel_gpu_va_plane``,
+   ``ov_property_key_intel_gpu_dev_object_handle`` on Linux (a ``VASurfaceID``),
+   ``ov_property_key_intel_gpu_ocl_context_device_id``, and ``ov_property_key_intel_gpu_tile_id``.
+   Passing such a value as an integer is undefined behavior.
+
 
 .. tab-set::
 


### PR DESCRIPTION
The C remote context API reads VA_PLANE and DEV_OBJECT_HANDLE with va_arg(..., char*), but the VAAPI snippet passed the VASurfaceID and plane index as integers, producing a garbage pointer at runtime. Being variadic, it compiled cleanly and looked correct.

Pass them as decimal strings and document the convention in the Remote Tensor API article.

### Tickets:
 - #28803

### AI Assistance:
 - AI assistance used: yes (problem analysis and whole solution)