### PR TITLE
Address Bandit B404 subprocess findings in GitHub Actions Python

### DIFF
--- a/.github/actions/coverage_toolkit/collect_cpp_coverage.py
+++ b/.github/actions/coverage_toolkit/collect_cpp_coverage.py
@@ -7,7 +7,8 @@ import os
 import re
 import shlex
 import shutil
-import subprocess
+# Coverage CI: fixed toolchain argv (lcov/gcov/genhtml), no shell.
+import subprocess  # nosec B404
 from pathlib import Path
 
 from coverage_workflow import CoverageContext, LOGGER, run_cmd

--- a/.github/actions/coverage_toolkit/coverage.py
+++ b/.github/actions/coverage_toolkit/coverage.py
@@ -11,7 +11,8 @@ import logging
 import os
 from pathlib import Path
 import shlex
-import subprocess
+# Coverage CI: run_cmd uses argv lists with shell=False unless explicitly opted in.
+import subprocess  # nosec B404
 import sys
 from typing import Any
 

--- a/.github/actions/coverage_toolkit/run_tests.py
+++ b/.github/actions/coverage_toolkit/run_tests.py
@@ -9,7 +9,8 @@ import os
 from pathlib import Path
 import shlex
 import shutil
-import subprocess
+# Coverage CI: pytest/coverage/python invoked as argv lists in the workflow workspace.
+import subprocess  # nosec B404
 import time
 import xml.etree.ElementTree as ET
 

--- a/.github/scripts/agentic-workflows/remediate_transient_failure.py
+++ b/.github/scripts/agentic-workflows/remediate_transient_failure.py
@@ -25,7 +25,8 @@ because the default token cannot re-trigger ``merge_group`` check runs.
 from __future__ import annotations
 
 import os
-import subprocess
+# Merge-queue remediation: gh called with a fixed argv; PR/repo ids validated in common.py.
+import subprocess  # nosec B404
 
 from common import (
     github_client,

--- a/.github/scripts/meat/build_report.py
+++ b/.github/scripts/meat/build_report.py
@@ -27,7 +27,8 @@ Output files:
 import json
 import os
 import pathlib
-import subprocess
+# Posts report via gh using argv lists; comment body is passed as a dedicated argument.
+import subprocess  # nosec B404
 import sys
 import textwrap
 

--- a/.github/scripts/meat/create_agent_pr.py
+++ b/.github/scripts/meat/create_agent_pr.py
@@ -22,7 +22,8 @@ Exit codes:
 import argparse
 import json
 import pathlib
-import subprocess
+# Agent PR helper: git/gh invoked as argv lists; no shell string composition.
+import subprocess  # nosec B404
 import sys
 import textwrap
 

--- a/.github/scripts/meat/enable_operator.py
+++ b/.github/scripts/meat/enable_operator.py
@@ -33,7 +33,8 @@ Shortcut for: run_agent.py enable-operator <context-file>
 """
 
 import os
-import subprocess
+# Thin wrapper: re-execs run_agent.py via sys.executable and a fixed script path (no shell).
+import subprocess  # nosec B404
 import sys
 
 

--- a/.github/scripts/meat/install_copilot_env.py
+++ b/.github/scripts/meat/install_copilot_env.py
@@ -18,7 +18,8 @@ import json
 import os
 import platform
 import shutil
-import subprocess
+# Local setup helper: subprocess.run on fixed installer/version-check argv from this script only.
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 from typing import Optional

--- a/.github/scripts/meat/run_agent.py
+++ b/.github/scripts/meat/run_agent.py
@@ -20,7 +20,8 @@ Copilot CLI reference:
 """
 
 import os
-import subprocess
+# Runs the copilot CLI with fixed flags; prompt is a separate -p argument, not a shell command.
+import subprocess  # nosec B404
 import sys
 
 AGENTS = [

--- a/.github/scripts/meat/tests/conftest.py
+++ b/.github/scripts/meat/tests/conftest.py
@@ -20,7 +20,8 @@ SCRIPTS_DIR = pathlib.Path(__file__).parent.parent
 
 def run_script(script: pathlib.Path, cwd, *args, extra_env=None):
     """Run a Python script as a subprocess, return CompletedProcess."""
-    import subprocess
+    # Test harness only: sys.executable + script path argv, no shell.
+    import subprocess  # nosec B404
 
     env = os.environ.copy()
     if extra_env:


### PR DESCRIPTION
## Summary

- Suppress Bandit **B404** (`import subprocess`) with `# nosec B404` and a one-line rationale on each affected import, aligned with SDL438 / existing repo practice (e.g. `scripts/utils/utils.py`).
- Covers maintainer-controlled CI/automation paths that invoke external tools via **argv lists** (no shell string composition at the import sites addressed here).

**JIRA (CVS, component GitHub Actions):**
- [CVS-185680](https://jira.devtools.intel.com/browse/CVS-185680) — partial (legacy `.github/scripts/coverage/` paths no longer exist; covered via `coverage_toolkit`)
- [CVS-188440](https://jira.devtools.intel.com/browse/CVS-188440) — partial (MEAT + coverage_toolkit; see deferred list)
- [CVS-192724](https://jira.devtools.intel.com/browse/CVS-192724) — `remediate_transient_failure.py`
- [CVS-193009](https://jira.devtools.intel.com/browse/CVS-193009) — partial (coverage_toolkit + MEAT subset)
- [CVS-193010](https://jira.devtools.intel.com/browse/CVS-193010) — partial (MEAT subset)

## Deferred (follow-up PR)

These files still need hardening or explicit Bandit handling; **not** included in this change:

- `.github/actions/handle_docker/helpers.py` — `shell=True` + shell-string Docker commands
- `.github/actions/handle_docker/images_api.py` — same pattern (`check_output` with `shell=True`)
- `.github/scripts/meat/try_conversion.py` — untrusted-adjacent inputs (`model_profile.json`) and optional `shell=True` on Windows

## Test plan

- [ ] Re-run Bandit / SDL438 scan on `.github/` and confirm B404 cleared for the 10 modified files
- [ ] Spot-check coverage toolkit and agentic-workflow jobs in CI (no functional code changes)