### PR TITLE
Fix gtest_discover_tests failed by timeout during build

### DIFF
--- a/cmake/developer_package/add_target_helpers.cmake
+++ b/cmake/developer_package/add_target_helpers.cmake
@@ -267,8 +267,10 @@ function(ov_add_test_target_per_source)
         endif()
 
         if(_has_gtest)
+            # PRE_TEST keeps enumeration out of the build: it runs under ctest
             gtest_discover_tests(${_target}
-                DISCOVERY_MODE POST_BUILD
+                DISCOVERY_MODE PRE_TEST
+                DISCOVERY_TIMEOUT 300
                 PROPERTIES LABELS "${ARG_LABELS}"
             )
         endif()
@@ -317,7 +319,7 @@ without it has no effect and triggers a warning):
   CHECK_SOURCES_EXTENSIONS         <ext1> [<ext2>]     Extensions to scan (default: cpp)
   CHECK_SOURCES_EXCLUDE_FILES      <file1> [<file2>]   Files never matching the target's raw SOURCES property
                                                         (e.g. listed behind a generator expression). Must be
-                                                        plain, unconditional paths (see example below) 
+                                                        plain, unconditional paths (see example below)
                                                         instead of wrapping the path in a genex.
   CHECK_SOURCES_EXCLUDE_DIRECTORIES <dir1> [<dir2>]    Directories skipped entirely by the scan
   CHECK_SOURCES_EXCLUDE_TARGETS    <tgt1> [<tgt2>]     Other targets whose SOURCES should count as "listed" too
@@ -517,8 +519,10 @@ function(ov_add_test_target)
         include(GoogleTest OPTIONAL RESULT_VARIABLE has_gtest)
 
         if(has_gtest)
+            # PRE_TEST keeps enumeration out of the build: it runs under ctest
             gtest_discover_tests(${ARG_NAME}
-                DISCOVERY_MODE POST_BUILD
+                DISCOVERY_MODE PRE_TEST
+                DISCOVERY_TIMEOUT 300
                 PROPERTIES LABELS "${ARG_LABELS}"
             )
         endif()


### PR DESCRIPTION
### Details:
 - Fix gtest_discover_tests failed by timeout during build


### Tickets:
 - CVS-190346

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
