### PR TITLE
docs: update 2026.3.1 archive package URLs

### DIFF
--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -61,7 +61,7 @@ Step 1: Download and Install the OpenVINO Core Components
 
       cd <user_home>/Downloads
 
-4. Download the `OpenVINO Runtime archive file for your system <https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/>`_,
+4. Download the `OpenVINO Runtime archive file for your system <https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/>`_,
    extract the files, rename the extracted folder and move it to the desired path:
 
    .. tab-set::
@@ -77,9 +77,9 @@ Step 1: Download and Install the OpenVINO Core Components
                .. code-block:: sh
 
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu26_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
-                  tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_ubuntu26_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/openvino_toolkit_ubuntu26_2026.3.1.22476.56d9685302d_x86_64.tgz --output openvino_2026.3.1.tgz
+                  tar -xf openvino_2026.3.1.tgz
+                  sudo mv openvino_toolkit_ubuntu26_2026.3.1.22476.56d9685302d_x86_64 /opt/intel/openvino_2026.3.1
 
             .. tab-item:: Ubuntu 24.04
                :sync: ubuntu-24
@@ -87,9 +87,9 @@ Step 1: Download and Install the OpenVINO Core Components
                .. code-block:: sh
 
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu24_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
-                  tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_ubuntu24_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/openvino_toolkit_ubuntu24_2026.3.1.22476.56d9685302d_x86_64.tgz --output openvino_2026.3.1.tgz
+                  tar -xf openvino_2026.3.1.tgz
+                  sudo mv openvino_toolkit_ubuntu24_2026.3.1.22476.56d9685302d_x86_64 /opt/intel/openvino_2026.3.1
 
             .. tab-item:: Ubuntu 22.04
                :sync: ubuntu-22
@@ -97,9 +97,19 @@ Step 1: Download and Install the OpenVINO Core Components
                .. code-block:: sh
 
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu22_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
-                  tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_ubuntu22_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/openvino_toolkit_ubuntu22_2026.3.1.22476.56d9685302d_x86_64.tgz --output openvino_2026.3.1.tgz
+                  tar -xf openvino_2026.3.1.tgz
+                  sudo mv openvino_toolkit_ubuntu22_2026.3.1.22476.56d9685302d_x86_64 /opt/intel/openvino_2026.3.1
+
+
+            .. tab-item:: RHEL 9
+               :sync: rhel-9
+
+               .. code-block:: sh
+
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/openvino_toolkit_rhel9_2026.3.1.22476.56d9685302d_x86_64.tgz --output openvino_2026.3.1.tgz
+                  tar -xf openvino_2026.3.1.tgz
+                  sudo mv openvino_toolkit_rhel9_2026.3.1.22476.56d9685302d_x86_64 /opt/intel/openvino_2026.3.1
 
 
             .. tab-item:: RHEL 8
@@ -107,18 +117,18 @@ Step 1: Download and Install the OpenVINO Core Components
 
                .. code-block:: sh
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_rhel8_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
-                  tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_rhel8_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/openvino_toolkit_rhel8_2026.3.1.22476.56d9685302d_x86_64.tgz --output openvino_2026.3.1.tgz
+                  tar -xf openvino_2026.3.1.tgz
+                  sudo mv openvino_toolkit_rhel8_2026.3.1.22476.56d9685302d_x86_64 /opt/intel/openvino_2026.3.1
 
             .. tab-item:: CentOS 8
                :sync: centos-8
 
                .. code-block:: sh
 
-                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_centos8_2026.3.0.22451.bd8d6542e3c_x86_64.tgz --output openvino_2026.3.0.tgz
-                  tar -xf openvino_2026.3.0.tgz
-                  sudo mv openvino_toolkit_centos8_2026.3.0.22451.bd8d6542e3c_x86_64 /opt/intel/openvino_2026.3.0
+                  curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/openvino_toolkit_centos8_2026.3.1.22476.56d9685302d_x86_64.tgz --output openvino_2026.3.1.tgz
+                  tar -xf openvino_2026.3.1.tgz
+                  sudo mv openvino_toolkit_centos8_2026.3.1.22476.56d9685302d_x86_64 /opt/intel/openvino_2026.3.1
 
 
       .. tab-item:: ARM 64-bit
@@ -126,15 +136,15 @@ Step 1: Download and Install the OpenVINO Core Components
 
          .. code-block:: sh
 
-            curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_ubuntu22_2026.3.0.22451.bd8d6542e3c_arm64.tgz --output openvino_2026.3.0.tgz
-            tar -xf openvino_2026.3.0.tgz
-            sudo mv openvino_toolkit_ubuntu22_2026.3.0.22451.bd8d6542e3c_arm64 /opt/intel/openvino_2026.3.0
+            curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/openvino_toolkit_ubuntu22_2026.3.1.22476.56d9685302d_arm64.tgz --output openvino_2026.3.1.tgz
+            tar -xf openvino_2026.3.1.tgz
+            sudo mv openvino_toolkit_ubuntu22_2026.3.1.22476.56d9685302d_arm64 /opt/intel/openvino_2026.3.1
 
 5. Install required system dependencies on Linux. To do this, OpenVINO provides a script in the extracted installation directory. Run the following command:
 
    .. code-block:: sh
 
-      cd /opt/intel/openvino_2026.3.0
+      cd /opt/intel/openvino_2026.3.1
       sudo -E ./install_dependencies/install_openvino_dependencies.sh
 
 6. (Optional) Install *numpy* Python Library:
@@ -143,11 +153,11 @@ Step 1: Download and Install the OpenVINO Core Components
 
       This step is required only when you decide to use Python API.
 
-   You can use the ``requirements.txt`` file from the ``/opt/intel/openvino_2026.3.0/python`` folder:
+   You can use the ``requirements.txt`` file from the ``/opt/intel/openvino_2026.3.1/python`` folder:
 
    .. code-block:: sh
 
-      cd /opt/intel/openvino_2026.3.0
+      cd /opt/intel/openvino_2026.3.1
       python3 -m pip install -r ./python/requirements.txt
 
 7. For simplicity, it is useful to create a symbolic link as below:
@@ -156,7 +166,7 @@ Step 1: Download and Install the OpenVINO Core Components
 
       cd /opt/intel
 
-      sudo ln -s openvino_2026.3.0 openvino_2026
+      sudo ln -s openvino_2026.3.1 openvino_2026
 
    .. note::
       If you have already installed a previous release of OpenVINO 2026, a symbolic link to the ``openvino_2026`` folder may already exist.

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -47,7 +47,7 @@ Step 1: Install OpenVINO Core Components
       cd <user_home>/Downloads
 
 
-4. Download the `OpenVINO Runtime archive file for macOS <https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/macos/>`__,
+4. Download the `OpenVINO Runtime archive file for macOS <https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/macos/>`__,
    extract the files, rename the extracted folder and move it to the desired path:
 
    .. tab-set::
@@ -57,9 +57,9 @@ Step 1: Install OpenVINO Core Components
 
          .. code-block:: sh
 
-            curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/macos/openvino_toolkit_macos_12_6_2026.3.0.22451.bd8d6542e3c_arm64.tgz --output openvino_2026.3.0.tgz
-            tar -xf openvino_2026.3.0.tgz
-            sudo mv openvino_toolkit_macos_12_6_2026.3.0.22451.bd8d6542e3c_arm64 /opt/intel/openvino_2026.3.0
+            curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/macos/openvino_toolkit_macos_12_6_2026.3.1.22476.56d9685302d_arm64.tgz --output openvino_2026.3.1.tgz
+            tar -xf openvino_2026.3.1.tgz
+            sudo mv openvino_toolkit_macos_12_6_2026.3.1.22476.56d9685302d_arm64 /opt/intel/openvino_2026.3.1
 
 
 5. (Optional) Install *numpy* Python Library:
@@ -68,18 +68,18 @@ Step 1: Install OpenVINO Core Components
 
       This step is required only when you decide to use Python API.
 
-   You can use the ``requirements.txt`` file from the ``/opt/intel/openvino_2026.3.0/python`` folder:
+   You can use the ``requirements.txt`` file from the ``/opt/intel/openvino_2026.3.1/python`` folder:
 
    .. code-block:: sh
 
-      cd /opt/intel/openvino_2026.3.0
+      cd /opt/intel/openvino_2026.3.1
       python3 -m pip install -r ./python/requirements.txt
 
 6. For simplicity, it is useful to create a symbolic link as below:
 
    .. code-block:: sh
 
-      sudo ln -s /opt/intel/openvino_2026.3.0 /opt/intel/openvino_2026
+      sudo ln -s /opt/intel/openvino_2026.3.1 /opt/intel/openvino_2026
 
    .. note::
 

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -41,20 +41,20 @@ Step 1: Download and Install OpenVINO Core Components
       ``C:\Program Files (x86)\Intel`` is the recommended folder. You may also use a different path if desired or if you don't have administrator privileges on your computer.
 
 
-2. Download the `OpenVINO Runtime archive file for Windows <https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/windows/>`__ to your local ``Downloads`` folder.
+2. Download the `OpenVINO Runtime archive file for Windows <https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/windows/>`__ to your local ``Downloads`` folder.
 
    If you prefer using command-lines, run the following commands in the command prompt window you opened:
 
    .. code-block:: sh
 
       cd <user_home>/Downloads
-      curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/windows/openvino_toolkit_windows_2026.3.0.22451.bd8d6542e3c_x86_64.zip --output openvino_2026.3.0.zip
+      curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/windows/openvino_toolkit_windows_2026.3.1.22476.56d9685302d_x86_64.zip --output openvino_2026.3.1.zip
 
    .. note::
 
       A ``.sha256`` file is provided together with the archive file to validate your download
       process. To do that, download the ``.sha256`` file from the same repository and run
-      ``CertUtil -hashfile openvino_2026.3.0.zip SHA256``. Compare the returned value in the
+      ``CertUtil -hashfile openvino_2026.3.1.zip SHA256``. Compare the returned value in the
       output with what's in the ``.sha256`` file: if the values are the same, you have
       downloaded the correct file successfully; if not, create a Support ticket
       `here <https://www.intel.com/content/www/us/en/support/contact-intel.html>`__.
@@ -66,9 +66,9 @@ Step 1: Download and Install OpenVINO Core Components
 
    .. code-block:: sh
 
-      tar -xf openvino_2026.3.0.zip
-      ren openvino_toolkit_windows_2026.3.0.22451.bd8d6542e3c_x86_64 openvino_2026.3.0
-      move openvino_2026.3.0 "C:\Program Files (x86)\Intel"
+      tar -xf openvino_2026.3.1.zip
+      ren openvino_toolkit_windows_2026.3.1.22476.56d9685302d_x86_64 openvino_2026.3.1
+      move openvino_2026.3.1 "C:\Program Files (x86)\Intel"
 
 
 4. (Optional) Install *numpy* Python Library:
@@ -77,11 +77,11 @@ Step 1: Download and Install OpenVINO Core Components
 
       This step is required only when you decide to use Python API.
 
-   You can use the ``requirements.txt`` file from the ``C:\Program Files (x86)\Intel\openvino_2026.3.0\python`` folder:
+   You can use the ``requirements.txt`` file from the ``C:\Program Files (x86)\Intel\openvino_2026.3.1\python`` folder:
 
    .. code-block:: sh
 
-      cd "C:\Program Files (x86)\Intel\openvino_2026.3.0"
+      cd "C:\Program Files (x86)\Intel\openvino_2026.3.1"
       python -m pip install -r .\python\requirements.txt
 
 
@@ -90,7 +90,7 @@ Step 1: Download and Install OpenVINO Core Components
    .. code-block:: sh
 
       cd C:\Program Files (x86)\Intel
-      mklink /D openvino_2026 openvino_2026.3.0
+      mklink /D openvino_2026 openvino_2026.3.1
 
 
    .. note::

--- a/docs/articles_en/get-started/install-openvino/install-openvino-genai.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-genai.rst
@@ -64,40 +64,48 @@ Linux
 
             .. code-block:: sh
 
-               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu26_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
-               tar -xf openvino_genai_2026.3.0.0.tgz
+               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3.1/linux/openvino_genai_ubuntu26_2026.3.1.0_x86_64.tar.gz --output openvino_genai_2026.3.1.0.tgz
+               tar -xf openvino_genai_2026.3.1.0.tgz
 
          .. tab-item:: Ubuntu 24.04
             :sync: ubuntu-24
 
             .. code-block:: sh
 
-               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu24_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
-               tar -xf openvino_genai_2026.3.0.0.tgz
+               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3.1/linux/openvino_genai_ubuntu24_2026.3.1.0_x86_64.tar.gz --output openvino_genai_2026.3.1.0.tgz
+               tar -xf openvino_genai_2026.3.1.0.tgz
 
          .. tab-item:: Ubuntu 22.04
             :sync: ubuntu-22
 
             .. code-block:: sh
 
-               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu22_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
-               tar -xf openvino_genai_2026.3.0.0.tgz
+               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3.1/linux/openvino_genai_ubuntu22_2026.3.1.0_x86_64.tar.gz --output openvino_genai_2026.3.1.0.tgz
+               tar -xf openvino_genai_2026.3.1.0.tgz
+
+         .. tab-item:: RHEL 9
+            :sync: rhel-9
+
+            .. code-block:: sh
+
+               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3.1/linux/openvino_genai_rhel9_2026.3.1.0_x86_64.tar.gz --output openvino_genai_2026.3.1.0.tgz
+               tar -xf openvino_genai_2026.3.1.0.tgz
 
          .. tab-item:: RHEL 8
             :sync: rhel-8
 
             .. code-block:: sh
 
-               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_rhel8_2026.3.0.0_x86_64.tar.gz --output openvino_genai_2026.3.0.0.tgz
-               tar -xf openvino_genai_2026.3.0.0.tgz
+               curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3.1/linux/openvino_genai_rhel8_2026.3.1.0_x86_64.tar.gz --output openvino_genai_2026.3.1.0.tgz
+               tar -xf openvino_genai_2026.3.1.0.tgz
 
    .. tab-item:: ARM 64-bit
       :sync: arm-64
 
       .. code-block:: sh
 
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/linux/openvino_genai_ubuntu22_2026.3.0.0_arm64.tar.gz --output openvino_genai_2026.3.0.0.tgz
-         tar -xf openvino_genai_2026.3.0.0.tgz
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3.1/linux/openvino_genai_ubuntu22_2026.3.1.0_arm64.tar.gz --output openvino_genai_2026.3.1.0.tgz
+         tar -xf openvino_genai_2026.3.1.0.tgz
 
 
 Windows
@@ -106,7 +114,7 @@ Windows
 .. code-block:: sh
 
    cd <user_home>/Downloads
-   curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/windows/openvino_genai_windows_2026.3.0.0_x86_64.zip --output openvino_genai_2026.3.0.0.zip
+   curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3.1/windows/openvino_genai_windows_2026.3.1.0_x86_64.zip --output openvino_genai_2026.3.1.0.zip
 
 macOS
 ++++++++++++++++++++++++++
@@ -118,8 +126,8 @@ macOS
 
       .. code-block:: sh
 
-         curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3/macos/openvino_genai_macos_12_6_2026.3.0.0_arm64.tar.gz --output openvino_genai_2026.3.0.0.tgz
-         tar -xf openvino_genai_2026.3.0.0.tgz
+         curl -L https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2026.3.1/macos/openvino_genai_macos_12_6_2026.3.1.0_arm64.tar.gz --output openvino_genai_2026.3.1.0.tgz
+         tar -xf openvino_genai_2026.3.1.0.tgz
 
 
 Here are the full guides:

--- a/docs/dev/build_android.md
+++ b/docs/dev/build_android.md
@@ -11,15 +11,15 @@ This article describes how to build OpenVINO for Android operating systems.
 
 ## Use the prebuilt x86-64 archive
 
-For Android x86-64 targets, you can use the prebuilt OpenVINO 2026.3 Runtime package instead of building OpenVINO from source:
+For Android x86-64 targets, you can use the prebuilt OpenVINO 2026.3.1 Runtime package instead of building OpenVINO from source:
 
 ```sh
 mkdir openvino-android
 export OPV_HOME_DIR=${PWD}/openvino-android
-curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/linux/openvino_toolkit_android_2026.3.0.22451.bd8d6542e3c_x86_64.tgz \
-  --output $OPV_HOME_DIR/openvino_toolkit_android_2026.3.0.tgz
-tar -xf $OPV_HOME_DIR/openvino_toolkit_android_2026.3.0.tgz -C $OPV_HOME_DIR
-export OpenVINO_DIR=$OPV_HOME_DIR/openvino_toolkit_android_2026.3.0.22451.bd8d6542e3c_x86_64/runtime/cmake
+curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3.1/linux/openvino_toolkit_android_2026.3.1.22476.56d9685302d_x86_64.tgz \
+  --output $OPV_HOME_DIR/openvino_toolkit_android_2026.3.1.tgz
+tar -xf $OPV_HOME_DIR/openvino_toolkit_android_2026.3.1.tgz -C $OPV_HOME_DIR
+export OpenVINO_DIR=$OPV_HOME_DIR/openvino_toolkit_android_2026.3.1.22476.56d9685302d_x86_64/runtime/cmake
 ```
 
 The archive provides the OpenVINO headers, x86-64 Runtime libraries, CMake configuration, and required oneTBB libraries. For other Android architectures or a custom configuration, build OpenVINO from source as described below. The ADB example later in this guide demonstrates an aarch64 source build and does not apply directly to this x86-64 archive.


### PR DESCRIPTION
### Details:
 - *Updated OpenVINO Runtime and OpenVINO GenAI archive installation documentation for the 2026.3.1 release.*
 - *Updatde GenAI archive URLs and filenames to 2026.3.1*
 - *Added RHEL 9 x86_64 archive instructions for Runtime and GenAI.*
 - *Updated the Android prebuilt Runtime archive example, including `OpenVINO_DIR`.*
 - Kept unrelated package-index, selector-tool, Tokenizers, WinGet, and Node.js documentation unchanged.

### Tickets:
 - *no ticket*

### AI Assistance:
 - *AI assistance used: yes*
 - *Used AI to verify all 18 documented Runtime and GenAI archives against the production storage inventory; to download each archive and matching `.sha256` file and confirm all checksums; then verified manually what AI did, and verified in a local documentation build.*
