### PR TITLE
[NPU] Fix test for page aligned tensor

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/dynamic_host_pipeline/infer_with_host_compile.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/dynamic_host_pipeline/infer_with_host_compile.cpp
@@ -461,18 +461,12 @@ TEST_P(InferWithHostCompileTests, CompileAndInferWithDecreasedSize) {
            "inference, but got: "
         << logCapture.str();
 
-    logCapture.clear();
     ov::Tensor inTensor1 = ov::test::utils::create_and_fill_tensor(model->input().get_element_type(), shape, 100, 0);
     setInputInferAndCompare(model,
                             testContext.reqDynamic,
                             testContext.reqReference,
                             inTensor1,
                             "CompileAndInferWithDecreasedSize_third");
-    // A new host tensor with the same shape should still reuse the command list.
-    ASSERT_TRUE(logContains(logCapture, "Reuse command list without update since no tensor change detected"))
-        << "Expected log to contain 'Reuse command list without update since no tensor change detected' for third "
-           "inference, but got: "
-        << logCapture.str();
 
     logCapture.clear();
     ov::Shape shape2 = {1, 720, 720, 16};
@@ -532,18 +526,12 @@ TEST_P(InferWithHostCompileTests, CompileAndInferWithIncreasedSize) {
            "inference, but got: "
         << logCapture.str();
 
-    logCapture.clear();
     ov::Tensor inTensor1 = ov::test::utils::create_and_fill_tensor(model->input().get_element_type(), shape, 100, 0);
     setInputInferAndCompare(model,
                             testContext.reqDynamic,
                             testContext.reqReference,
                             inTensor1,
                             "CompileAndInferWithIncreasedSize_third");
-    // A new host tensor with the same shape should still reuse the command list.
-    ASSERT_TRUE(logContains(logCapture, "Reuse command list without update since no tensor change detected"))
-        << "Expected log to contain 'Reuse command list without update since no tensor change detected' for third "
-           "inference, but got: "
-        << logCapture.str();
 
     logCapture.clear();
     ov::Shape shape2 = {1, 720, 1280, 16};


### PR DESCRIPTION
### Details:
 - *Current tests expect user tensor not replace internal tensor if their shapes are same. But if user tensors are page aligned, they can be imported as zero tensor and trigger another work flow, the log check for this part can bring random test failure*

### Tickets:
 - *C192283*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
