### PR TITLE
[NPUW] Bounds-check closure indices on blob import

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -1012,11 +1012,13 @@ void ov::npuw::CompiledModel::CompiledModelDesc::serialize(ov::npuw::s11n::Strea
             lazy_closure.resize(closure_size);
             stream & cpu_closure_ids;
             serialize_weightless(stream, cpu_closures, ctx);
+            ov::npuw::s11n::validate_closure_ids(cpu_closure_ids, closure_desc.closure.size(), cpu_closures.size());
             std::size_t tidx = 0;
             for (const auto& idx : cpu_closure_ids) {
                 closure_desc.closure[idx] = std::move(cpu_closures[tidx++]);
             }
             stream & non_cpu_tensors_ids & non_cpu_tensors;
+            ov::npuw::s11n::validate_closure_ids(non_cpu_tensors_ids, lazy_closure.size(), non_cpu_tensors.size());
             std::size_t ltidx = 0;
             for (const auto& idx : non_cpu_tensors_ids) {
                 lazy_closure[idx] = std::move(non_cpu_tensors[ltidx++]);
@@ -1048,6 +1050,7 @@ void ov::npuw::CompiledModel::CompiledModelDesc::serialize(ov::npuw::s11n::Strea
         } else {
             stream & cpu_closure_ids;
             closure_desc.closure.resize(closure_size);
+            ov::npuw::s11n::validate_closure_ids(cpu_closure_ids, closure_desc.closure.size());
             for (const auto& cidx : cpu_closure_ids) {
                 stream & closure_desc.closure[cidx];
             }

--- a/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/serialization.hpp
@@ -304,6 +304,18 @@ inline void read_weightless(std::istream& stream, std::vector<ov::Tensor>& var, 
     orc::serialize_weightless(stream_io, var, ctx);
 }
 
+// Bounds-check untrusted closure indices before they subscript a closure vector.
+// Throws on any index >= container_size, or (if given) payload_size != ids.size().
+inline void validate_closure_ids(const std::vector<std::size_t>& ids,
+                                 std::size_t container_size,
+                                 std::optional<std::size_t> payload_size = std::nullopt) {
+    OPENVINO_ASSERT(!payload_size || *payload_size == ids.size(),
+                    "[NPU] NPUW closure index/payload length mismatch in deserialized blob");
+    for (const auto idx : ids) {
+        OPENVINO_ASSERT(idx < container_size, "[NPU] NPUW closure index out of range in deserialized blob");
+    }
+}
+
 }  // namespace s11n
 
 }  // namespace npuw

--- a/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
@@ -881,6 +881,32 @@ TEST(SerializationTest, OVTypes_Tensor_weightless_mmap_oob_overflow) {
     std::filesystem::remove(file_path);
 }
 
+// Guards CompiledModelDesc::serialize()'s deserialize path against attacker-controlled closure
+// indices that would otherwise subscript the closure vector out of bounds.
+TEST(SerializationTest, NPUW_ClosureIds_out_of_range_rejected) {
+    using namespace ov::npuw::s11n;
+
+    ASSERT_THROW(validate_closure_ids({2}, /*container_size=*/2), ov::AssertFailure);  // idx == size
+    ASSERT_THROW(validate_closure_ids({5}, /*container_size=*/2), ov::AssertFailure);
+    ASSERT_THROW(validate_closure_ids({0, 1, 9}, /*container_size=*/3), ov::AssertFailure);
+}
+
+TEST(SerializationTest, NPUW_ClosureIds_payload_mismatch_rejected) {
+    using namespace ov::npuw::s11n;
+
+    ASSERT_THROW(validate_closure_ids({0, 1}, /*container_size=*/4, /*payload_size=*/1), ov::AssertFailure);
+    ASSERT_THROW(validate_closure_ids({0}, /*container_size=*/4, /*payload_size=*/2), ov::AssertFailure);
+}
+
+TEST(SerializationTest, NPUW_ClosureIds_valid_accepted) {
+    using namespace ov::npuw::s11n;
+
+    ASSERT_NO_THROW(validate_closure_ids({0, 1, 2}, /*container_size=*/3, /*payload_size=*/3));
+    ASSERT_NO_THROW(validate_closure_ids({2, 0}, /*container_size=*/3, /*payload_size=*/2));
+    ASSERT_NO_THROW(validate_closure_ids({}, /*container_size=*/0));  // empty is legitimate
+    ASSERT_NO_THROW(validate_closure_ids({}, /*container_size=*/4, /*payload_size=*/0));
+}
+
 TEST(SerializationTest, OVTypes_OutputPort_roundtrips_into_parameter_pointer) {
     using namespace ov::npuw::s11n;
 


### PR DESCRIPTION
### Details:
CompiledModelDesc::serialize()'s deserialize path read closure indices straight from an untrusted blob and used them to subscript the closure / lazy_closure vectors, whose length comes from a different attacker- controlled field in the same blob. std::vector::operator[] is unchecked, so a crafted index yielded an out-of-bounds ov::Tensor write (and an arbitrary-address refcount release) inside any process calling ov::Core::import_model with an NPU-targeted blob.

Add s11n::validate_closure_ids() and call it before every closure scatter in the import direction, rejecting out-of-range indices and id/payload length mismatches with ov::AssertFailure. Covered by new unit tests.

### Tickets:
 - CVS-193457

### AI Assistance:
 - AI assistance used: yes
 - Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
