### PR TITLE
[py API] Torchvision enhance nearest interpolation handling for non-square images

### DIFF
--- a/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
@@ -311,12 +311,36 @@ class _(TransformConverterBase):
         ppp.input(input_idx).tensor().set_layout(Layout("NCHW"))
 
         input_shape = meta["input_shape"]
+        layout = meta["layout"]
 
-        input_shape[meta["layout"].get_index_by_name("H")] = -1
-        input_shape[meta["layout"].get_index_by_name("W")] = -1
+        input_shape[layout.get_index_by_name("H")] = -1
+        input_shape[layout.get_index_by_name("W")] = -1
 
         ppp.input(input_idx).tensor().set_shape(input_shape)
-        ppp.input(input_idx).preprocess().resize(resize_mode_map[transform.interpolation], target_h, target_w)
+
+        if transform.interpolation == InterpolationMode.NEAREST:
+            # Pillow (used by torchvision for PIL images) samples the source pixel at floor((x + 0.5) * scale),
+            # which corresponds to the `half_pixel` coordinate transformation with `round_prefer_ceil` rounding.
+            # ResizeAlgorithm.RESIZE_NEAREST rounds with `round_prefer_floor` and therefore selects a different
+            # source pixel whenever the mapped coordinate falls exactly halfway between two pixels.
+            axes = [layout.get_index_by_name("H"), layout.get_index_by_name("W")]
+
+            @custom_preprocess_function
+            def resize_nearest_pillow(output: Output) -> Callable:
+                return ops.interpolate(  # type: ignore
+                    output,
+                    np.array([target_h, target_w], dtype=np.int32),
+                    mode="nearest",
+                    shape_calculation_mode="sizes",
+                    coordinate_transformation_mode="half_pixel",
+                    nearest_mode="round_prefer_ceil",
+                    axes=np.array(axes, dtype=np.int32),
+                )
+
+            ppp.input(input_idx).preprocess().custom(resize_nearest_pillow)
+        else:
+            ppp.input(input_idx).preprocess().resize(resize_mode_map[transform.interpolation], target_h, target_w)
+
         meta["input_shape"] = input_shape
         meta["image_dimensions"] = (target_h, target_w)
 

--- a/tests/layer_tests/py_frontend_tests/test_torchvision_preprocessor.py
+++ b/tests/layer_tests/py_frontend_tests/test_torchvision_preprocessor.py
@@ -89,13 +89,15 @@ def test_normalize():
     ("target_size", "current_size", "interpolation", "tolerance"),
     [
         (224, (220, 220, 3), transforms.InterpolationMode.NEAREST, 4e-05),
-        (224, (200, 240, 3), transforms.InterpolationMode.NEAREST, 0.3),  # Ticket 127670
+        (224, (200, 240, 3), transforms.InterpolationMode.NEAREST, 4e-05),
         (224, (220, 220, 3), transforms.InterpolationMode.BILINEAR, 4e-03),
         (224, (200, 240, 3), transforms.InterpolationMode.BILINEAR, 4e-03),
         (224, (220, 220, 3), transforms.InterpolationMode.BICUBIC, 4e-03),
         (224, (200, 240, 3), transforms.InterpolationMode.BICUBIC, 4e-03),
         ((224, 224), (220, 220, 3), transforms.InterpolationMode.NEAREST, 4e-05),
         ((224, 224), (200, 240, 3), transforms.InterpolationMode.NEAREST, 4e-05),
+        # integer scale factor -> every sampled coordinate is a rounding tie
+        ((224, 224), (448, 448, 3), transforms.InterpolationMode.NEAREST, 4e-05),
         ((224, 224), (220, 220, 3), transforms.InterpolationMode.BILINEAR, 4e-03),
         ((224, 224), (200, 240, 3), transforms.InterpolationMode.BILINEAR, 4e-03),
         ((224, 224), (220, 220, 3), transforms.InterpolationMode.BICUBIC, 4e-03),


### PR DESCRIPTION
### Details:
 - Enhance nearest interpolation handling for non-square images in torchvisioin


### Tickets:
 - CVS-127670

### AI Assistance:
 - *yes*
