### PR TITLE
[NPUW] Bounds-check weight offset/size on weightless import

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -9,6 +9,7 @@
 #include <variant>
 
 #include "logging.hpp"
+#include "openvino/core/except.hpp"
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/reference/convert.hpp"
@@ -76,7 +77,13 @@ ov::Tensor Const::eval() const {
         }
         m_mmaped_weights =
             std::make_shared<ov::npuw::s11n::Weights>(mapped_memory->data(), mapped_memory->size(), mapped_memory);
-        return ov::Tensor(m_cached_type, m_cached_shape, m_mmaped_weights->get_ptr(m_offset));
+        // offset/byte_size come from the imported blob; bound them before exposing a zero-copy
+        // view, and require byte_size to match shape*type so the view can't read past it
+        const auto wsz = m_mmaped_weights->size();
+        OPENVINO_ASSERT(m_offset <= wsz && m_byte_size <= wsz - m_offset, "[NPU] weight offset/size out of range");
+        ov::Tensor t(m_cached_type, m_cached_shape, m_mmaped_weights->get_ptr(m_offset));
+        OPENVINO_ASSERT(t.get_byte_size() == m_byte_size, "[NPU] weight byte_size does not match tensor shape");
+        return t;
     }
 
     NPUW_ASSERT(m_read_from_bin && "Underlying data should have been read first! Or the tensor is already detached.");
@@ -107,6 +114,9 @@ void Const::read_weight(const ov::npuw::s11n::WeightsContext& ctx) {
     if (ctx.weights) {
         if (ctx.bf16_consts.find({m_offset, m_byte_size}) != ctx.bf16_consts.end()) {
             NPUW_ASSERT(m_cached_type == ov::element::f16);
+            // offset/byte_size come from the imported blob; bound them before the memcpy
+            const auto wsz = ctx.weights->size();
+            OPENVINO_ASSERT(m_offset <= wsz && m_byte_size <= wsz - m_offset, "[NPU] weight offset/size out of range");
             // Read original bf16 weight
             auto bf16_tensor = ov::Tensor(ov::element::bf16, m_cached_shape);
             NPUW_ASSERT(bf16_tensor.get_byte_size() == m_byte_size);

--- a/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
@@ -1097,6 +1097,118 @@ TEST(SerializationTest, OVTypes_Tensor_weightless_mmap_oob_overflow) {
     std::filesystem::remove(file_path);
 }
 
+// Craft a Const whose blob-supplied offset/size exceeds the backing weights file and assert its
+// two weightless consumers -- the zero-copy view in eval() and the bf16 memcpy in read_weight() -- reject it.
+
+TEST(SerializationTest, OVTypes_LazyTensor_weightless_mmap_oob) {
+    using namespace ov::npuw::s11n;
+
+    auto constant = make_weightless_constant<float>(ov::element::f32, ov::Shape{4}, {1.0f, 2.0f, 3.0f, 4.0f}, 0);
+    ov::npuw::weights::LazyTensor var(constant);
+
+    std::stringstream ss;
+    write(ss, var);
+
+    std::filesystem::path file_path = ov::test::utils::generateTestFilePrefix() + "_npuw_lt_mmap_oob.bin";
+    {
+        std::ofstream os(file_path, std::ios::binary);
+        const std::vector<uint8_t> tiny(8, 0xAB);
+        os.write(reinterpret_cast<const char*>(tiny.data()), static_cast<std::streamsize>(tiny.size()));
+    }
+
+    {
+        ov::npuw::weights::LazyTensor res;
+        read(ss, res);
+
+        auto mapped = ov::load_mmap_object(file_path);
+        ASSERT_NE(mapped, nullptr);
+        auto weights = std::make_shared<Weights>(reinterpret_cast<char*>(mapped->data()), mapped->size(), mapped);
+
+        // Empty bf16_consts -> read_weight only records the path; the OOB read happens in eval().
+        WeightsContext import_ctx(weights, file_path.string(), {}, {});
+        res.read_weight(import_ctx);
+        EXPECT_THROW(res.eval(), ov::AssertFailure);
+
+        res.detach();  // release the mmap before removing the file (Windows handle)
+    }
+
+    std::filesystem::remove(file_path);
+}
+
+TEST(SerializationTest, OVTypes_LazyTensor_weightless_bf16_oob) {
+    using namespace ov::npuw::s11n;
+
+    auto constant = make_weightless_constant<ov::float16>(
+        ov::element::f16,
+        ov::Shape{4},
+        {ov::float16(1.0f), ov::float16(2.0f), ov::float16(3.0f), ov::float16(4.0f)},
+        0);
+    ov::npuw::weights::LazyTensor var(constant);
+
+    std::stringstream ss;
+    write(ss, var);
+
+    std::filesystem::path file_path = ov::test::utils::generateTestFilePrefix() + "_npuw_lt_bf16_oob.bin";
+    {
+        std::ofstream os(file_path, std::ios::binary);
+        const std::vector<uint8_t> tiny(4, 0xAB);
+        os.write(reinterpret_cast<const char*>(tiny.data()), static_cast<std::streamsize>(tiny.size()));
+    }
+
+    {
+        ov::npuw::weights::LazyTensor res;
+        read(ss, res);
+
+        auto mapped = ov::load_mmap_object(file_path);
+        ASSERT_NE(mapped, nullptr);
+        auto weights = std::make_shared<Weights>(reinterpret_cast<char*>(mapped->data()), mapped->size(), mapped);
+
+        // The bf16_consts entry drives read_weight into the guarded bf16 memcpy branch.
+        WeightsContext import_ctx(weights, file_path.string(), {}, {{0, constant->get_byte_size()}});
+        EXPECT_THROW(res.read_weight(import_ctx), ov::AssertFailure);
+    }
+
+    std::filesystem::remove(file_path);
+}
+
+TEST(SerializationTest, OVTypes_LazyTensor_weightless_mmap_valid) {
+    using namespace ov::npuw::s11n;
+
+    // Positive regression: a well-formed Const must still import through the mmap zero-copy path.
+    const std::vector<float> values = {1.0f, 2.0f};
+    auto constant = make_weightless_constant<float>(ov::element::f32, ov::Shape{2}, values, 0);
+    ov::npuw::weights::LazyTensor var(constant);
+
+    std::stringstream ss;
+    write(ss, var);
+
+    std::filesystem::path file_path = ov::test::utils::generateTestFilePrefix() + "_npuw_lt_mmap_valid.bin";
+    {
+        std::ofstream os(file_path, std::ios::binary);
+        os.write(reinterpret_cast<const char*>(values.data()),
+                 static_cast<std::streamsize>(values.size() * sizeof(float)));
+    }
+
+    {
+        ov::npuw::weights::LazyTensor res;
+        read(ss, res);
+
+        auto mapped = ov::load_mmap_object(file_path);
+        ASSERT_NE(mapped, nullptr);
+        auto weights = std::make_shared<Weights>(reinterpret_cast<char*>(mapped->data()), mapped->size(), mapped);
+
+        WeightsContext import_ctx(weights, file_path.string(), {}, {});
+        res.read_weight(import_ctx);
+
+        ov::Tensor expected(ov::element::f32, ov::Shape{2}, const_cast<float*>(values.data()));
+        expect_tensors_equal(expected, res.eval());
+
+        res.detach();  // release the mmap before removing the file (Windows handle)
+    }
+
+    std::filesystem::remove(file_path);
+}
+
 TEST(SerializationTest, OVTypes_OutputPort_roundtrips_into_parameter_pointer) {
     using namespace ov::npuw::s11n;
 

--- a/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/serialization.cpp
@@ -27,6 +27,7 @@
 #include "openvino/openvino.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
 #include "openvino/util/mmap_object.hpp"
+#include "orc.hpp"
 #include "pyramid_attention.hpp"
 #include "spatial.hpp"
 #include "weights_bank.hpp"
@@ -1202,6 +1203,62 @@ TEST(SerializationTest, OVTypes_LazyTensor_weightless_mmap_valid) {
 
         ov::Tensor expected(ov::element::f32, ov::Shape{2}, const_cast<float*>(values.data()));
         expect_tensors_equal(expected, res.eval());
+
+        res.detach();  // release the mmap before removing the file (Windows handle)
+    }
+
+    std::filesystem::remove(file_path);
+}
+
+// A legitimate constant always has byte_size == shape*type, so isolating the shape/byte_size assert
+// in eval() needs a hand-crafted blob: shape (f32 x4 = 16 B) disagrees with byte_size (8 B), and the
+// 8 B stays inside the 8 B mapping so the range check passes and only that assert can reject it.
+TEST(SerializationTest, OVTypes_LazyTensor_weightless_shape_bytesize_mismatch) {
+    using namespace ov::npuw::s11n;
+
+    std::stringstream payload_ss(std::ios::in | std::ios::out | std::ios::binary);
+    {
+        auto pw = ov::npuw::orc::Stream::writer(payload_ss);
+        std::string type_str = "f32";
+        ov::Shape shape{4};  // f32 x4 -> tensor byte size 16
+        std::size_t offset = 0;
+        std::size_t byte_size = 8;  // lies: does not match shape*type
+        bool contains_weight = false;
+        pw & type_str & shape & offset & byte_size & contains_weight;
+    }
+    const std::string payload_str = payload_ss.str();
+    std::vector<std::byte> payload(payload_str.size());
+    std::memcpy(payload.data(), payload_str.data(), payload_str.size());
+
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+    {
+        auto w = ov::npuw::orc::Stream::writer(ss);
+        bool is_initialized = true;
+        std::size_t hash = 0;
+        w & is_initialized & hash;
+        // type id 1 == TransformType::CONST, version 0 == op::Const::kVersion
+        auto section = ov::npuw::orc::Section::raw(1, 0, payload);
+        ov::npuw::orc::serialize(w, section);
+    }
+
+    std::filesystem::path file_path = ov::test::utils::generateTestFilePrefix() + "_npuw_lt_shape_mismatch.bin";
+    {
+        std::ofstream os(file_path, std::ios::binary);
+        const std::vector<uint8_t> tiny(8, 0xAB);
+        os.write(reinterpret_cast<const char*>(tiny.data()), static_cast<std::streamsize>(tiny.size()));
+    }
+
+    {
+        ov::npuw::weights::LazyTensor res;
+        read(ss, res);
+
+        auto mapped = ov::load_mmap_object(file_path);
+        ASSERT_NE(mapped, nullptr);
+        auto weights = std::make_shared<Weights>(reinterpret_cast<char*>(mapped->data()), mapped->size(), mapped);
+
+        WeightsContext import_ctx(weights, file_path.string(), {}, {});
+        res.read_weight(import_ctx);
+        EXPECT_THROW(res.eval(), ov::AssertFailure);
 
         res.detach();  // release the mmap before removing the file (Windows handle)
     }


### PR DESCRIPTION
### Details:
On the weightless import path op::Const deserializes m_offset and m_byte_size straight from the imported blob and passes them to AlignedBuffer::get_ptr (bare pointer arithmetic) in two consumers: the memcpy in Const::read_weight and the zero-copy ov::Tensor view in Const::eval. Neither compared the offset/length against the mapped weights size, so a blob authored by whoever a victim application imports could pick an arbitrary 64-bit displacement -- an unmapped offset faults, a mapped one silently loads process memory as weights.

Add the same guard already present on the sibling serialize_weightless path, plus a byte_size-matches-shape check on the eval view. Cover both consumers and the valid mmap path with unit tests.

### Tickets:
 - CVS-193460

### AI Assistance:
 - AI assistance used: yes
 - Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
