### PR TITLE
[NPUW] Filter config from compiled model to CACHED options only

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/config.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/config.hpp
@@ -16,6 +16,7 @@
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -483,7 +484,13 @@ public:
 
     virtual void updateAny(const ov::AnyMap& options);
 
+    // Like updateAny(), but silently ignores keys that are not registered instead of throwing.
+    void updateAnyKnown(const ov::AnyMap& options);
+
     void parseEnvVars();
+
+    // Returns this config's currently-set options whose keys are contained in `keys`.
+    ConfigMap extract(const std::unordered_set<std::string>& keys) const;
 
     template <class Opt>
     bool has() const;

--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/npuw.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <string>
 #include <thread>
+#include <unordered_set>
 
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/npu_private_properties.hpp"
@@ -43,6 +45,9 @@ namespace intel_npu {
 void registerNPUWOptions(OptionsDesc& desc);
 void registerNPUWLLMOptions(OptionsDesc& desc);
 void registerNPUWKokoroOptions(OptionsDesc& desc);
+
+// NPUW option keys marked CACHED.
+const std::unordered_set<std::string>& cachedNPUWOptionKeys();
 
 #define DEFINE_NPUW_SIMPLE_OPT(Name, Type, DefaultValue, KeyLiteral) \
     struct Name final : OptionBase<Name, Type> {                     \

--- a/src/plugins/intel_npu/src/al/src/config/config.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/config.cpp
@@ -282,6 +282,29 @@ void Config::updateAny(const ov::AnyMap& options) {
     }
 }
 
+void Config::updateAnyKnown(const ov::AnyMap& options) {
+    ov::AnyMap known;
+    for (const auto& p : options) {
+        if (_desc->has(p.first)) {
+            known.emplace(p.first, p.second);
+        }
+    }
+    if (!known.empty()) {
+        updateAny(known);
+    }
+}
+
+Config::ConfigMap Config::extract(const std::unordered_set<std::string>& keys) const {
+    ConfigMap out;
+    for (const auto& p : _impl) {
+        std::string key(p.first);
+        if (keys.count(key) != 0) {
+            out.emplace(std::move(key), p.second->toString());
+        }
+    }
+    return out;
+}
+
 std::string Config::toString() const {
     std::stringstream resultStream;
     for (auto it = _impl.cbegin(); it != _impl.cend(); ++it) {

--- a/src/plugins/intel_npu/src/al/src/config/npuw.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/npuw.cpp
@@ -32,6 +32,18 @@ void intel_npu::registerNPUWKokoroOptions(OptionsDesc& desc) {
     });
 }
 
+const std::unordered_set<std::string>& intel_npu::cachedNPUWOptionKeys() {
+    static const std::unordered_set<std::string> keys = [] {
+        std::unordered_set<std::string> result;
+        for_each_cached_npuw_option([&](auto tag) {
+            using Opt = typename decltype(tag)::type;
+            result.insert(std::string(Opt::key()));
+        });
+        return result;
+    }();
+    return keys;
+}
+
 std::string ov::npuw::s11n::anyToString(const ov::Any& var) {
 #define HNDL(anyt, t)                                                \
     auto type = static_cast<int>(AnyType::anyt);                     \

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -1258,8 +1258,18 @@ std::shared_ptr<ov::npuw::CompiledModel> ov::npuw::CompiledModel::deserialize_or
         meta_stream & compiled->m_inputs_to_submodels_inputs & compiled->m_outputs_to_submodels_outputs &
             compiled->m_param_subscribers & compiled->m_submodels_input_to_prev_output;
         meta_stream & compiled->m_dev_list;
-        meta_stream & compiled->m_cfg;
+
+        // Config precedence, low to high: blob -> env vars -> host import props.
+        //
+        // Security: the config comes from a potentially untrusted cache blob.
+        // Read it into a temporary Config and copy over only the options meant to round-trip through a blob (CACHED).
+        // Any UNCACHED / HIDDEN debug knobs (e.g. NPUW_DUMP_*, NPUW_CACHE_DIR) are dropped.
+        ::intel_npu::Config blob_cfg(compiled->m_options_desc);
+        meta_stream & blob_cfg;
+        compiled->m_cfg.update(blob_cfg.extract(::intel_npu::cachedNPUWOptionKeys()));
         compiled->m_cfg.parseEnvVars();
+        compiled->m_cfg.updateAnyKnown(properties);
+
         meta_stream & compiled->m_non_npuw_props;
         meta_stream & is_weightless;
         meta_stream & compiled->m_bf16_consts;

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1730,7 +1730,14 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
         stream & compiled->m_longrope_tables;
 
         // Deserialize config
-        stream & compiled->m_cfg;
+        // Security: the config comes from a potentially untrusted cache blob.
+        // Read it into a temporary Config and copy over only the options meant to round-trip through a blob (CACHED).
+        // Any UNCACHED / HIDDEN debug knobs (e.g. NPUW_DUMP_*, NPUW_CACHE_DIR) are dropped.
+        ::intel_npu::Config blob_cfg(compiled->m_options_desc);
+        stream & blob_cfg;
+        compiled->m_cfg.update(blob_cfg.extract(::intel_npu::cachedNPUWOptionKeys()));
+        // Re-apply the import properties, so a host that passes an NPUW property into import_model wins over the blob.
+        compiled->m_cfg.updateAnyKnown(properties);
         compiled->implement_properties();
         // Not serialized. Recomputed from the deserialized config so older blobs stay loadable.
         compiled->m_enable_continuous_prefill = compiled->m_cfg.get<::intel_npu::NPUW_LLM_ENABLE_CONTINUOUS_PREFILL>();

--- a/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/npuw_options_smoke_test.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "intel_npu/config/config.hpp"
@@ -213,6 +214,49 @@ TEST(NPUWConfigOptionsSmokeTest, AttentionHintDefaultsCanDifferPerOption) {
 
     EXPECT_EQ(cfg.getString<::intel_npu::NPUW_LLM_PREFILL_ATTENTION_HINT>(), "PYRAMID");
     EXPECT_EQ(cfg.getString<::intel_npu::NPUW_LLM_GENERATE_ATTENTION_HINT>(), "STATIC");
+}
+
+TEST(NPUWConfigOptionsSmokeTest, UpdateAnyKnownIgnoresUnregisteredKeys) {
+    auto cfg = make_config();
+
+    ov::AnyMap mixed;
+    mixed[std::string(::intel_npu::NPUW_LLM_BATCH_DIM::key())] = uint32_t{7};
+    mixed["COMPLETELY_UNKNOWN_KEY"] = std::string("value");
+
+    ASSERT_NO_THROW(cfg.updateAnyKnown(mixed));
+    EXPECT_EQ(cfg.get<::intel_npu::NPUW_LLM_BATCH_DIM>(), 7);
+}
+
+TEST(NPUWConfigOptionsSmokeTest, UpdateAnyKnownEmptyMapIsNoop) {
+    auto cfg = make_config({{std::string(::intel_npu::NPUW_LLM_BATCH_DIM::key()), "3"}});
+
+    ASSERT_NO_THROW(cfg.updateAnyKnown(ov::AnyMap{}));
+    EXPECT_EQ(cfg.get<::intel_npu::NPUW_LLM_BATCH_DIM>(), 3);
+}
+
+TEST(NPUWConfigOptionsSmokeTest, ExtractReturnsOnlyMatchingKeys) {
+    auto cfg = make_config({
+        {std::string(::intel_npu::NPUW_LLM_BATCH_DIM::key()), "5"},
+        {std::string(::intel_npu::NPUW_FOLD::key()), "YES"},
+    });
+
+    std::unordered_set<std::string> wanted{std::string(::intel_npu::NPUW_FOLD::key()), "NO_SUCH_KEY"};
+    auto result = cfg.extract(wanted);
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.count(std::string(::intel_npu::NPUW_FOLD::key())), 1);
+}
+
+TEST(NPUWConfigOptionsSmokeTest, ExtractEmptyKeysReturnsEmpty) {
+    auto cfg = make_config({{std::string(::intel_npu::NPUW_LLM_BATCH_DIM::key()), "1"}});
+
+    auto result = cfg.extract({});
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(NPUWConfigOptionsSmokeTest, CachedNPUWOptionKeys) {
+    const auto& keys = ::intel_npu::cachedNPUWOptionKeys();
+    EXPECT_FALSE(keys.empty());
 }
 
 }  // namespace


### PR DESCRIPTION
### Details:
Previously, `CompiledModel::deserialize_or_compile` and `LLMCompiledModel::deserialize` loaded the full config verbatim from the cache blob into `m_cfg`. Since the blob may come from an untrusted source, this allowed debug/internal knobs (e.g. `NPUW_DUMP_*`, `NPUW_CACHE_DIR`) to be injected through a crafted blob.

This PR introduces a CACHED-only allowlist filter so that deserialization only restores options explicitly marked CACHED. The config precedence is now (low to high):

- Blob (CACHED keys only)
- Environment variables
- Host import properties

### Tickets:
 - CVS-193461

### AI Assistance:
 - AI assistance used:  yes
 - AI found this issue and suggested the fix. AI wrote the code according to the suggested fix, human reviewed the code several rounds and ran the tests