### PR TITLE
[NPUW] Bounds-check KVCacheDesc::dim to prevent OOB write on imported blobs

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.cpp
@@ -16,9 +16,21 @@ ov::SoPtr<ov::ITensor> ov::npuw::util::make_tensor_slice(ov::SoPtr<ov::ITensor> 
                                                          uint32_t dim,
                                                          uint32_t start_pos,
                                                          uint32_t end_pos) {
-    ov::Shape start_shape(std::vector<size_t>(tensor->get_shape().size(), 0u));
+    // `dim` may originate from a deserialized KVCacheDesc and is used below to subscript
+    // freshly-allocated ov::Shape vectors. Validate it against the actual tensor rank before
+    // the stores, otherwise a malformed axis is an out-of-bounds write on the shape vectors.
+    const auto& shape = tensor->get_shape();
+    OPENVINO_ASSERT(dim < shape.size(), "KV slice axis ", dim, " is out of range for a rank-", shape.size(), " tensor");
+    OPENVINO_ASSERT(start_pos <= end_pos && end_pos <= shape[dim],
+                    "KV slice [",
+                    start_pos,
+                    ", ",
+                    end_pos,
+                    ") is out of range for extent ",
+                    shape[dim]);
+    ov::Shape start_shape(std::vector<size_t>(shape.size(), 0u));
     start_shape[dim] = start_pos;
-    ov::Shape end_shape = tensor->get_shape();
+    ov::Shape end_shape = shape;
     end_shape[dim] = end_pos;
     return ov::get_tensor_impl(ov::Tensor(ov::make_tensor(tensor), start_shape, end_shape));
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1800,10 +1800,9 @@ void ov::npuw::LLMCompiledModel::validate_imported_kvcache_dim() const {
         // A port can carry several tensor names; match against all of them, as the runtime does
         // when it collects the past-KV ports, so get_any_name()'s choice of alias can't hide one.
         const auto& names = port.get_names();
-        const bool is_past_key =
-            std::any_of(names.begin(), names.end(), [](const std::string& name) {
-                return ov::npuw::util::isPastKeyParam(name);
-            });
+        const bool is_past_key = std::any_of(names.begin(), names.end(), [](const std::string& name) {
+            return ov::npuw::util::isPastKeyParam(name);
+        });
         if (!is_past_key) {
             continue;
         }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -3,6 +3,8 @@
 //
 #include "llm_compiled_model.hpp"
 
+#include <algorithm>
+
 #include "embedding/embedding_infer_request.hpp"
 #include "embedding/encoder_embedding_infer_request.hpp"
 #include "embedding/prepare_embedding_model.hpp"
@@ -1757,6 +1759,9 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
             compiled->m_kvcache_compiled = compiled->m_generate_compiled_variants.back();
         }
 
+        // Reject blobs whose KVCacheDesc::dim is not a valid axis for the restored KV tensors.
+        compiled->validate_imported_kvcache_dim();
+
         compiled->m_prefill_compiled = ov::npuw::CompiledModel::deserialize(model_stream, plugin, properties, enc_ctx);
         bool is_shared_lm_head = false;
         stream & is_shared_lm_head;
@@ -1781,6 +1786,31 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
     NPUW_ASSERT(compiled && "Couldn't create NPUW compiled model!");
 
     return compiled;
+}
+
+void ov::npuw::LLMCompiledModel::validate_imported_kvcache_dim() const {
+    // Nothing to validate for pipelines without a generate stage / KV cache.
+    if (m_generate_compiled_variants.empty()) {
+        return;
+    }
+    // KVCacheDesc::dim indexes the sequence axis of the past-key tensors. Cross-check it against
+    // the rank those restored tensors actually declare; on the compile path dim is a derived axis
+    // in [0, rank), so a dim outside that range can only come from a tampered blob.
+    for (const auto& port : m_generate_compiled_variants.back()->inputs()) {
+        // A port can carry several tensor names; match against all of them, as the runtime does
+        // when it collects the past-KV ports, so get_any_name()'s choice of alias can't hide one.
+        const auto& names = port.get_names();
+        const bool is_past_key =
+            std::any_of(names.begin(), names.end(), [](const std::string& name) {
+                return ov::npuw::util::isPastKeyParam(name);
+            });
+        if (!is_past_key) {
+            continue;
+        }
+        const auto& rank = port.get_partial_shape().rank();
+        NPUW_ASSERT(rank.is_static() && m_kvcache_desc.dim < static_cast<uint32_t>(rank.get_length()) &&
+                    "Imported KVCacheDesc::dim is out of range for the KV tensor rank");
+    }
 }
 
 std::shared_ptr<const ov::Model> ov::npuw::LLMCompiledModel::get_runtime_model() const {

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.hpp
@@ -109,6 +109,12 @@ private:
                                                          const ov::AnyMap& properties,
                                                          const ov::npuw::s11n::CompiledContext& ctx);
 
+    // Trust-boundary check for imported blobs: KVCacheDesc::dim is read verbatim from the stream
+    // and later used to subscript shape vectors in the KV-slice helpers. Reject any imported
+    // descriptor whose dim is not a valid axis of the restored KV tensors before it can be used.
+    // No-op when there are no KV tensors.
+    void validate_imported_kvcache_dim() const;
+
     std::string m_name;
     std::shared_ptr<::intel_npu::OptionsDesc> m_options_desc;
     ::intel_npu::Config m_cfg;

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_infer_request_variant_switch_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_infer_request_variant_switch_test.cpp
@@ -42,6 +42,29 @@ struct LLMVariantSwitchTestAccess {
         compiled->m_kvcache_desc.num_stored_tokens = num_tokens;
     }
 
+    static void set_kv_dim(const std::shared_ptr<ov::npuw::LLMCompiledModel>& compiled, uint32_t dim) {
+        compiled->m_kvcache_desc.dim = dim;
+    }
+
+    static void validate_imported_kvcache_dim(const std::shared_ptr<ov::npuw::LLMCompiledModel>& compiled) {
+        compiled->validate_imported_kvcache_dim();
+    }
+
+    // Mirrors the production name-matching in validate_imported_kvcache_dim(): a port may carry
+    // several names, so match against all of them rather than get_any_name()'s single alias.
+    static uint32_t past_key_tensor_rank(const std::shared_ptr<ov::npuw::LLMCompiledModel>& compiled) {
+        for (const auto& port : compiled->m_generate_compiled_variants.back()->inputs()) {
+            const auto& names = port.get_names();
+            const bool is_past_key = std::any_of(names.begin(), names.end(), [](const std::string& name) {
+                return ov::npuw::util::isPastKeyParam(name);
+            });
+            if (is_past_key) {
+                return static_cast<uint32_t>(port.get_partial_shape().rank().get_length());
+            }
+        }
+        return 0u;
+    }
+
     static uint32_t kv_dim_for_name(const ov::npuw::LLMInferRequest& req, const std::string& name) {
         const auto& desc = req.m_npuw_llm_compiled_model->m_kvcache_desc;
         return (ov::npuw::util::isPastValueParam(name) && desc.v_tensors_transposed_gen) ? 3u : desc.dim;
@@ -316,6 +339,29 @@ TEST_F(LLMInferRequestVariantSwitchTest, BlockKvVariantsExposeCompatibleBindings
     ASSERT_FALSE(small_value_block0.empty());
     EXPECT_EQ(small_key_block0, large_key_block0);
     EXPECT_EQ(small_value_block0, large_value_block0);
+}
+
+// KVCacheDesc::dim is read verbatim from an imported blob and is later used to subscript shape
+// vectors in the KV-slice helpers, so a malformed value is a heap out-of-bounds write. deserialize()
+// runs validate_imported_kvcache_dim() at the trust boundary to reject such blobs.
+TEST_F(LLMInferRequestVariantSwitchTest, RejectsImportedKvcacheDimOutOfTensorRank) {
+    VariantSwitchFactory factory;
+    auto compiled = create_compiled_model({}, factory);
+    ASSERT_NE(compiled, nullptr);
+
+    const uint32_t rank = LLMVariantSwitchTestAccess::past_key_tensor_rank(compiled);
+    ASSERT_GT(rank, 0u) << "test model is expected to expose past-key KV tensors";
+
+    for (uint32_t dim = 0; dim < rank; ++dim) {
+        LLMVariantSwitchTestAccess::set_kv_dim(compiled, dim);
+        EXPECT_NO_THROW(LLMVariantSwitchTestAccess::validate_imported_kvcache_dim(compiled)) << "dim=" << dim;
+    }
+
+    LLMVariantSwitchTestAccess::set_kv_dim(compiled, rank);
+    EXPECT_THROW(LLMVariantSwitchTestAccess::validate_imported_kvcache_dim(compiled), ov::Exception);
+
+    LLMVariantSwitchTestAccess::set_kv_dim(compiled, 0xFFFFFFFFu);
+    EXPECT_THROW(LLMVariantSwitchTestAccess::validate_imported_kvcache_dim(compiled), ov::Exception);
 }
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/make_tensor_slice_bounds_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/make_tensor_slice_bounds_test.cpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "infer_request_utils.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/runtime/make_tensor.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace {
+
+class SliceableTensor {
+public:
+    explicit SliceableTensor(const ov::Shape& shape) : m_tensor(ov::element::f32, shape) {}
+
+    ov::SoPtr<ov::ITensor> impl() const {
+        return ov::get_tensor_impl(m_tensor);
+    }
+
+private:
+    ov::Tensor m_tensor;
+};
+
+// These tests pin the bounds checks in ov::npuw::util::make_tensor_slice(), the single choke point
+// every KV-slice caller funnels through.
+TEST(MakeTensorSliceBoundsTest, ValidSliceProducesExpectedShape) {
+    SliceableTensor tensor(ov::Shape{1, 4, 8, 16});
+
+    ov::SoPtr<ov::ITensor> slice;
+    ASSERT_NO_THROW(slice = ov::npuw::util::make_tensor_slice(tensor.impl(), /*dim=*/2u, /*start=*/2u, /*end=*/5u));
+    EXPECT_EQ(slice->get_shape(), (ov::Shape{1, 4, 3, 16}));
+}
+
+TEST(MakeTensorSliceBoundsTest, FullExtentSliceIsAccepted) {
+    SliceableTensor tensor(ov::Shape{1, 4, 8, 16});
+
+    ov::SoPtr<ov::ITensor> slice;
+    ASSERT_NO_THROW(slice = ov::npuw::util::make_tensor_slice(tensor.impl(), /*dim=*/2u, /*start=*/0u, /*end=*/8u));
+    EXPECT_EQ(slice->get_shape(), (ov::Shape{1, 4, 8, 16}));
+}
+
+TEST(MakeTensorSliceBoundsTest, AxisEqualToRankIsRejected) {
+    SliceableTensor tensor(ov::Shape{1, 4, 8, 16});
+    EXPECT_THROW(ov::npuw::util::make_tensor_slice(tensor.impl(), /*dim=*/4u, /*start=*/0u, /*end=*/1u),
+                 ov::Exception);
+}
+
+TEST(MakeTensorSliceBoundsTest, AxisFarBeyondRankIsRejected) {
+    SliceableTensor tensor(ov::Shape{1, 4, 8, 16});
+    EXPECT_THROW(ov::npuw::util::make_tensor_slice(tensor.impl(), /*dim=*/0xFFFFFFFFu, /*start=*/0u, /*end=*/1u),
+                 ov::Exception);
+}
+
+TEST(MakeTensorSliceBoundsTest, EndBeyondExtentIsRejected) {
+    SliceableTensor tensor(ov::Shape{1, 4, 8, 16});
+    EXPECT_THROW(ov::npuw::util::make_tensor_slice(tensor.impl(), /*dim=*/2u, /*start=*/0u, /*end=*/9u),
+                 ov::Exception);
+}
+
+TEST(MakeTensorSliceBoundsTest, InvertedIntervalIsRejected) {
+    SliceableTensor tensor(ov::Shape{1, 4, 8, 16});
+    EXPECT_THROW(ov::npuw::util::make_tensor_slice(tensor.impl(), /*dim=*/2u, /*start=*/5u, /*end=*/2u),
+                 ov::Exception);
+}
+
+}  // namespace


### PR DESCRIPTION
### Details:
`KVCacheDesc::dim` is read verbatim from an imported blob with no range check, then used to subscript `ov::Shape` (`std::vector`) vectors in `make_tensor_slice` before any validation — a controlled heap out-of-bounds write reachable via `ov::Core::import_model`.

### Fix
Two layers, neither rejecting any valid blob:
- `deserialize` runs `validate_imported_kvcache_dim()`, rejecting a `dim` that is not a valid axis of the restored KV tensors.
- `make_tensor_slice` validates `dim < rank` and `start <= end <= extent` before the stores — one choke point covering all KV-slice callers.


### Tickets:
 - *CVS-193458*

### AI Assistance:
 - *AI assistance used: yes*
 - *Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.*
