### PR TITLE
[GPU] Guard ExpandBroadcastReshapeSDPAFusion against different rank-mismatched K/V rewire

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/expand_broadcast_reshape_sdpa_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/expand_broadcast_reshape_sdpa_fusion.cpp
@@ -189,9 +189,16 @@ ExpandBroadcastReshapeSDPAFusion::ExpandBroadcastReshapeSDPAFusion() {
                 }
             }
 
+            auto rank_matches_order = [](const ov::Output<ov::Node>& out, size_t order_size) -> bool {
+                const auto& r = out.get_partial_shape().rank();
+                return r.is_static() && r.get_length() == static_cast<int64_t>(order_size);
+            };
             auto replace_sdpa_inputs = [&](ov::Node* reshape_k, ov::Node* reshape_v) {
                 auto key_source = reshape_k->input_value(0);
                 auto value_source = reshape_v->input_value(0);
+                if (!rank_matches_order(key_source, sdpa->get_input1_transpose_order().size()) ||
+                    !rank_matches_order(value_source, sdpa->get_input2_transpose_order().size()))
+                    return false;
                 sdpa->input(1).replace_source_output(key_source);
                 sdpa->input(2).replace_source_output(value_source);
                 return true;

--- a/src/plugins/intel_gpu/tests/unit/transformations/expand_broadcast_reshape_sdpa_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/expand_broadcast_reshape_sdpa_fusion_test.cpp
@@ -602,6 +602,45 @@ TEST_F(TransformationTestsF, ExpandBroadReshapeSDPAFusion11) {
     }
 }
 
+TEST_F(TransformationTestsF, ExpandBroadReshapeSDPAFusion12) {
+    // Dynamic-rank K/V sources: the rank guard must decline the Pattern B rewire
+    // (rank.is_static() == false), leaving the broadcast/concat expand chain in place.
+    std::vector<int64_t> in0_order = {0, 2, 1, 3};
+    std::vector<int64_t> in1_order = {0, 2, 1, 3};
+    std::vector<int64_t> in2_order = {0, 2, 1, 3};
+    std::vector<int64_t> out_order = {0, 1, 2, 3};
+    const bool is_causal = false;
+
+    auto build_model = [&]() {
+        auto input_q = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 4, 8, 256});
+        auto input_k = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic());
+        auto input_v = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic());
+        auto k_5d_pat = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{5}, {1, 1, 1, 8, 256});
+        auto v_5d_pat = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{5}, {1, 1, 1, 8, 256});
+        auto k_5d = std::make_shared<ov::op::v1::Reshape>(input_k, k_5d_pat, false);
+        auto v_5d = std::make_shared<ov::op::v1::Reshape>(input_v, v_5d_pat, false);
+        auto concat_k = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{k_5d, k_5d, k_5d, k_5d}, 2);
+        auto concat_v = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{v_5d, v_5d, v_5d, v_5d}, 2);
+        auto k_4d_pat = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, 4, 8, 256});
+        auto v_4d_pat = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, 4, 8, 256});
+        auto k_4d = std::make_shared<ov::op::v1::Reshape>(concat_k, k_4d_pat, false);
+        auto v_4d = std::make_shared<ov::op::v1::Reshape>(concat_v, v_4d_pat, false);
+
+        auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(
+            ov::OutputVector{input_q, k_4d, v_4d}, is_causal, in0_order, in1_order, in2_order, out_order);
+        return std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, input_k, input_v});
+    };
+
+    {
+        model = build_model();
+        manager.register_pass<ExpandBroadcastReshapeSDPAFusion>();
+    }
+    {
+        model_ref = build_model();
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
 }  // namespace intel_gpu
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_gpu/tests/unit/transformations/expand_broadcast_reshape_sdpa_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/expand_broadcast_reshape_sdpa_fusion_test.cpp
@@ -565,6 +565,43 @@ TEST_F(TransformationTestsF, ExpandBroadReshapeSDPAFusion10) {
     }
 }
 
+TEST_F(TransformationTestsF, ExpandBroadReshapeSDPAFusion11) {
+    std::vector<int64_t> in0_order = {0, 2, 1, 3};
+    std::vector<int64_t> in1_order = {0, 2, 1, 3};
+    std::vector<int64_t> in2_order = {0, 2, 1, 3};
+    std::vector<int64_t> out_order = {0, 1, 2, 3};
+    const bool is_causal = false;
+
+    auto build_model = [&]() {
+        auto input_q = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 4, 8, 256});
+        auto input_k = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 8, 256});
+        auto input_v = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::Shape{1, 8, 256});
+        auto k_5d_pat = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{5}, {1, 1, 1, 8, 256});
+        auto v_5d_pat = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{5}, {1, 1, 1, 8, 256});
+        auto k_5d = std::make_shared<ov::op::v1::Reshape>(input_k, k_5d_pat, false);
+        auto v_5d = std::make_shared<ov::op::v1::Reshape>(input_v, v_5d_pat, false);
+        auto concat_k = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{k_5d, k_5d, k_5d, k_5d}, 2);
+        auto concat_v = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{v_5d, v_5d, v_5d, v_5d}, 2);
+        auto k_4d_pat = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, 4, 8, 256});
+        auto v_4d_pat = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {1, 4, 8, 256});
+        auto k_4d = std::make_shared<ov::op::v1::Reshape>(concat_k, k_4d_pat, false);
+        auto v_4d = std::make_shared<ov::op::v1::Reshape>(concat_v, v_4d_pat, false);
+
+        auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(
+            ov::OutputVector{input_q, k_4d, v_4d}, is_causal, in0_order, in1_order, in2_order, out_order);
+        return std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, input_k, input_v});
+    };
+
+    {
+        model = build_model();
+        manager.register_pass<ExpandBroadcastReshapeSDPAFusion>();
+    }
+    {
+        model_ref = build_model();
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
 }  // namespace intel_gpu
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
The Pattern B rewrite in ExpandBroadcastReshapeSDPAFusion (replace_sdpa_inputs) rewires the fused SDPA's K/V inputs directly to the source feeding the 5D expand chain. That source can have a rank that differs from the SDPA's per-input transpose-order size (typically 4). On ANY such mismatch - or a dynamic rank - op::SDPA::shape_infer accesses an out-of-range PartialShape dimension during validation ("Accessing out-of-range dimension").

Add a rank guard: only rewire when the pre-broadcast source rank matches the SDPA's per-input transpose-order size. Otherwise decline the rewrite, leaving the (correct) broadcast/concat expand chain in place.

### Tickets:
 - [CVS-174294](https://jira.devtools.intel.com/browse/CVS-174294)

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
