### PR TITLE
[NPU] Skip all-whitespace layer names in parsePerLayerValues

### DIFF
--- a/src/plugins/intel_npu/tools/single-image-test/argument_parse_helpers.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/argument_parse_helpers.cpp
@@ -263,6 +263,11 @@ utils::PerLayerValueMap utils::parsePerLayerValues(const std::string& str, doubl
             valueStr.erase(0, valueStr.find_first_not_of(" \t"));
             valueStr.erase(valueStr.find_last_not_of(" \t") + 1);
 
+            if (layerName.empty()) {
+                std::cerr << "Warning: Skipping entry with empty layer name: '" << pair << "'" << std::endl;
+                continue;
+            }
+
             try {
                 double value = std::stod(valueStr);
                 result[layerName] = value;


### PR DESCRIPTION
### Details:

- In `parsePerLayerValues` (NPU single-image-test tool), an all-whitespace layer name like `"   :0.05"` gets trimmed down to an empty string and stored under the `""` key in the result map. Since `getValueForLayer` does exact-name lookups, no real layer ever matches `""`, so the user's value is silently discarded and the `"*"` wildcard fallback is used instead. No warning is emitted.
- Added a guard after the trim step: if the layer name is empty after trimming, print a warning to stderr and skip the entry instead of inserting an unreachable key.
- Valid entries around the bad one are still parsed correctly.

### Tickets:

- [**bug: All-whitespace layer name produces unreachable empty-string key in result map #37534**](https://github.com/openvinotoolkit/openvino/issues/37534)

Closes #37534

### AI Assistance:

- AI assistance used: no
