### PR TITLE
[TRANSFORMATIONS] Convert and Read pipelines alignment 

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/add_fake_quantize_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/add_fake_quantize_fusion.cpp
@@ -79,7 +79,7 @@ AddFakeQuantizeFusion::AddFakeQuantizeFusion() {
             if (diff > 0) {
                 // Reshape constants like (C, 1, 1) to (1, C, 1, 1)
                 const_shape.insert(const_shape.begin(), diff, 1);
-                new_const = std::make_shared<v1::Reshape>(
+                new_const = ov::op::util::make_try_fold<v1::Reshape>(
                     new_const,
                     v0::Constant::create(element::u64, Shape{const_shape.size()}, const_shape),
                     false);

--- a/src/common/transformations/src/transformations/common_optimizations/binarize_weights.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/binarize_weights.cpp
@@ -16,6 +16,7 @@
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/utils/utils.hpp"
 
 using namespace ov;
 
@@ -197,10 +198,10 @@ BinarizeWeights::BinarizeWeights() {
             v0::Constant::create(element::i64, Shape{norm_factor_shape.size()}, norm_factor_shape);
 
         auto activations_norm_factor_reshaped =
-            std::make_shared<v1::Reshape>(activations_norm_factor, norm_factor_shape_const, false);
+            ov::op::util::make_try_fold<v1::Reshape>(activations_norm_factor, norm_factor_shape_const, false);
         auto mul = std::make_shared<v1::Multiply>(new_conv, activations_norm_factor_reshaped);
         auto weights_norm_factor_reshaped =
-            std::make_shared<v1::Reshape>(weights_norm_factor, norm_factor_shape_const, false);
+            ov::op::util::make_try_fold<v1::Reshape>(weights_norm_factor, norm_factor_shape_const, false);
         auto mul2 = std::make_shared<v1::Multiply>(mul, weights_norm_factor_reshaped);
 
         copy_runtime_info(

--- a/src/common/transformations/src/transformations/common_optimizations/conv_mul_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/conv_mul_fusion.cpp
@@ -64,7 +64,7 @@ ConvolutionMultiplyFusion::ConvolutionMultiplyFusion() {
         if (!is_scalar_multiplier) {
             auto final_const_shape = Shape(weights_rank, 1);
             final_const_shape[0] = channel_dim;
-            final_const = std::make_shared<v1::Reshape>(
+            final_const = ov::op::util::make_try_fold<v1::Reshape>(
                 m_const,
                 v0::Constant::create(element::i64, Shape{final_const_shape.size()}, final_const_shape),
                 true);
@@ -147,7 +147,7 @@ GroupConvolutionMultiplyFusion::GroupConvolutionMultiplyFusion() {
                 final_const_shape[0] = G;
                 final_const_shape[1] = O;
             }
-            final_const = std::make_shared<v1::Reshape>(
+            final_const = ov::op::util::make_try_fold<v1::Reshape>(
                 m_const,
                 v0::Constant::create(element::i64, Shape{final_const_shape.size()}, final_const_shape),
                 true);
@@ -215,7 +215,7 @@ ConvolutionBackpropDataMultiplyFusion::ConvolutionBackpropDataMultiplyFusion() {
         if (!is_scalar_multiplier) {
             auto final_const_shape = Shape(weights_rank - 1, 1);
             final_const_shape[0] = channel_dim;
-            final_const = std::make_shared<v1::Reshape>(
+            final_const = ov::op::util::make_try_fold<v1::Reshape>(
                 m_const,
                 v0::Constant::create(element::i64, Shape{final_const_shape.size()}, final_const_shape),
                 true);
@@ -292,7 +292,7 @@ GroupConvolutionBackpropDataMultiplyFusion::GroupConvolutionBackpropDataMultiply
             auto final_const_shape = Shape(weights_rank, 1);
             final_const_shape[0] = G;
             final_const_shape[2] = O;
-            final_const = std::make_shared<v1::Reshape>(
+            final_const = ov::op::util::make_try_fold<v1::Reshape>(
                 m_const,
                 v0::Constant::create(element::i64, Shape{final_const_shape.size()}, final_const_shape),
                 true);

--- a/src/common/transformations/src/transformations/common_optimizations/fq_mul_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fq_mul_fusion.cpp
@@ -104,7 +104,7 @@ ov::pass::FakeQuantizeMulFusion::FakeQuantizeMulFusion() {
             auto diff = rank - mul_constant_shape.size();
             if (diff > 0) {
                 mul_constant_shape.insert(mul_constant_shape.begin(), diff, 1);
-                mul_constant = std::make_shared<v1::Reshape>(
+                mul_constant = ov::op::util::make_try_fold<v1::Reshape>(
                     mul_constant,
                     v0::Constant::create(element::i64, Shape{mul_constant_shape.size()}, mul_constant_shape),
                     false);

--- a/src/common/transformations/src/transformations/common_optimizations/matmul_multiply_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/matmul_multiply_fusion.cpp
@@ -139,7 +139,7 @@ static std::shared_ptr<Node> fuse_const_to_weights(const std::shared_ptr<Node>& 
         // Scalars were fused before, it suffices to check for 1D shape here
         if (const_rank == 1) {
             const_shape.insert(const_shape.begin(), 1);
-            new_const = std::make_shared<v1::Reshape>(
+            new_const = ov::op::util::make_try_fold<v1::Reshape>(
                 mul_const,
                 v0::Constant::create(element::u64, Shape{const_shape.size()}, const_shape),
                 false);

--- a/src/common/transformations/src/transformations/common_optimizations/mul_conv_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/mul_conv_fusion.cpp
@@ -137,10 +137,10 @@ ov::pass::MultiplyGroupConvolutionFusion::MultiplyGroupConvolutionFusion() {
             if (!op_util::check_for_broadcast(weights_shape, new_shape)) {
                 return false;
             }
-            mul_const =
-                std::make_shared<v1::Reshape>(mul_const,
-                                              v0::Constant::create(element::u64, Shape{new_shape.size()}, new_shape),
-                                              false);
+            mul_const = ov::op::util::make_try_fold<v1::Reshape>(
+                mul_const,
+                v0::Constant::create(element::u64, Shape{new_shape.size()}, new_shape),
+                false);
         }
 
         auto weights_multiply = std::make_shared<v1::Multiply>(weights, mul_const);
@@ -212,10 +212,10 @@ ov::pass::MultiplyConvolutionBackpropDataFusion::MultiplyConvolutionBackpropData
             if (!op_util::check_for_broadcast(weights_shape, new_shape)) {
                 return false;
             }
-            mul_const =
-                std::make_shared<v1::Reshape>(mul_const,
-                                              v0::Constant::create(element::u64, Shape{new_shape.size()}, new_shape),
-                                              false);
+            mul_const = ov::op::util::make_try_fold<v1::Reshape>(
+                mul_const,
+                v0::Constant::create(element::u64, Shape{new_shape.size()}, new_shape),
+                false);
         }
 
         auto weights_multiply = std::make_shared<v1::Multiply>(weights, mul_const);
@@ -289,10 +289,10 @@ ov::pass::MultiplyGroupConvolutionBackpropDataFusion::MultiplyGroupConvolutionBa
             if (!op_util::check_for_broadcast(weights_shape, new_shape)) {
                 return false;
             }
-            mul_const =
-                std::make_shared<v1::Reshape>(mul_const,
-                                              v0::Constant::create(element::u64, Shape{new_shape.size()}, new_shape),
-                                              false);
+            mul_const = ov::op::util::make_try_fold<v1::Reshape>(
+                mul_const,
+                v0::Constant::create(element::u64, Shape{new_shape.size()}, new_shape),
+                false);
         }
 
         auto weights_multiply = std::make_shared<v1::Multiply>(weights, mul_const);

--- a/src/common/transformations/src/transformations/common_optimizations/mul_fake_quantize_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/mul_fake_quantize_fusion.cpp
@@ -82,7 +82,7 @@ ov::pass::MulFakeQuantizeFusion::MulFakeQuantizeFusion() {
             if (diff > 0) {
                 // Reshape constants like (C, 1, 1) to (1, C, 1, 1)
                 const_shape.insert(const_shape.begin(), diff, 1);
-                new_const = std::make_shared<v1::Reshape>(
+                new_const = ov::op::util::make_try_fold<v1::Reshape>(
                     new_const,
                     v0::Constant::create(element::u64, Shape{const_shape.size()}, const_shape),
                     false);

--- a/src/common/transformations/src/transformations/common_optimizations/pack_multi_head_attention.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/pack_multi_head_attention.cpp
@@ -158,6 +158,26 @@ static std::shared_ptr<ov::Node> extract_scale_node(const std::shared_ptr<ov::No
     return nullptr;
 };
 
+static std::shared_ptr<ov::Node> get_reciprocal_divide_scale(const std::shared_ptr<ov::Node>& scale_node) {
+    auto div = ov::as_type_ptr<v1::Divide>(scale_node);
+    if (!div) {
+        return nullptr;
+    }
+
+    auto scale = ov::as_type_ptr<v0::Constant>(div->input_value(1).get_node_shared_ptr());
+    if (!scale || ov::shape_size(scale->get_shape()) != 1) {
+        return nullptr;
+    }
+
+    const auto scale_values = scale->cast_vector<float>();
+    if (scale_values.front() == 0.0f) {
+        return nullptr;
+    }
+    auto reciprocal_scale = v0::Constant::create(scale->get_element_type(), scale->get_shape(), {1.0f / scale_values.front()});
+    copy_runtime_info(scale, reciprocal_scale);
+    return reciprocal_scale;
+}
+
 }  // namespace
 
 bool PackMultiHeadAttention::run_on_model(const std::shared_ptr<ov::Model>& model) {
@@ -283,12 +303,24 @@ MergeUnrolledSDPA::MergeUnrolledSDPA() {
             return false;
         }
 
+        bool scale_absorbed = false;
+        std::shared_ptr<ov::Node> scores_scaled;
+        if (scale1 && scale2) {
+            if (ov::is_type<v1::Divide>(scale2)) {
+                if (auto reciprocal_scale = get_reciprocal_divide_scale(scale1)) {
+                    K = std::make_shared<v1::Multiply>(K, reciprocal_scale);
+                    copy_runtime_info({scale1, scale2}, K);
+                    scale_absorbed = true;
+                }
+            }
+        }
+
         // Build fused SDPA
         auto qk_fused = qk1->copy_with_new_inputs({Q, K});
         copy_runtime_info({qk1, qk2}, qk_fused);
 
-        std::shared_ptr<ov::Node> scores_scaled = qk_fused;
-        if (scale1 && scale2) {
+        scores_scaled = qk_fused;
+        if (scale1 && scale2 && !scale_absorbed) {
             scores_scaled = scale1->copy_with_new_inputs({qk_fused, scale1->input_value(1)});
             copy_runtime_info({scale1, scale2}, scores_scaled);
         }

--- a/src/common/transformations/tests/common_optimizations/matmul_multiply_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/matmul_multiply_fusion.cpp
@@ -9,10 +9,14 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
 #include "openvino/opsets/opset8_decl.hpp"
 #include "openvino/pass/manager.hpp"
+#include "transformations/common_optimizations/common_optimizations.hpp"
 
 using namespace ov;
 
@@ -145,6 +149,32 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionAllowedForFP16DynamicWeightsRed
         auto mul_const = opset8::Constant::create(element::f16, Shape{1, 1}, {0.5f});
         auto mul = std::make_shared<opset8::Multiply>(weights, mul_const);
         auto matmul = std::make_shared<opset8::MatMul>(data, mul, false, true);
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data, weights});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+TEST_F(TransformationTestsF, CommonOptimizationsFuseMatMulReshapeDivideConvertedConstant) {
+    {
+        auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 32, 5, 96});
+        auto weights = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 32, 5, 96});
+        auto matmul = std::make_shared<opset8::MatMul>(data, weights, false, true);
+        auto reshape_pattern = opset8::Constant::create(element::i64, Shape{4}, {1, 32, 5, 5});
+        auto reshape = std::make_shared<opset8::Reshape>(matmul, reshape_pattern, false);
+        auto scale = opset8::Constant::create(element::f16, Shape{1, 1, 1, 1}, {8.0f});
+        auto converted_scale = std::make_shared<opset8::Convert>(scale, element::f32);
+        auto divide = std::make_shared<opset8::Divide>(reshape, converted_scale);
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{data, weights});
+
+        manager.register_pass<ov::pass::CommonOptimizations>();
+    }
+
+    {
+        auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 32, 5, 96});
+        auto weights = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 32, 5, 96});
+        auto scale = opset8::Constant::create(element::f32, Shape{1, 1, 1, 1}, {0.125f});
+        auto scaled_weights = std::make_shared<opset8::Multiply>(weights, scale);
+        auto matmul = std::make_shared<opset8::MatMul>(data, scaled_weights, false, true);
         model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data, weights});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/common/transformations/tests/common_optimizations/pack_multi_head_attention_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/pack_multi_head_attention_test.cpp
@@ -74,10 +74,16 @@ std::shared_ptr<ov::Node> build_ROPE(const std::shared_ptr<ov::Node>& input, con
 std::shared_ptr<ov::Node> build_sdpa(const std::shared_ptr<ov::Node>& q,
                                      const std::shared_ptr<ov::Node>& k,
                                      const std::shared_ptr<ov::Node>& v,
-                                     const Shape& bias_shape) {
+                                     const Shape& bias_shape,
+                                     bool add_divide_scale = false) {
     auto qk = std::make_shared<MatMul>(q, k, false, true);
+    std::shared_ptr<ov::Node> qk_scaled = qk;
+    if (add_divide_scale) {
+        auto scale = Constant::create(element::f32, Shape{1, 1, 1, 1}, {8.0f});
+        qk_scaled = std::make_shared<Divide>(qk, scale);
+    }
     auto bias = Constant::create(element::f32, bias_shape, {0.0f});
-    auto add = std::make_shared<Add>(qk, bias);
+    auto add = std::make_shared<Add>(qk_scaled, bias);
     auto softmax = std::make_shared<Softmax>(add, -1);
     auto attn = std::make_shared<MatMul>(softmax, v);
     return attn;
@@ -100,7 +106,8 @@ std::shared_ptr<ov::Model> build_model_mha(size_t batch,
                                            size_t seq_len,
                                            size_t head_size,
                                            size_t num_heads,
-                                           size_t num_groups) {
+                                           size_t num_groups,
+                                           bool add_divide_scale = false) {
     OPENVINO_ASSERT(num_heads % num_groups == 0, "num_heads must be divisible by num_groups");
 
     const ov::Shape input_shape{batch, seq_len, head_size};
@@ -123,7 +130,7 @@ std::shared_ptr<ov::Model> build_model_mha(size_t batch,
         for (size_t h = 0; h < heads_per_group; ++h) {
             auto q_proj = build_qkv_projection(norm, proj_shape, bias_shape);
             auto q = build_ROPE(q_proj, rope_shape);
-            auto attn_out = build_sdpa(q, k, v, sdpa_bias_shape);
+            auto attn_out = build_sdpa(q, k, v, sdpa_bias_shape, add_divide_scale);
             auto projected = build_post_sdpa(attn_out, input_shape, post_sdpa_weights_shape);
             all_head_outputs.push_back(projected);
         }
@@ -138,7 +145,8 @@ std::shared_ptr<ov::Model> build_model_mha(size_t batch,
 std::shared_ptr<ov::Model> build_model_mha_packed_ref(size_t batch,
                                                       size_t seq_len,
                                                       size_t head_size,
-                                                      size_t num_heads) {
+                                                      size_t num_heads,
+                                                      bool absorb_divide_scale = false) {
     const ov::Shape input_shape{batch, seq_len, head_size};
 
     auto input = std::make_shared<Parameter>(element::f32, input_shape);
@@ -161,6 +169,9 @@ std::shared_ptr<ov::Model> build_model_mha_packed_ref(size_t batch,
     const ov::Shape rope_shape{batch, num_heads, seq_len, head_size};
     auto q = build_ROPE(q_proj, rope_shape);
     auto k = build_ROPE(k_proj, rope_shape);
+    if (absorb_divide_scale) {
+        k = std::make_shared<Multiply>(k, Constant::create(element::f32, Shape{1, 1, 1, 1}, {0.125f}));
+    }
 
     auto attn_out = build_sdpa(q, k, v_proj, sdpa_bias_shape);
 
@@ -196,6 +207,19 @@ TEST_P(PackGQATest, PackGQA) {
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, PackMHAAbsorbsDivideScaleIntoMatMulInput) {
+    {
+        model = build_model_mha(1, 128, 64, 2, 2, true);
+        manager.register_pass<ov::pass::PackMultiHeadAttention>();
+    }
+
+    { model_ref = build_model_mha_packed_ref(1, 128, 64, 2, true); }
+
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+    disable_rt_info_check();
 }
 
 INSTANTIATE_TEST_SUITE_P(PackGQATests,


### PR DESCRIPTION
### Details:
The changed transformations could add additional Reshape layers that are not taken into account by subsequent transformations because we expect them to be fused by the ConstantFolding transformation.

As an alternative, we could run ConstantFolding one more time, but from a performance perspective, it would be better to try to fuse the Reshape layers when creating them.

### Tickets:
 - *CVS-187131*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
