### PR TITLE
[GHA] dGPU LLM Accuracy to post-commits

### DIFF
--- a/.github/workflows/ubuntu_24.yml
+++ b/.github/workflows/ubuntu_24.yml
@@ -214,10 +214,15 @@ jobs:
   LLM_Accuracy_dGPU:
     name: LLM accuracy dGPU tests
     needs: [ Docker, Build, Smart_CI, Openvino_tokenizers ]
-    if: github.event_name == 'schedule'
+    if: |
+      github.event_name == 'push' && (
+        fromJSON(needs.smart_ci.outputs.affected_components).GPU ||
+        fromJSON(needs.smart_ci.outputs.affected_components).transformations ||
+        fromJSON(needs.smart_ci.outputs.affected_components).Core
+      )
     uses: ./.github/workflows/job_llm_accuracy_tests.yml
     with:
-      runner: '{"group": "Intel-GPU", "labels": ["self-hosted", "dgpu", "Arc-B580", "Battlemage", "Linux"]}'
+      runner: '{"group": "Intel-GPU", "labels": ["self-hosted", "dgpu", "Arc-B50", "Battlemage", "Linux"]}'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.ubuntu_24_04_x64_dgpu }}
       container-options: '--group-add 44 --group-add 993 --device /dev/dri/renderD129:/dev/dri/renderD129'
       device: 'GPU'


### PR DESCRIPTION
### Details:
Previously added to pre-commits, disabled due to queues, keeping in post-commit until we get more dGPU cards for HRZ.
Updating the label to B50 (more hosts are available with it; although the pool is shared with iGPU still)
