### PR TITLE
[GPU] Enable f8e4m3 Gather for windowed KV-cache GroupQueryAttention

### DIFF
--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -4717,13 +4717,15 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_i4kv_sliding_window_cache) {
 // CUDA-only there), so the reference is an independent numpy oracle mirroring the decomposition
 // (dequant f8 -> window mask -> SDPA) that also confirms the rolling buffer equals the full-length
 // cache + local_window_size. Capacity C=4, local_window_size=2, absolute past 5; present keeps the
-// last 2 f8 rows + the new token, tail zeroed.
+// last 2 f8 rows + the new token, tail zeroed. Runs on CPU and GPU (both now have an f8e4m3 Gather
+// kernel for the windowed present assembly).
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_sliding_window_cache) {
-    // The windowed present assembly gathers f8e4m3 KV rows; the GPU plugin and the TEMPLATE reference
-    // have no f8e4m3 Gather kernel yet, so this path is exercised on CPU only. (Non-windowed f8 GQA,
-    // which does not gather the f8 cache, runs on all three backends.)
-    if (s_device != ov::test::utils::DEVICE_CPU) {
-        GTEST_SKIP() << "f8e4m3 Gather for the windowed KV-cache assembly is only supported on CPU.";
+    // TEMPLATE hits a pre-existing shape-inference quirk on this fully-static graph ("to_shape was
+    // called on a dynamic shape"), the same class of INTERPRETER-only issue documented on
+    // onnx_model_gqa_sliding_window_cache_static_staging below; verified correct on CPU/GPU.
+    if (s_device == ov::test::utils::DEVICE_TEMPLATE) {
+        GTEST_SKIP() << "TEMPLATE hits a pre-existing dynamic-shape quirk on this fully-static "
+                        "f8e4m3 windowed-cache graph; verified correct on CPU/GPU. Needs follow-up.";
     }
     auto model = convert_model("com.microsoft/gqa_f8e4m3fnkv_swc.onnx");
     model->reshape({{"query", ov::PartialShape{1, 1, 64}},

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -908,10 +908,10 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
 
             should_fuse |= legacy_fusion;
 
-            // fp8 concatenation/scatter_update take a byte-copy kernel path that cannot run fused ops
+            // fp8 concatenation/scatter_update/gather take a byte-copy kernel path that cannot run fused ops
             // (ACTIVATION does not compile on the 1-byte fp8 struct), so block fusion into an fp8 output.
             if (should_fuse && input.get_output_layout().data_type == data_types::f8e4m3 &&
-                (input.is_type<concatenation>() || input.is_type<scatter_update>())) {
+                (input.is_type<concatenation>() || input.is_type<scatter_update>() || input.is_type<gather>())) {
                 should_fuse = false;
             }
 
@@ -990,7 +990,9 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                            (!lo.has_all_enabled_onednn_impls_optimization_attribute() ||
                              in_dt_is_i8_u8 || !out_dt_is_i8_u8);
 
-            should_fuse |= input_data.is_type<gather>() && quantize_node.get_scale_shift_opt();
+            // fp8 gather byte-copies its data; fused ops don't compile on the fp8 struct, so don't fuse into it.
+            should_fuse |=
+                input_data.is_type<gather>() && quantize_node.get_scale_shift_opt() && input_data.get_output_layout().data_type != data_types::f8e4m3;
 
             should_fuse |= input_data.is_type<gather_nd>() && quantize_node.get_scale_shift_opt();
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -203,16 +203,15 @@ std::unique_ptr<primitive_impl> GatherImplementationManager::create_impl(const p
 namespace detail {
 
 attach_gather_impl::attach_gather_impl() {
-    auto dyn_types = {
-        data_types::f32,
-        data_types::f16,
-        data_types::bf16,
-        data_types::i8,
-        data_types::u8,
-        data_types::i4,
-        data_types::u4,
-        data_types::i32
-    };
+    auto dyn_types = {data_types::f32,
+                      data_types::f16,
+                      data_types::bf16,
+                      data_types::i8,
+                      data_types::u8,
+                      data_types::i4,
+                      data_types::u4,
+                      data_types::i32,
+                      data_types::f8e4m3};
 
     auto dyn_formats = {
         format::bfyx,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gather_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gather_ref.cl
@@ -4,6 +4,9 @@
 
 #include "include/batch_headers/fetch_data.cl"
 #include "include/batch_headers/int4_utils.cl"
+#if INPUT0_IS_F8E4M3
+#include "include/f8_utils.cl"  // fp8e4m3_t typedef
+#endif
 
 #ifdef INDEX_DIM
 inline uint FUNC(get_positive_index)(OPTIONAL_SHAPE_INFO_ARG int in)
@@ -99,6 +102,18 @@ KERNEL(gather_ref)(
     }
 	// Variable val for fused ops
 	OUTPUT_TYPE val = TO_OUTPUT_TYPE(val_compute);
+#elif INPUT0_IS_F8E4M3
+    // fp8 is a 1-byte struct with no arithmetic/decode overloads; Gather just moves data by index,
+    // so copy the raw byte directly (ACTIVATION/TO_OUTPUT_TYPE won't compile on the struct). An
+    // out-of-range index yields a zero fp8 byte, mirroring the generic bounds check below.
+    #if GATHER_AXIS_SHAPE_INFO_INDEX
+        bool in_range = (INPUT_AXIS_INDEX >= 0 && INPUT_AXIS_INDEX < shape_info[GATHER_AXIS_SHAPE_INFO_INDEX]);
+    #elif AXIS_DIM
+        bool in_range = (INPUT_AXIS_INDEX >= 0 && INPUT_AXIS_INDEX < AXIS_DIM);
+    #else
+        bool in_range = true;
+    #endif
+    output[output_idx] = in_range ? dictionary[dictionary_idx] : INPUT0_VAL_ZERO;
 #else
     #if GATHER_AXIS_SHAPE_INFO_INDEX
         INPUT0_COMPUTE_TYPE val_compute = (INPUT_AXIS_INDEX >= 0 && INPUT_AXIS_INDEX < shape_info[GATHER_AXIS_SHAPE_INFO_INDEX]) ? DECODE_INPUT0_COMPUTE_TYPE(dictionary[dictionary_idx]) : 0;
@@ -111,7 +126,10 @@ KERNEL(gather_ref)(
 	INPUT0_TYPE val = TO_INPUT0_TYPE(val_compute);
 #endif
 
-#if HAS_FUSED_OPS
+#if INPUT0_IS_F8E4M3
+    // Output already written above; fp8 gather never carries fused ops (blocked in
+    // prepare_primitive_fusing.cpp since ACTIVATION/FUSED_OPS don't compile on the fp8 struct).
+#elif HAS_FUSED_OPS
     FUSED_OPS;
     output[output_idx] = FUSED_OPS_RESULT;
 #else

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
@@ -43,6 +43,7 @@ ParamsKey GatherKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::UINT4);
     k.EnableInputDataType(Datatype::INT4);
+    k.EnableInputDataType(Datatype::F8E4M3);
 
     k.EnableOutputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::BF16);
@@ -50,6 +51,7 @@ ParamsKey GatherKernelRef::GetSupportedKey() const {
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT8);
     k.EnableOutputDataType(Datatype::UINT8);
+    k.EnableOutputDataType(Datatype::F8E4M3);
 
     k.EnableAllInputLayout();
     k.EnableAllOutputLayout();
@@ -249,6 +251,10 @@ CommonDispatchData GatherKernelRef::SetDefault(const gather_params& params) cons
 
 JitConstants GatherKernelRef::GetJitConstants(const gather_params& params) const {
     JitConstants jit = MakeBaseParamsJitConstants(params);
+
+    // Flag fp8 input so the kernel copies the byte instead of running ACTIVATION on the fp8 struct
+    // (see gather_ref.cl).
+    jit.AddConstant(MakeJitConstant("INPUT0_IS_F8E4M3", params.inputs[0].GetDType() == Datatype::F8E4M3));
 
     jit.AddConstant(MakeJitConstant("DICTIONARY_INDEX_ORDER", GetDictionaryIndexOrder(params, GetGatherChannelIndex(params))));
     jit.AddConstant(MakeJitConstant("INDICES_INDEX_ORDER", GetIndicesIdxOrder(params, GetGatherChannelIndex(params), GetGatherBatchDim(params))));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gather_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gather_gpu_test.cpp
@@ -2738,3 +2738,41 @@ TEST(gather_gpu_fp32, dynamic_support_scalar_indice_empty_memory) {
         ASSERT_EQ(expected_results[i], output_ptr[i]) << i;
     }
 }
+
+// f8e4m3 Gather: values are exactly representable, so the gathered (byte-moved) result is exact.
+// Covers the f8 path used by the windowed KV-cache assembly of a quantized GroupQueryAttention.
+TEST(gather_gpu_f8e4m3, d33_axisF) {
+    //  Dictionary : 3x3x1x1
+    //  Indexes : 2x2x1x1
+    //  Axis : 1
+    //  Output : 3x2x2x1
+    auto& engine = get_test_engine();
+
+    auto input1 = engine.allocate_memory({ov::PartialShape{3, 3, 1, 1}, data_types::f8e4m3, format::bfyx});  // data
+    auto input2 = engine.allocate_memory({ov::PartialShape{2, 2, 1, 1}, data_types::i32, format::bfyx});     // indexes
+    int64_t axis = 1;
+
+    set_values<ov::float8_e4m3>(input1, {0.f, 1.f, 2.f, 10.f, 11.f, 12.f, 20.f, 21.f, 22.f});
+    set_values(input2, {1, 0, 2, 1});
+
+    topology topology;
+    topology.add(input_layout("InputDictionary", input1->get_layout()));
+    topology.add(input_layout("InputText", input2->get_layout()));
+    topology.add(gather("gather", input_info("InputDictionary"), input_info("InputText"), axis, 4, ov::Shape{3, 2, 2, 1}));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("InputDictionary", input1);
+    network.set_input_data("InputText", input2);
+
+    auto outputs = network.execute();
+
+    auto output = outputs.at("gather").get_memory();
+    cldnn::mem_lock<ov::float8_e4m3, mem_lock_type::read> output_ptr(output, get_test_stream());
+
+    std::vector<ov::float8_e4m3> expected_results = {1.f, 0.f, 2.f, 1.f, 11.f, 10.f, 12.f, 11.f, 21.f, 20.f, 22.f, 21.f};
+
+    ASSERT_EQ(expected_results.size(), output_ptr.size());
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << i;
+    }
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/slice_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/slice_gpu_test.cpp
@@ -372,6 +372,47 @@ TEST(slice_gpu_i8, bfyx) {
         ASSERT_EQ(expected_results[i], output_ptr[i]) << "i=" << i;
 }
 
+// uint8 Slice: dedicated small-value case, following the i8 test above. Covers the u8 output path
+// enabled for a quantized KV cache (GroupQueryAttention int4-as-u8-packed dynamic Slice+Concat).
+TEST(slice_gpu_u8, bfyx) {
+    auto& engine = get_test_engine();
+
+    // input [1,1,2,4] u8, slice axis 2 -> [1,1,1,4] (second row).
+    auto input = engine.allocate_memory({ov::PartialShape{1, 1, 2, 4}, data_types::u8, format::bfyx});
+    auto start = engine.allocate_memory({ov::PartialShape{1}, data_types::i64, format::bfyx});
+    auto stop = engine.allocate_memory({ov::PartialShape{1}, data_types::i64, format::bfyx});
+    auto step = engine.allocate_memory({ov::PartialShape{1}, data_types::i64, format::bfyx});
+    auto axes = engine.allocate_memory({ov::PartialShape{1}, data_types::i64, format::bfyx});
+
+    set_values<uint8_t>(input, {1, 2, 3, 4, 250, 251, 252, 253});
+    set_values<int64_t>(start, {1});
+    set_values<int64_t>(stop, {2});
+    set_values<int64_t>(step, {1});
+    set_values<int64_t>(axes, {2});
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(data("start", start));
+    topology.add(data("stop", stop));
+    topology.add(data("step", step));
+    topology.add(data("axes", axes));
+    topology.add(slice("slice", {input_info("input"), input_info("start"), input_info("stop"), input_info("step"), input_info("axes")}));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    cldnn::network network(engine, topology, config);
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+
+    auto output = outputs.at("slice").get_memory();
+    cldnn::mem_lock<uint8_t, mem_lock_type::read> output_ptr(output, get_test_stream());
+
+    std::vector<uint8_t> expected_results = {250, 251, 252, 253};
+    ASSERT_EQ(output_ptr.size(), expected_results.size());
+    for (size_t i = 0; i < expected_results.size(); ++i)
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << "i=" << i;
+}
+
 // f8e4m3 Slice: values are exactly representable, so the sliced (byte-moved) result is exact. Covers
 // the f8 output path enabled for a quantized KV cache (GroupQueryAttention f8e4m3 dynamic Slice+Concat).
 TEST(slice_gpu_f8e4m3, bfyx) {

--- a/src/plugins/template/backend/ops/gather.cpp
+++ b/src/plugins/template/backend/ops/gather.cpp
@@ -65,6 +65,8 @@ bool evaluate_node<ov::op::v8::Gather>(std::shared_ptr<ov::Node> node,
         return evaluate<ov::element::f64>(ov::as_type_ptr<ov::op::v8::Gather>(node), outputs, inputs);
     case ov::element::f32:
         return evaluate<ov::element::f32>(ov::as_type_ptr<ov::op::v8::Gather>(node), outputs, inputs);
+    case ov::element::f8e4m3:
+        return evaluate<ov::element::f8e4m3>(ov::as_type_ptr<ov::op::v8::Gather>(node), outputs, inputs);
     case ov::element::i4:
         return evaluate<ov::element::i4>(ov::as_type_ptr<ov::op::v8::Gather>(node), outputs, inputs);
     case ov::element::i8:


### PR DESCRIPTION
### Details:
Enables com.microsoft GroupQueryAttention's f8e4m3fn quantized KV cache on the windowed (sliding_window_cache) path on the Intel GPU plugin. This was the last skipped device combination for GQA f8 support: the windowed present assembly gathers f8e4m3 KV rows via Gather, which had no f8e4m3 kernel on GPU or on the TEMPLATE reference. Extends the i8/i4/f8 GPU work from #36751/#36798/#36806 to this op.

- Adds f8e4m3 to Gather's impl and kernel-selector supported-type lists, and a byte-copy path in gather_ref.cl gated on INPUT0_IS_F8E4M3 (ACTIVATION/TO_OUTPUT_TYPE don't compile on the 1-byte fp8 struct), mirroring the pattern already used for Slice/Concat/ScatterUpdate.
- Blocks fusion into an fp8 Gather output in prepare_primitive_fusing.cpp, same reasoning as the existing concat/scatter_update fp8 fusion guards.
- Adds the missing f8e4m3 case to TEMPLATE's Gather reference dispatch.
- Un-skips onnx_model_gqa_f8e4m3fnkv_sliding_window_cache on GPU (passes). TEMPLATE keeps a skip for a separate, pre-existing dynamic-shape quirk on this fully-static graph, the same symptom class as the existing sliding_window_cache_static_staging INTERPRETER skip; tracked as a follow-up, not caused by this change.
- Adds gather_gpu_f8e4m3 and slice_gpu_u8 GPU unit tests. The latter was an outstanding ask from tkrupa on #36806, a follow-up to #36798's i8-only Slice coverage.

Tests: GQA ONNX FE suite green on CPU/GPU (TEMPLATE skip documented above); GPU gather/scatter/slice/concatenation/fusing unit suites (89 tests) pass with no regressions.

### Tickets:
- none

### AI Assistance:
- AI assistance used: yes
- Aided GPU kernel debug, unit test authoring, and root-causing the TEMPLATE-only shape quirk.