### PR TITLE
[Snippets] CPU func tests: moved an additional validation to validate() in order to avoid skipped instances handling

### DIFF
--- a/src/tests/functional/base_func_tests/include/shared_test_classes/base/snippets_test_utils.hpp
+++ b/src/tests/functional/base_func_tests/include/shared_test_classes/base/snippets_test_utils.hpp
@@ -13,9 +13,8 @@ namespace snippets {
 using ov::test::operator<<;
 class SnippetsTestsCommon : virtual public ov::test::SubgraphBaseTest {
 protected:
+    void validate() override;
     void validateNumSubgraphs();
-
-    void validateOriginalLayersNamesByType(const std::string& layerType, const std::string& originalLayersNames);
 
     void setInferenceType(ov::element::Type type);
 

--- a/src/tests/functional/base_func_tests/src/base/snippets_test_utils.cpp
+++ b/src/tests/functional/base_func_tests/src/base/snippets_test_utils.cpp
@@ -16,6 +16,10 @@ void SnippetsTestsCommon::validate() {
 }
 
 void SnippetsTestsCommon::validateNumSubgraphs() {
+    // Some derived tests don't set expected counts, so skip validation for them.
+    if (ref_num_nodes == 0 && ref_num_subgraphs == 0)
+        return;
+
     const auto& compiled_model = compiledModel.get_runtime_model();
     size_t num_subgraphs = 0;
     size_t num_nodes = 0;

--- a/src/tests/functional/base_func_tests/src/base/snippets_test_utils.cpp
+++ b/src/tests/functional/base_func_tests/src/base/snippets_test_utils.cpp
@@ -10,11 +10,12 @@
 namespace ov {
 namespace test {
 namespace snippets {
-void SnippetsTestsCommon::validateNumSubgraphs() {
-    bool isCurrentTestDisabled = ov::test::utils::current_test_is_disabled();
-    if (isCurrentTestDisabled)
-        GTEST_SKIP() << "Disabled test due to configuration" << std::endl;
+void SnippetsTestsCommon::validate() {
+    ov::test::SubgraphBaseTest::validate();
+    validateNumSubgraphs();
+}
 
+void SnippetsTestsCommon::validateNumSubgraphs() {
     const auto& compiled_model = compiledModel.get_runtime_model();
     size_t num_subgraphs = 0;
     size_t num_nodes = 0;
@@ -38,24 +39,6 @@ void SnippetsTestsCommon::validateNumSubgraphs() {
     ASSERT_EQ(ref_num_subgraphs, num_subgraphs) << "Compiled model contains invalid number of subgraphs.";
 }
 
-void SnippetsTestsCommon::validateOriginalLayersNamesByType(const std::string& layerType, const std::string& originalLayersNames) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    const auto& compiled_model = compiledModel.get_runtime_model();
-    for (const auto& op : compiled_model->get_ops()) {
-        const auto& rtInfo = op->get_rt_info();
-
-        const auto& typeIt = rtInfo.find("layerType");
-        const auto type = typeIt->second.as<std::string>();
-        if (type == layerType) {
-            const auto& nameIt = rtInfo.find("originalLayersNames");
-            const auto name = nameIt->second.as<std::string>();
-            ASSERT_EQ(originalLayersNames, name);
-            return;
-        }
-    }
-
-    ASSERT_TRUE(false) << "Layer type '" << layerType << "' was not found in compiled model";
-}
 void SnippetsTestsCommon::setInferenceType(ov::element::Type type) {
     configuration.emplace(ov::hint::inference_precision(type));
 }

--- a/src/tests/functional/plugin/shared/include/snippets/fake_quantize_decomposition_test.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/fake_quantize_decomposition_test.hpp
@@ -43,6 +43,13 @@ public:
 
 protected:
     void SetUp() override;
+    void validate() override;
+
+private:
+    void validateOriginalLayersNamesByType(const std::string& layerType, const std::string& originalLayersNames);
+
+    std::string expected_layer_type;
+    std::string expected_original_layers_names;
 };
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/functional/plugin/shared/src/snippets/add.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/add.cpp
@@ -127,22 +127,18 @@ void AddPair::SetUp() {
 
 TEST_P(Add, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(AddConst, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(AddRollConst, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(AddPair, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/check_broadcast.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/check_broadcast.cpp
@@ -83,7 +83,6 @@ void CheckBroadcast::SetUp() {
 
 TEST_P(CheckBroadcast, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/conv_eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/conv_eltwise.cpp
@@ -42,7 +42,6 @@ namespace snippets {
 
 TEST_P(ConvEltwise, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 };
 
 

--- a/src/tests/functional/plugin/shared/src/snippets/convert.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/convert.cpp
@@ -213,42 +213,34 @@ void ConvertManyOnInputOutput::SetUp() {
 
 TEST_P(Convert, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ConvertInput, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ConvertOutput, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ConvertStub, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ConvertPartialInputsAndResults, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ConvertManyOnInputs, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ConvertManyOnOutputs, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ConvertManyOnInputOutput, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
@@ -37,7 +37,6 @@ void EdgeReplace::SetUp() {
 
 TEST_P(EdgeReplace, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/eltwise_two_results.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/eltwise_two_results.cpp
@@ -45,7 +45,6 @@ void EltwiseTwoResults::SetUp() {
 
 TEST_P(EltwiseTwoResults, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/enforce_precision.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/enforce_precision.cpp
@@ -39,7 +39,6 @@ void EnforcePrecisionTest::SetUp() {
 
 TEST_P(EnforcePrecisionTest, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/fake_quantize_decomposition_test.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/fake_quantize_decomposition_test.cpp
@@ -63,16 +63,37 @@ void FakeQuantizeDecompositionTest::SetUp() {
         values.zeroPoint,
         {},
         op);
+
+    expected_layer_type = std::string(operation.second.first);
+    expected_original_layers_names = operation.second.second;
+}
+
+void FakeQuantizeDecompositionTest::validate() {
+    SnippetsTestsCommon::validate();
+    validateOriginalLayersNamesByType(expected_layer_type, expected_original_layers_names);
+}
+
+void FakeQuantizeDecompositionTest::validateOriginalLayersNamesByType(const std::string& layerType,
+                                                                       const std::string& originalLayersNames) {
+    const auto& compiled_model = compiledModel.get_runtime_model();
+    for (const auto& op : compiled_model->get_ops()) {
+        const auto& rtInfo = op->get_rt_info();
+
+        const auto& typeIt = rtInfo.find("layerType");
+        const auto type = typeIt->second.as<std::string>();
+        if (type == layerType) {
+            const auto& nameIt = rtInfo.find("originalLayersNames");
+            const auto name = nameIt->second.as<std::string>();
+            ASSERT_EQ(originalLayersNames, name);
+            return;
+        }
+    }
+
+    ASSERT_TRUE(false) << "Layer type '" << layerType << "' was not found in compiled model";
 }
 
 TEST_P(FakeQuantizeDecompositionTest, CompareWithRefImpl) {
     run();
-
-    const auto operation = std::get<1>(this->GetParam());
-    auto elementType = std::string(operation.second.first);
-    validateOriginalLayersNamesByType(elementType, operation.second.second);
-
-    validateNumSubgraphs();
 };
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/functional/plugin/shared/src/snippets/fake_quantize_decomposition_test.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/fake_quantize_decomposition_test.cpp
@@ -1,4 +1,3 @@
-
 // Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -80,9 +79,12 @@ void FakeQuantizeDecompositionTest::validateOriginalLayersNamesByType(const std:
         const auto& rtInfo = op->get_rt_info();
 
         const auto& typeIt = rtInfo.find("layerType");
+        if (typeIt == rtInfo.end())
+            continue;
         const auto type = typeIt->second.as<std::string>();
         if (type == layerType) {
             const auto& nameIt = rtInfo.find("originalLayersNames");
+            ASSERT_NE(nameIt, rtInfo.end()) << "Failed to find originalLayersNames in " << op->get_friendly_name() << " rt_info.";
             const auto name = nameIt->second.as<std::string>();
             ASSERT_EQ(originalLayersNames, name);
             return;

--- a/src/tests/functional/plugin/shared/src/snippets/gated_mlp.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/gated_mlp.cpp
@@ -58,9 +58,7 @@ std::string GatedMLP::getTestCaseName(const testing::TestParamInfo<ov::test::sni
 }
 
 TEST_P(GatedMLP, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 }  // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/group_normalization.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/group_normalization.cpp
@@ -61,9 +61,7 @@ InputShape GroupNormalization::ExtractScaleShiftShape(const InputShape& shape) {
 }
 
 TEST_P(GroupNormalization, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
@@ -139,59 +139,41 @@ std::shared_ptr<MatMulFunctionBase> MatMulEltwiseChainCascade::get_builder(const
 }
 
 TEST_P(MatMul, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MatMulTransposeB, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MatMulFQ, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     abs_threshold = 0.5;
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MatMulBias, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MatMulBiasQuantized, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MatMulsQuantized, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MatMulsQuantizedSoftmax, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     abs_threshold = 4e-6;
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MatMulEltwiseChain, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MatMulEltwiseChainCascade, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/max_num_params_eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/max_num_params_eltwise.cpp
@@ -40,9 +40,7 @@ void MaxNumParamsEltwise::SetUp() {
 }
 
 TEST_P(MaxNumParamsEltwise, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -358,112 +358,76 @@ std::shared_ptr<SnippetsFunctionBase> MHASharedKV::get_subgraph() const {
 }
 
 TEST_P(MHA, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAConstB, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHATwoConstB, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAWithThreadCount, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHA2D, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHASelect, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAWOTransposeOnInputs, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAWOTranspose, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAMulAdd, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHATransposedB, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAINT8MatMul, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAQuantMatMul0, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAFQAfterMatMul, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     abs_threshold = 4e-6;
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAFQ, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAWithExtractedReshape, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHARankUpgradeToReductionReshape, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHAWithDynamicMul, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MHASharedKV, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 }  // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/mlp_seq.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mlp_seq.cpp
@@ -100,15 +100,11 @@ std::shared_ptr<SnippetsFunctionBase> MLPSeqQuantized::get_subgraph(size_t num_h
 }
 
 TEST_P(MLPSeq, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(MLPSeqQuantized, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 }  // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/precision_propagation_convertion.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/precision_propagation_convertion.cpp
@@ -44,7 +44,6 @@ void PrecisionPropagationConvertion::SetUp() {
 
 TEST_P(PrecisionPropagationConvertion, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/reduce.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/reduce.cpp
@@ -44,9 +44,7 @@ void Reduce::SetUp() {
 }
 
 TEST_P(Reduce, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/select.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/select.cpp
@@ -140,12 +140,10 @@ void BroadcastSelect::generate_inputs(const std::vector<ov::Shape>& targetInputS
 
 TEST_P(Select, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(BroadcastSelect, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/softmax.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/softmax.cpp
@@ -50,21 +50,15 @@ std::shared_ptr<SnippetsFunctionBase> SoftmaxSum::get_subgraph(const std::vector
 }
 
 TEST_P(Softmax, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(AddSoftmax, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(SoftmaxSum, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/three_inputs_eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/three_inputs_eltwise.cpp
@@ -51,7 +51,6 @@ void ThreeInputsEltwise::SetUp() {
 
 TEST_P(ThreeInputsEltwise, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/transpose.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/transpose.cpp
@@ -60,15 +60,11 @@ void TransposeMul::SetUp() {
 }
 
 TEST_P(Transpose, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(TransposeMul, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/transpose_matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/transpose_matmul.cpp
@@ -81,28 +81,20 @@ std::shared_ptr<MatMulFunctionBase> ExplicitTransposeMatMulBias::get_builder(con
 }
 
 TEST_P(TransposeMatMul, CompareWithRefImpl) {
-   SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(TransposeMatMulFQ, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     abs_threshold = 5e-6;
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ExplicitTransposeMatMul, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ExplicitTransposeMatMulBias, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/transpose_softmax.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/transpose_softmax.cpp
@@ -59,15 +59,11 @@ void TransposeSoftmaxEltwise::SetUp() {
 }
 
 TEST_P(TransposeSoftmax, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(TransposeSoftmaxEltwise, CompareWithRefImpl) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
-    validateNumSubgraphs();
 }
 
 

--- a/src/tests/functional/plugin/shared/src/snippets/two_inputs_and_outputs.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/two_inputs_and_outputs.cpp
@@ -53,12 +53,10 @@ void TwoInputsAndOutputsWithReversedOutputs::SetUp() {
 
 TEST_P(TwoInputsAndOutputs, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(TwoInputsAndOutputsWithReversedOutputs, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/unary_activation.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/unary_activation.cpp
@@ -60,22 +60,18 @@ std::shared_ptr<SnippetsFunctionBase> SoftSign::get_subgraph(const std::vector<P
 
 TEST_P(Exp, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(ExpReciprocal, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(HSigmoid, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 TEST_P(SoftSign, CompareWithRefImpl) {
     run();
-    validateNumSubgraphs();
 }
 
 } // namespace snippets


### PR DESCRIPTION
### Details:
`validateNumSubgraphs` is moved to `SnippetsTestsCommon::validate()` in order to avoid unnecessary skipped instances handling. The `TEST_P` code for snippets related instances became shorter.
Was:
```
TEST_P(<Name>, CompareWithRefImpl) {
    SKIP_IF_CURRENT_TEST_IS_DISABLED()
    run();
    validateNumSubgraphs();
}
```

Now:
```
TEST_P(<Name>, CompareWithRefImpl) {
    run();
}
```

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to perform refactoring*
