### PR TITLE
[Transformations] Fix per-channel axis mapping in MoveEltwiseUpThroughDataMov

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
@@ -5,12 +5,17 @@
 #include "transformations/common_optimizations/move_eltwise_up_data_movement.hpp"
 
 #include <algorithm>
+#include <iterator>
+#include <limits>
 #include <memory>
+#include <optional>
+#include <set>
 
 #include "itt.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/core/type.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/op/batch_to_space.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/depth_to_space.hpp"
@@ -26,6 +31,7 @@
 #include "openvino/op/util/broadcast_base.hpp"
 #include "openvino/op/util/gather_base.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/symbolic_transformations/utils.hpp"
 #include "transformations/utils/utils.hpp"
 
 using ov::pass::pattern::Matcher;
@@ -41,6 +47,164 @@ bool is_data_movement_operation(const std::shared_ptr<ov::Node>& node,
     return std::any_of(allowed_data_movement_ops.begin(), allowed_data_movement_ops.end(), [&](const auto& type) {
         return node->get_type_info().is_castable(type);
     });
+}
+
+std::optional<std::set<size_t>> get_normalized_axes(const std::shared_ptr<ov::Node>& operation, size_t rank) {
+    if (operation->get_input_size() < 2)
+        return std::nullopt;
+
+    const auto axes_const = ov::as_type_ptr<v0::Constant>(operation->get_input_node_shared_ptr(1));
+    if (!axes_const)
+        return std::nullopt;
+
+    auto axes = axes_const->cast_vector<int64_t>();
+    ov::util::try_normalize_axes(axes, ov::Rank(static_cast<int64_t>(rank)), *operation);
+    return std::set<size_t>(axes.begin(), axes.end());
+}
+
+std::optional<size_t> map_squeeze_axis(const std::shared_ptr<v0::Squeeze>& squeeze, size_t output_axis) {
+    const auto& input_shape = squeeze->get_input_partial_shape(0);
+    const auto& output_shape = squeeze->get_output_partial_shape(0);
+    if (input_shape.rank().is_dynamic() || output_shape.rank().is_dynamic())
+        return std::nullopt;
+
+    const size_t input_rank = input_shape.size();
+    const size_t output_rank = output_shape.size();
+    std::set<size_t> removed_axes;
+
+    if (squeeze->get_input_size() == 1) {
+        for (size_t axis = 0; axis < input_rank; ++axis) {
+            if (input_shape[axis].compatible(1))
+                removed_axes.insert(axis);
+        }
+    } else {
+        const auto normalized_axes = get_normalized_axes(squeeze, input_rank);
+        if (!normalized_axes.has_value())
+            return std::nullopt;
+
+        if (normalized_axes->empty()) {
+            for (size_t axis = 0; axis < input_rank; ++axis) {
+                if (input_shape[axis].compatible(1))
+                    removed_axes.insert(axis);
+            }
+        } else {
+            for (const auto axis : *normalized_axes) {
+                if (axis >= input_rank)
+                    return std::nullopt;
+                if (input_shape[axis].compatible(1))
+                    removed_axes.insert(axis);
+            }
+        }
+    }
+
+    if (output_axis >= output_rank || output_rank + removed_axes.size() != input_rank)
+        return std::nullopt;
+
+    size_t current_output_axis = 0;
+    for (size_t input_axis = 0; input_axis < input_rank; ++input_axis) {
+        if (removed_axes.count(input_axis) != 0)
+            continue;
+        if (current_output_axis == output_axis)
+            return input_axis;
+        ++current_output_axis;
+    }
+    return std::nullopt;
+}
+
+std::optional<size_t> map_unsqueeze_axis(const std::shared_ptr<v0::Unsqueeze>& unsqueeze, size_t output_axis) {
+    const auto& input_shape = unsqueeze->get_input_partial_shape(0);
+    const auto& output_shape = unsqueeze->get_output_partial_shape(0);
+    if (input_shape.rank().is_dynamic() || output_shape.rank().is_dynamic())
+        return std::nullopt;
+
+    const size_t input_rank = input_shape.size();
+    const size_t output_rank = output_shape.size();
+    if (unsqueeze->get_input_size() != 2 || output_rank <= input_rank)
+        return std::nullopt;
+
+    const size_t inserted_axes_count = output_rank - input_rank;
+    const auto axes_const = ov::as_type_ptr<v0::Constant>(unsqueeze->get_input_node_shared_ptr(1));
+    if (!axes_const || ov::shape_size(axes_const->get_shape()) != inserted_axes_count)
+        return std::nullopt;
+
+    const auto inserted_axes = get_normalized_axes(unsqueeze, output_rank);
+    if (!inserted_axes.has_value() || inserted_axes->size() != inserted_axes_count ||
+        inserted_axes->count(output_axis) != 0) {
+        return std::nullopt;
+    }
+
+    return output_axis -
+           static_cast<size_t>(std::distance(inserted_axes->begin(), inserted_axes->lower_bound(output_axis)));
+}
+
+std::optional<int64_t> trailing_stride(const ov::PartialShape& shape, size_t axis) {
+    int64_t stride = 1;
+    for (size_t i = axis + 1; i < shape.size(); ++i) {
+        if (shape[i].is_dynamic())
+            return std::nullopt;
+        const int64_t dim = shape[i].get_length();
+        if (dim != 0 && stride > std::numeric_limits<int64_t>::max() / dim)
+            return std::nullopt;
+        stride *= dim;
+    }
+    return stride;
+}
+
+bool trailing_shapes_match(const ov::PartialShape& input_shape,
+                           size_t input_axis,
+                           const ov::PartialShape& output_shape,
+                           size_t output_axis) {
+    // Products preserve valid split/merge reshapes. If either product is dynamic, require the
+    // non-unit tails to match one-to-one through static values or shared symbols.
+    const auto input_stride = trailing_stride(input_shape, input_axis);
+    const auto output_stride = trailing_stride(output_shape, output_axis);
+    if (input_stride.has_value() && output_stride.has_value())
+        return input_stride == output_stride;
+
+    size_t input_idx = input_axis + 1;
+    size_t output_idx = output_axis + 1;
+    while (true) {
+        while (input_idx < input_shape.size() && input_shape[input_idx].is_static() &&
+               input_shape[input_idx].get_length() == 1) {
+            ++input_idx;
+        }
+        while (output_idx < output_shape.size() && output_shape[output_idx].is_static() &&
+               output_shape[output_idx].get_length() == 1) {
+            ++output_idx;
+        }
+
+        if (input_idx == input_shape.size() || output_idx == output_shape.size())
+            return input_idx == input_shape.size() && output_idx == output_shape.size();
+        if (!ov::symbol::util::dims_are_equal(input_shape[input_idx], output_shape[output_idx]))
+            return false;
+
+        ++input_idx;
+        ++output_idx;
+    }
+}
+
+std::optional<size_t> map_reshape_axis(const ov::PartialShape& input_shape,
+                                       const ov::PartialShape& output_shape,
+                                       size_t output_axis,
+                                       size_t channel_size) {
+    std::optional<size_t> mapped_axis;
+    for (size_t input_axis = 0; input_axis < input_shape.size(); ++input_axis) {
+        if (!trailing_shapes_match(input_shape, input_axis, output_shape, output_axis))
+            continue;
+
+        const auto& input_dim = input_shape[input_axis];
+        if (input_dim.is_dynamic()) {
+            if (input_dim.compatible(channel_size))
+                return std::nullopt;
+            continue;
+        }
+        if (static_cast<size_t>(input_dim.get_length()) != channel_size)
+            continue;
+        if (mapped_axis.has_value())
+            return std::nullopt;
+        mapped_axis = input_axis;
+    }
+    return mapped_axis;
 }
 }  // namespace
 
@@ -176,8 +340,9 @@ ov::pass::MoveEltwiseUpThroughDataMovPerChannel::MoveEltwiseUpThroughDataMovPerC
 
     auto eltw_data_flow_in = wrap_type<v1::Reshape, v0::Squeeze, v0::Unsqueeze>(ov::pass::pattern::consumers_count(1));
     auto eltw_const_in = wrap_type<v0::Constant>(const_predicate);
-    auto eltwise_pattern =
-        wrap_type<op_util::BinaryElementwiseArithmetic>({eltw_data_flow_in, eltw_const_in}, eltw_predicate);
+    auto eltwise_pattern = wrap_type<op_util::BinaryElementwiseArithmetic>(
+        {eltw_data_flow_in, eltw_const_in},
+        eltw_predicate && ov::pass::pattern::attrs_match({{"auto_broadcast", "numpy"}}));
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
@@ -202,16 +367,40 @@ ov::pass::MoveEltwiseUpThroughDataMovPerChannel::MoveEltwiseUpThroughDataMovPerC
 
         auto parent = eltwise->get_input_node_shared_ptr(data_flow_idx);
         const auto& parent_in_pshape = parent->get_input_partial_shape(0);
-        auto parent_in_channel_dim =
-            parent_in_pshape.size() <= channel_idx ? ov::Dimension(1) : parent_in_pshape[channel_idx];
-        auto parent_out_channel_dim = parent->get_output_partial_shape(0)[channel_idx];
-        if (parent_in_channel_dim.is_dynamic() || parent_in_channel_dim != channel_val ||
-            parent_out_channel_dim.is_dynamic() || parent_out_channel_dim != channel_val)
+        const auto& parent_out_pshape = parent->get_output_partial_shape(0);
+        if (parent_in_pshape.rank().is_dynamic() || parent_out_pshape.rank().is_dynamic())
             return false;
 
-        auto new_shape = ov::Shape(parent->get_input_partial_shape(0).size(), 1);
+        const size_t in_rank = parent_in_pshape.size();
+        const size_t out_rank = parent_out_pshape.size();
+        const size_t const_rank = const_shape.size();
+        if (const_rank > out_rank)
+            return false;
 
-        new_shape[channel_idx] = const_shape[channel_idx];
+        // The constant is right-aligned against the data flow shape by NumPy broadcasting, so its
+        // non-unit axis sits at this position in the parent's output space.
+        const size_t output_channel_idx = out_rank - const_rank + channel_idx;
+        if (parent_out_pshape[output_channel_idx].is_dynamic() ||
+            static_cast<size_t>(parent_out_pshape[output_channel_idx].get_length()) != channel_val) {
+            return false;
+        }
+
+        std::optional<size_t> input_channel_idx;
+        if (const auto squeeze = ov::as_type_ptr<v0::Squeeze>(parent)) {
+            input_channel_idx = map_squeeze_axis(squeeze, output_channel_idx);
+        } else if (const auto unsqueeze = ov::as_type_ptr<v0::Unsqueeze>(parent)) {
+            input_channel_idx = map_unsqueeze_axis(unsqueeze, output_channel_idx);
+        } else {
+            input_channel_idx = map_reshape_axis(parent_in_pshape, parent_out_pshape, output_channel_idx, channel_val);
+        }
+        if (!input_channel_idx.has_value() || parent_in_pshape[*input_channel_idx].is_dynamic() ||
+            static_cast<size_t>(parent_in_pshape[*input_channel_idx].get_length()) != channel_val) {
+            return false;
+        }
+
+        auto new_shape = ov::Shape(in_rank, 1);
+
+        new_shape[*input_channel_idx] = channel_val;
         auto old_const = ov::as_type_ptr<v0::Constant>(eltwise->get_input_node_shared_ptr(const_idx));
         auto new_const = std::make_shared<v0::Constant>(*old_const, new_shape);
         ov::replace_node_update_name(old_const, new_const);

--- a/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
@@ -400,6 +400,32 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseUnsqueezeReverseInOrder
     }
 }
 
+// The data movement op inserts an axis before the constant's channel axis, so the channel axis
+// shifts. Matching on extent alone picks input axis 2 instead of axis 1 when both measure 5.
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelUnsqueezeMiddleAxisSquareDims) {
+    const ov::Shape shape{1, 5, 5};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto unsqueeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto unsqueeze = std::make_shared<v0::Unsqueeze>(input, unsqueeze_axis);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 5, 1}, {0.f, 1.f, 2.f, 3.f, 4.f});
+        auto add = std::make_shared<v1::Add>(unsqueeze, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 5, 1}, {0.f, 1.f, 2.f, 3.f, 4.f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto unsqueeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto unsqueeze = std::make_shared<v0::Unsqueeze>(add, unsqueeze_axis);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
 TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseSqueeze) {
     const ov::Shape shape{10, 20, 1, 1};
     {
@@ -548,4 +574,247 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SharedConstantNotReshapedForOtherConsume
         model_ref =
             std::make_shared<ov::Model>(ov::OutputVector{unsqueeze, slice}, ov::ParameterVector{input, slice_input});
     }
+}
+
+// The data movement op drops an axis *before* the constant's channel axis, so the channel axis
+// shifts. Matching on extent alone picks input axis 2 instead of axis 3 when both measure 5.
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelSqueezeMiddleAxisSquareDims) {
+    const ov::Shape shape{1, 1, 5, 5};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto squeeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto squeeze = std::make_shared<v0::Squeeze>(input, squeeze_axis);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 5}, {0.f, 1.f, 2.f, 3.f, 4.f});
+        auto add = std::make_shared<v1::Add>(squeeze, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 1, 5}, {0.f, 1.f, 2.f, 3.f, 4.f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto squeeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto squeeze = std::make_shared<v0::Squeeze>(add, squeeze_axis);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelReshapeReduceRankSquareDims) {
+    const ov::Shape shape{1, 1, 5, 5};
+    const std::vector<int64_t> target_shape{1, 5, 5};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto reshape_pattern =
+            std::make_shared<v0::Constant>(ov::element::i64, ov::Shape{target_shape.size()}, target_shape);
+        auto reshape = std::make_shared<v1::Reshape>(input, reshape_pattern, false);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 5}, {0.f, 1.f, 2.f, 3.f, 4.f});
+        auto add = std::make_shared<v1::Add>(reshape, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 1, 5}, {0.f, 1.f, 2.f, 3.f, 4.f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto reshape_pattern =
+            std::make_shared<v0::Constant>(ov::element::i64, ov::Shape{target_shape.size()}, target_shape);
+        auto reshape = std::make_shared<v1::Reshape>(add, reshape_pattern, false);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+// The constant has lower rank than the eltwise output and must be right-aligned before its
+// channel axis can be mapped back through the Squeeze.
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelSqueezeLowerRankConstant) {
+    const ov::Shape shape{1, 1, 5, 5};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto squeeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto squeeze = std::make_shared<v0::Squeeze>(input, squeeze_axis);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {5}, {0.f, 1.f, 2.f, 3.f, 4.f});
+        auto add = std::make_shared<v1::Add>(squeeze, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 1, 5}, {0.f, 1.f, 2.f, 3.f, 4.f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto squeeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto squeeze = std::make_shared<v0::Squeeze>(add, squeeze_axis);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelSqueezeNoAxesInput) {
+    const ov::Shape shape{10, 1, 20};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto squeeze = std::make_shared<v0::Squeeze>(input);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 20}, {0.5f});
+        auto add = std::make_shared<v1::Add>(squeeze, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 20}, {0.5f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto squeeze = std::make_shared<v0::Squeeze>(add);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{input});
+    }
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelSqueezeDynamicDimension) {
+    const ov::PartialShape shape{1, -1, 5, 5};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto squeeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto squeeze = std::make_shared<v0::Squeeze>(input, squeeze_axis);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 5}, {0.5f});
+        auto add = std::make_shared<v1::Add>(squeeze, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 1, 5}, {0.5f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto squeeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto squeeze = std::make_shared<v0::Squeeze>(add, squeeze_axis);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{input});
+    }
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelSqueezeDynamicTrailingDimensionsMultipleAxes) {
+    const ov::PartialShape shape{1, -1, 1, 5, -1, 1};
+    const std::vector<int64_t> axes{0, 2, -1};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto squeeze_axes = v0::Constant::create(ov::element::i64, ov::Shape{axes.size()}, axes);
+        auto squeeze = std::make_shared<v0::Squeeze>(input, squeeze_axes);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 5, 1}, {0.5f});
+        auto add = std::make_shared<v1::Add>(squeeze, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 1, 5, 1, 1}, {0.5f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto squeeze_axes = v0::Constant::create(ov::element::i64, ov::Shape{axes.size()}, axes);
+        auto squeeze = std::make_shared<v0::Squeeze>(add, squeeze_axes);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{input});
+    }
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelUnsqueezeDynamicDimensionsNegativeAxes) {
+    const ov::PartialShape shape{-1, 5, -1};
+    const std::vector<int64_t> axes{0, -1};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto unsqueeze_axes = v0::Constant::create(ov::element::i64, ov::Shape{axes.size()}, axes);
+        auto unsqueeze = std::make_shared<v0::Unsqueeze>(input, unsqueeze_axes);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 1, 5, 1, 1}, {0.5f});
+        auto add = std::make_shared<v1::Add>(unsqueeze, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 5, 1}, {0.5f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto unsqueeze_axes = v0::Constant::create(ov::element::i64, ov::Shape{axes.size()}, axes);
+        auto unsqueeze = std::make_shared<v0::Unsqueeze>(add, unsqueeze_axes);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input});
+    }
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelReshapeSymbolicTrailingDimension) {
+    auto trailing_dim = ov::Dimension::dynamic();
+    trailing_dim.set_symbol(std::make_shared<ov::Symbol>());
+    const ov::PartialShape shape{1, 5, trailing_dim};
+    const std::vector<int64_t> target_shape{5, 1, -1};
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto reshape_pattern =
+            std::make_shared<v0::Constant>(ov::element::i64, ov::Shape{target_shape.size()}, target_shape);
+        auto reshape = std::make_shared<v1::Reshape>(input, reshape_pattern, false);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {5, 1, 1}, {0.5f});
+        auto add = std::make_shared<v1::Add>(reshape, per_channel_const);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+        manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    }
+    {
+        auto input = std::make_shared<v0::Parameter>(ov::element::f32, shape);
+        auto per_channel_const = v0::Constant::create(ov::element::f32, {1, 5, 1}, {0.5f});
+        auto add = std::make_shared<v1::Add>(input, per_channel_const);
+        auto reshape_pattern =
+            std::make_shared<v0::Constant>(ov::element::i64, ov::Shape{target_shape.size()}, target_shape);
+        auto reshape = std::make_shared<v1::Reshape>(add, reshape_pattern, false);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
+    }
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelReshapeAnonymousDynamicTrailingDimensionReject) {
+    auto input = std::make_shared<v0::Parameter>(ov::element::f32, ov::PartialShape{1, 5, -1});
+    auto reshape_pattern = v0::Constant::create(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{5, 1, -1});
+    auto reshape = std::make_shared<v1::Reshape>(input, reshape_pattern, false);
+    auto per_channel_const = v0::Constant::create(ov::element::f32, {5, 1, 1}, {0.5f});
+    auto add = std::make_shared<v1::Add>(reshape, per_channel_const);
+
+    model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+    manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+}
+
+// PDPD broadcasting anchors the constant at an explicit axis instead of right-aligning it, so the
+// NumPy-based axis mapping does not apply.
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelReshapePDPDAxisZeroReject) {
+    auto input = std::make_shared<v0::Parameter>(ov::element::f32, ov::Shape{5, 2, 5});
+    auto reshape_pattern =
+        std::make_shared<v0::Constant>(ov::element::i64, ov::Shape{3}, std::vector<int64_t>{5, 2, 5});
+    auto reshape = std::make_shared<v1::Reshape>(input, reshape_pattern, false);
+    auto per_channel_const = v0::Constant::create(ov::element::f32, {5}, {0.f, 1.f, 2.f, 3.f, 4.f});
+    auto add = std::make_shared<v1::Add>(reshape,
+                                         per_channel_const,
+                                         ov::op::AutoBroadcastSpec(ov::op::AutoBroadcastType::PDPD, 0));
+
+    model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+    manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+}
+
+TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelSqueezePDPDAxisOneReject) {
+    auto input = std::make_shared<v0::Parameter>(ov::element::f32, ov::Shape{2, 1, 5, 5});
+    auto squeeze_axis = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+    auto squeeze = std::make_shared<v0::Squeeze>(input, squeeze_axis);
+    auto per_channel_const = v0::Constant::create(ov::element::f32, {5}, {0.f, 1.f, 2.f, 3.f, 4.f});
+    auto add = std::make_shared<v1::Add>(squeeze,
+                                         per_channel_const,
+                                         ov::op::AutoBroadcastSpec(ov::op::AutoBroadcastType::PDPD, 1));
+
+    model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
+    manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }


### PR DESCRIPTION
Backport of https://github.com/openvinotoolkit/openvino/pull/37490 to `releases/2026/3`.

### Details:
- Backports the per-channel axis remapping fix for `MoveEltwiseUpThroughDataMovPerChannel`.
- Preserves NumPy right-alignment and maps channel axes correctly across `Reshape`, `Squeeze`, and `Unsqueeze`.
- Clean cherry-pick of squash merge commit `11f8743cc6b81abf45802d014dc97b45dfb5110d`; no release-specific code changes.

### Validation:
- Both changed C++ translation units compile with the `releases/2026/3` generated build rules.
- `git diff --check` passes.
- Source PR validation: `MoveEltwiseUpThroughDataMovTest.*` 25/25 and full `ov_transformations_tests` 10151/10151.

### Tickets:
- 186460

### AI Assistance:
- AI assistance used: yes
- GitHub Copilot prepared the clean backport and PR metadata. The resulting diff was checked against #37490, both changed translation units were compiled with release-branch build rules, and whitespace was validated.