### PR TITLE
[GPU] Reject in-place crop optimization when it feeds a contiguous-input SDPA consumer

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -32,6 +32,7 @@
 #include "pass_manager.h"
 #include "program_helpers.h"
 
+#include <algorithm>
 #include <utility>
 #include <list>
 #include <vector>

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -743,7 +743,7 @@ bool crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
             const auto& reshape_users = user_info.first->get_users();
             const bool feeds_unsafe_consumer = std::any_of(reshape_users.begin(), reshape_users.end(),
                 [](const program_node* user) { return requires_contiguous_input(*user); });
-            if (is_axis1_size1_squeeze && feeds_unsafe_consumer)
+            if (feeds_unsafe_consumer)
                 return false;
 
             if (is_axis1_size1_squeeze) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -410,6 +410,10 @@ static bool is_optimizable_padding_for_crop(const crop_node& node,
     return true;
 }
 
+// Denylist, not allowlist: eltwise/reorder/rope/vl_sdpa already read padded/strided
+// input correctly via the standard pitch-aware layout addressing; sdpa's 4 kernels
+// (ref/opt/gen_opt/gen_micro) are the only ones known to assume contiguous memory.
+// If another kernel is found to make the same assumption, add it here too.
 static bool requires_contiguous_input(const program_node& node) {
     return node.is_type<scaled_dot_product_attention>();
 }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -27,6 +27,7 @@
 #include "border_inst.h"
 #include "lora_inst.h"
 #include "mvn_inst.h"
+#include "scaled_dot_product_attention_inst.h"
 
 #include "pass_manager.h"
 #include "program_helpers.h"
@@ -409,6 +410,10 @@ static bool is_optimizable_padding_for_crop(const crop_node& node,
     return true;
 }
 
+static bool requires_contiguous_input(const program_node& node) {
+    return node.is_type<scaled_dot_product_attention>();
+}
+
 bool crop_in_place_optimization::can_crop_be_optimized_along_feature(const layout& crop_layout,
                                                                      const layout& input_layout) {
     auto format = crop_layout.format;
@@ -729,6 +734,12 @@ bool crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
             // scaling cannot be represented on the L (batch) axis.
             const bool is_axis1_size1_squeeze = reshape_mode == reshape::reshape_mode::base && crop_axis == 1 && crop_dim_val == 1 &&
                                                 reshape_ps.size() + 1 == crop_ps.size() && reshape_ps.size() >= 2 && reshape_ps[1].is_static();
+
+            const auto& reshape_users = user_info.first->get_users();
+            const bool feeds_unsafe_consumer = std::any_of(reshape_users.begin(), reshape_users.end(),
+                [](const program_node* user) { return requires_contiguous_input(*user); });
+            if (is_axis1_size1_squeeze && feeds_unsafe_consumer)
+                return false;
 
             if (is_axis1_size1_squeeze) {
                 const auto h_size = reshape_ps[1].get_length();

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -10,6 +10,7 @@
 #include <intel_gpu/primitives/vl_sdpa.hpp>
 #include "vl_sdpa_inst.h"
 #include "graph/impls/ocl/kernel_selector_helper.h"
+#include "intel_gpu/primitives/scaled_dot_product_attention.hpp"
 
 #include "intel_gpu/runtime/engine.hpp"
 
@@ -3082,6 +3083,65 @@ TEST(prepare_buffer_fusing, in_place_crop_split_axis1_three_crops_eltwise_consum
     ASSERT_TRUE(net.get_primitive("crop0")->can_be_optimized()) << "crop0 should be in-place";
     ASSERT_TRUE(net.get_primitive("crop1")->can_be_optimized()) << "crop1 should be in-place";
     ASSERT_TRUE(net.get_primitive("crop2")->can_be_optimized()) << "crop2 should be in-place";
+}
+
+TEST(prepare_buffer_fusing, in_place_crop_split_axis1_three_crops_sdpa_consumer) {
+    auto& engine = get_test_engine();
+    tests::random_generator rg(GET_SUITE_NAME);
+
+    const int64_t H = 4, S = 8;
+    const int64_t L = 16;  // batch (sequence length)
+
+    auto in_layout_dyn  = layout{ov::PartialShape{-1, 3, H, S}, data_types::f16, format::bfyx};
+    auto input_mem      = engine.allocate_memory({{L, 3, H, S}, data_types::f16, format::bfyx});
+    auto axis_mem       = engine.allocate_memory({{}, data_types::i64, format::bfyx});
+    auto splits_len_mem = engine.allocate_memory({{3}, data_types::i64, format::bfyx});
+
+    auto input_data = rg.generate_random_1d<ov::float16>(L * 3 * H * S, -1.f, 1.f);
+    set_values(input_mem, input_data);
+    set_values<int64_t>(axis_mem, {1});
+    set_values<int64_t>(splits_len_mem, {1, 1, 1});
+
+    auto op_mode = cldnn::crop_ngraph_op_mode::variadic_split;
+    const int64_t axis = 1;
+
+    const std::vector<int64_t> rs_pattern{-1, H, S};
+    auto rs_shape_dyn = ov::PartialShape{-1, H, S};
+    const std::vector<int64_t> identity_order{0, 1, 2};
+
+    topology topo_dyn(
+        input_layout("input", in_layout_dyn),
+        data("axis",       axis_mem),
+        data("splits_len", splits_len_mem),
+        crop("crop0", {input_info("input"), input_info("axis"), input_info("splits_len")},
+             cldnn::tensor(1), cldnn::tensor(0), op_mode, 0, axis),
+        reshape("reshape0", input_info("crop0"), false, rs_pattern, rs_shape_dyn, cldnn::reshape::reshape_mode::base),
+        crop("crop1", {input_info("input"), input_info("axis"), input_info("splits_len")},
+             cldnn::tensor(1), cldnn::tensor(0), op_mode, 1, axis),
+        reshape("reshape1", input_info("crop1"), false, rs_pattern, rs_shape_dyn, cldnn::reshape::reshape_mode::base),
+        crop("crop2", {input_info("input"), input_info("axis"), input_info("splits_len")},
+             cldnn::tensor(1), cldnn::tensor(0), op_mode, 2, axis),
+        reshape("reshape2", input_info("crop2"), false, rs_pattern, rs_shape_dyn, cldnn::reshape::reshape_mode::base),
+        scaled_dot_product_attention("sdpa",
+            {input_info("reshape0"), input_info("reshape1"), input_info("reshape2")},
+            true /*is_causal, avoids needing an attn_mask input*/, -1,
+            identity_order, identity_order, identity_order, identity_order),
+        reorder("output", input_info("sdpa"), format::bfyx, data_types::f16)
+    );
+    ExecutionConfig config_dyn = get_test_default_config(engine);
+    config_dyn.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config_dyn.set_property(ov::intel_gpu::optimize_data(true));
+
+    network net(engine, topo_dyn, config_dyn);
+    net.set_input_data("input", input_mem);
+    net.execute();
+
+    ASSERT_FALSE(net.get_primitive("crop0")->can_be_optimized())
+        << "crop0 (Q->generic sdpa) must NOT be in-place: sdpa kernels don't honor propagated padding";
+    ASSERT_FALSE(net.get_primitive("crop1")->can_be_optimized())
+        << "crop1 (K->generic sdpa) must NOT be in-place";
+    ASSERT_FALSE(net.get_primitive("crop2")->can_be_optimized())
+        << "crop2 (V->generic sdpa) must NOT be in-place";
 }
 
 // =============================================================================


### PR DESCRIPTION
### Details:
  - Prevents the GPU crop+reshape in-place (no-copy) optimization from silently feeding a padded/strided view into a GPU kernel that assumes contiguous memory, which was producing wrong image captions for Qwen3-VL family models on GPU.
### Description of the issue (symptom, root-cause, how it was resolved)
  - **Symptom**:
    - `openvino_genai.VLMPipeline` on GPU (Intel Arc A770, `dGPU`) with `Qwen3.8-27B-int4-ov` produces a completely unrelated image caption for `Describe this image.` (e.g. describing a labeled stratovolcano cross-section diagram as "the word CALIUM rendered in a specific font").
    - CPU device on the same model/image produces the correct description. The same graph pattern (crop+reshape feeding a generic, non-VL `scaled_dot_product_attention`) affects other Qwen3.x-Vision variants (Qwen3.5, Qwen3.6, Qwen3.8) whenever `SDPAToVLSDPA` is not applied (see Root Cause).
  - **Root Cause**:
    - `crop_in_place_optimization::update_in_place_crop_padding_along_feature()` in `src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp` optimizes out a real memory copy for a `Split(axis=1)` crop that feeds a squeeze-reshape (the `TransposeSplitMatcher` packed-QKV pattern), by propagating the crop's padding/offset into the reshape's output layout instead of copying data.
    - `rope` and `vl_sdpa` consumers of that reshape correctly read the propagated offset (via `shape_info` / CM `token_offset_*` scalars), but none of the 4 generic `scaled_dot_product_attention` GPU kernel selector implementations (`sdpa_ref`/`sdpa_opt`/`sdpa_gen_opt`/`sdpa_gen_micro`) read this metadata — they assume a physically contiguous input buffer and silently read wrong bytes when it is not.
    - On this machine, `SDPAToVLSDPA` (in `transformations_pipeline.cpp`) is disabled because `check_cm_jit_support()` returns false (CM/IGC interface-version mismatch), so the model keeps the generic `scaled_dot_product_attention` instead of the safe `vl_sdpa`, exposing the defect. The CM/IGC mismatch itself is an environment issue and out of scope.
  - **Resolution**:
    - Added a general kernel-capability predicate `requires_contiguous_input()` and reject the in-place optimization (`return false`, forcing a real copy) whenever any direct consumer of the reshape requires contiguous input — currently only generic `scaled_dot_product_attention`. `rope`/`vl_sdpa` consumers are unaffected and keep the zero-copy optimization.

#### The code and line that caused this issue (if it is not changed directly)
N/A — the fix is applied directly inside the function that contains the missing safety check (`update_in_place_crop_padding_along_feature()` in `prepare_buffer_fusing.cpp`).

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
```python
import numpy as np
import openvino as ov
import openvino_genai as ov_genai
import requests
from PIL import Image
device = "GPU" 
model_path = "Qwen3.8-27B-int4-ov"
pipe = ov_genai.VLMPipeline(model_path, device)
url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/ai2d-demo.jpg"
image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
image_tensor = ov.Tensor(np.array(image)[None])
print(pipe.generate("Describe this image.", image=image_tensor, max_new_tokens=200))
```

Before fix (GPU): `"The image consists of a single word rendered in a very specific visual
style ... CALIUM ..."` — wrong; the image is a labeled stratovolcano cross-section diagram.

After fix (GPU): matches the CPU reference, correctly describing the labeled stratovolcano
cross-section diagram (magma chamber, crust/bedrock layer, conduit, ...).

#### Problematic graph
- Before fix:
<img width="1732" height="563" alt="image" src="https://github.com/user-attachments/assets/f5de51e6-1265-4ddc-ad2d-5e975ffb0a2f" />

- Fix:
<img width="1689" height="494" alt="image" src="https://github.com/user-attachments/assets/43c58b3e-65fc-4b0d-96b3-b95d6b559a57" />

#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [v] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Which test did you review?
       Reviewed `prepare_buffer_fusing_test.cpp`'s existing `in_place_crop_split_axis1_three_crops_eltwise_consumer` and `..._vlsdpa_consumer` cases (same crop+reshape pattern, different consumer types); neither exercises a generic `scaled_dot_product_attention` consumer, so a new sibling case `in_place_crop_split_axis1_three_crops_sdpa_consumer` was added following the same fixture style (confirmed fails before the fix, passes after).

### Tickets:
  - *CVS-192936, CVS-194023, CVS-194029*
