### PR TITLE
[core] Reuse per-source test mechanism for file_load_benchmark

### DIFF
--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -187,14 +187,18 @@ endif()
 
 ov_build_target_faster(${TARGET_NAME} PCH)
 
-if(ENABLE_TESTS_PER_SOURCE)
-    set(BENCHMARK_TARGET_NAME ov_file_load_benchmark)
-    add_executable(${BENCHMARK_TARGET_NAME} EXCLUDE_FROM_ALL
-        ${CMAKE_CURRENT_SOURCE_DIR}/file_load_benchmark.cpp)
-    target_link_libraries(${BENCHMARK_TARGET_NAME} PRIVATE
+# - standalone per-source executable,
+# - excluded from ov_core_unit_tests.
+# - ENABLE_TESTS_PER_SOURCE has to be set to ON else no-op
+# - new target name ov_file_load_benchmark -> ov_core_unit_tests_file_load_benchmark
+ov_add_test_target_per_source(
+    NAME ${TARGET_NAME}
+    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/file_load_benchmark.cpp
+    LINK_LIBRARIES
         common_test_utils
-        openvino::util)
-    target_include_directories(${BENCHMARK_TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-endif()
+        openvino::util
+    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
+    LABELS OV UNIT CORE
+)
 
 add_subdirectory(frontend)

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -141,9 +141,9 @@ ov_add_test_target(
     CHECK_SOURCES_LISTED
     CHECK_SOURCES_EXCLUDE_TARGETS
         openvino_mock1_frontend
-        ov_file_load_benchmark
     CHECK_SOURCES_EXCLUDE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/dnnl.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/file_load_benchmark.cpp
 )
 
 target_include_directories(${TARGET_NAME} PRIVATE $<TARGET_PROPERTY:openvino_core_obj,SOURCE_DIR>/src
@@ -187,12 +187,14 @@ endif()
 
 ov_build_target_faster(${TARGET_NAME} PCH)
 
-set(BENCHMARK_TARGET_NAME ov_file_load_benchmark)
-add_executable(${BENCHMARK_TARGET_NAME} EXCLUDE_FROM_ALL
-    ${CMAKE_CURRENT_SOURCE_DIR}/file_load_benchmark.cpp)
-target_link_libraries(${BENCHMARK_TARGET_NAME} PRIVATE
-    common_test_utils
-    openvino::util)
-target_include_directories(${BENCHMARK_TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+if(ENABLE_TESTS_PER_SOURCE)
+    set(BENCHMARK_TARGET_NAME ov_file_load_benchmark)
+    add_executable(${BENCHMARK_TARGET_NAME} EXCLUDE_FROM_ALL
+        ${CMAKE_CURRENT_SOURCE_DIR}/file_load_benchmark.cpp)
+    target_link_libraries(${BENCHMARK_TARGET_NAME} PRIVATE
+        common_test_utils
+        openvino::util)
+    target_include_directories(${BENCHMARK_TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 add_subdirectory(frontend)

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -97,6 +97,10 @@ set(OV_CORE_TESTS_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/weight_sharing_util_test.cpp
 )
 
+if(ENABLE_TESTS_PER_SOURCE)
+    list(APPEND OV_CORE_TESTS_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/file_load_benchmark.cpp)
+endif()
+
 include(conditional_compilation/sources.cmake)
 include(frontend/sources.cmake)
 include(pass/sources.cmake)
@@ -187,18 +191,5 @@ endif()
 
 ov_build_target_faster(${TARGET_NAME} PCH)
 
-# - standalone per-source executable,
-# - excluded from ov_core_unit_tests.
-# - ENABLE_TESTS_PER_SOURCE has to be set to ON else no-op
-# - new target name ov_file_load_benchmark -> ov_core_unit_tests_file_load_benchmark
-ov_add_test_target_per_source(
-    NAME ${TARGET_NAME}
-    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/file_load_benchmark.cpp
-    LINK_LIBRARIES
-        common_test_utils
-        openvino::util
-    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}
-    LABELS OV UNIT CORE
-)
 
 add_subdirectory(frontend)

--- a/src/core/tests/file_load_benchmark.cpp
+++ b/src/core/tests/file_load_benchmark.cpp
@@ -39,13 +39,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/file_utils.hpp"
 
-// These benchmarks measure wall-clock timing and are meaningless (and extremely slow for
-// multi-GB files) in a Debug (-O0) build.
-#ifndef NDEBUG
-#    error \
-        "file_load_benchmark.cpp must be built in Release mode: rebuild with -DCMAKE_BUILD_TYPE=Release, or delete this #error to build in Debug anyway."
-#endif
-
 namespace ov::test {
 
 namespace {
@@ -287,9 +280,18 @@ void native_stream_read(const std::filesystem::path& path, size_t file_size) {
 
 }  // namespace
 
-// See developer_benchmarks.md for build/run instructions.
+// See file_load_benchmark_guide.md for build/run instructions.
 
-class FileLoadBenchmark : public ::testing::Test {};
+class FileLoadBenchmark : public ::testing::Test {
+protected:
+    void SetUp() override {
+#ifndef NDEBUG
+        // These benchmarks measure wall-clock timing and are meaningless (and extremely slow for
+        // multi-GB files) in a Debug (-O0) build. Build in Release for meaningful results.
+        GTEST_SKIP() << "FileLoadBenchmark is a Release-only benchmark; rebuild with -DCMAKE_BUILD_TYPE=Release, or remove the skip to run it in Debug.";
+#endif
+    }
+};
 
 TEST_F(FileLoadBenchmark, native_stream_vs_parallel_stream) {
     const std::vector<size_t> sizes_bytes = {2 * util::one_mib,

--- a/src/core/tests/file_load_benchmark_guide.md
+++ b/src/core/tests/file_load_benchmark_guide.md
@@ -20,7 +20,7 @@ cmake --build <dir> --target ov_core_unit_tests_file_load_benchmark
 ## Run
 
 ```bash
-./ov_core_unit_tests_file_load_benchmark --gtest_filter=*FileLoadBenchmark*
+./ov_core_unit_tests_file_load_benchmark
 ```
 
 ## Environment Requirements

--- a/src/core/tests/file_load_benchmark_guide.md
+++ b/src/core/tests/file_load_benchmark_guide.md
@@ -3,19 +3,24 @@
 Developer-only benchmarks for comparing file-loading strategies. Use these to evaluate I/O
 performance on new hardware or to validate changes to `ov::MappedMemory`.
 
-These tests are **not compiled by default** — the target uses `EXCLUDE_FROM_ALL`.
+These tests are **not compiled by default**. The executable is built only when the
+developer option `ENABLE_TESTS_PER_SOURCE=ON` is set, and even then the target is
+`EXCLUDE_FROM_ALL` — it must be built explicitly by name. `ENABLE_TESTS_PER_SOURCE` is a
+developer-only flag and is not enabled in CI.
+
+**Build in Release.** In a Debug build the file still compiles, but every `FileLoadBenchmark` test is **skipped**, because the measurements are meaningless without optimizations.
 
 ## Build
 
 ```bash
-cmake -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Release <other flags> ..
-cmake --build <dir> --target ov_file_load_benchmark
+cmake -DENABLE_TESTS=ON -DENABLE_TESTS_PER_SOURCE=ON -DCMAKE_BUILD_TYPE=Release <other flags> ..
+cmake --build <dir> --target ov_core_unit_tests_file_load_benchmark
 ```
 
 ## Run
 
 ```bash
-./ov_file_load_benchmark --gtest_filter=*FileLoadBenchmark*
+./ov_core_unit_tests_file_load_benchmark --gtest_filter=*FileLoadBenchmark*
 ```
 
 ## Environment Requirements


### PR DESCRIPTION
### Details:
 - Build file_load_benchmark.cpp as a standalone `ov_core_unit_tests_file_load_benchmark` executable via `ENABLE_TESTS_PER_SOURCE`. (Previously `ov_file_load_benchmark`)
 - Replace the Debug-build #error with a runtime GTEST_SKIP() so the benchmark compiles in any build type and simply skips its tests when NDEBUG is not defined.
 - Update docs with the new target name and the `-DENABLE_TESTS_PER_SOURCE=ON` build step

### Tickets:
 - [CVS-190392](https://jira.devtools.intel.com/browse/CVS-190392)

### AI Assistance:
 - *AI assistance used: yes, code analysis *
