### PR TITLE
docs: fix typo basicly -> basically

### DIFF
--- a/src/plugins/intel_npu/docs/npu-properties-howto.md
+++ b/src/plugins/intel_npu/docs/npu-properties-howto.md
@@ -260,7 +260,7 @@ at this point, the npu plugin will take care of registering and managing the opt
 It ensures that it is enabled or disabled based in the current system/environment/application configuration. 
 
 ## Step 4. Link the new property to the new option
-Fourth step is to create and register the Property (which is basicly the interface to this configuration option) for both Plugin and CompiledModel (if needed) 
+Fourth step is to create and register the Property (which is basically the interface to this configuration option) for both Plugin and CompiledModel (if needed) 
 ### For plugin
 npu_plugin/plugin/src/plugin_property_manager.cpp > function PluginPropertyManager::registerProperties()
 ```cpp


### PR DESCRIPTION
Corrects the misspelling `basicly` -> `basically` in `src/plugins/intel_npu/docs/npu-properties-howto.md`.

Documentation only, no behaviour change.