### PR TITLE
[TEMPLATE] Fix Gather f8e4m3/exotic-dtype shape-infer bug surfaced by GQA sliding-window cache

### DIFF
--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -6106,12 +6106,11 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_sliding_window_cache_staging) {
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_sliding_window_cache_static_staging) {
     // INTERPRETER returns present_key/present_value with shape [0] instead of [1,1,4,16] on this fully-static
     // staging graph, while CPU matches expected values exactly - a template-backend constant-folding quirk in
-    // this backend, not a decomposition bug. Fixed by the infer_postprocess copy-back fix, split into its own
-    // PR per reviewer request; drop this skip once that PR lands on this branch.
+    // this backend, not a decomposition bug. Needs follow-up; not blocking.
     if (std::string("${BACKEND_NAME}") == std::string("INTERPRETER")) {
         GTEST_SKIP() << "INTERPRETER computes present_key/present_value as shape [0] on this fully-static "
-                        "staging graph; verified correct on CPU (exact expected-value match). Fixed by the "
-                        "infer_postprocess copy-back fix in a separate PR, not yet on this branch.";
+                        "staging graph; verified correct on CPU (exact expected-value match). Likely a "
+                        "template-backend constant-folding quirk, not a decomposition bug. Needs follow-up.";
     }
     auto model = convert_model("com.microsoft/gqa_sliding_window_cache_static_staging.onnx");
     model->reshape({{"past_key", ov::PartialShape{1, 1, 4, 16}},

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -4720,13 +4720,6 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_i4kv_sliding_window_cache) {
 // last 2 f8 rows + the new token, tail zeroed. Runs on CPU and GPU (both now have an f8e4m3 Gather
 // kernel for the windowed present assembly).
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_f8e4m3fnkv_sliding_window_cache) {
-    // TEMPLATE hits a pre-existing shape-inference quirk on this fully-static graph ("to_shape was
-    // called on a dynamic shape"), the same class of INTERPRETER-only issue documented on
-    // onnx_model_gqa_sliding_window_cache_static_staging below; verified correct on CPU/GPU.
-    if (s_device == ov::test::utils::DEVICE_TEMPLATE) {
-        GTEST_SKIP() << "TEMPLATE hits a pre-existing dynamic-shape quirk on this fully-static "
-                        "f8e4m3 windowed-cache graph; verified correct on CPU/GPU. Needs follow-up.";
-    }
     auto model = convert_model("com.microsoft/gqa_f8e4m3fnkv_swc.onnx");
     model->reshape({{"query", ov::PartialShape{1, 1, 64}},
                     {"past_key", ov::PartialShape{1, 1, 4, 16}},
@@ -6113,11 +6106,12 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_sliding_window_cache_staging) {
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_sliding_window_cache_static_staging) {
     // INTERPRETER returns present_key/present_value with shape [0] instead of [1,1,4,16] on this fully-static
     // staging graph, while CPU matches expected values exactly - a template-backend constant-folding quirk in
-    // this backend, not a decomposition bug. Needs follow-up; not blocking.
+    // this backend, not a decomposition bug. Fixed by the infer_postprocess copy-back fix, split into its own
+    // PR per reviewer request; drop this skip once that PR lands on this branch.
     if (std::string("${BACKEND_NAME}") == std::string("INTERPRETER")) {
         GTEST_SKIP() << "INTERPRETER computes present_key/present_value as shape [0] on this fully-static "
-                        "staging graph; verified correct on CPU (exact expected-value match). Likely a "
-                        "template-backend constant-folding quirk, not a decomposition bug. Needs follow-up.";
+                        "staging graph; verified correct on CPU (exact expected-value match). Fixed by the "
+                        "infer_postprocess copy-back fix in a separate PR, not yet on this branch.";
     }
     auto model = convert_model("com.microsoft/gqa_sliding_window_cache_static_staging.onnx");
     model->reshape({{"past_key", ov::PartialShape{1, 1, 4, 16}},

--- a/src/plugins/template/backend/ops/gather.cpp
+++ b/src/plugins/template/backend/ops/gather.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/gather.hpp"
 
 #include "evaluate_node.hpp"
+#include "gather_shape_inference.hpp"
 #include "openvino/core/type/element_type_traits.hpp"
 #include "openvino/op/gather.hpp"
 
@@ -13,31 +14,39 @@ bool evaluate(const std::shared_ptr<ov::op::v8::Gather>& op,
               ov::TensorVector& outputs,
               const ov::TensorVector& inputs) {
     using T = typename ov::element_type_traits<ET>::value_type;
+    const auto& data_shape = inputs[0].get_shape();
+    const auto& indices_shape = inputs[1].get_shape();
+    // Shape-infer from actual tensor shapes (as GatherND's evaluate does), not op->get_output_shape()
+    // (throws if the node's static PartialShape is dynamic, e.g. indices from a data-dependent subgraph).
+    const auto output_shapes =
+        ov::op::shape_infer(op.get(), ov::util::get_tensors_partial_shapes(inputs), ov::make_tensor_accessor(inputs));
+    const auto output_shape = output_shapes[0].get_shape();
+    outputs[0].set_shape(output_shape);
     if (op->get_input_element_type(1) == ov::element::u64) {
         ov::reference::gather<T, uint64_t>(inputs[0].data<T>(),
                                            inputs[1].data<uint64_t>(),
                                            outputs[0].data<T>(),
-                                           op->get_input_shape(0),
-                                           op->get_input_shape(1),
-                                           op->get_output_shape(0),
+                                           data_shape,
+                                           indices_shape,
+                                           output_shape,
                                            static_cast<size_t>(op->get_axis()),
                                            op->get_batch_dims());
     } else if (op->get_input_element_type(1) == ov::element::i64) {
         ov::reference::gather<T, int64_t>(inputs[0].data<T>(),
                                           inputs[1].data<int64_t>(),
                                           outputs[0].data<T>(),
-                                          op->get_input_shape(0),
-                                          op->get_input_shape(1),
-                                          op->get_output_shape(0),
+                                          data_shape,
+                                          indices_shape,
+                                          output_shape,
                                           static_cast<size_t>(op->get_axis()),
                                           op->get_batch_dims());
     } else if (op->get_input_element_type(1) == ov::element::i32) {
         ov::reference::gather<T, int32_t>(inputs[0].data<T>(),
                                           inputs[1].data<int32_t>(),
                                           outputs[0].data<T>(),
-                                          op->get_input_shape(0),
-                                          op->get_input_shape(1),
-                                          op->get_output_shape(0),
+                                          data_shape,
+                                          indices_shape,
+                                          output_shape,
                                           static_cast<size_t>(op->get_axis()),
                                           op->get_batch_dims());
     } else {

--- a/src/plugins/template/backend/ops/gather.cpp
+++ b/src/plugins/template/backend/ops/gather.cpp
@@ -22,6 +22,12 @@ bool evaluate(const std::shared_ptr<ov::op::v8::Gather>& op,
         ov::op::shape_infer(op.get(), ov::util::get_tensors_partial_shapes(inputs), ov::make_tensor_accessor(inputs));
     const auto output_shape = output_shapes[0].get_shape();
     outputs[0].set_shape(output_shape);
+    // Normalize against runtime ranks, like GatherBase::evaluate - op->get_axis()/get_batch_dims() only
+    // normalize against the node's static IR shape, underflowing to size_t when that shape is dynamic.
+    const auto axis = static_cast<size_t>(
+        ov::util::normalize(ov::get_tensor_data_as<int64_t>(inputs[2])[0], static_cast<int64_t>(data_shape.size())));
+    const auto batch_dims =
+        static_cast<size_t>(ov::util::normalize(op->get_batch_dims(), static_cast<int64_t>(indices_shape.size())));
     if (op->get_input_element_type(1) == ov::element::u64) {
         ov::reference::gather<T, uint64_t>(inputs[0].data<T>(),
                                            inputs[1].data<uint64_t>(),
@@ -29,8 +35,8 @@ bool evaluate(const std::shared_ptr<ov::op::v8::Gather>& op,
                                            data_shape,
                                            indices_shape,
                                            output_shape,
-                                           static_cast<size_t>(op->get_axis()),
-                                           op->get_batch_dims());
+                                           axis,
+                                           batch_dims);
     } else if (op->get_input_element_type(1) == ov::element::i64) {
         ov::reference::gather<T, int64_t>(inputs[0].data<T>(),
                                           inputs[1].data<int64_t>(),
@@ -38,8 +44,8 @@ bool evaluate(const std::shared_ptr<ov::op::v8::Gather>& op,
                                           data_shape,
                                           indices_shape,
                                           output_shape,
-                                          static_cast<size_t>(op->get_axis()),
-                                          op->get_batch_dims());
+                                          axis,
+                                          batch_dims);
     } else if (op->get_input_element_type(1) == ov::element::i32) {
         ov::reference::gather<T, int32_t>(inputs[0].data<T>(),
                                           inputs[1].data<int32_t>(),
@@ -47,8 +53,8 @@ bool evaluate(const std::shared_ptr<ov::op::v8::Gather>& op,
                                           data_shape,
                                           indices_shape,
                                           output_shape,
-                                          static_cast<size_t>(op->get_axis()),
-                                          op->get_batch_dims());
+                                          axis,
+                                          batch_dims);
     } else {
         OPENVINO_THROW("Unexpected indices type for Gather operation");
     }

--- a/src/plugins/template/tests/functional/op_reference/gather.cpp
+++ b/src/plugins/template/tests/functional/op_reference/gather.cpp
@@ -791,10 +791,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_Gather_With_Hardcoded_Refs,
 
 class ReferenceGatherRegressionTest : public CommonReferenceTest, public testing::Test {};
 
-// The node's own PartialShape is dynamic (indices declared with a dynamic shape, as when they come from
-// a data-dependent subgraph) even though every tensor is concrete at evaluate() time. Previously crashed
-// with "to_shape was called on a dynamic shape" because evaluate<ET>() shape-inferred from
-// op->get_output_shape() instead of the actual runtime tensor shapes.
 TEST_F(ReferenceGatherRegressionTest, ExoticDtypeDynamicShapeIndices) {
     const auto P = std::make_shared<op::v0::Parameter>(element::f8e4m3, Shape{4, 2});
     const auto I = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));

--- a/src/plugins/template/tests/functional/op_reference/gather.cpp
+++ b/src/plugins/template/tests/functional/op_reference/gather.cpp
@@ -788,4 +788,25 @@ INSTANTIATE_TEST_SUITE_P(smoke_Gather_With_Hardcoded_Refs,
                          ReferenceGatherTestV8,
                          testing::ValuesIn(generateCombinedParamsV8()),
                          ReferenceGatherTestV8::getTestCaseName);
+
+class ReferenceGatherRegressionTest : public CommonReferenceTest, public testing::Test {};
+
+// The node's own PartialShape is dynamic (indices declared with a dynamic shape, as when they come from
+// a data-dependent subgraph) even though every tensor is concrete at evaluate() time. Previously crashed
+// with "to_shape was called on a dynamic shape" because evaluate<ET>() shape-inferred from
+// op->get_output_shape() instead of the actual runtime tensor shapes.
+TEST_F(ReferenceGatherRegressionTest, ExoticDtypeDynamicShapeIndices) {
+    const auto P = std::make_shared<op::v0::Parameter>(element::f8e4m3, Shape{4, 2});
+    const auto I = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
+    const auto A = op::v0::Constant::create(element::i64, Shape{}, {0});
+    const auto G = std::make_shared<op::v8::Gather>(P, I, A);
+    function = std::make_shared<Model>(G, ParameterVector{P, I});
+
+    inputData = {CreateTensor(Shape{4, 2},
+                              element::f8e4m3,
+                              std::vector<ov::float8_e4m3>{1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f}),
+                 CreateTensor(Shape{2}, element::i64, std::vector<int64_t>{0, 2})};
+    refOutData = {CreateTensor(Shape{2, 2}, element::f8e4m3, std::vector<ov::float8_e4m3>{1.f, 2.f, 5.f, 6.f})};
+    Exec();
+}
 }  // namespace


### PR DESCRIPTION
## Summary

A pre-existing TEMPLATE (reference/interpreter) plugin bug surfaced by GroupQueryAttention's `sliding_window_cache` decomposition but not specific to it. Split out of this PR's original scope per reviewer request — the unrelated `sync_infer_request.cpp` output copy-back fix now lives in its own PR (#TBD, will link once opened).

- **Gather (`src/plugins/template/backend/ops/gather.cpp`)**: the per-type reference `evaluate()` built shapes via `op->get_input_shape()`/`get_output_shape()`, which convert the node's *static* PartialShape and throw if it's dynamic. That shape is genuinely dynamic whenever `Gather`'s indices come from a data-dependent subgraph (e.g. a windowed KV-cache eviction count computed from a runtime scalar), even though every tensor is concrete at `evaluate()` time. Only element types missing from the generic core Gather dispatch (`f8e4m3, bf16, f64, i4, i16, u1, u4, u16`) take this path — every common dtype already goes through the unaffected generic `GatherBase::evaluate()`. Fixed to shape-infer from actual tensor shapes and values via `ov::op::shape_infer(op.get(), ov::util::get_tensors_partial_shapes(inputs), ov::make_tensor_accessor(inputs))`, mirroring the pattern `gather_nd.cpp` already uses correctly. The tensor accessor was added per review feedback.

Un-skips `onnx_model_gqa_f8e4m3fnkv_sliding_window_cache` on TEMPLATE/INTERPRETER, fixed by the above.

**On the non-Constant `axis` case raised in review:** confirmed by direct reproduction that this is unreachable through the standard compile pipeline today — a graph with a non-Constant `axis` input already fails during `compile_model()` in the core `EliminateGather` common-optimization pass (`Check 'const_op' failed ... axis value is not set`), independent of this plugin or this fix. So `axis` is always Constant-resolvable by the time TEMPLATE's `evaluate()` runs, and no test was added for that specific scenario — it isn't constructible. The tensor accessor addition above is kept as suggested since it's correct and harmless, but the practical bug (and the new regression test) is about the *indices* input's dynamic shape, not `axis`.

Added a dedicated TEMPLATE-plugin regression test (`ReferenceGatherRegressionTest.ExoticDtypeDynamicShapeIndices` in `src/plugins/template/tests/functional/op_reference/gather.cpp`) that reproduces the original crash directly — f8e4m3 data with indices declared with a dynamic `PartialShape` — independent of the GQA ONNX model, per review request for template-plugin-level coverage.

## Test plan

- `ov_onnx_frontend_tests --gtest_filter=*gqa*` (CPU+GPU+INTERPRETER): 153 passed, 6 skipped (5 pre-existing unrelated GPU present-cache staging gaps, plus `onnx_model_gqa_sliding_window_cache_static_staging` on INTERPRETER which is fixed by the split-out PR, not this one)
- `ov_core_unit_tests`/`ov_transformations_tests` (GQA filters): 19/19 and 31/31, no change
- `ov_npu_unit_tests` (GQA/NPUW filters): 87/87 passed, no change
- `ov_template_func_tests --gtest_filter=*Gather*` (excluding the pre-existing flaky `someLayersToMajorPluginOthersToFallback` randomized-model tests): 770/770 passed, including the new independent regression test
- A/B verified against unmodified `gather.cpp`: the fix only changes behavior on the previously-crashing dynamic-shape path; all pre-existing Gather cases unaffected

## Ticket

- CVS-192121

## AI Assistance:

AI assistance used: yes
AI helped debug & create the basic change, and it is reviewed and modified by engineer.