### PR TITLE
docs: fix typo exisiting -> existing

### DIFF
--- a/src/bindings/python/docs/code_examples.md
+++ b/src/bindings/python/docs/code_examples.md
@@ -34,7 +34,7 @@ openvino/               <-- Main package/namespace
     └── myclass.py
 ```
 
-Now let's add it to your exisiting `PYTHONPATH` (replace `[your_path]` with correct path to the OpenVINO™ project):
+Now let's add it to your existing `PYTHONPATH` (replace `[your_path]` with correct path to the OpenVINO™ project):
 
     export PYTHONPATH=$PYTHONPATH:[your_path]/openvino/src/bindings/python/docs/examples/
 


### PR DESCRIPTION
Corrects the misspelling `exisiting` -> `existing` in `src/bindings/python/docs/code_examples.md`.

Documentation only, no behaviour change.