### PR TITLE
fix: guard against empty cpu_ids in pin_thread_to_vacant_core on Windows

### DIFF
--- a/src/inference/src/dev/threading/thread_affinity.cpp
+++ b/src/inference/src/dev/threading/thread_affinity.cpp
@@ -126,7 +126,6 @@ bool pin_thread_to_vacant_core(int thrIdx,
                                int ncores,
                                const CpuSet& procMask,
                                const std::vector<int>& cpu_ids) {
-    // Guard: if cpu_ids is empty (e.g. restricted process affinity, VM, THREADING=SEQ),
     // skip pinning silently instead of crashing with out-of-bounds access.
     if (cpu_ids.empty()) {
         return false;

--- a/src/inference/src/dev/threading/thread_affinity.cpp
+++ b/src/inference/src/dev/threading/thread_affinity.cpp
@@ -126,6 +126,11 @@ bool pin_thread_to_vacant_core(int thrIdx,
                                int ncores,
                                const CpuSet& procMask,
                                const std::vector<int>& cpu_ids) {
+    // Guard: if cpu_ids is empty (e.g. restricted process affinity, VM, THREADING=SEQ),
+    // skip pinning silently instead of crashing with out-of-bounds access.
+    if (cpu_ids.empty()) {
+        return false;
+    }
     auto proc_type_table = get_proc_type_table();
     if (proc_type_table.size() > 1) {
         int cores_in_numa = proc_type_table[1][MAIN_CORE_PROC] + proc_type_table[1][HYPER_THREADING_PROC] +

--- a/src/inference/tests/unit/thread_affinity_test.cpp
+++ b/src/inference/tests/unit/thread_affinity_test.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/test_common.hpp"
+#include "dev/threading/thread_affinity.hpp"
+
+using namespace ov::threading;
+
+#if defined(_WIN32)
+
+// Regression test for: pin_thread_to_vacant_core crashes with read access violation
+// when cpu_ids is empty (e.g. THREADING=SEQ build, VM, restricted process affinity on Windows).
+// Fix: added cpu_ids.empty() guard that returns false instead of indexing out-of-bounds.
+
+TEST(ThreadAffinityTest, PinThreadToVacantCore_EmptyCpuIds_ReturnsFalse) {
+    CpuSet mask = nullptr;
+    std::vector<int> empty_cpu_ids = {};
+
+    // Before fix: read access violation crash on cpu_ids[thrIdx]
+    // After fix:  returns false gracefully
+    bool result = pin_thread_to_vacant_core(0, 1, 4, mask, empty_cpu_ids);
+
+    EXPECT_FALSE(result);
+}
+
+TEST(ThreadAffinityTest, PinThreadToVacantCore_ValidCpuIds_DoesNotThrow) {
+    // Normal path: ensure guard did not break the valid case
+    CpuSet mask = nullptr;
+    std::vector<int> cpu_ids = {0, 1, 2, 3};
+
+    EXPECT_NO_THROW(pin_thread_to_vacant_core(0, 1, 4, mask, cpu_ids));
+}
+
+#endif  // defined(_WIN32)

--- a/src/inference/tests/unit/thread_affinity_test.cpp
+++ b/src/inference/tests/unit/thread_affinity_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2026 Intel Corporation
+﻿// Copyright (C) 2018-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -10,24 +10,15 @@
 using namespace ov::threading;
 
 #if defined(_WIN32)
-
-// Regression test for: pin_thread_to_vacant_core crashes with read access violation
-// when cpu_ids is empty (e.g. THREADING=SEQ build, VM, restricted process affinity on Windows).
-// Fix: added cpu_ids.empty() guard that returns false instead of indexing out-of-bounds.
-
 TEST(ThreadAffinityTest, PinThreadToVacantCore_EmptyCpuIds_ReturnsFalse) {
     CpuSet mask = nullptr;
     std::vector<int> empty_cpu_ids = {};
-
-    // Before fix: read access violation crash on cpu_ids[thrIdx]
-    // After fix:  returns false gracefully
     bool result = pin_thread_to_vacant_core(0, 1, 4, mask, empty_cpu_ids);
 
     EXPECT_FALSE(result);
 }
-
 TEST(ThreadAffinityTest, PinThreadToVacantCore_ValidCpuIds_DoesNotThrow) {
-    // Normal path: ensure guard did not break the valid case
+    // Normal path: ensure guard didn't break the valid case
     CpuSet mask = nullptr;
     std::vector<int> cpu_ids = {0, 1, 2, 3};
 


### PR DESCRIPTION
### Details:
 - Fixed a read access violation crash in `pin_thread_to_vacant_core` on Windows
   when `cpu_ids` is empty. This occurs when building with `THREADING=SEQ` or
   running in environments with restricted process affinity (VMs, containers,
   limited Windows affinity masks).
 - The Windows implementation indexed into `cpu_ids[thrIdx]` without a size check,
   causing a crash. Added an early `return false` guard when `cpu_ids` is empty,
   preventing the out-of-bounds access.
 - Added regression tests in `thread_affinity_test.cpp` covering:
   - Empty `cpu_ids` returns `false` without crashing
   - Valid `cpu_ids` path still works correctly after the guard

 **Note for future improvement:** Even with `THREADING=SEQ`, `CPUStreamsExecutor`
 still spawns an internal `std::thread` unconditionally. In single-threaded use
 cases, which are likely on resource-constrained systems, this worker thread
 is wasteful. A more complete fix would skip thread spawning entirely when
 sequential mode is configured. Since OV_THREAD_SEQ is already used as a guard elsewhere in
the same file, skipping thread spawning in SEQ mode would be a straightforward
follow-up improvement. Let me know if i should implement this follow up fix.

### Tickets:
 - #37367

### AI Assistance:
 - *AI assistance used: yes*
 - Used for navigating the codebase and identifying the root cause.
   Human validation: fix logic reviewed manually against the Linux implementation.
   Writing unit tests.