### PR TITLE
[Snippets] Share nodes in GroupNormalization decomposition

### DIFF
--- a/src/common/snippets/src/lowered/pass/move_scalar_to_consumer.cpp
+++ b/src/common/snippets/src/lowered/pass/move_scalar_to_consumer.cpp
@@ -5,10 +5,13 @@
 #include "snippets/lowered/pass/move_scalar_to_consumer.hpp"
 
 #include <iterator>
+#include <set>
+#include <vector>
 
 #include "openvino/core/except.hpp"
 #include "openvino/core/type.hpp"
 #include "snippets/itt.hpp"
+#include "snippets/lowered/expression_port.hpp"
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/op/scalar.hpp"
 
@@ -31,9 +34,17 @@ bool MoveScalarToConsumer::run(LinearIR& linear_ir) {
             auto consumer_expr = consumers.begin()->get_expr();
             const auto& loop_ids = consumer_expr->get_loop_ids();
             for (const auto& consumer : consumers) {
-                OPENVINO_ASSERT(consumer.get_expr()->get_loop_ids() == loop_ids,
-                                "All consumers of a Scalar expression are expected to have the same loop IDs");
-                if (consumer.get_expr()->get_exec_num() < consumer_expr->get_exec_num()) {
+                if (consumer.get_expr()->get_loop_ids() != loop_ids) {
+                    const auto scalar = ov::as_type_ptr<op::Scalar>(expr->get_node());
+                    const auto consumer_expr_it = linear_ir.find(consumer.get_expr());
+                    const auto scalar_clone = std::make_shared<op::Scalar>(*scalar);
+                    linear_ir.insert_node(scalar_clone,
+                                          std::vector<PortConnectorPtr>{},
+                                          consumer.get_expr()->get_loop_ids(),
+                                          false,
+                                          consumer_expr_it,
+                                          std::set<ExpressionPort>{consumer});
+                } else if (consumer.get_expr()->get_exec_num() < consumer_expr->get_exec_num()) {
                     consumer_expr = consumer.get_expr();
                 }
             }

--- a/src/common/snippets/src/pass/gn_decomposition.cpp
+++ b/src/common/snippets/src/pass/gn_decomposition.cpp
@@ -65,12 +65,12 @@ GNDecomposition::GNDecomposition() {
         ov::Shape group_shape = {orig_shape[0], num_groups, 1UL, c_in_group * spatial_dim};
         std::shared_ptr<ov::Node> reshaped_node_orig = std::make_shared<ov::snippets::op::Reshape>(data, group_shape);
 
-        std::shared_ptr<ov::Node> reshaped_node1 = reshaped_node_orig;
+        std::shared_ptr<ov::Node> reshaped_node = reshaped_node_orig;
         if (data.get_element_type() != element::f32) {
-            reshaped_node1 = std::make_shared<ov::snippets::op::ConvertSaturation>(reshaped_node_orig, element::f32);
+            reshaped_node = std::make_shared<ov::snippets::op::ConvertSaturation>(reshaped_node_orig, element::f32);
         }
 
-        const auto reduce_sum = std::make_shared<ov::snippets::op::ReduceSum>(reshaped_node1, group_rank - 1);
+        const auto reduce_sum = std::make_shared<ov::snippets::op::ReduceSum>(reshaped_node, group_rank - 1);
         op::ReduceBase::compute_and_set_reduce_subtensors(reduce_sum);
 
         // reduceMean
@@ -80,11 +80,7 @@ GNDecomposition::GNDecomposition() {
         const auto reduce_mean = std::make_shared<ov::op::v1::Multiply>(reduce_sum, group_size_inv_node);
 
         // x - mean
-        std::shared_ptr<ov::Node> reshaped_node2 = reshaped_node_orig;
-        if (data.get_element_type() != element::f32) {
-            reshaped_node2 = std::make_shared<ov::snippets::op::ConvertSaturation>(reshaped_node_orig, element::f32);
-        }
-        auto sub_mean = std::make_shared<ov::op::v1::Subtract>(reshaped_node2, reduce_mean);
+        auto sub_mean = std::make_shared<ov::op::v1::Subtract>(reshaped_node, reduce_mean);
         // (x - mean) ^ 2
         auto sqr_const = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{1}, std::vector<float>{2});
         auto sqr = std::make_shared<ov::op::v1::Power>(sub_mean, sqr_const);
@@ -92,9 +88,7 @@ GNDecomposition::GNDecomposition() {
         auto sqr_reduce_sum = std::make_shared<ov::snippets::op::ReduceSum>(sqr, group_rank - 1);
         op::ReduceBase::compute_and_set_reduce_subtensors(sqr_reduce_sum);
         // reduceMean((x - mean) ^ 2)
-        const auto group_size_inv_node_aux =
-            std::make_shared<ov::op::v0::Constant>(element::f32, Shape{}, std::vector<float>{group_size_inv});
-        auto sqr_mean = std::make_shared<ov::op::v1::Multiply>(sqr_reduce_sum, group_size_inv_node_aux);
+        auto sqr_mean = std::make_shared<ov::op::v1::Multiply>(sqr_reduce_sum, group_size_inv_node);
         // reduceMean((x - mean) ^ 2) + eps
         auto eps_node = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{1}, std::vector<float>{eps});
         auto eps_add = std::make_shared<ov::op::v1::Add>(sqr_mean, eps_node);  // fma to this add and parent multiply

--- a/src/common/snippets/tests/src/pass/gn_decomposition.cpp
+++ b/src/common/snippets/tests/src/pass/gn_decomposition.cpp
@@ -5,6 +5,15 @@
 #include <gtest/gtest.h>
 #include "pass/gn_decomposition.hpp"
 #include "common_test_utils/common_utils.hpp"
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/group_normalization.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/subtract.hpp"
+#include "snippets/op/convert_saturation.hpp"
+#include "snippets/op/reduce.hpp"
+#include "snippets/op/reshape.hpp"
+#include "snippets/pass/gn_decomposition.hpp"
 #include "subgraph_group_normalization.hpp"
 #include "subgraph_lowered.hpp"
 
@@ -35,6 +44,55 @@ TEST_P(GNDecompositionTest, GNDecomposition) {
     auto subgraph = getLoweredSubgraph(snippets_model->getOriginal());
     model = subgraph->body_ptr();
     model_ref = snippets_model->getLowered();
+}
+
+TEST_F(TransformationTestsF, GNDecompositionNonF32SharesCommonNodes) {
+    const auto data = std::make_shared<op::v0::Parameter>(element::f16, Shape{1, 8, 2, 2});
+    const auto scale = std::make_shared<op::v0::Parameter>(element::f32, Shape{8});
+    const auto bias = std::make_shared<op::v0::Parameter>(element::f32, Shape{8});
+    const auto group_norm = std::make_shared<op::v12::GroupNormalization>(data, scale, bias, 4, 0.0001);
+    model = std::make_shared<Model>(OutputVector{group_norm}, ParameterVector{data, scale, bias});
+
+    ov::pass::Manager decomposition_manager;
+    decomposition_manager.register_pass<ov::snippets::pass::GNDecomposition>();
+    decomposition_manager.run_passes(model);
+
+    std::vector<std::shared_ptr<ov::snippets::op::ConvertSaturation>> data_converts;
+    std::vector<std::shared_ptr<op::v0::Constant>> group_size_constants;
+    for (const auto& node : model->get_ops()) {
+        if (const auto convert = ov::as_type_ptr<ov::snippets::op::ConvertSaturation>(node)) {
+            const auto reshape = convert->input_value(0).get_node_shared_ptr();
+            if (ov::is_type<ov::snippets::op::Reshape>(reshape) &&
+                reshape->input_value(0).get_node_shared_ptr() == data) {
+                data_converts.push_back(convert);
+            }
+        }
+
+        if (const auto constant = ov::as_type_ptr<op::v0::Constant>(node);
+            constant && constant->get_shape() == Shape{} && constant->get_vector<float>().at(0) == 0.125F) {
+            group_size_constants.push_back(constant);
+        }
+    }
+
+    ASSERT_EQ(data_converts.size(), 1);
+    const auto& convert_consumers = data_converts.front()->output(0).get_target_inputs();
+    ASSERT_EQ(convert_consumers.size(), 2);
+    bool has_reduce_sum = false;
+    bool has_subtract = false;
+    for (const auto& consumer : convert_consumers) {
+        has_reduce_sum |= ov::is_type<ov::snippets::op::ReduceSum>(consumer.get_node());
+        has_subtract |= ov::is_type<op::v1::Subtract>(consumer.get_node());
+    }
+    EXPECT_TRUE(has_reduce_sum);
+    EXPECT_TRUE(has_subtract);
+
+    ASSERT_EQ(group_size_constants.size(), 1);
+    const auto& constant_consumers = group_size_constants.front()->output(0).get_target_inputs();
+    ASSERT_EQ(constant_consumers.size(), 2);
+    for (const auto& consumer : constant_consumers) {
+        EXPECT_TRUE(ov::is_type<op::v1::Multiply>(consumer.get_node()));
+        EXPECT_EQ(consumer.get_index(), 1);
+    }
 }
 
 namespace GNDecompositionTestInstantiation {


### PR DESCRIPTION

### Details:
- Avoid duplicate conversion and group size nodes
- Keep lowering valid when consumers use different loops

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
 - Implementation is assisted and after that manually tested and reviewed
