### PR TITLE
Avoid GCC psABI notes for pair values

### DIFF
--- a/src/common/low_precision_transformations/tests/kv_cache_static_quantization.cpp
+++ b/src/common/low_precision_transformations/tests/kv_cache_static_quantization.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+
 #include "common_test_utils/ov_test_utils.hpp"
 #include "common_test_utils/subgraph_builders/llm_builders.hpp"
 #include "low_precision/concat.hpp"
@@ -229,11 +231,11 @@ std::shared_ptr<ov::Model> KVCacheStaticQuantization::get_model_ref(ov::element:
             const auto [lower_bound, upper_bound] = [&]() {
                 switch (low_precision) {
                 case ov::element::f8e4m3:
-                    return std::make_pair(static_cast<double>(std::numeric_limits<ov::float8_e4m3>::lowest()),
-                                          static_cast<double>(std::numeric_limits<ov::float8_e4m3>::max()));
+                    return std::array<double, 2>{static_cast<double>(std::numeric_limits<ov::float8_e4m3>::lowest()),
+                                                 static_cast<double>(std::numeric_limits<ov::float8_e4m3>::max())};
                 case ov::element::f8e5m2:
-                    return std::make_pair(static_cast<double>(std::numeric_limits<ov::float8_e5m2>::lowest()),
-                                          static_cast<double>(std::numeric_limits<ov::float8_e5m2>::max()));
+                    return std::array<double, 2>{static_cast<double>(std::numeric_limits<ov::float8_e5m2>::lowest()),
+                                                 static_cast<double>(std::numeric_limits<ov::float8_e5m2>::max())};
                 default:
                     OPENVINO_THROW("Unsupported destination element type: ", low_precision);
                 }

--- a/src/common/snippets/src/lowered/pass/init_live_ranges.cpp
+++ b/src/common/snippets/src/lowered/pass/init_live_ranges.cpp
@@ -108,7 +108,7 @@ bool InitLiveRanges::run(LinearIR& linear_ir) {
                 }
             }
             regs_to_expire[stop].insert(reg);
-            m_reg_manager.set_live_range(reg, std::make_pair(start, stop));
+            m_reg_manager.set_live_range(reg, LiveInterval{start, stop});
         }
     }
 

--- a/src/common/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
@@ -135,12 +135,12 @@ ConvertQuantizeDequantize::ConvertQuantizeDequantize(const ov::element::TypeVect
         if (!op_util::get_single_value(output_high, out_high_val))
             return false;
 
-#define PRECISION_LIMITS_FOR(type)                                                                           \
-    {                                                                                                        \
-        ov::element::type,                                                                                   \
-            std::pair<float, float>{                                                                        \
-                static_cast<float>(std::numeric_limits<ov::fundamental_type_for<ov::element::type>>::min()), \
-                static_cast<float>(std::numeric_limits<ov::fundamental_type_for<ov::element::type>>::max())} \
+#define PRECISION_LIMITS_FOR(type)                                                                          \
+    {                                                                                                       \
+        ov::element::type, std::pair<float, float> {                                                        \
+            static_cast<float>(std::numeric_limits<ov::fundamental_type_for<ov::element::type>>::min()),    \
+                static_cast<float>(std::numeric_limits<ov::fundamental_type_for<ov::element::type>>::max()) \
+        }                                                                                                   \
     }
 
         static const std::unordered_map<ov::element::Type_t, std::pair<float, float>> supported_intervals{

--- a/src/common/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_quantize_dequantize.cpp
@@ -138,9 +138,9 @@ ConvertQuantizeDequantize::ConvertQuantizeDequantize(const ov::element::TypeVect
 #define PRECISION_LIMITS_FOR(type)                                                                           \
     {                                                                                                        \
         ov::element::type,                                                                                   \
-            std::make_pair(                                                                                  \
+            std::pair<float, float>{                                                                        \
                 static_cast<float>(std::numeric_limits<ov::fundamental_type_for<ov::element::type>>::min()), \
-                static_cast<float>(std::numeric_limits<ov::fundamental_type_for<ov::element::type>>::max())) \
+                static_cast<float>(std::numeric_limits<ov::fundamental_type_for<ov::element::type>>::max())} \
     }
 
         static const std::unordered_map<ov::element::Type_t, std::pair<float, float>> supported_intervals{
@@ -154,7 +154,7 @@ ConvertQuantizeDequantize::ConvertQuantizeDequantize(const ov::element::TypeVect
         // check if (out_low_val, out_high_val) pair is mapped on the expected precision ranges
         auto interval_it = supported_intervals.find(type);
         if (interval_it == supported_intervals.end() ||
-            interval_it->second != std::make_pair(out_low_val, out_high_val)) {
+            interval_it->second != std::pair<float, float>{out_low_val, out_high_val}) {
             return false;
         }
 

--- a/src/common/transformations/src/transformations/op_conversions/fake_convert_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/fake_convert_decomposition.cpp
@@ -4,6 +4,8 @@
 
 #include "transformations/op_conversions/fake_convert_decomposition.hpp"
 
+#include <array>
+
 #include "itt.hpp"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
@@ -65,11 +67,11 @@ ov::pass::FakeConvertDecomposition::FakeConvertDecomposition() {
         const auto [lower_bound, upper_bound] = [&]() {
             switch (fake_convert->get_destination_element_type()) {
             case ov::element::f8e4m3:
-                return std::make_pair(static_cast<double>(std::numeric_limits<ov::float8_e4m3>::lowest()),
-                                      static_cast<double>(std::numeric_limits<ov::float8_e4m3>::max()));
+                return std::array<double, 2>{static_cast<double>(std::numeric_limits<ov::float8_e4m3>::lowest()),
+                                             static_cast<double>(std::numeric_limits<ov::float8_e4m3>::max())};
             case ov::element::f8e5m2:
-                return std::make_pair(static_cast<double>(std::numeric_limits<ov::float8_e5m2>::lowest()),
-                                      static_cast<double>(std::numeric_limits<ov::float8_e5m2>::max()));
+                return std::array<double, 2>{static_cast<double>(std::numeric_limits<ov::float8_e5m2>::lowest()),
+                                             static_cast<double>(std::numeric_limits<ov::float8_e5m2>::max())};
             default:
                 OPENVINO_THROW("Unsupported destination element type: ", fake_convert->get_destination_element_type());
             }

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -5,6 +5,7 @@
 #include "roi_pooling.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <common/float16.hpp>
 #include <common/utils.hpp>
@@ -987,15 +988,15 @@ std::tuple<int, int, int, int> ROIPooling::ROIPoolingExecutor::getBordersForMaxM
 }
 
 std::array<float, 2> ROIPooling::ROIPoolingExecutor::getXYForBilinearMode(const float roi_start_h,
-                                                                             const float roi_end_h,
-                                                                             const float roi_start_w,
-                                                                             const float roi_end_w,
-                                                                             const int ih,
-                                                                             const int oh,
-                                                                             const int iw,
-                                                                             const int ow,
-                                                                             const int pooled_h,
-                                                                             const int pooled_w) {
+                                                                          const float roi_end_h,
+                                                                          const float roi_start_w,
+                                                                          const float roi_end_w,
+                                                                          const int ih,
+                                                                          const int oh,
+                                                                          const int iw,
+                                                                          const int ow,
+                                                                          const int pooled_h,
+                                                                          const int pooled_w) {
     float height_scale =
         (pooled_h > 1 ? ((roi_end_h - roi_start_h) * static_cast<float>(ih - 1)) / static_cast<float>(pooled_h - 1)
                       : 0.0F);

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -986,7 +986,7 @@ std::tuple<int, int, int, int> ROIPooling::ROIPoolingExecutor::getBordersForMaxM
     return std::make_tuple(hstart, hend, wstart, wend);
 }
 
-std::pair<float, float> ROIPooling::ROIPoolingExecutor::getXYForBilinearMode(const float roi_start_h,
+std::array<float, 2> ROIPooling::ROIPoolingExecutor::getXYForBilinearMode(const float roi_start_h,
                                                                              const float roi_end_h,
                                                                              const float roi_start_w,
                                                                              const float roi_end_w,
@@ -1023,7 +1023,7 @@ std::pair<float, float> ROIPooling::ROIPoolingExecutor::getXYForBilinearMode(con
         in_x = 0.5F * (roi_start_w + roi_end_w) * static_cast<float>(iw - 1);
     }
 
-    return std::make_pair(in_x, in_y);
+    return {in_x, in_y};
 }
 
 template <typename T>

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <cassert>
 #include <cstddef>
 #include <memory>
@@ -119,7 +120,7 @@ private:
                                                                    int ow,
                                                                    int pooled_h,
                                                                    int pooled_w);
-        static std::pair<float, float> getXYForBilinearMode(float roi_start_h,
+        static std::array<float, 2> getXYForBilinearMode(float roi_start_h,
                                                             float roi_end_h,
                                                             float roi_start_w,
                                                             float roi_end_w,

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.h
@@ -121,15 +121,15 @@ private:
                                                                    int pooled_h,
                                                                    int pooled_w);
         static std::array<float, 2> getXYForBilinearMode(float roi_start_h,
-                                                            float roi_end_h,
-                                                            float roi_start_w,
-                                                            float roi_end_w,
-                                                            int ih,
-                                                            int oh,
-                                                            int iw,
-                                                            int ow,
-                                                            int pooled_h,
-                                                            int pooled_w);
+                                                         float roi_end_h,
+                                                         float roi_start_w,
+                                                         float roi_end_w,
+                                                         int ih,
+                                                         int oh,
+                                                         int iw,
+                                                         int ow,
+                                                         int pooled_h,
+                                                         int pooled_w);
 
     private:
         template <typename T>

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/clamp.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/single_layer_tests/clamp.cpp
@@ -29,6 +29,10 @@ const std::vector<std::pair<double, double>> intervals_unsigned = {
     {10.6, 20.6}
 };
 
+const std::vector<std::pair<double, double>> intervals_i64 = {
+    {static_cast<double>(std::numeric_limits<int64_t>::min()),
+     static_cast<double>(std::numeric_limits<int64_t>::max())}};
+
 const std::vector<ov::element::Type> model_type = {
     ov::element::f32,
     ov::element::f16,
@@ -52,8 +56,7 @@ const auto test_Clamp_unsigned = ::testing::Combine(
 
 const auto test_Clamp_i64 = ::testing::Combine(
     ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_static)),
-    ::testing::Values(std::pair<double, double>({static_cast<double>(std::numeric_limits<int64_t>::min()),
-                                                 static_cast<double>(std::numeric_limits<int64_t>::max())})),
+    ::testing::ValuesIn(intervals_i64),
     ::testing::Values(ov::element::i64),
     ::testing::Values(ov::test::utils::DEVICE_CPU)
 );

--- a/src/tests/functional/base_func_tests/include/shared_test_classes/base/utils/calculate_thresholds.hpp
+++ b/src/tests/functional/base_func_tests/include/shared_test_classes/base/utils/calculate_thresholds.hpp
@@ -34,7 +34,7 @@ static std::map<ov::NodeTypeInfo, Threshold> custom_op_thresholds = {
         // { ov::op::v0::Add::get_type_info_static(), { 1e-7, 1e-4 }},
 };
 
-std::pair<double, double> calculate_thresholds_by_model(
+Threshold calculate_thresholds_by_model(
     const std::shared_ptr<ov::Model>& model,
     const std::shared_ptr<ov::Model>& ref_model = nullptr,
     const ov::element::Type& inference_precision = ov::element::dynamic);

--- a/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp
@@ -517,13 +517,13 @@ void SubgraphBaseTest::validate() {
 }
 
 void SubgraphBaseTest::init_thresholds() {
-    const auto& [max_abs_threshold, max_rel_threshold] =
+    const auto thresholds =
         ov::test::utils::calculate_thresholds_by_model(function, functionRefs, inference_precision);
     if (abs_threshold == disable_threshold) {
-        abs_threshold = max_abs_threshold;
+        abs_threshold = thresholds.abs_threshold;
     }
     if (rel_threshold == disable_threshold) {
-        rel_threshold = max_rel_threshold;
+        rel_threshold = thresholds.rel_threshold;
     }
 }
 

--- a/src/tests/functional/base_func_tests/src/base/utils/calculate_thresholds.cpp
+++ b/src/tests/functional/base_func_tests/src/base/utils/calculate_thresholds.cpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace test {
 namespace utils {
 
-inline std::pair<double, double>
+inline Threshold
 calculate_thresholds_by_whole_model(const std::shared_ptr<ov::Model>& model) {
     double max_abs_threshold = DISABLE_THRESHOLD, max_rel_threshold = DISABLE_THRESHOLD;
 
@@ -49,7 +49,7 @@ calculate_thresholds_by_whole_model(const std::shared_ptr<ov::Model>& model) {
     return {max_abs_threshold, max_rel_threshold};
 }
 
-inline std::pair<double, double>
+inline Threshold
 calculate_thresholds_by_model_results(const std::shared_ptr<ov::Model>& model,
                                       const std::shared_ptr<ov::Model>& ref_model,
                                       const ov::element::Type& inference_precision) {
@@ -72,22 +72,23 @@ calculate_thresholds_by_model_results(const std::shared_ptr<ov::Model>& model,
             max_rel_threshold = rel_value;
         }
     }
-    return { max_abs_threshold, max_rel_threshold };
+    return {max_abs_threshold, max_rel_threshold};
 }
 
-std::pair<double, double>
+Threshold
 calculate_thresholds_by_model(const std::shared_ptr<ov::Model>& model,
                               const std::shared_ptr<ov::Model>& ref_model,
                               const ov::element::Type& inference_precision) {
-    double model_max_abs_threshold = DISABLE_THRESHOLD, model_max_rel_threshold = DISABLE_THRESHOLD,
-           out_max_abs_threshold = DISABLE_THRESHOLD, out_max_rel_threshold = DISABLE_THRESHOLD;
-    std::tie(model_max_abs_threshold, model_max_rel_threshold) = ov::test::utils::calculate_thresholds_by_whole_model(model);
+    const auto model_thresholds = ov::test::utils::calculate_thresholds_by_whole_model(model);
+    auto max_abs_threshold = model_thresholds.abs_threshold;
+    auto max_rel_threshold = model_thresholds.rel_threshold;
     if (ref_model) {
-        std::tie(out_max_abs_threshold, out_max_rel_threshold) =
+        const auto output_thresholds =
             ov::test::utils::calculate_thresholds_by_model_results(model, ref_model, inference_precision);
+        max_abs_threshold = std::max(max_abs_threshold, output_thresholds.abs_threshold);
+        max_rel_threshold = std::max(max_rel_threshold, output_thresholds.rel_threshold);
     }
-    return { std::max(model_max_abs_threshold, out_max_abs_threshold),
-             std::max(model_max_rel_threshold, out_max_rel_threshold) };
+    return {max_abs_threshold, max_rel_threshold};
 }
 
 } // namespace utils

--- a/src/tests/functional/plugin/shared/src/subgraph/quantized_mat_mul.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/quantized_mat_mul.cpp
@@ -42,8 +42,8 @@ void QuantMatMulTest::SetUp() {
                                 std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(inputShape1))};
 
     auto makeFakeQuantizeNode = [element_type = element_type](size_t quantLevels,
-                                                              QuantRange inputRange,
-                                                              QuantRange outputRange,
+                                                              const QuantRange& inputRange,
+                                                              const QuantRange& outputRange,
                                                               ov::test::utils::QuantizationGranularity quantGranularity,
                                                               const ov::Output<ov::Node>& in,
                                                               ov::Shape inputShape,


### PR DESCRIPTION
### Details:
GCC (13.3.0 on aarch64) emits noisy ABI diagnostics for pair values under C++17

```note: parameter passing for argument of type 'std::pair<float, float>' when C++17 is enabled changed to match C++14 in GCC 10.1```

Replace affected pair-valued returns with `std::array` or the named structure. Where `std::pair` remains required, construct it explicitly instead of using `std::make_pair`. This preserves behavior while avoiding the diagnostic.

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
 - Implementation is assisted and after that manually tested and reviewed
