### PR TITLE
Cecilia/1d deconv/fix

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -93,7 +93,16 @@ public:
 
             input_layout.set_partial_shape(input_pshape);
             weights_layout.set_partial_shape(weights_pshape);
-            weights_layout.format = format::adjust_to_rank(weights_layout.format, weights_pshape.size());
+            // format::adjust_to_rank() requires an exact pre-registered format at the new rank
+            // with the same dims order as the *current* weights format, which doesn't exist for
+            // exotic formats like byfx (assigned by the O/I-swap permute-fusion optimizer to
+            // grouped deconv weights). Resolve directly to the canonical grouped/non-grouped
+            // weights format instead: for depthwise (groups == channels) weights -- the only
+            // grouped 1d case this promotion is needed for -- O/G == I/G == 1, so whatever O/I
+            // swap the current format encodes is a no-op on those singleton dims, and it's safe
+            // to normalize straight to goiyx/oizyx.
+            const auto& primitive = impl_params.typed_desc<deconvolution>();
+            weights_layout.format = format::get_default_format(weights_pshape.size(), /*is_weights=*/true, primitive->grouped_weights_shape);
             output_layout.set_partial_shape(output_pshape);
 
             updated_impl_params.weights_layout = weights_layout;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -71,6 +71,40 @@ public:
 
         return params;
     }
+
+    static kernel_impl_params static_canonicalize_shapes(const kernel_impl_params& impl_params) {
+        auto updated_impl_params = canonicalize_fused_shapes(impl_params);
+
+        auto& input_layout = updated_impl_params.input_layouts[0];
+        auto& weights_layout = updated_impl_params.input_layouts[1];
+        auto& output_layout = updated_impl_params.output_layouts[0];
+
+        auto input_pshape = input_layout.get_partial_shape();
+        auto weights_pshape = weights_layout.get_partial_shape();
+        auto output_pshape = output_layout.get_partial_shape();
+        // For 1d deconvolution we need to extend weights shape and format
+        // as by default it will be bfyx which is converted to oiyx (or oiyx-shaped goiyx)
+        // instead of a properly-grouped format, so a grouped 1d weight's kernel-size axis
+        // ends up on a different cldnn spatial axis than the data tensor's real spatial axis.
+        if (input_pshape.size() == 3) {
+            input_pshape.insert(input_pshape.end(), 1);
+            weights_pshape.insert(weights_pshape.end(), 1);
+            output_pshape.insert(output_pshape.end(), 1);
+
+            input_layout.set_partial_shape(input_pshape);
+            weights_layout.set_partial_shape(weights_pshape);
+            weights_layout.format = format::adjust_to_rank(weights_layout.format, weights_pshape.size());
+            output_layout.set_partial_shape(output_pshape);
+
+            updated_impl_params.weights_layout = weights_layout;
+        }
+
+        return updated_impl_params;
+    }
+
+    kernel_impl_params canonicalize_shapes(const kernel_impl_params& impl_params) const override {
+        return static_canonicalize_shapes(impl_params);
+    }
 };
 
 namespace detail {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -3159,6 +3159,158 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     }
 }
 
+// Regression test for a GPU-only functional bug found while debugging silent/attenuated audio
+// output from MiniMax-H3's audio VAE decoder on GPU (see
+// pack_minimax_h3_bundle/minimax_h3_gpu_blank_video_silent_audio_handoff_zh.md). The decoder's
+// Snake/anti-alias-filter upsample stage is a 1D depthwise (groups == channels)
+// GroupConvolutionBackpropData with kernel_size(12) > stride(2), fed with a dynamic-length input
+// (1D op mapped to a 2D cldnn primitive with a single-element ov::Strides, matching how
+// ProgramBuilder::CreateGroupConvolutionBackpropDataOp constructs it for a dynamic-shape 1D op --
+// see src/plugins/intel_gpu/src/plugin/ops/convolution.cpp). For any output position, a correctly
+// implemented deconv must overlap-add contributions from multiple input samples whenever
+// kernel_size > stride; the observed regression left every other output element exactly zero,
+// as if only a single kernel tap were ever applied per output position (both the specialized
+// b_fs_zyx_fsv16_dw kernel and the plain OCL reference kernel showed the identical wrong result,
+// and disabling onednn made no difference -- ruling out any single specific implementation and
+// pointing at the shared weight/stride-to-kernel_selector-params conversion for this exact
+// "1D op with explicit group dim" shape). Uses a small, hand-computed-in-Python ground truth
+// (all-ones kernel over [1,2,3]/[10,20,30] inputs, stride 2, kernel size 4) so any exact-zero
+// output element unambiguously fails the test, independent of which GPU kernel gets selected.
+TEST(deconvolution_gpu_test, dw_1d_stride2_kernel_gt_stride_no_output_gaps) {
+    auto& engine = get_test_engine();
+
+    const int32_t groups = 2;   // groups == channels: fully depthwise, matches the real bug
+    const int32_t kernel_size = 4;   // kernel_size > stride: every output position must overlap-add
+    const int32_t stride = 2;
+    const int32_t input_length = 3;
+
+    ov::PartialShape input_pshape = {1, groups, input_length};
+    ov::PartialShape weights_pshape = {groups, 1, 1, kernel_size};  // [G, O/G, I/G, K], matches
+                                                                    // ProgramBuilder's grouped 1D
+                                                                    // deconv weight shape.
+
+    layout in_layout{ ov::PartialShape::dynamic(input_pshape.size()), data_types::f32, format::bfyx };
+    layout weights_layout{ weights_pshape, data_types::f32, format::bfyx };
+
+    auto weights_mem = engine.allocate_memory(weights_layout);
+    set_values(weights_mem, std::vector<float>(groups * kernel_size, 1.0f));
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights_mem));
+    topology.add(deconvolution("deconv",
+                               input_info("input"),
+                               "weights",
+                               "",
+                               static_cast<uint32_t>(groups),
+                               ov::Strides{ static_cast<size_t>(stride) },
+                               ov::CoordinateDiff{ 0 },
+                               ov::Strides{ 1 },
+                               ov::CoordinateDiff{ 0 },
+                               ov::CoordinateDiff{ 0 },
+                               ov::CoordinateDiff{ 0 },
+                               true /* grouped_weights_shape, matches weights_have_group_dim=true
+                                       in CreateGroupConvolutionBackpropDataOp */));
+    topology.add(reorder("out", input_info("deconv"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
+
+    auto input_mem = engine.allocate_memory({ input_pshape, data_types::f32, format::bfyx });
+    set_values(input_mem, { 1.f, 2.f, 3.f,
+                           10.f, 20.f, 30.f });
+    network.set_input_data("input", input_mem);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
+
+    auto output_mem = outputs.begin()->second.get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output_mem, get_test_stream());
+
+    // Ground truth computed independently in Python via the textbook "scatter" definition of
+    // transposed convolution: out[i*stride + k] += in[i] * w[k]. With an all-ones kernel and
+    // kernel_size(4) > stride(2), every one of the 8 output positions per channel receives
+    // contributions from at least two different input samples, so none can legitimately be zero.
+    std::vector<float> expected = {
+        1.f, 1.f, 3.f, 3.f, 5.f, 5.f, 3.f, 3.f,
+        10.f, 10.f, 30.f, 30.f, 50.f, 50.f, 30.f, 30.f
+    };
+    ASSERT_EQ(output_mem->count(), expected.size());
+    for (size_t i = 0; i < expected.size(); i++) {
+        ASSERT_FLOAT_EQ(expected[i], output_ptr[i]) << "at flattened index " << i;
+    }
+}
+
+TEST(deconvolution_gpu_test, nongrouped_1d_stride2_kernel_gt_stride) {
+    // Regression coverage for a 1d, non-grouped deconvolution with stride > 1: the existing
+    // spatial_1d test family only ever exercises stride=1, so this combination was previously
+    // untested even though it is unaffected by the grouped-weights axis-mapping bug (see
+    // dw_1d_stride2_kernel_gt_stride_no_output_gaps above).
+    auto& engine = get_test_engine();
+
+    const int32_t groups = 1;
+    const int32_t kernel_size = 4;
+    const int32_t stride = 2;
+    const int32_t input_length = 3;
+
+    ov::PartialShape input_pshape = {1, groups, input_length};
+    ov::PartialShape weights_pshape = {1, 1, kernel_size};  // [O, I, K], non-grouped.
+
+    layout in_layout{ ov::PartialShape::dynamic(input_pshape.size()), data_types::f32, format::bfyx };
+    layout weights_layout{ weights_pshape, data_types::f32, format::bfyx };
+
+    auto weights_mem = engine.allocate_memory(weights_layout);
+    set_values(weights_mem, std::vector<float>(kernel_size, 1.0f));
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights_mem));
+    topology.add(deconvolution("deconv",
+                               input_info("input"),
+                               "weights",
+                               "",
+                               static_cast<uint32_t>(groups),
+                               ov::Strides{ static_cast<size_t>(stride) },
+                               ov::CoordinateDiff{ 0 },
+                               ov::Strides{ 1 },
+                               ov::CoordinateDiff{ 0 },
+                               ov::CoordinateDiff{ 0 },
+                               ov::CoordinateDiff{ 0 },
+                               false /* grouped_weights_shape, matches weights_have_group_dim=false
+                                        in CreateConvolutionBackpropDataOp */));
+    topology.add(reorder("out", input_info("deconv"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
+
+    auto input_mem = engine.allocate_memory({ input_pshape, data_types::f32, format::bfyx });
+    set_values(input_mem, { 1.f, 2.f, 3.f });
+    network.set_input_data("input", input_mem);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
+
+    auto output_mem = outputs.begin()->second.get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output_mem, get_test_stream());
+
+    // Same scatter formula as dw_1d_stride2_kernel_gt_stride_no_output_gaps, single channel.
+    std::vector<float> expected = {
+        1.f, 1.f, 3.f, 3.f, 5.f, 5.f, 3.f, 3.f
+    };
+    ASSERT_EQ(output_mem->count(), expected.size());
+    for (size_t i = 0; i < expected.size(); i++) {
+        ASSERT_FLOAT_EQ(expected[i], output_ptr[i]) << "at flattened index " << i;
+    }
+}
+
 TEST(deconvolution_gpu_onednn, input_b_fs_zyx_fsv16_output_bfzyx_stride2_nopad) {
     auto& engine = get_test_engine();
     if (!engine.get_device_info().supports_immad)

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -10,6 +10,7 @@
 #include <intel_gpu/primitives/crop.hpp>
 #include <intel_gpu/primitives/eltwise.hpp>
 #include <intel_gpu/primitives/reorder.hpp>
+#include <intel_gpu/primitives/permute.hpp>
 #include <intel_gpu/primitives/data.hpp>
 
 using namespace cldnn;
@@ -3235,6 +3236,81 @@ TEST(deconvolution_gpu_test, dw_1d_stride2_kernel_gt_stride_no_output_gaps) {
     // transposed convolution: out[i*stride + k] += in[i] * w[k]. With an all-ones kernel and
     // kernel_size(4) > stride(2), every one of the 8 output positions per channel receives
     // contributions from at least two different input samples, so none can legitimately be zero.
+    std::vector<float> expected = {
+        1.f, 1.f, 3.f, 3.f, 5.f, 5.f, 3.f, 3.f,
+        10.f, 10.f, 30.f, 30.f, 50.f, 50.f, 30.f, 30.f
+    };
+    ASSERT_EQ(output_mem->count(), expected.size());
+    for (size_t i = 0; i < expected.size(); i++) {
+        ASSERT_FLOAT_EQ(expected[i], output_ptr[i]) << "at flattened index " << i;
+    }
+}
+
+TEST(deconvolution_gpu_test, dw_1d_stride2_kernel_gt_stride_permuted_weight_format) {
+    // Regression test for a real-model-only crash: ProgramBuilder::CreateGroupConvolutionBackpropDataOp
+    // always inserts a `permute` to swap the O/I weight dims before the deconv (see
+    // ops/convolution.cpp). When the weight is a Constant with a single user, the
+    // prepare_primitive_fusing optimizer pass (with optimize_data(true)) fuses that permute
+    // directly into the constant's cldnn format tag (e.g. bfyx -> byfx) instead of materializing
+    // a physical transpose. This test reproduces that exact topology shape so the weight layout
+    // deconvolution_impl actually sees at kernel-param time carries a non-default, permuted
+    // format, which previously crashed format::adjust_to_rank() with
+    // "Can't adjust format byfx to the new rank (5)".
+    auto& engine = get_test_engine();
+
+    const int32_t groups = 2;   // groups == channels: fully depthwise, matches the real bug.
+    const int32_t kernel_size = 4;
+    const int32_t stride = 2;
+    const int32_t input_length = 3;
+
+    ov::PartialShape input_pshape = {1, groups, input_length};
+    ov::PartialShape weights_pshape = {groups, 1, 1, kernel_size};  // [G, O/G, I/G, K]
+
+    layout in_layout{ ov::PartialShape::dynamic(input_pshape.size()), data_types::f32, format::bfyx };
+    layout weights_layout{ weights_pshape, data_types::f32, format::bfyx };
+
+    auto weights_mem = engine.allocate_memory(weights_layout);
+    set_values(weights_mem, std::vector<float>(groups * kernel_size, 1.0f));
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weights", weights_mem));
+    // Swap O/I (indices 1, 2), exactly as CreateGroupConvolutionBackpropDataOp does.
+    topology.add(permute("weights_permuted", input_info("weights"), { 0, 2, 1, 3 }));
+    topology.add(deconvolution("deconv",
+                               input_info("input"),
+                               "weights_permuted",
+                               "",
+                               static_cast<uint32_t>(groups),
+                               ov::Strides{ static_cast<size_t>(stride) },
+                               ov::CoordinateDiff{ 0 },
+                               ov::Strides{ 1 },
+                               ov::CoordinateDiff{ 0 },
+                               ov::CoordinateDiff{ 0 },
+                               ov::CoordinateDiff{ 0 },
+                               true /* grouped_weights_shape */));
+    topology.add(reorder("out", input_info("deconv"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
+
+    auto input_mem = engine.allocate_memory({ input_pshape, data_types::f32, format::bfyx });
+    set_values(input_mem, { 1.f, 2.f, 3.f,
+                           10.f, 20.f, 30.f });
+    network.set_input_data("input", input_mem);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "out");
+
+    auto output_mem = outputs.begin()->second.get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output_mem, get_test_stream());
+
+    // Same expected values as dw_1d_stride2_kernel_gt_stride_no_output_gaps: for a depthwise
+    // weight (O/G == I/G == 1), swapping O and I is a no-op on the actual values.
     std::vector<float> expected = {
         1.f, 1.f, 3.f, 3.f, 5.f, 5.f, 3.f, 3.f,
         10.f, 10.f, 30.f, 30.f, 50.f, 50.f, 30.f, 30.f


### PR DESCRIPTION
### Details:
 - *Problem*
 1D grouped/depthwise GPU deconvolution was silently producing wrong results, and in the real MiniMax/H3 model path it could crash during weight-format normalization. The bug showed up when the deconv weight layout was treated as the wrong grouped/non-grouped format during 1D rank promotion.

- *Root cause*
In deconvolution.cpp, 1D deconv weights were not being promoted to the canonical rank before resolving cldnn weight format. For grouped depthwise weights, that meant a rank-4 weight could be misread as non-grouped oiyx instead of grouped goiyx, so the kernel axis landed on the wrong spatial dimension. In the real model case, a fused permute also produced exotic formats like byfx; calling format::adjust_to_rank() on that format failed because no matching rank-5 registration existed.

- *Fix*
The fix adds the missing 1D shape canonicalization step and resolves weight format explicitly via the canonical default for grouped/non-grouped weights instead of trying to extend the current permuted format. The code now promotes rank-3 1D inputs/weights/outputs before format selection and uses format::get_default_format(..., grouped_weights_shape) so the kernel axis stays aligned with the real data axis. Regression coverage was added in deconvolution_gpu_test.cpp for:

    - depthwise 1D stride-2 deconv with kernel > stride
    - the real-model permuted-weight topology that previously crashed
    - non-grouped stride > 1 1D deconv

### Tickets:
 - *[CVS-194671](https://jira.devtools.intel.com/browse/CVS-194671)*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used for debugging and narrowing down, and compose the final implementation code. Human validation was performed on build, manual checks, guide AI to explore different solutions.*
