### PR TITLE
[GPU] Remove planar format forcing for static nodes with reshape user

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1394,19 +1394,6 @@ format layout_optimizer::get_preferred_format(program_node& node) {
     if (allow_new_shape_infer) {
         // Let reorder_input pass to check input format instead of output_format in forward investigation, vice versa
         auto out_lay_rank = node.get_output_layout(false).get_rank();
-        auto has_reshape_user = [&](const program_node& node) -> bool {
-            for (const auto& user_node : node.get_users()) {
-                if (user_node->is_type<reshape>())
-                    return true;
-            }
-            return false;
-        };
-
-        // Return default format for output layout rank when user node is reshape
-        // to add reorder in front of reshape in reorder_input stage instead of handle_reshpae stage.
-        // It is only applied for the dynamic shape with static input shape
-        if (!node.is_dynamic() &&  has_reshape_user(node))
-            return format::get_default_format(out_lay_rank);
 
         if (node.is_type<shape_of>())
             return format::get_default_format(node.get_input_layout(0).get_rank());


### PR DESCRIPTION
Fix format selection regression for static nodes with reshape user.

### Details:
#### Root cause
- Enable RMS fusion to match RMS without gamma (#36865) lets the gamma-less RMS pattern in StyleGAN2 fuse into a single RMS op, which is the intended behavior.
- RMS is listed in `requires_new_shape_infer()`, so the newly fused RMS op turns  `allow_new_shape_infer` on for a fully static model that never had RMS before.
- Once `allow_new_shape_infer` is on, `get_preferred_format()` returns planar  early for every static node with a reshape user, skipping the per-type format  selection below, so `get_expected_format(deconvolution)` is never reached.
- 8 deconvolutions fall back from `b_fs_yx_fsv16` to `bfyx`: FP32 25.95 -> 13.26 FPS.
#### Fix
Remove the early return. The condition was added by #18448 and #18486 by written when `allow_new_shape_infer` implied a dynamic  model. (3 years ago)
- The removed condition only applied to `!is_dynamic()` nodes, so the dynamic-node
  path preserved by #18486 is untouched.
- Validation: StyleGAN2 FP32 13.26 -> 25.76 FPS, FP16 gain preserved.
- Validation: MaskRCNN-10 from CVS-100495, the ticket that introduced the solutuion, converted with both legacy MO and the current ONNX frontend;  No regression on FP32 or FP16.

### Tickets:
 - *CVS-192666*

### AI Assistance:
 - *AI assistance used: yes
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
