### PR TITLE
[GPU] Fix GPU performance regression when performance counters are enabled (backport to 2026.4 release)

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_clock.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_clock.cpp
@@ -10,19 +10,6 @@
 
 using namespace cldnn::ocl;
 
-namespace {
-
-constexpr int sample_attempts = 5;
-
-// Closer than this the two anchors carry no rate signal, so only the offset is used.
-constexpr std::chrono::nanoseconds min_rate_span = std::chrono::milliseconds(1);
-
-// Real drift is a few ppm; anything outside this means a bogus sample.
-constexpr double min_plausible_rate = 0.9;
-constexpr double max_plausible_rate = 1.1;
-
-}  // namespace
-
 device_clock_sync::device_clock_sync(const cl::Device& device) : m_device(device) {
     m_base = sample(m_device);
     m_last_refresh = host_now();
@@ -31,6 +18,8 @@ device_clock_sync::device_clock_sync(const cl::Device& device) : m_device(device
 // Cristian's algorithm: attribute the device reading to the midpoint of the host
 // interval bracketing the call, keeping the attempt with the tightest bracket.
 device_clock_sync::anchor device_clock_sync::sample(const cl::Device& device) {
+    constexpr int sample_attempts = 5;
+
     anchor best;
 #if defined(CL_VERSION_2_1)
     if (device.get() == nullptr)
@@ -73,7 +62,10 @@ void device_clock_sync::refresh_if_stale(std::chrono::nanoseconds min_interval) 
         const auto now = host_now();
         if (now - m_last_refresh < min_interval)
             return;
-        // Claimed up front so concurrent callers do not stack up driver calls.
+        // Claim the refresh window before releasing the lock so concurrent callers
+        // do not stack up driver calls. A failed or superseded sample still consumes
+        // this window intentionally; retrying for every event would restore the
+        // profiling regression this cache avoids.
         m_last_refresh = now;
     }
 
@@ -81,13 +73,19 @@ void device_clock_sync::refresh_if_stale(std::chrono::nanoseconds min_interval) 
 
     std::lock_guard<std::mutex> lock(m_mutex);
     // Concurrent samplers may finish out of order; never step back to an older anchor.
-    if (fresh.valid && fresh.host > m_base.host && fresh.host > m_late.host)
-        m_late = fresh;
+    if (fresh.valid && fresh.host > m_base.host && fresh.host > m_latest.host)
+        m_latest = fresh;
 }
 
 std::chrono::nanoseconds device_clock_sync::interpolate(const anchor& base,
                                                         const anchor& late,
                                                         std::chrono::nanoseconds host_ts) {
+    // Closer than this the two anchors carry no rate signal, so only the offset is used.
+    constexpr std::chrono::nanoseconds min_rate_span = std::chrono::milliseconds(1);
+    // Real drift is a few ppm; anything outside this range indicates a bogus sample.
+    constexpr double min_plausible_rate = 0.9;
+    constexpr double max_plausible_rate = 1.1;
+
     auto delta = host_ts - base.host;
 
     // A second anchor gives the rate as well as the offset, cancelling drift.
@@ -111,5 +109,5 @@ std::optional<std::chrono::nanoseconds> device_clock_sync::to_device(std::chrono
     if (!m_base.valid)
         return std::nullopt;
 
-    return interpolate(m_base, m_late, host_ts);
+    return interpolate(m_base, m_latest, host_ts);
 }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_clock.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_clock.cpp
@@ -1,0 +1,115 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ocl_device_clock.hpp"
+
+#include "CL/cl.h"
+
+#include <cstdint>
+
+using namespace cldnn::ocl;
+
+namespace {
+
+constexpr int sample_attempts = 5;
+
+// Closer than this the two anchors carry no rate signal, so only the offset is used.
+constexpr std::chrono::nanoseconds min_rate_span = std::chrono::milliseconds(1);
+
+// Real drift is a few ppm; anything outside this means a bogus sample.
+constexpr double min_plausible_rate = 0.9;
+constexpr double max_plausible_rate = 1.1;
+
+}  // namespace
+
+device_clock_sync::device_clock_sync(const cl::Device& device) : m_device(device) {
+    m_base = sample(m_device);
+    m_last_refresh = host_now();
+}
+
+// Cristian's algorithm: attribute the device reading to the midpoint of the host
+// interval bracketing the call, keeping the attempt with the tightest bracket.
+device_clock_sync::anchor device_clock_sync::sample(const cl::Device& device) {
+    anchor best;
+#if defined(CL_VERSION_2_1)
+    if (device.get() == nullptr)
+        return best;
+
+    auto best_rtt = std::chrono::nanoseconds::max();
+    for (int i = 0; i < sample_attempts; ++i) {
+        const auto h0 = host_now();
+        cl_ulong device_ts = 0;
+        cl_ulong host_ts = 0;  // unused: clGetHostTimer domain, unrelated to steady_clock
+        // Devices may lack the OpenCL 2.1 timer even when the headers have it.
+        if (clGetDeviceAndHostTimer(device.get(), &device_ts, &host_ts) != CL_SUCCESS)
+            break;
+        const auto h1 = host_now();
+
+        const auto rtt = h1 - h0;
+        if (rtt < best_rtt) {
+            best_rtt = rtt;
+            best.host = h0 + rtt / 2;
+            best.device = std::chrono::nanoseconds(static_cast<int64_t>(device_ts));
+            best.valid = true;
+        }
+    }
+#else
+    (void)device;
+#endif
+    return best;
+}
+
+bool device_clock_sync::is_valid() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_base.valid;
+}
+
+void device_clock_sync::refresh_if_stale(std::chrono::nanoseconds min_interval) {
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (!m_base.valid)
+            return;
+        const auto now = host_now();
+        if (now - m_last_refresh < min_interval)
+            return;
+        // Claimed up front so concurrent callers do not stack up driver calls.
+        m_last_refresh = now;
+    }
+
+    const auto fresh = sample(m_device);
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    // Concurrent samplers may finish out of order; never step back to an older anchor.
+    if (fresh.valid && fresh.host > m_base.host && fresh.host > m_late.host)
+        m_late = fresh;
+}
+
+std::chrono::nanoseconds device_clock_sync::interpolate(const anchor& base,
+                                                        const anchor& late,
+                                                        std::chrono::nanoseconds host_ts) {
+    auto delta = host_ts - base.host;
+
+    // A second anchor gives the rate as well as the offset, cancelling drift.
+    if (late.valid) {
+        const auto span = late.host - base.host;
+        if (span > min_rate_span) {
+            const double rate = static_cast<double>((late.device - base.device).count()) /
+                                static_cast<double>(span.count());
+            if (rate > min_plausible_rate && rate < max_plausible_rate) {
+                delta = std::chrono::nanoseconds(
+                    static_cast<int64_t>(static_cast<double>(delta.count()) * rate));
+            }
+        }
+    }
+
+    return base.device + delta;
+}
+
+std::optional<std::chrono::nanoseconds> device_clock_sync::to_device(std::chrono::nanoseconds host_ts) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_base.valid)
+        return std::nullopt;
+
+    return interpolate(m_base, m_late, host_ts);
+}

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_clock.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_clock.hpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "ocl_common.hpp"
+
+#include <chrono>
+#include <mutex>
+#include <optional>
+
+namespace cldnn {
+namespace ocl {
+
+/// @brief Maps the host steady clock onto the OpenCL device profiling clock, so that
+/// host-timed synthetic events are comparable with native ones. The correlation is
+/// affine, so it is sampled a few times and applied arithmetically rather than
+/// calling clGetDeviceAndHostTimer() per event, which costs a driver round trip.
+class device_clock_sync {
+public:
+    struct anchor {
+        std::chrono::nanoseconds host{0};
+        std::chrono::nanoseconds device{0};
+        bool valid = false;
+    };
+
+    static constexpr std::chrono::nanoseconds default_refresh_interval = std::chrono::milliseconds(100);
+
+    explicit device_clock_sync(const cl::Device& device);
+
+    static std::chrono::nanoseconds host_now() {
+        return std::chrono::steady_clock::now().time_since_epoch();
+    }
+
+    /// @brief Maps @p host_ts through @p base, refined by @p late when the anchors are
+    /// far enough apart and imply a plausible rate. Pure; exposed for testing.
+    static std::chrono::nanoseconds interpolate(const anchor& base,
+                                                const anchor& late,
+                                                std::chrono::nanoseconds host_ts);
+
+    /// @brief False when the device has no usable timer, i.e. no start timestamp can
+    /// ever be synthesized.
+    bool is_valid() const;
+
+    /// @brief Re-samples the correlation if the last sample is older than
+    /// @p min_interval. Does the driver query, so it must stay off the inference
+    /// path - call it only when profiling data is collected.
+    void refresh_if_stale(std::chrono::nanoseconds min_interval = default_refresh_interval);
+
+    /// @brief Returns nullopt when the device provides no usable timer.
+    std::optional<std::chrono::nanoseconds> to_device(std::chrono::nanoseconds host_ts) const;
+
+private:
+    static anchor sample(const cl::Device& device);
+
+    // Immutable after construction, so sample() may read it without the lock.
+    cl::Device m_device;
+
+    mutable std::mutex m_mutex;
+    anchor m_base;
+    anchor m_late;
+    std::chrono::nanoseconds m_last_refresh{0};
+};
+
+}  // namespace ocl
+}  // namespace cldnn

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_clock.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_clock.hpp
@@ -15,8 +15,9 @@ namespace ocl {
 
 /// @brief Maps the host steady clock onto the OpenCL device profiling clock, so that
 /// host-timed synthetic events are comparable with native ones. The correlation is
-/// affine, so it is sampled a few times and applied arithmetically rather than
-/// calling clGetDeviceAndHostTimer() per event, which costs a driver round trip.
+/// approximated as affine over short refresh intervals and applied arithmetically
+/// rather than calling clGetDeviceAndHostTimer() per event, which costs a driver
+/// round trip.
 class device_clock_sync {
 public:
     struct anchor {
@@ -43,9 +44,8 @@ public:
     /// ever be synthesized.
     bool is_valid() const;
 
-    /// @brief Re-samples the correlation if the last sample is older than
-    /// @p min_interval. Does the driver query, so it must stay off the inference
-    /// path - call it only when profiling data is collected.
+    /// @brief Re-samples the correlation if the last attempt is older than
+    /// @p min_interval. The rate limit amortizes the driver query across events.
     void refresh_if_stale(std::chrono::nanoseconds min_interval = default_refresh_interval);
 
     /// @brief Returns nullopt when the device provides no usable timer.
@@ -59,7 +59,7 @@ private:
 
     mutable std::mutex m_mutex;
     anchor m_base;
-    anchor m_late;
+    anchor m_latest;
     std::chrono::nanoseconds m_last_refresh{0};
 };
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -202,6 +202,14 @@ void set_arguments_impl(ocl_kernel_type& kernel,
     }
 }
 
+std::shared_ptr<device_clock_sync> make_device_clock(const ocl_engine& engine, const ExecutionConfig& config) {
+    if (!config.get_enable_profiling())
+        return nullptr;
+
+    auto clock = std::make_shared<device_clock_sync>(engine.get_cl_device());
+    return clock->is_valid() ? clock : nullptr;
+}
+
 }  // namespace
 
 ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config)
@@ -226,11 +234,7 @@ ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config)
     queue_builder.set_supports_queue_families(queue_families_extension);
 
     _command_queue = queue_builder.build(context, device);
-#if defined(CL_VERSION_2_1)
-    if (config.get_enable_profiling()) {
-        _profiling_device = _engine.get_cl_device();
-    }
-#endif
+    _device_clock = make_device_clock(_engine, config);
 }
 
 ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config, void *handle)
@@ -238,11 +242,7 @@ ocl_stream::ocl_stream(const ocl_engine &engine, const ExecutionConfig& config, 
     , _engine(engine) {
     auto* casted_handle = static_cast<cl_command_queue>(handle);
     _command_queue = ocl_queue_type(casted_handle, true);
-#if defined(CL_VERSION_2_1)
-    if (config.get_enable_profiling()) {
-        _profiling_device = _engine.get_cl_device();
-    }
-#endif
+    _device_clock = make_device_clock(_engine, config);
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
@@ -359,7 +359,7 @@ event::ptr ocl_stream::enqueue_marker(std::vector<event::ptr> const& deps, bool 
         sync_events(deps, is_output);
         return std::make_shared<ocl_event>(_last_barrier_ev, _last_barrier);
     }
-    return std::make_shared<ocl_user_event>(_engine.get_cl_context(), true, _profiling_device);
+    return std::make_shared<ocl_user_event>(_engine.get_cl_context(), true, _device_clock);
 }
 
 event::ptr ocl_stream::group_events(std::vector<event::ptr> const& deps) {
@@ -369,7 +369,7 @@ event::ptr ocl_stream::group_events(std::vector<event::ptr> const& deps) {
 }
 
 event::ptr ocl_stream::create_user_event(bool set) {
-    return std::make_shared<ocl_user_event>(_engine.get_cl_context(), set, _profiling_device);
+    return std::make_shared<ocl_user_event>(_engine.get_cl_context(), set, _device_clock);
 }
 
 event::ptr ocl_stream::create_base_event() {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.hpp
@@ -7,6 +7,7 @@
 #include "intel_gpu/runtime/event.hpp"
 #include "intel_gpu/runtime/stream.hpp"
 #include "ocl_common.hpp"
+#include "ocl_device_clock.hpp"
 #include "ocl_engine.hpp"
 
 #include <memory>
@@ -28,7 +29,7 @@ public:
         , _queue_counter(other._queue_counter.load())
         , _last_barrier(other._last_barrier.load())
         , _last_barrier_ev(other._last_barrier_ev)
-        , _profiling_device(other._profiling_device) {}
+        , _device_clock(other._device_clock) {}
 
     ~ocl_stream() override = default;
 
@@ -66,7 +67,9 @@ private:
     std::atomic<uint64_t> _queue_counter{0};
     std::atomic<uint64_t> _last_barrier{0};
     cl::Event _last_barrier_ev;
-    cl::Device _profiling_device;
+    // Non-null only when profiling is enabled; shared with user events, which may
+    // outlive the stream.
+    std::shared_ptr<device_clock_sync> _device_clock;
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
     std::shared_ptr<dnnl::stream> _onednn_stream = nullptr;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.cpp
@@ -30,8 +30,8 @@ void ocl_user_event::set_impl() {
     _duration = std::unique_ptr<cldnn::instrumentation::profiling_period_basic>(
         new cldnn::instrumentation::profiling_period_basic(_timer.uptime()));
 
-    // Host clock only; the device correlation needs a driver call and is deferred
-    // to get_profiling_info_impl().
+    // Capture only the host clock here; device correlation is shared and refreshed
+    // periodically while profiling information is collected.
     if (_device_clock) {
         _host_end = device_clock_sync::host_now();
     }
@@ -45,8 +45,7 @@ bool ocl_user_event::get_profiling_info_impl(std::list<cldnn::instrumentation::p
     auto period = std::make_shared<instrumentation::profiling_period_basic>(_duration->value());
     info.push_back({ instrumentation::profiling_stage::duration, period });
 
-    // Reached only when the application collects counters, never from the
-    // inference loop, so the driver call in refresh_if_stale() is affordable.
+    // The stream-level rate limit amortizes refresh_if_stale() across user events.
     if (_device_clock) {
         _device_clock->refresh_if_stale();
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.cpp
@@ -3,22 +3,19 @@
 //
 
 #include "ocl_user_event.hpp"
-#include "CL/cl.h"
+#include <chrono>
 #include <list>
+#include <memory>
+#include <utility>
 
 using namespace cldnn::ocl;
 
 ocl_user_event::ocl_user_event(const cl::Context& ctx,
                                bool is_set,
-                               const cl::Device& device)
-    : _ctx(ctx)
+                               std::shared_ptr<device_clock_sync> device_clock)
+    : _device_clock(std::move(device_clock))
+    , _ctx(ctx)
     , _event(_ctx) {
-#if defined(CL_VERSION_2_1)
-    if (device.get() != nullptr) {
-        _device = device;
-    }
-#endif
-
     if (is_set) {
         set();
     }
@@ -32,15 +29,12 @@ void ocl_user_event::set_impl() {
     static_cast<cl::UserEvent&&>(get()).setStatus(CL_COMPLETE);
     _duration = std::unique_ptr<cldnn::instrumentation::profiling_period_basic>(
         new cldnn::instrumentation::profiling_period_basic(_timer.uptime()));
-#if defined(CL_VERSION_2_1)
-    if (_device.get() != nullptr) {
-        cl_ulong device_ts = 0;
-        cl_ulong host_ts = 0;
-        if (clGetDeviceAndHostTimer(_device.get(), &device_ts, &host_ts) == CL_SUCCESS) {
-            _exec_start = std::chrono::nanoseconds(static_cast<long long>(device_ts)) - _duration->value();
-        }
+
+    // Host clock only; the device correlation needs a driver call and is deferred
+    // to get_profiling_info_impl().
+    if (_device_clock) {
+        _host_end = device_clock_sync::host_now();
     }
-#endif
 }
 
 bool ocl_user_event::get_profiling_info_impl(std::list<cldnn::instrumentation::profiling_interval>& info) {
@@ -51,13 +45,21 @@ bool ocl_user_event::get_profiling_info_impl(std::list<cldnn::instrumentation::p
     auto period = std::make_shared<instrumentation::profiling_period_basic>(_duration->value());
     info.push_back({ instrumentation::profiling_stage::duration, period });
 
-    if (_device.get() != nullptr) {
-        auto zero_period = std::make_shared<instrumentation::profiling_period_basic>(std::chrono::nanoseconds::zero());
-        info.push_back({ instrumentation::profiling_stage::starting, zero_period, _exec_start, true });
-        info.push_back({ instrumentation::profiling_stage::executing, period, _exec_start, true });
-    } else {
-        info.push_back({ instrumentation::profiling_stage::executing, period });
+    // Reached only when the application collects counters, never from the
+    // inference loop, so the driver call in refresh_if_stale() is affordable.
+    if (_device_clock) {
+        _device_clock->refresh_if_stale();
+
+        if (const auto mapped = _device_clock->to_device(_host_end)) {
+            const auto exec_start = *mapped - _duration->value();
+            auto zero_period = std::make_shared<instrumentation::profiling_period_basic>(std::chrono::nanoseconds::zero());
+            info.push_back({ instrumentation::profiling_stage::starting, zero_period, exec_start, true });
+            info.push_back({ instrumentation::profiling_stage::executing, period, exec_start, true });
+            return true;
+        }
     }
+
+    info.push_back({ instrumentation::profiling_stage::executing, period });
 
     return true;
 }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_user_event.hpp
@@ -7,6 +7,8 @@
 #include "intel_gpu/runtime/profiling.hpp"
 #include "openvino/util/util.hpp"
 #include "ocl_base_event.hpp"
+#include "ocl_device_clock.hpp"
+#include <chrono>
 #include <memory>
 #include <list>
 
@@ -19,7 +21,7 @@ namespace ocl {
 struct ocl_user_event : public ocl_base_event {
     explicit ocl_user_event(const cl::Context& ctx,
                             bool is_set = false,
-                            const cl::Device& device = cl::Device());
+                            std::shared_ptr<device_clock_sync> device_clock = nullptr);
 
     void set_impl() override;
     bool get_profiling_info_impl(std::list<instrumentation::profiling_interval>& info) override;
@@ -28,8 +30,9 @@ struct ocl_user_event : public ocl_base_event {
 protected:
     cldnn::instrumentation::timer<> _timer;
     std::unique_ptr<cldnn::instrumentation::profiling_period_basic> _duration;
-    std::chrono::nanoseconds _exec_start = std::chrono::nanoseconds::zero();
-    cl::Device _device;
+    // Completion time on the host; mapped to the device domain when queried.
+    std::chrono::nanoseconds _host_end = std::chrono::nanoseconds::zero();
+    std::shared_ptr<device_clock_sync> _device_clock;
     const cl::Context& _ctx;
     cl::UserEvent _event;
 

--- a/src/plugins/intel_gpu/tests/unit/module_tests/events_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/events_test.cpp
@@ -4,19 +4,154 @@
 
 #include "test_utils.h"
 
+#include "runtime/ocl/ocl_device_clock.hpp"
+#include "runtime/ocl/ocl_engine.hpp"
 #include "runtime/ocl/ocl_stream.hpp"
 #include "runtime/ocl/ocl_user_event.hpp"
 
+#include "CL/cl.h"
+
+#include <chrono>
+#include <cstdint>
 #include <memory>
+#include <thread>
 
 using namespace cldnn;
 using namespace ::tests;
+
+namespace {
+// Synthesized start timestamps need the optional OpenCL 2.1 device/host timer; without
+// it device_clock_sync stays invalid and user events fall back to two intervals.
+bool has_device_timer(const engine& eng) {
+#if defined(CL_VERSION_2_1)
+    cl_ulong device_ts = 0, host_ts = 0;
+    auto cl_device = dynamic_cast<const ocl::ocl_engine&>(eng).get_cl_device().get();
+    return clGetDeviceAndHostTimer(cl_device, &device_ts, &host_ts) == CL_SUCCESS;
+#else
+    (void)eng;
+    return false;
+#endif
+}
+}  // namespace
 
 TEST(user_event, can_create_as_complete) {
     auto& stream = get_test_stream();
     auto user_ev = stream.create_user_event(true);
 
     ASSERT_NE(std::dynamic_pointer_cast<ocl::ocl_user_event>(user_ev), nullptr);
+}
+
+// Needs the 2.1 timer directly to bracket the expected value, so it only exists when
+// the plugin is targeting OpenCL 2.1 or newer.
+#if defined(CL_VERSION_2_1)
+TEST(user_event, profiling_reports_device_domain_start_timestamp) {
+    auto& engine = get_test_engine();
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::enable_profiling(true));
+    auto stream = engine.create_stream(config);
+
+    if (!has_device_timer(engine))
+        GTEST_SKIP() << "device does not support clGetDeviceAndHostTimer";
+
+    cl_ulong device_before = 0, host_before = 0;
+    auto cl_device = dynamic_cast<const ocl::ocl_engine&>(engine).get_cl_device().get();
+    ASSERT_EQ(clGetDeviceAndHostTimer(cl_device, &device_before, &host_before), CL_SUCCESS);
+
+    auto user_ev = stream->create_user_event(true);
+    const auto profiling_info = user_ev->get_profiling_info();
+
+    cl_ulong device_after = 0, host_after = 0;
+    ASSERT_EQ(clGetDeviceAndHostTimer(cl_device, &device_after, &host_after), CL_SUCCESS);
+
+    ASSERT_EQ(profiling_info.size(), 3);
+    EXPECT_EQ(profiling_info[0].stage, instrumentation::profiling_stage::duration);
+    EXPECT_EQ(profiling_info[1].stage, instrumentation::profiling_stage::starting);
+    EXPECT_EQ(profiling_info[2].stage, instrumentation::profiling_stage::executing);
+
+    EXPECT_TRUE(profiling_info[1].is_valid_start);
+    EXPECT_TRUE(profiling_info[2].is_valid_start);
+
+    // The start must land in the device domain, inside the bracketing window.
+    const auto start_ns = profiling_info[2].start.count();
+    EXPECT_GT(start_ns, 0);
+    EXPECT_GE(start_ns, static_cast<int64_t>(device_before) - 1000000);  // 1 ms of slack
+    EXPECT_LE(start_ns, static_cast<int64_t>(device_after) + 1000000);
+}
+#endif  // CL_VERSION_2_1
+
+TEST(user_event, profiling_start_timestamps_are_ordered) {
+    auto& engine = get_test_engine();
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::enable_profiling(true));
+    auto stream = engine.create_stream(config);
+
+    if (!has_device_timer(engine))
+        GTEST_SKIP() << "device does not support clGetDeviceAndHostTimer";
+
+    auto first = stream->create_user_event(true);
+    // Separate them beyond clock resolution so this tests ordering.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    auto second = stream->create_user_event(true);
+
+    const auto first_info = first->get_profiling_info();
+    const auto second_info = second->get_profiling_info();
+
+    ASSERT_EQ(first_info.size(), 3);
+    ASSERT_EQ(second_info.size(), 3);
+    ASSERT_TRUE(first_info[2].is_valid_start);
+    ASSERT_TRUE(second_info[2].is_valid_start);
+
+    EXPECT_LE(first_info[2].start.count(), second_info[2].start.count());
+}
+
+namespace {
+using ns = std::chrono::nanoseconds;
+using anchor = ocl::device_clock_sync::anchor;
+
+// base maps host 1ms -> device 5ms.
+constexpr anchor make_base() { return anchor{ns(1000000), ns(5000000), true}; }
+
+std::chrono::nanoseconds map_host(const anchor& late, int64_t host_ns) {
+    return ocl::device_clock_sync::interpolate(make_base(), late, ns(host_ns));
+}
+}  // namespace
+
+TEST(device_clock_sync, interpolate_uses_offset_only_without_second_anchor) {
+    EXPECT_EQ(map_host(anchor{}, 2000000), ns(6000000));
+}
+
+TEST(device_clock_sync, interpolate_applies_rate_from_second_anchor) {
+    // 2 ms of host maps to 2.1 ms of device -> rate 1.05.
+    const anchor late{ns(3000000), ns(7100000), true};
+    EXPECT_EQ(map_host(late, 2000000), ns(6050000));
+}
+
+TEST(device_clock_sync, interpolate_ignores_rate_when_anchors_are_too_close) {
+    // 0.5 ms apart is below the minimum span, so the 2x rate must be ignored.
+    const anchor late{ns(1500000), ns(6000000), true};
+    EXPECT_EQ(map_host(late, 2000000), ns(6000000));
+}
+
+TEST(device_clock_sync, interpolate_ignores_implausible_rate) {
+    // rate 1.5 is far outside real host/device drift and must be rejected.
+    const anchor late{ns(3000000), ns(8000000), true};
+    EXPECT_EQ(map_host(late, 2000000), ns(6000000));
+}
+
+TEST(user_event, no_start_timestamp_when_profiling_disabled) {
+    auto& engine = get_test_engine();
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::enable_profiling(false));
+    auto stream = engine.create_stream(config);
+
+    auto user_ev = stream->create_user_event(true);
+    const auto profiling_info = user_ev->get_profiling_info();
+
+    ASSERT_EQ(profiling_info.size(), 2);
+    EXPECT_EQ(profiling_info[0].stage, instrumentation::profiling_stage::duration);
+    EXPECT_EQ(profiling_info[1].stage, instrumentation::profiling_stage::executing);
+    EXPECT_FALSE(profiling_info[0].is_valid_start);
+    EXPECT_FALSE(profiling_info[1].is_valid_start);
 }
 
 TEST(user_event, can_create_as_not_complete) {


### PR DESCRIPTION
### Details:
**Backport of https://github.com/openvinotoolkit/openvino/pull/37561 to 2026.4 release**

The GPU performance regression with performance counters enabled was introduced by #36488, which added `ProfilingInfo::start_time` and populated it from backend profiling clocks.

The key point is that the host/device correlation does not have to be sampled per event - it is an affine relation, so it is enough to sample it a few times and apply it arithmetically:

1. **Calibrate once per stream.** A new `cldnn::ocl::device_clock_sync` samples `clGetDeviceAndHostTimer()` once at stream construction, and only when profiling is enabled. Sampling uses Cristian's algorithm: the device reading is bracketed by two  `steady_clock` reads and attributed to their midpoint, with the tightest of five attempts kept. This is also more accurate than the previous inline query, which charged the driver latency straight into the reported timestamp.
2. **Convert lazily, off the hot path.** `ocl_user_event::set_impl()` now only records a host timestamp (a vDSO `steady_clock` read, ~20 ns). The conversion into the device domain happens in `get_profiling_info_impl()`, i.e. only when the application actually collects performance counters. A second anchor is taken there (rate-limited to once per 100 ms), which yields the clock rate in addition to the offset and so cancels host/device drift rather than merely bounding it.

Net effect: one driver call per stream plus one per profiling query, instead of one per user event per inference. The reported intervals are unchanged - `duration`, `starting` and `executing` with `is_valid_start = true`, exactly as on master.

**Latency hint (1 inference request)**

| Build | Perf counters | Median latency | Throughput | Latency vs master | Throughput vs master |
| --- | --- | --- | --- | --- | --- |
| master (contains #36488) | disabled | 1.99 ms | 503.67 FPS | – | – |
| master (contains #36488) | **enabled (`-pc`)** | **5.28 ms** | **188.81 FPS** | – | – |
| #37561 previous revision (#36488 reverted) | disabled | 1.98 ms | 505.55 FPS | −0.5 % | +0.4 % |
| #37561 previous revision (#36488 reverted) | **enabled (`-pc`)** | **4.00 ms** | **249.37 FPS** | **−24.2 %** | **+32.1 %** |
| #37561 this revision (calibrated clock) | disabled | 2.00 ms | 502.04 FPS | +0.5 % | −0.3 % |
| #37561 this revision (calibrated clock) | **enabled (`-pc`)** | **4.02 ms** | **248.23 FPS** | **−23.9 %** | **+31.5 %** |

**Throughput hint (128 inference requests)**

| Build | Perf counters | Median latency | Throughput | Latency vs master | Throughput vs master |
| --- | --- | --- | --- | --- | --- |
| master (contains #36488) | disabled | 147.64 ms | 842.52 FPS | – | – |
| master (contains #36488) | enabled (`-pc`) | 150.71 ms | 825.77 FPS | – | – |
| #37561 previous revision (#36488 reverted) | disabled | 147.68 ms | 842.60 FPS | +0.0 % | +0.0 % |
| #37561 previous revision (#36488 reverted) | enabled (`-pc`) | 150.54 ms | 826.70 FPS | −0.1 % | +0.1 % |
| #37561 this revision (calibrated clock) | disabled | 147.49 ms | 843.92 FPS | −0.1 % | +0.2 % |
| #37561 this revision (calibrated clock) | enabled (`-pc`) | 150.49 ms | 826.95 FPS | −0.1 % | +0.1 % |

### Tickets:
 - CVS-192659
