### PR TITLE
[Specs] Update Paged Linear Attention Ops Specification

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-causal-conv1d.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-causal-conv1d.rst
@@ -155,7 +155,7 @@ the constraint ``out_channels == hidden_size``), and ``out_channels`` must equal
   Input token embeddings from all sequences in the batch. **Required.**
 
 * **1**: ``conv_state_table``
-  A 3D tensor of type *T* with shape ``[num_physical_blocks, hidden_size, kernel_size]``.
+  A 3D tensor of type *T_cache* with shape ``[num_physical_blocks, hidden_size, kernel_size]``.
   Paged block table holding the convolution cache states. The paged memory block size is fixed at ``BLOCK_SIZE=1``,
   meaning each physical block stores exactly one convolution state of shape ``[hidden_size, kernel_size]``,
   representing the last ``kernel_size`` input vectors seen by the corresponding sequence.
@@ -221,7 +221,11 @@ the constraint ``out_channels == hidden_size``), and ``out_channels`` must equal
 **Types**
 
 * *T*: any floating point type.
+
 * *T_IND*: ``int32``.
+
+* *T_cache* - cache precision; may differ from *T*.
+  Allowed for ``conv_state_table`` (input 1): ``f16``, ``f32``, ``bf16``.
 
 
 **Example**

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-gated-delta-net.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-gated-delta-net.rst
@@ -136,7 +136,7 @@ Cases for reading and updating blocks:
 * **2**: ``value`` - Tensor of type *T* and shape ``[batch_size_in_tokens, v_num_heads, value_head_dim]``.
   Value vectors for all tokens in the batch. **Required.**
 
-* **3**: ``recurrent_state_table`` - Tensor of type *T* and shape
+* **3**: ``recurrent_state_table`` - Tensor of type *T_cache* and shape
   ``[num_blocks, v_num_heads, value_head_dim, key_head_dim]``.
   Paged table of recurrent state snapshots. Each row is one block storing a complete state for
   all value heads at a cached token position. This tensor is updated in place during execution.
@@ -195,4 +195,8 @@ Cases for reading and updating blocks:
 **Types**
 
 * *T*: any floating-point type.
-* *T_IND*: ``int32`` or ``int64``.
+
+* *T_IND*: ``int32``.
+
+* *T_cache* - cache precision; may differ from *T*.
+  Allowed for ``recurrent_state_table`` (input 3): ``f16``, ``f32``, ``bf16``.

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-selective-ssm.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/internal/paged-selective-ssm.rst
@@ -124,7 +124,7 @@ Cases for reading and updating blocks:
   Grouped output projection for all tokens in the batch. Shared across heads within a group.
   **Required.**
 
-* **6**: ``recurrent_state_table`` - Tensor of type *T* and shape
+* **6**: ``recurrent_state_table`` - Tensor of type *T_cache* and shape
   ``[num_blocks, num_heads, head_dim, state_size]``.
   Paged table of recurrent state snapshots. Each row is one block storing a complete state for
   all heads at a cached token position. This tensor is updated in place during execution.
@@ -177,7 +177,11 @@ Cases for reading and updating blocks:
 **Types**
 
 * *T*: any floating-point type.
-* *T_IND*: ``int32`` or ``int64``.
+
+* *T_IND*: ``int32``.
+
+* *T_cache* - cache precision; may differ from *T*.
+  Allowed for ``recurrent_state_table`` (input 6): ``f16``, ``f32``, ``bf16``.
 
 
 **Example**


### PR DESCRIPTION
**Details:** Not allow i64 for block indices since GPU has restrictions on usage of i64. Cache type can be different from data type.

**Ticket:** 189605

*AI assistance used: no*
