### PR TITLE
[GPU] Fix ScatterUpdate OOB index causing memory corruption/driver crash

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_update_ref.cl
@@ -22,10 +22,43 @@
 
 #if OUTPUT_DIMS == 4
     #define ORDER b,f,y,x
+#    if AXIS_VALUE == AXIS_B
+#        define AXIS_SIZE OUTPUT_BATCH_NUM
+#    elif AXIS_VALUE == AXIS_F
+#        define AXIS_SIZE OUTPUT_FEATURE_NUM
+#    elif AXIS_VALUE == AXIS_Y
+#        define AXIS_SIZE OUTPUT_SIZE_Y
+#    else
+#        define AXIS_SIZE OUTPUT_SIZE_X
+#    endif
 #elif OUTPUT_DIMS == 5
     #define ORDER b,f,z,y,x
+#    if AXIS_VALUE == AXIS_B
+#        define AXIS_SIZE OUTPUT_BATCH_NUM
+#    elif AXIS_VALUE == AXIS_F
+#        define AXIS_SIZE OUTPUT_FEATURE_NUM
+#    elif AXIS_VALUE == AXIS_Z
+#        define AXIS_SIZE OUTPUT_SIZE_Z
+#    elif AXIS_VALUE == AXIS_Y
+#        define AXIS_SIZE OUTPUT_SIZE_Y
+#    else
+#        define AXIS_SIZE OUTPUT_SIZE_X
+#    endif
 #elif OUTPUT_DIMS == 6
     #define ORDER b,f,w,z,y,x
+#    if AXIS_VALUE == AXIS_B
+#        define AXIS_SIZE OUTPUT_BATCH_NUM
+#    elif AXIS_VALUE == AXIS_F
+#        define AXIS_SIZE OUTPUT_FEATURE_NUM
+#    elif AXIS_VALUE == AXIS_W
+#        define AXIS_SIZE OUTPUT_SIZE_W
+#    elif AXIS_VALUE == AXIS_Z
+#        define AXIS_SIZE OUTPUT_SIZE_Z
+#    elif AXIS_VALUE == AXIS_Y
+#        define AXIS_SIZE OUTPUT_SIZE_Y
+#    else
+#        define AXIS_SIZE OUTPUT_SIZE_X
+#    endif
 #endif
 
 #ifdef USE_LAYOUT_AWARE_INDEXING
@@ -207,6 +240,11 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
         const uint index_by_axis = convert_int(indices[OUTPUT_INDEX_ON_AXIS]);
     #endif
 
+        // No exception path on GPU (unlike CPU's assert in scatter_update.cpp): skip OOB writes instead.
+        if (index_by_axis >= (uint)AXIS_SIZE) {
+            return;
+        }
+
     const uint output_idx = GET_OUTPUT_INDEX(SECOND_ITER_OUTPUT_INDEX_ORDER);
 
     #ifdef USE_LAYOUT_AWARE_INDEXING
@@ -258,3 +296,4 @@ KERNEL(scatter_update_ref)(OPTIONAL_SHAPE_INFO_ARG
 #undef AXIS_Z
 #undef AXIS_Y
 #undef AXIS_X
+#undef AXIS_SIZE

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_update_gpu_test.cpp
@@ -2381,3 +2381,39 @@ TEST(scatter_update_gpu_f8e4m3, d8111_axisB) {
     for (size_t i = 0; i < expected_results.size(); ++i)
         ASSERT_EQ(expected_results[i], output_ptr[i]) << "i=" << i;
 }
+
+// GPU has no exception path for OOB indices (unlike CPU's assert): it must skip the write, not corrupt memory.
+TEST(scatter_update_gpu_fp32, out_of_bounds_indices) {
+    auto& engine = get_test_engine();
+
+    //  Dictionary: 1..8; Indexes: 100, -1, 1000000, 3; Updates: 90,91,92,93; Axis 0
+    //  -> only index 3 is in-range, so only dictionary[3] is updated.
+    auto dictionary = engine.allocate_memory({data_types::f32, format::bfyx, tensor{8, 1, 1, 1}});
+    auto indices = engine.allocate_memory({data_types::f32, format::bfyx, tensor{4, 1, 1, 1}});
+    auto updates = engine.allocate_memory({data_types::f32, format::bfyx, tensor{4, 1, 1, 1}});
+    auto axis = 0;
+
+    set_values(dictionary, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f});
+    set_values(indices, {100.f, -1.f, 1000000.f, 3.f});
+    set_values(updates, {90.0f, 91.0f, 92.0f, 93.0f});
+
+    topology topology;
+    topology.add(input_layout("InputDictionary", dictionary->get_layout()));
+    topology.add(input_layout("InputText", indices->get_layout()));
+    topology.add(input_layout("InputUpdates", updates->get_layout()));
+    topology.add(scatter_update("scatter_update", input_info("InputDictionary"), input_info("InputText"), input_info("InputUpdates"), axis));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("InputDictionary", dictionary);
+    network.set_input_data("InputText", indices);
+    network.set_input_data("InputUpdates", updates);
+
+    auto outputs = network.execute();
+    auto output = outputs.at("scatter_update").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+
+    std::vector<float> expected_results = {1.f, 2.f, 3.f, 93.f, 5.f, 6.f, 7.f, 8.f};
+    for (size_t i = 0; i < expected_results.size(); ++i) {
+        ASSERT_EQ(expected_results[i], output_ptr[i]) << "i=" << i;
+    }
+}


### PR DESCRIPTION
## Description

`ScatterUpdate`'s OCL reference kernel (`scatter_update_ref.cl`) read the scatter index directly from the `indices` tensor and used it unchecked to compute the output write offset, with no bounds check against the axis size. A mildly out-of-range index silently corrupted memory past the buffer; a grossly out-of-range or negative index hit `CL_OUT_OF_RESOURCES` at the driver level. CPU already guards this with an `OPENVINO_ASSERT` (`scatter_update.cpp:913`), and the shared `ov::reference::scatter_update` also asserts; GPU had no equivalent protection.

This was surfaced during review of #37653 (GroupQueryAttention causal attention + KV-cache safety fixes): reviewer sgbihu flagged that the interim `Minimum`-based scatter-index clamp added there (`group_query_attention_decomposition.cpp`) was a GQA-side mitigation masking a real gap in `ScatterUpdate` itself, and asked for GPU and NPU tracking tickets. This PR is the GPU-side fix.

The fix adds an `AXIS_SIZE` macro resolved per output rank through the kernel's existing dynamic-shape-aware `OUTPUT_*` macros, so both static and dynamic shapes are handled correctly, and skips the write when the index falls outside `[0, axis_size)` instead of corrupting memory or crashing the driver.

## Scope

In scope: `ScatterUpdate` (opset3) OCL reference kernel bounds check, for all static and dynamic output ranks the kernel already supports.

Out of scope: the NPU-side equivalent (no bounds check there either, tracked in EISW-232323), and removal of the GQA decomposition clamp from #37653 — that clamp is currently NPU's only protection against this class of bug and stays until NPU also lands a fix; its removal will follow in a separate PR.

## Tests

- `ov_gpu_unit_tests --gtest_filter=*scatter_update*` — 105/105 passed, including a new `out_of_bounds_indices` regression test (mixed in-range/OOB/negative indices, asserts only the in-range write lands) and all pre-existing dynamic-shape `ScatterUpdate` cases.
- Full 4-level GQA regression sweep (type_prop, decomposition, ONNX FE CPU/GPU/INTERPRETER, NPU unit tests) re-run on top of this fix with zero regressions, confirming the existing GQA clamp from #37653 continues to behave correctly.

## Tickets
- CVS-193698
- EISW-232323 (NPU companion ticket, VPUX/NPU compiler team)

## AI Assistance
- Yes — used for kernel-level root-cause analysis of the OOB gap, drafting the bounds-check fix, and cross-configuration (static/dynamic shape) test verification.