### PR TITLE
[GPU] Ensure CPU_VA remote tensors are not cached

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -473,9 +473,10 @@ bool RemoteTensorImpl::is_shared() const noexcept {
 
 bool RemoteTensorImpl::supports_caching() const {
 #ifdef _WIN32
-    return is_shared() && !m_mapped_memory;
+    return is_shared() && !m_mapped_memory && m_mem_type != TensorType::BT_CPU_VA;
 #else
-    return is_shared() && !m_mapped_memory && m_mem_type != TensorType::BT_SURF_SHARED;
+    return is_shared() && !m_mapped_memory && m_mem_type != TensorType::BT_CPU_VA &&
+           m_mem_type != TensorType::BT_SURF_SHARED;
 #endif
 }
 

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/ocl_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/ocl_remote_tensor_tests.cpp
@@ -3108,6 +3108,29 @@ TEST(GpuRemoteTensorFromCpu, smoke_allocAlignedCPUMemory) {
     ov::util::aligned_free(output_ptr);
 }
 
+TEST(GpuRemoteTensorFromCpu, smoke_cpuVAMemoryIsNotCached) {
+    ov::Core core;
+    const std::string target_device = ov::test::utils::DEVICE_GPU;
+    const auto cacheline_size = core.get_property(target_device, ov::intel_gpu::cacheline_size);
+    ASSERT_GT(cacheline_size, 0u);
+
+    void* host_ptr = ov::util::aligned_alloc(cacheline_size, cacheline_size);
+    ASSERT_NE(host_ptr, nullptr);
+
+    auto ctx = core.get_default_context(target_device).as<ov::intel_gpu::ocl::ClContext>();
+    const ov::Shape shape{cacheline_size};
+    const ov::intel_gpu::VirtualAddressMemory va_memory{host_ptr, static_cast<int64_t>(cacheline_size)};
+
+    {
+        auto first = ctx.create_tensor(ov::element::u8, shape, va_memory);
+        auto second = ctx.create_tensor(ov::element::u8, shape, va_memory);
+
+        EXPECT_NE(first.get(), second.get());
+    }
+
+    ov::util::aligned_free(host_ptr);
+}
+
 
 using MmapFileMemoryParams = std::tuple<std::size_t, std::size_t>;
 


### PR DESCRIPTION
### Details:

CPU_VA remote tensors may be cached inside allocate() - https://github.com/openvinotoolkit/openvino/blob/609798397b9f577e81105f5fa614b61f6099fcd6/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp#L351

But this can cause issue when:

* File A is mapped, ptrA is passed as the pointer to CPU_VA remote tensor A
* work is being done using remote tensor A
* remote tensor, session, model destroyed, file A unmapped-
* File B is mapped, ptrB is passed as the pointer to CPU_VA remote tensor B
   * it's likely that the ptrB may have the same address as ptrA (OS may reuse that same address for file mapping)
   * if file A has the same size as file B, and the addresses are the same, then hashes for the cache entry will also be the same https://github.com/openvinotoolkit/openvino/blob/609798397b9f577e81105f5fa614b61f6099fcd6/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp#L24

Found in OVEP, one test failed due to this caching.

Disabling maybe the quickest option, and safest, while it might have very limited performance impacts, as creation of a remote tensor is relatively easy (no data copy, but some system/driver calls may happen).

### Tickets:
CVS-192956

### AI Assistance:
 - AI assistance used: yes
 - If yes, summarize how AI was used and what human validation was performed: code changes, validation, but human testing
