### PR TITLE
[core, cmake] Fix ADD_CLANG_FORMAT in ov_add_test_target_per_source

### DIFF
--- a/cmake/developer_package/add_target_helpers.cmake
+++ b/cmake/developer_package/add_target_helpers.cmake
@@ -201,6 +201,7 @@ function(ov_add_test_target_per_source)
 
     set(options
         GTEST_DISCOVER
+        ADD_CLANG_FORMAT
     )
     set(oneValueRequiredArgs
         NAME
@@ -212,6 +213,9 @@ function(ov_add_test_target_per_source)
         INCLUDES
         # accept but ignore
         DEPENDENCIES
+        DEFINES
+        LINK_LIBRARIES_WHOLE_ARCHIVE
+        LINK_FLAGS
     )
     cmake_parse_arguments(ARG "${options}" "${oneValueRequiredArgs}" "${multiValueArgs}" ${ARGN})
 


### PR DESCRIPTION
### Details:
 - `ADD_CLANG_FORMAT` was not declared as an option in `ov_add_test_target_per_source`, so cmake_parse_arguments absorbed it into the LINK_LIBRARIES list, causing the linker to fail with _cannot find -lADD_CLANG_FORMAT._
 - Also declares DEFINES, LINK_LIBRARIES_WHOLE_ARCHIVE, and LINK_FLAGS as known (ignored) keywords to prevent the same silent misparse if any caller uses them after LINK_LIBRARIES.

### Tickets:
 - [CVS-193771](https://jira.devtools.intel.com/browse/CVS-193771)

### AI Assistance:
 - *AI assistance used: yes, analysis*
