### PR TITLE
[TEMPLATE] Fix infer_postprocess stale-shape copy skip surfaced by GQA sliding-window cache

### DIFF
--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -6104,14 +6104,6 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_sliding_window_cache_staging) {
 // the FE conversion-time path directly. The decomposition picks the staging vs. in-place branch from the
 // runtime past/total length, not static-ness of S, so results must be byte-identical to the dynamic version.
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_gqa_sliding_window_cache_static_staging) {
-    // INTERPRETER returns present_key/present_value with shape [0] instead of [1,1,4,16] on this fully-static
-    // staging graph, while CPU matches expected values exactly - a template-backend constant-folding quirk in
-    // this backend, not a decomposition bug. Needs follow-up; not blocking.
-    if (std::string("${BACKEND_NAME}") == std::string("INTERPRETER")) {
-        GTEST_SKIP() << "INTERPRETER computes present_key/present_value as shape [0] on this fully-static "
-                        "staging graph; verified correct on CPU (exact expected-value match). Likely a "
-                        "template-backend constant-folding quirk, not a decomposition bug. Needs follow-up.";
-    }
     auto model = convert_model("com.microsoft/gqa_sliding_window_cache_static_staging.onnx");
     model->reshape({{"past_key", ov::PartialShape{1, 1, 4, 16}},
                     {"past_value", ov::PartialShape{1, 1, 4, 16}},

--- a/src/plugins/template/src/sync_infer_request.cpp
+++ b/src/plugins/template/src/sync_infer_request.cpp
@@ -256,7 +256,10 @@ void ov::template_plugin::InferRequest::infer_postprocess() {
         const auto& result = get_template_model()->m_model->get_results()[i];
         const auto& host_tensor = m_backend_output_tensors[i];
         auto tensor = get_tensor(get_outputs()[i]);
-        if (result->get_output_partial_shape(0).is_dynamic()) {
+        // The outer tensor may have been allocated earlier from a still-dynamic shape, before this
+        // plugin's post-transform model resolved it to static - so is_dynamic() alone can wrongly
+        // skip the copy below. Also copy whenever the shapes don't already match.
+        if (result->get_output_partial_shape(0).is_dynamic() || tensor->get_shape() != host_tensor.get_shape()) {
             ov::Output<const ov::Node> output{result->output(0).get_node(), result->output(0).get_index()};
             allocate_tensor(output, [&host_tensor](ov::SoPtr<ov::ITensor>& tensor) {
                 allocate_tensor_impl(tensor, host_tensor.get_element_type(), host_tensor.get_shape());

--- a/src/plugins/template/tests/functional/subgraph_reference/infer_postprocess.cpp
+++ b/src/plugins/template/tests/functional/subgraph_reference/infer_postprocess.cpp
@@ -4,14 +4,18 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
 #include "common_test_utils/ov_plugin_cache.hpp"
 #include "openvino/op/group_query_attention.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/runtime/core.hpp"
 
-using namespace ov;
-
+namespace ov {
+namespace test {
 namespace {
 
 // infer_postprocess() regression test: ICompiledModel freezes its public output shape before
@@ -103,3 +107,5 @@ TEST(TemplateInferPostprocess, PresentKeyValueCopiedAfterShapeResolvesPostDecomp
 }
 
 }  // namespace
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/template/tests/functional/subgraph_reference/infer_postprocess.cpp
+++ b/src/plugins/template/tests/functional/subgraph_reference/infer_postprocess.cpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/ov_plugin_cache.hpp"
+#include "openvino/op/group_query_attention.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/runtime/core.hpp"
+
+using namespace ov;
+
+namespace {
+
+// infer_postprocess() regression test: ICompiledModel freezes its public output shape before
+// CommonOptimizations runs, so an output resolved dynamic->static only by a decomposition pass
+// inside CommonOptimizations must still get copied, not skipped as "already up to date".
+// GroupQueryAttention triggers this directly: present_key/value start dynamic (tied to query's
+// dynamic batch) and the decomposition's ScatterUpdate branch makes them static (past_key's shape).
+// Verified via OV_ENABLE_SERIALIZE_TRACING IR dumps: [-1,1,4,16] before, [1,1,4,16] after.
+TEST(TemplateInferPostprocess, PresentKeyValueCopiedAfterShapeResolvesPostDecomposition) {
+    const auto query = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{Dimension::dynamic(), 1, 1, 16});
+    const auto key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 1, 1, 16});
+    const auto value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 1, 1, 16});
+    const auto past_key = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 1, 4, 16});
+    const auto past_value = std::make_shared<op::v0::Parameter>(element::f32, PartialShape{1, 1, 4, 16});
+    const auto seqlens_k = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{1});
+
+    const auto gqa = std::make_shared<op::internal::GroupQueryAttention>(
+        OutputVector{query, key, value, past_key, past_value, seqlens_k},
+        /*num_heads=*/1,
+        /*kv_num_heads=*/1,
+        /*scale=*/1.0f,
+        /*do_rotary=*/false,
+        /*rotary_interleaved=*/false);
+
+    const auto output = std::make_shared<op::v0::Result>(gqa->output(0));
+    const auto present_key = std::make_shared<op::v0::Result>(gqa->output(1));
+    const auto present_value = std::make_shared<op::v0::Result>(gqa->output(2));
+    const auto model = std::make_shared<Model>(ResultVector{output, present_key, present_value},
+                                               ParameterVector{query, key, value, past_key, past_value, seqlens_k});
+
+    ASSERT_TRUE(model->output(1).get_partial_shape().is_dynamic())
+        << "Precondition: present_key must be declared dynamic before decomposition runs, "
+           "otherwise this test no longer exercises the bug it targets.";
+
+    auto core = ov::test::utils::PluginCache::get().core("TEMPLATE");
+    auto compiled_model = core->compile_model(model, "TEMPLATE");
+    auto infer_request = compiled_model.create_infer_request();
+
+    Tensor query_tensor(element::f32, Shape{1, 1, 1, 16});
+    std::fill_n(query_tensor.data<float>(), query_tensor.get_size(), 0.f);
+
+    Tensor key_tensor(element::f32, Shape{1, 1, 1, 16});
+    std::fill_n(key_tensor.data<float>(), key_tensor.get_size(), 9.f);
+    Tensor value_tensor(element::f32, Shape{1, 1, 1, 16});
+    std::fill_n(value_tensor.data<float>(), value_tensor.get_size(), 90.f);
+
+    // Rows 0-3 filled with 1/2/3/4 (past_key) and 10/20/30/40 (past_value), 16 elements per row.
+    Tensor past_key_tensor(element::f32, Shape{1, 1, 4, 16});
+    Tensor past_value_tensor(element::f32, Shape{1, 1, 4, 16});
+    for (size_t row = 0; row < 4; ++row) {
+        std::fill_n(past_key_tensor.data<float>() + row * 16, 16, static_cast<float>(row + 1));
+        std::fill_n(past_value_tensor.data<float>() + row * 16, 16, static_cast<float>((row + 1) * 10));
+    }
+
+    Tensor seqlens_tensor(element::i32, Shape{1});
+    seqlens_tensor.data<int32_t>()[0] = 3;  // past_seqlen(3) + current_seqlen(1) - 1
+
+    infer_request.set_tensor(compiled_model.input(0), query_tensor);
+    infer_request.set_tensor(compiled_model.input(1), key_tensor);
+    infer_request.set_tensor(compiled_model.input(2), value_tensor);
+    infer_request.set_tensor(compiled_model.input(3), past_key_tensor);
+    infer_request.set_tensor(compiled_model.input(4), past_value_tensor);
+    infer_request.set_tensor(compiled_model.input(5), seqlens_tensor);
+    infer_request.infer();
+
+    // scatter_idx = [past_seqlen] = [3]: only row 3 of the capacity-4 buffer is overwritten by the new
+    // token; rows 0-2 keep past_key/past_value's values unchanged.
+    std::vector<float> expected_present_key(64);
+    std::vector<float> expected_present_value(64);
+    for (size_t row = 0; row < 4; ++row) {
+        const float key_val = row < 3 ? static_cast<float>(row + 1) : 9.f;
+        const float value_val = row < 3 ? static_cast<float>((row + 1) * 10) : 90.f;
+        std::fill_n(expected_present_key.begin() + row * 16, 16, key_val);
+        std::fill_n(expected_present_value.begin() + row * 16, 16, value_val);
+    }
+
+    const auto actual_present_key = infer_request.get_tensor(compiled_model.output(1));
+    const auto actual_present_value = infer_request.get_tensor(compiled_model.output(2));
+
+    ASSERT_EQ(actual_present_key.get_shape(), Shape({1, 1, 4, 16}));
+    ASSERT_EQ(actual_present_value.get_shape(), Shape({1, 1, 4, 16}));
+
+    const auto* key_ptr = actual_present_key.data<float>();
+    const auto* value_ptr = actual_present_value.data<float>();
+    for (size_t i = 0; i < expected_present_key.size(); ++i) {
+        EXPECT_FLOAT_EQ(key_ptr[i], expected_present_key[i]) << "present_key mismatch at index " << i;
+        EXPECT_FLOAT_EQ(value_ptr[i], expected_present_value[i]) << "present_value mismatch at index " << i;
+    }
+}
+
+}  // namespace

--- a/src/plugins/template/tests/functional/subgraph_reference/sources.cmake
+++ b/src/plugins/template/tests/functional/subgraph_reference/sources.cmake
@@ -3,6 +3,7 @@
 #
 
 set(OV_TEMPLATE_TESTS_SUBGRAPH_REFERENCE_SRCS
+    ${CMAKE_CURRENT_LIST_DIR}/infer_postprocess.cpp
     ${CMAKE_CURRENT_LIST_DIR}/preprocess.cpp
     ${CMAKE_CURRENT_LIST_DIR}/preprocess_opencv.cpp
     ${CMAKE_CURRENT_LIST_DIR}/stateful_model.cpp


### PR DESCRIPTION
## Summary

Split out of #37734 per reviewer request (unrelated bug to the Gather fix there). A pre-existing TEMPLATE (reference/interpreter) plugin bug surfaced by GroupQueryAttention's `sliding_window_cache` decomposition but general to the plugin's infer-request machinery, not specific to GQA.

- **`sync_infer_request.cpp`**: `infer_postprocess()` decided whether to copy the computed result back into the user-visible output tensor using only the post-transform model's `is_dynamic()` flag. `ICompiledModel`'s public output shape is snapshotted into a detached copy *before* `CommonOptimizations` runs (`icompiled_model.cpp`'s base constructor, called from TEMPLATE's `CompiledModel` ctor initializer list, before its body runs `transform_model()`). So an output whose shape only resolves from dynamic to static as a *result* of a decomposition pass registered inside `CommonOptimizations` stays "dynamic" on the frozen public API forever, while the live post-transform model correctly reports it as static. `infer_postprocess()`'s `is_dynamic()`-only check then wrongly treats this as "already up to date, nothing to copy" - leaving the user-facing tensor stale/empty from its original allocation. Fixed to also copy whenever the outer tensor's shape doesn't already match what was actually computed.

Un-skips `onnx_model_gqa_sliding_window_cache_static_staging` on INTERPRETER, which was hitting exactly this bug.

## Independent regression test

Added `TemplateInferPostprocess.PresentKeyValueCopiedAfterShapeResolvesPostDecomposition` (`src/plugins/template/tests/functional/subgraph_reference/infer_postprocess.cpp`), built directly on the internal `GroupQueryAttention` op (no ONNX involved) - the minimal available way to trigger the exact condition: `GroupQueryAttention`'s own shape inference ties `present_key`/`present_value` to query's (deliberately dynamic) batch dimension, while `GroupQueryAttentionDecomposition`'s `is_static_input` branch replaces them with a `ScatterUpdate` that inherits `past_key`'s always-static shape. Verified with `OV_ENABLE_SERIALIZE_TRACING` IR dumps: `present_key` is `[-1,1,4,16]` before `CommonOptimizations`, `[1,1,4,16]` after. Confirmed against the unfixed code: fails with `present_key` shape `{0}` (the exact stale-tensor symptom), passes with the fix.

## Test plan

- New independent test: `ov_template_func_tests --gtest_filter=*TemplateInferPostprocess*` passes with the fix, fails (shape `{0}`) without it
- `ov_onnx_frontend_tests --gtest_filter=*gqa*` (CPU+GPU+INTERPRETER): 153 passed, 6 skipped (5 pre-existing unrelated GPU present-cache staging gaps, plus `onnx_model_gqa_f8e4m3fnkv_sliding_window_cache` on TEMPLATE/INTERPRETER which is fixed by the split-out Gather PR, not this one)
- `ov_core_unit_tests`/`ov_transformations_tests` (GQA filters): 19/19 and 31/31, no change
- `ov_npu_unit_tests` (GQA/NPUW filters): 87/87 passed, no change

## Ticket

- CVS-192121

## AI Assistance:

AI assistance used: yes
AI helped debug & create the basic change, and it is reviewed and modified by engineer.
