### PR TITLE
[GQA] Remove static-cache ScatterUpdate clamp workaround

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -275,24 +275,12 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     } else if (is_static_input) {
         // Static full-length cache (max length, valid KVs left-aligned). Insert current K/V at
         // [past_seqlen, past_seqlen + curr_seqlen] with ScatterUpdate, keeping the buffer shape.
-        // past_seqlen is a runtime value (derived from seqlens_k) and cannot be bounded at trace time, so a
-        // caller that overruns the declared cache capacity would otherwise scatter past the end of the C
-        // buffer. C and curr_seqlen are both statically known here (is_static_input), so clamp past_seqlen to
-        // the largest value that keeps the whole write in bounds. Measured what an unclamped ScatterUpdate
-        // actually does on an overrun (PR #37653 review, sgbihu): CPU throws cleanly ("indices value that
-        // points to non-existing output tensor element"), but GPU hits an unhandled SEH access violation
-        // (0xc0000005) - a process crash, not a graceful error. The clamp trades a caller's mis-sized
-        // seqlens_k for a silently-truncated write instead of a device-dependent crash. ORT enforces the
-        // same bound with an explicit runtime check (group_query_attention.cc:336-345); OV has no
-        // graph-level assert primitive to replicate that hard-stop, so clamping is the safe substitute.
-        const int64_t capacity = past_key.get_partial_shape()[2].get_length();
-        const int64_t curr_len = K.get_partial_shape()[2].get_length();
-        const auto max_past_seqlen =
-            register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {capacity - curr_len}));
-        const auto clamped_past_seqlen = register_new_node<v1::Minimum>(past_seqlen, max_past_seqlen);
+        // An out-of-range past_seqlen is ScatterUpdate's own bounds-check responsibility, not something to
+        // guard against here via a graph-level clamp; the decomposition assumes the caller-supplied
+        // seqlens_k stays within the declared cache capacity.
         std::shared_ptr<ov::Node> scatter_idx =
             register_new_node<v4::Range>(zero_without_shape, curr_seqlen_scalar, one_without_shape, ov::element::i64);
-        scatter_idx = register_new_node<v1::Add>(scatter_idx, clamped_past_seqlen);
+        scatter_idx = register_new_node<v1::Add>(scatter_idx, past_seqlen);
         const auto scatter_axis = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {2}));
         K = register_new_node<v3::ScatterUpdate>(past_key, scatter_idx, K, scatter_axis);
         V = register_new_node<v3::ScatterUpdate>(past_value, scatter_idx, V, scatter_axis);

--- a/src/common/transformations/tests/op_conversions/group_query_attention_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/group_query_attention_decomposition_test.cpp
@@ -372,10 +372,9 @@ TEST(GroupQueryAttentionValues, sliding_window_boundary_uses_window_size_constan
     EXPECT_EQ(window_const->cast_vector<int64_t>(), std::vector<int64_t>{W});
 }
 
-TEST(GroupQueryAttentionValues, static_cache_scatter_index_clamped_to_capacity) {
-    // capacity (past_len) = 8, curr_seqlen = 1 -> max valid past_seqlen = capacity - curr_seqlen = 7. A
-    // caller-supplied seqlens_k implying a larger past_seqlen must not push the ScatterUpdate write past
-    // the end of the static full-length cache buffer (G10: unguarded static-cache overflow).
+TEST(GroupQueryAttentionValues, static_cache_scatter_index_unclamped) {
+    // past_seqlen feeds the scatter index directly, with no Minimum clamp in the chain - bounds checking
+    // for an out-of-range past_seqlen is ScatterUpdate's own responsibility, not this decomposition's.
     auto model = make_gqa_model(GqaParams{"static_scatter"}.shape(1, 8));
     decompose(model);
 
@@ -390,18 +389,12 @@ TEST(GroupQueryAttentionValues, static_cache_scatter_index_clamped_to_capacity) 
     }
     ASSERT_NE(cache_scatter, nullptr) << "static full-length cache ScatterUpdate not found";
 
-    // indices = Range(0, S) + Minimum(past_seqlen, capacity - S)
+    // indices = Range(0, S) + past_seqlen
     auto add = as_type_ptr<op::v1::Add>(cache_scatter->get_input_node_shared_ptr(1));
     ASSERT_NE(add, nullptr);
-    std::shared_ptr<op::v1::Minimum> clamp;
     for (size_t i = 0; i < add->get_input_size(); ++i)
-        if (auto m = as_type_ptr<op::v1::Minimum>(add->get_input_node_shared_ptr(i)))
-            clamp = m;
-    ASSERT_NE(clamp, nullptr) << "past_seqlen feeding the static-cache scatter index is not clamped";
-
-    auto cap_const = as_type_ptr<op::v0::Constant>(clamp->get_input_node_shared_ptr(1));
-    ASSERT_NE(cap_const, nullptr) << "clamp bound is not a constant";
-    EXPECT_EQ(cap_const->cast_vector<int64_t>(), std::vector<int64_t>{7});
+        EXPECT_EQ(as_type_ptr<op::v1::Minimum>(add->get_input_node_shared_ptr(i)), nullptr)
+            << "past_seqlen feeding the static-cache scatter index must no longer be clamped";
 }
 
 TEST(GroupQueryAttentionValues, smooth_softmax_sink_is_zero) {


### PR DESCRIPTION
## Summary
- Removes the interim clamp on `past_seqlen` in `GroupQueryAttentionDecomposition`'s static full-length KV-cache `ScatterUpdate` path, so an out-of-range `past_seqlen` surfaces at the `ScatterUpdate` op itself instead of being silently truncated by a graph-level `Minimum`.
- Updates the existing decomposition test (`GroupQueryAttentionValues.static_cache_scatter_index_unclamped`, previously `..._clamped_to_capacity`) to assert the scatter index is no longer clamped.

## Why
The clamp was only ever an interim mitigation added because GPU/NPU `ScatterUpdate` had no bounds check on out-of-range indices (CPU already throws cleanly there). Bounds checking a caller-supplied index belongs in `ScatterUpdate` itself, not bolted onto this decomposition.

## Follow-up required before this is fully safe
- GPU: #37762 adds the missing `ScatterUpdate` OOB bounds check on GPU and is still open/under review. Residual risk on GPU (silent output corruption on a small overrun, driver-level `CL_OUT_OF_RESOURCES` on a gross one) stays live until #37762 merges.
- NPU: `ScatterUpdate` has no bounds check at all today; an out-of-range index can hang/reset the device (`ZE_RESULT_ERROR_DEVICE_LOST`). Tracked in EISW-232323 (VPUX/NPU compiler team) — root-caused, not yet fixed, no PR against this repo.
- Both risks only trigger if a caller feeds a `seqlens_k` that overruns the declared static cache capacity; no current OV test model or normal-range usage hits this path.

## Test plan
- `ov_transformations_tests --gtest_filter=*GroupQueryAttention*`: 31/31 green, including the updated unclamped-index test.
- Full GQA regression sweep: `ov_core_unit_tests` (19/19 type_prop), `ov_onnx_frontend_tests` (152 pass + 7 pre-existing documented CPU/GPU/INTERPRETER skips, unchanged from baseline), `ov_npu_unit_tests` (87/87). No regressions.