### PR TITLE
[NPU] Extract the VCL dependency from VCLCompilerImpl

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/compiler_adapter/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/include/model_serializer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/parser.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/plugin_compiler_adapter.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/vcl_version_utils.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/weightless_graph.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/weightless_utils.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/include/xml_serializer.hpp

--- a/src/plugins/intel_npu/src/compiler_adapter/include/compiler_impl.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/compiler_impl.hpp
@@ -20,7 +20,7 @@ namespace intel_npu {
 
 class VCLCompilerImpl final : public std::enable_shared_from_this<VCLCompilerImpl> {
 public:
-    VCLCompilerImpl(const std::string& libraryDir,
+    VCLCompilerImpl(std::shared_ptr<const VCLApi> api,
                     const std::optional<IDevice::DeviceProperties>& deviceProperties = std::nullopt);
     ~VCLCompilerImpl();
 
@@ -85,7 +85,7 @@ public:
     /**
      * @brief Returns the compiler supported options list
      */
-    void get_supported_options(std::vector<char>& options) const;
+    std::vector<std::string> get_supported_options() const;
 
     /**
      * @brief Checks whether the given option and value are supported by the compiler
@@ -108,6 +108,7 @@ private:
                                                               const FilteredConfig& config,
                                                               const bool storeWeightlessCacheAttributeFlag) const;
 
+    std::shared_ptr<const VCLApi> _api;
     vcl_log_handle_t _logHandle = nullptr;
     vcl_compiler_handle_t _compilerHandle = nullptr;
     vcl_compiler_properties_t _compilerProperties;

--- a/src/plugins/intel_npu/src/compiler_adapter/include/compiler_impl.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/compiler_impl.hpp
@@ -20,7 +20,7 @@ namespace intel_npu {
 
 class VCLCompilerImpl final : public std::enable_shared_from_this<VCLCompilerImpl> {
 public:
-    VCLCompilerImpl(std::shared_ptr<const VCLApi> api,
+    VCLCompilerImpl(std::shared_ptr<const VCLFunctionTable> functions,
                     const std::optional<IDevice::DeviceProperties>& deviceProperties = std::nullopt);
     ~VCLCompilerImpl();
 
@@ -96,8 +96,6 @@ public:
     bool is_option_supported(const std::string& option,
                              const std::optional<std::string>& optValue = std::nullopt) const;
 
-    std::shared_ptr<void> getLinkedLibrary() const;
-
 private:
     /**
      * @brief Compiles the given model according to the given configuration. During the model serialization step,
@@ -108,7 +106,7 @@ private:
                                                               const FilteredConfig& config,
                                                               const bool storeWeightlessCacheAttributeFlag) const;
 
-    std::shared_ptr<const VCLApi> _api;
+    std::shared_ptr<const VCLFunctionTable> _functions;
     vcl_log_handle_t _logHandle = nullptr;
     vcl_compiler_handle_t _compilerHandle = nullptr;
     vcl_compiler_properties_t _compilerProperties;

--- a/src/plugins/intel_npu/src/compiler_adapter/include/vcl_version_utils.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/vcl_version_utils.hpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include "openvino/core/except.hpp"
+
+namespace intel_npu::vcl_version_utils {
+
+/**
+ * @brief The VCL API version the plugin will actually speak: the lower of what the plugin was built
+ * against and what the loaded compiler library reports.
+ */
+struct UsedVersion {
+    uint16_t Major;
+    uint16_t Minor;
+};
+
+/**
+ * @brief Negotiates the VCL version to use.
+ *
+ * Expressed in plain integers rather than `vcl_version_info_t`, since the negotiation itself has no
+ * dependency on VCL types.
+ *
+ * - Same major: take the lower minor.
+ * - Plugin major newer than the library: downgrade to the library's version.
+ * - Plugin major older than the library: keep the plugin's version.
+ */
+inline UsedVersion getUsedVclVersion(uint16_t pluginMajor,
+                                     uint16_t pluginMinor,
+                                     uint16_t loadedMajor,
+                                     uint16_t loadedMinor) {
+    uint16_t usedMajor = pluginMajor, usedMinor = pluginMinor;
+    if (pluginMajor == loadedMajor) {
+        usedMinor = std::min(pluginMinor, loadedMinor);
+    } else if (pluginMajor > loadedMajor) {
+        usedMajor = loadedMajor;
+        usedMinor = loadedMinor;
+    }
+    return {usedMajor, usedMinor};
+}
+
+/**
+ * @brief Throws if the negotiated version is below the floor the plugin requires.
+ * @param usedVersion Result of `getUsedVclVersion`.
+ * @param loadedMajor,loadedMinor Version reported by the compiler library, used for the message.
+ * @param floorMajor,floorMinor Minimum version the plugin supports (`VCL_COMPILER_VERSION_*`).
+ */
+inline void checkVclVersion(const UsedVersion& usedVersion,
+                            uint16_t loadedMajor,
+                            uint16_t loadedMinor,
+                            uint16_t floorMajor,
+                            uint16_t floorMinor) {
+    if (usedVersion.Major < floorMajor || (usedVersion.Major == floorMajor && usedVersion.Minor < floorMinor)) {
+        OPENVINO_THROW("Unsupported VCL version: ",
+                       loadedMajor,
+                       ".",
+                       loadedMinor,
+                       ", please use VCL ",
+                       floorMajor,
+                       ".",
+                       floorMinor,
+                       " or later");
+    }
+}
+
+}  // namespace intel_npu::vcl_version_utils

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
@@ -18,46 +18,15 @@
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/util/file_util.hpp"
 #include "openvino/util/shared_object.hpp"
+#include "vcl_version_utils.hpp"
 #include "weightless_utils.hpp"
 #include "ze_graph_ext_wrappers.hpp"
 
-namespace {
-
-struct UsedVersion {
-    int Major;
-    int Minor;
-    UsedVersion(int major, int minor) : Major(major), Minor(minor) {}
-};
-
-UsedVersion getUsedVclVersion(uint16_t pluginMajor, uint16_t pluginMinor, const vcl_version_info_t& loadedVersion) {
-    uint16_t usedMajor = pluginMajor, usedMinor = pluginMinor;
-    if (pluginMajor == loadedVersion.major) {
-        usedMinor = std::min(pluginMinor, loadedVersion.minor);
-    } else if (pluginMajor > loadedVersion.major) {
-        usedMajor = loadedVersion.major;
-        usedMinor = loadedVersion.minor;
-    }
-    return {usedMajor, usedMinor};
-}
-
-void checkVclVersion(const UsedVersion& usedVersion, const vcl_version_info_t& loadedVersion) {
-    if (usedVersion.Major < VCL_COMPILER_VERSION_MAJOR ||
-        (usedVersion.Major == VCL_COMPILER_VERSION_MAJOR && usedVersion.Minor < VCL_COMPILER_VERSION_MINOR)) {
-        OPENVINO_THROW("Unsupported VCL version: ",
-                       loadedVersion.major,
-                       ".",
-                       loadedVersion.minor,
-                       ", please use VCL ",
-                       VCL_COMPILER_VERSION_MAJOR,
-                       ".",
-                       VCL_COMPILER_VERSION_MINOR,
-                       " or later");
-    }
-}
-
-}  // namespace
-
 namespace intel_npu {
+
+using vcl_version_utils::checkVclVersion;
+using vcl_version_utils::getUsedVclVersion;
+using vcl_version_utils::UsedVersion;
 
 static inline std::string getLatestVCLLog(vcl_log_handle_t logHandle) {
     Logger _logger("VCLAPI", Logger::global().level());
@@ -254,9 +223,14 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
     _logger.debug("compile start");
 
     /// Check the linked vcl version whether supported in plugin
-    UsedVersion usedVersion = getUsedVclVersion(VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR, _vclVersion);
+    UsedVersion usedVersion =
+        getUsedVclVersion(VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR, _vclVersion.major, _vclVersion.minor);
     _logger.debug("the finally used compiler vcl version is %d.%d", usedVersion.Major, usedVersion.Minor);
-    checkVclVersion(usedVersion, _vclVersion);
+    checkVclVersion(usedVersion,
+                    _vclVersion.major,
+                    _vclVersion.minor,
+                    VCL_COMPILER_VERSION_MAJOR,
+                    VCL_COMPILER_VERSION_MINOR);
 
     const auto maxOpsetVersion = _compilerProperties.supportedOpsets;
     _logger.info("getSupportedOpsetVersion Max supported version of opset in CiD: %d", maxOpsetVersion);
@@ -378,9 +352,14 @@ std::pair<std::vector<ov::Tensor>, std::optional<std::string>> VCLCompilerImpl::
     _logger.debug("compileWsOneShot start");
 
     /// Check the linked vcl version whether supported in plugin
-    UsedVersion usedVersion = getUsedVclVersion(VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR, _vclVersion);
+    UsedVersion usedVersion =
+        getUsedVclVersion(VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR, _vclVersion.major, _vclVersion.minor);
     _logger.debug("the finally used compiler vcl version is %d.%d", usedVersion.Major, usedVersion.Minor);
-    checkVclVersion(usedVersion, _vclVersion);
+    checkVclVersion(usedVersion,
+                    _vclVersion.major,
+                    _vclVersion.minor,
+                    VCL_COMPILER_VERSION_MAJOR,
+                    VCL_COMPILER_VERSION_MINOR);
 
     const auto maxOpsetVersion = _compilerProperties.supportedOpsets;
     _logger.info("getSupportedOpsetVersion Max supported version of opset in CiD: %d", maxOpsetVersion);
@@ -546,7 +525,8 @@ ov::SupportedOpsMap VCLCompilerImpl::query(const std::shared_ptr<const ov::Model
     _logger.debug("query start");
 
     /// Check the linked vcl version whether supported in plugin
-    UsedVersion usedVersion = getUsedVclVersion(VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR, _vclVersion);
+    UsedVersion usedVersion =
+        getUsedVclVersion(VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR, _vclVersion.major, _vclVersion.minor);
     _logger.debug("the finally used vcl version is %d.%d", usedVersion.Major, usedVersion.Minor);
 
     const auto maxOpsetVersion = _compilerProperties.supportedOpsets;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
@@ -624,6 +624,10 @@ std::vector<std::string> VCLCompilerImpl::get_supported_options() const {
     auto trailingNul = std::find(options.begin(), options.end(), '\0');
     std::string optionsStr(options.begin(), trailingNul);
 
+    // Marker grepped by tests/functional/internal/plugin/test_compiler_option_support_helper.cpp to
+    // assert the bulk retrieval runs exactly once per compiler-type key. Keep the text in sync.
+    _logger.debug("VCLCompilerImpl return supported_options: %s", optionsStr.c_str());
+
     std::vector<std::string> result;
     std::istringstream iss(optionsStr);
     std::string token;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
@@ -106,18 +106,18 @@ static std::optional<std::string> getVCLCompatibilityString(const VCLApi& api,
     return compatibilityString;
 }
 
-#define THROW_ON_FAIL_FOR_VCL(step, ret, logHandle)      \
-    {                                                    \
-        vcl_result_t result = ret;                       \
-        if (result != VCL_RESULT_SUCCESS) {              \
-            OPENVINO_THROW("Failed to call VCL API : ",  \
-                           step,                         \
-                           " result: 0x",                \
-                           std::hex,                     \
-                           result,                       \
-                           " - ",                        \
+#define THROW_ON_FAIL_FOR_VCL(step, ret, logHandle)            \
+    {                                                          \
+        vcl_result_t result = ret;                             \
+        if (result != VCL_RESULT_SUCCESS) {                    \
+            OPENVINO_THROW("Failed to call VCL API : ",        \
+                           step,                               \
+                           " result: 0x",                      \
+                           std::hex,                           \
+                           result,                             \
+                           " - ",                              \
                            getLatestVCLLog(*_api, logHandle)); \
-        }                                                \
+        }                                                      \
     }
 
 VCLCompilerImpl::VCLCompilerImpl(std::shared_ptr<const VCLApi> api,
@@ -128,6 +128,9 @@ VCLCompilerImpl::VCLCompilerImpl(std::shared_ptr<const VCLApi> api,
     _logger.debug("VCLCompilerImpl constructor start");
 
     OPENVINO_ASSERT(_api != nullptr, "VCLCompilerImpl requires a non-null VCLApi instance");
+    OPENVINO_ASSERT(_api->hasAllRequiredSymbols(),
+                    "VCLCompilerImpl received a VCLApi with unresolved entry points. Was it built "
+                    "with VCLApi::NoLoad and left unwired?");
 
     // Initialize the VCL API
     THROW_ON_FAIL_FOR_VCL("vclGetVersion", _api->vclGetVersion(&_vclVersion, &_vclProfilingVersion), nullptr);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
@@ -30,13 +30,13 @@ using vcl_version_utils::checkVclVersion;
 using vcl_version_utils::getUsedVclVersion;
 using vcl_version_utils::UsedVersion;
 
-static inline std::string getLatestVCLLog(const VCLApi& api, vcl_log_handle_t logHandle) {
+static inline std::string getLatestVCLLog(const VCLFunctionTable& functions, vcl_log_handle_t logHandle) {
     Logger _logger("VCLAPI", Logger::global().level());
     _logger.debug("getLatestVCLLog start");
 
     vcl_version_info_t compilerVersion;
     vcl_version_info_t profilingVersion;
-    vcl_result_t ret = api.vclGetVersion(&compilerVersion, &profilingVersion);
+    vcl_result_t ret = functions.vclGetVersion(&compilerVersion, &profilingVersion);
 
     if (ret != VCL_RESULT_SUCCESS || compilerVersion.major < 3) {
         _logger.warning("Failed to get VCL version: 0x%x", ret);
@@ -46,7 +46,7 @@ static inline std::string getLatestVCLLog(const VCLApi& api, vcl_log_handle_t lo
     // Get log size
     size_t size = 0;
     // Null graph handle to get error log
-    ret = api.vclLogHandleGetString(logHandle, &size, nullptr);
+    ret = functions.vclLogHandleGetString(logHandle, &size, nullptr);
     if (VCL_RESULT_SUCCESS != ret) {
         return "Failed to get size of latest VCL log";
     }
@@ -58,7 +58,7 @@ static inline std::string getLatestVCLLog(const VCLApi& api, vcl_log_handle_t lo
     // Get log content
     std::string logContent{};
     logContent.resize(size);
-    ret = api.vclLogHandleGetString(logHandle, &size, const_cast<char*>(logContent.data()));
+    ret = functions.vclLogHandleGetString(logHandle, &size, const_cast<char*>(logContent.data()));
     if (VCL_RESULT_SUCCESS != ret) {
         return "Size of latest error log > 0, failed to get content";
     }
@@ -66,11 +66,11 @@ static inline std::string getLatestVCLLog(const VCLApi& api, vcl_log_handle_t lo
     return logContent;
 }
 
-static std::optional<std::string> getVCLCompatibilityString(const VCLApi& api,
+static std::optional<std::string> getVCLCompatibilityString(const VCLFunctionTable& functions,
                                                             vcl_executable_handle_t executable,
                                                             vcl_log_handle_t logHandle) {
     uint64_t compatibilityStringSize = 0;
-    auto result = api.vclExecutableGetCompatibilityString(executable, nullptr, &compatibilityStringSize);
+    auto result = functions.vclExecutableGetCompatibilityString(executable, nullptr, &compatibilityStringSize);
     if (result == VCL_RESULT_ERROR_UNSUPPORTED_FEATURE) {
         return std::nullopt;
     }
@@ -79,20 +79,21 @@ static std::optional<std::string> getVCLCompatibilityString(const VCLApi& api,
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(api, logHandle));
+                       getLatestVCLLog(functions, logHandle));
     }
 
     if (compatibilityStringSize > std::numeric_limits<size_t>::max()) {
         OPENVINO_THROW("Compatibility string size is too large to allocate a local buffer");
     }
     std::string compatibilityString(static_cast<size_t>(compatibilityStringSize), '\0');
-    result = api.vclExecutableGetCompatibilityString(executable, compatibilityString.data(), &compatibilityStringSize);
+    result =
+        functions.vclExecutableGetCompatibilityString(executable, compatibilityString.data(), &compatibilityStringSize);
     if (result != VCL_RESULT_SUCCESS) {
         OPENVINO_THROW("Failed to get compatibility string. vclExecutableGetCompatibilityString result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(api, logHandle));
+                       getLatestVCLLog(functions, logHandle));
     }
     if (compatibilityStringSize > compatibilityString.size()) {
         OPENVINO_THROW("Returned compatibility string size exceeds the allocated buffer size");
@@ -106,34 +107,34 @@ static std::optional<std::string> getVCLCompatibilityString(const VCLApi& api,
     return compatibilityString;
 }
 
-#define THROW_ON_FAIL_FOR_VCL(step, ret, logHandle)            \
-    {                                                          \
-        vcl_result_t result = ret;                             \
-        if (result != VCL_RESULT_SUCCESS) {                    \
-            OPENVINO_THROW("Failed to call VCL API : ",        \
-                           step,                               \
-                           " result: 0x",                      \
-                           std::hex,                           \
-                           result,                             \
-                           " - ",                              \
-                           getLatestVCLLog(*_api, logHandle)); \
-        }                                                      \
+#define THROW_ON_FAIL_FOR_VCL(step, ret, logHandle)                  \
+    {                                                                \
+        vcl_result_t result = ret;                                   \
+        if (result != VCL_RESULT_SUCCESS) {                          \
+            OPENVINO_THROW("Failed to call VCL API : ",              \
+                           step,                                     \
+                           " result: 0x",                            \
+                           std::hex,                                 \
+                           result,                                   \
+                           " - ",                                    \
+                           getLatestVCLLog(*_functions, logHandle)); \
+        }                                                            \
     }
 
-VCLCompilerImpl::VCLCompilerImpl(std::shared_ptr<const VCLApi> api,
+VCLCompilerImpl::VCLCompilerImpl(std::shared_ptr<const VCLFunctionTable> functions,
                                  const std::optional<IDevice::DeviceProperties>& deviceProperties)
-    : _api(std::move(api)),
+    : _functions(std::move(functions)),
       _logHandle(nullptr),
       _logger("VCLCompilerImpl", Logger::global().level()) {
     _logger.debug("VCLCompilerImpl constructor start");
 
-    OPENVINO_ASSERT(_api != nullptr, "VCLCompilerImpl requires a non-null VCLApi instance");
-    OPENVINO_ASSERT(_api->hasAllRequiredSymbols(),
-                    "VCLCompilerImpl received a VCLApi with unresolved entry points. Was it built "
-                    "with VCLApi::NoLoad and left unwired?");
+    OPENVINO_ASSERT(_functions != nullptr, "VCLCompilerImpl requires a non-null VCLFunctionTable");
+    OPENVINO_ASSERT(_functions->hasAllRequiredSymbols(),
+                    "VCLCompilerImpl received a VCLFunctionTable with unresolved entry points. Was "
+                    "it populated from a VCLLoader?");
 
     // Initialize the VCL API
-    THROW_ON_FAIL_FOR_VCL("vclGetVersion", _api->vclGetVersion(&_vclVersion, &_vclProfilingVersion), nullptr);
+    THROW_ON_FAIL_FOR_VCL("vclGetVersion", _functions->vclGetVersion(&_vclVersion, &_vclProfilingVersion), nullptr);
     _logger.info("Plugin VCL API Version: %d.%d", VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR);
     _logger.info("Plugin VCL Profiling API Version: %d.%d", VCL_PROFILING_VERSION_MAJOR, VCL_PROFILING_VERSION_MINOR);
     _logger.info("Lib VCL Compiler Version: %d.%d", _vclVersion.major, _vclVersion.minor);
@@ -182,10 +183,10 @@ VCLCompilerImpl::VCLCompilerImpl(std::shared_ptr<const VCLApi> api,
     }
 
     THROW_ON_FAIL_FOR_VCL("vclCompilerCreate",
-                          _api->vclCompilerCreate(&compilerDesc, &vclDeviceDesc, &_compilerHandle, &_logHandle),
+                          _functions->vclCompilerCreate(&compilerDesc, &vclDeviceDesc, &_compilerHandle, &_logHandle),
                           nullptr);
     THROW_ON_FAIL_FOR_VCL("vclCompilerGetProperties",
-                          _api->vclCompilerGetProperties(_compilerHandle, &_compilerProperties),
+                          _functions->vclCompilerGetProperties(_compilerHandle, &_compilerProperties),
                           _logHandle);
     _logger.info("VCL Compiler created successfully");
     _logger.info("VCL Compiler Properties: ID: %s, Version: %d.%d, Supported Opsets: %u",
@@ -197,12 +198,12 @@ VCLCompilerImpl::VCLCompilerImpl(std::shared_ptr<const VCLApi> api,
 
 VCLCompilerImpl::~VCLCompilerImpl() {
     if (_compilerHandle) {
-        vcl_result_t result = _api->vclCompilerDestroy(_compilerHandle);
+        vcl_result_t result = _functions->vclCompilerDestroy(_compilerHandle);
         _compilerHandle = nullptr;
         if (result != VCL_RESULT_SUCCESS) {
             _logger.warning("Failed to destroy VCL compiler: result 0x%x - %s",
                             result,
-                            getLatestVCLLog(*_api, _logHandle).c_str());
+                            getLatestVCLLog(*_functions, _logHandle).c_str());
         }
     }
 
@@ -210,10 +211,6 @@ VCLCompilerImpl::~VCLCompilerImpl() {
         _logHandle = nullptr;  // Log handle is released automatically with the compiler
     }
     _logger.info("VCL Compiler destroyed successfully");
-}
-
-std::shared_ptr<void> VCLCompilerImpl::getLinkedLibrary() const {
-    return _api->getLibrary();
 }
 
 std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
@@ -285,8 +282,12 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
     uint64_t blobSize = 0;
     vcl_executable_handle_t executable = nullptr;
 
-    auto result =
-        _api->vclAllocatedExecutableCreate4(_compilerHandle, exeDesc, allocator.get(), &blob, &blobSize, &executable);
+    auto result = _functions->vclAllocatedExecutableCreate4(_compilerHandle,
+                                                            exeDesc,
+                                                            allocator.get(),
+                                                            &blob,
+                                                            &blobSize,
+                                                            &executable);
     if (result != VCL_RESULT_SUCCESS) {
         // Check if allocations were performed before throwing exception
         auto tracked_allocations = allocator->m_info;
@@ -294,13 +295,13 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
             allocator->deallocate(allocator.get(), buffer);
         }
         if (executable != nullptr) {
-            _api->vclExecutableDestroy(executable);
+            _functions->vclExecutableDestroy(executable);
         }
         OPENVINO_THROW("Compilation failed. vclAllocatedExecutableCreate4 result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(*_api, _logHandle));
+                       getLatestVCLLog(*_functions, _logHandle));
     }
     OPENVINO_ASSERT(executable != nullptr, "Failed to create VCL executable, executable handle is null");
     OPENVINO_ASSERT(blobSize != 0 && blob != nullptr,
@@ -325,9 +326,9 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
 
     std::optional<std::string> compatibilityString;
     try {
-        compatibilityString = getVCLCompatibilityString(*_api, executable, _logHandle);
+        compatibilityString = getVCLCompatibilityString(*_functions, executable, _logHandle);
     } catch (...) {
-        _api->vclExecutableDestroy(executable);
+        _functions->vclExecutableDestroy(executable);
         throw;
     }
     if (!compatibilityString.has_value()) {
@@ -339,13 +340,13 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
         _logger.debug("Compatibility string from VCL: %s", compatibilityString->c_str());
     }
 
-    result = _api->vclExecutableDestroy(executable);
+    result = _functions->vclExecutableDestroy(executable);
     if (result != VCL_RESULT_SUCCESS) {
         OPENVINO_THROW("Failed to destroy VCL executable. vclExecutableDestroy result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(*_api, _logHandle));
+                       getLatestVCLLog(*_functions, _logHandle));
     }
 
     return std::make_pair<ov::Tensor, std::optional<std::string>>(std::move(alignedBlob),
@@ -413,23 +414,24 @@ std::pair<std::vector<ov::Tensor>, std::optional<std::string>> VCLCompilerImpl::
     auto allocator = std::make_shared<vcl_allocator_2>();
     vcl_executable_handle_t executable = nullptr;
 
-    auto result = _api->vclAllocatedExecutableCreateWSOneShot2(_compilerHandle, exeDesc, allocator.get(), &executable);
+    auto result =
+        _functions->vclAllocatedExecutableCreateWSOneShot2(_compilerHandle, exeDesc, allocator.get(), &executable);
     if (result != VCL_RESULT_SUCCESS) {
         if (executable != nullptr) {
-            _api->vclExecutableDestroy(executable);
+            _functions->vclExecutableDestroy(executable);
         }
         OPENVINO_THROW("Compilation failed. vclAllocatedExecutableCreateWSOneShot2 result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(*_api, _logHandle));
+                       getLatestVCLLog(*_functions, _logHandle));
     }
     if (executable == nullptr) {
         OPENVINO_THROW("Failed to create VCL executable, executable handle is null");
     }
 
     if (allocator->m_info.size() == 0) {
-        _api->vclExecutableDestroy(executable);
+        _functions->vclExecutableDestroy(executable);
         OPENVINO_THROW("Failed to create VCL executable, blobCount is zero");
     }
 
@@ -442,9 +444,9 @@ std::pair<std::vector<ov::Tensor>, std::optional<std::string>> VCLCompilerImpl::
 
     std::optional<std::string> compatibilityString;
     try {
-        compatibilityString = getVCLCompatibilityString(*_api, executable, _logHandle);
+        compatibilityString = getVCLCompatibilityString(*_functions, executable, _logHandle);
     } catch (...) {
-        _api->vclExecutableDestroy(executable);
+        _functions->vclExecutableDestroy(executable);
         throw;
     }
     if (!compatibilityString.has_value()) {
@@ -455,13 +457,13 @@ std::pair<std::vector<ov::Tensor>, std::optional<std::string>> VCLCompilerImpl::
         _logger.debug("Compatibility string from VCL: %s", compatibilityString->c_str());
     }
 
-    result = _api->vclExecutableDestroy(executable);
+    result = _functions->vclExecutableDestroy(executable);
     if (result != VCL_RESULT_SUCCESS) {
         OPENVINO_THROW("Failed to destroy executable. vclExecutableDestroy result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(*_api, _logHandle));
+                       getLatestVCLLog(*_functions, _logHandle));
     }
 
     return std::make_pair(std::move(initMainTensors), std::move(compatibilityString));
@@ -486,12 +488,12 @@ std::vector<ov::ProfilingInfo> VCLCompilerImpl::process_profiling_output(const s
     vcl_profiling_input_t profilingInput = {network.data(), network.size(), profData.data(), profData.size()};
     vcl_log_handle_t logHandle;
     THROW_ON_FAIL_FOR_VCL("vclProfilingCreate",
-                          _api->vclProfilingCreate(&profilingInput, &profilingHandle, &logHandle),
+                          _functions->vclProfilingCreate(&profilingInput, &profilingHandle, &logHandle),
                           nullptr);
 
     vcl_profiling_properties_t profProperties;
     THROW_ON_FAIL_FOR_VCL("vclProfilingGetProperties",
-                          _api->vclProfilingGetProperties(profilingHandle, &profProperties),
+                          _functions->vclProfilingGetProperties(profilingHandle, &profProperties),
                           logHandle);
 
     _logger.info("VCL Profiling Properties: Version: %d.%d",
@@ -504,7 +506,7 @@ std::vector<ov::ProfilingInfo> VCLCompilerImpl::process_profiling_output(const s
     vcl_profiling_output_t profOutput;
     profOutput.data = NULL;
     THROW_ON_FAIL_FOR_VCL("vclGetDecodedProfilingBuffer",
-                          _api->vclGetDecodedProfilingBuffer(profilingHandle, request, &profOutput),
+                          _functions->vclGetDecodedProfilingBuffer(profilingHandle, request, &profOutput),
                           logHandle);
     if (profOutput.data == NULL) {
         OPENVINO_THROW("Failed to get VCL profiling output");
@@ -516,7 +518,7 @@ std::vector<ov::ProfilingInfo> VCLCompilerImpl::process_profiling_output(const s
         std::memcpy(layerInfo.data(), profOutput.data, profOutput.size);
     }
 
-    THROW_ON_FAIL_FOR_VCL("vclProfilingDestroy", _api->vclProfilingDestroy(profilingHandle), logHandle);
+    THROW_ON_FAIL_FOR_VCL("vclProfilingDestroy", _functions->vclProfilingDestroy(profilingHandle), logHandle);
 
     // Return processed profiling info
     return intel_npu::profiling::convertLayersToIeProfilingInfo(layerInfo);
@@ -567,18 +569,19 @@ ov::SupportedOpsMap VCLCompilerImpl::query(const std::shared_ptr<const ov::Model
     vcl_query_handle_t queryHandle;
     vcl_query_desc_t queryDesc = {serializedIR.buffer.get(), serializedIR.size, buildFlags.c_str(), buildFlags.size()};
     THROW_ON_FAIL_FOR_VCL("vclQueryNetworkCreate",
-                          _api->vclQueryNetworkCreate(_compilerHandle, queryDesc, &queryHandle),
+                          _functions->vclQueryNetworkCreate(_compilerHandle, queryDesc, &queryHandle),
                           _logHandle);
 
     uint64_t size = 0;
-    THROW_ON_FAIL_FOR_VCL("vclQueryNetwork", _api->vclQueryNetwork(queryHandle, nullptr, &size), _logHandle);
+    THROW_ON_FAIL_FOR_VCL("vclQueryNetwork", _functions->vclQueryNetwork(queryHandle, nullptr, &size), _logHandle);
 
     std::vector<char> supportedLayers(size);
-    THROW_ON_FAIL_FOR_VCL("vclQueryNetwork",
-                          _api->vclQueryNetwork(queryHandle, reinterpret_cast<uint8_t*>(supportedLayers.data()), &size),
-                          _logHandle);
+    THROW_ON_FAIL_FOR_VCL(
+        "vclQueryNetwork",
+        _functions->vclQueryNetwork(queryHandle, reinterpret_cast<uint8_t*>(supportedLayers.data()), &size),
+        _logHandle);
 
-    THROW_ON_FAIL_FOR_VCL("vclQueryNetworkDestroy", _api->vclQueryNetworkDestroy(queryHandle), _logHandle);
+    THROW_ON_FAIL_FOR_VCL("vclQueryNetworkDestroy", _functions->vclQueryNetworkDestroy(queryHandle), _logHandle);
 
     const std::string deviceName = "NPU";
     ov::SupportedOpsMap result;
@@ -595,7 +598,7 @@ std::vector<std::string> VCLCompilerImpl::get_supported_options() const {
     _logger.debug("get_supported_options start");
     size_t str_size = 0;
     THROW_ON_FAIL_FOR_VCL("vclGetCompilerSupportedOptions",
-                          _api->vclGetCompilerSupportedOptions(_compilerHandle, nullptr, &str_size),
+                          _functions->vclGetCompilerSupportedOptions(_compilerHandle, nullptr, &str_size),
                           _logHandle);
 
     if (str_size == 0) {
@@ -606,7 +609,7 @@ std::vector<std::string> VCLCompilerImpl::get_supported_options() const {
     _logger.debug("obtain list");
     std::vector<char> options(str_size);
     THROW_ON_FAIL_FOR_VCL("vclGetCompilerSupportedOptions",
-                          _api->vclGetCompilerSupportedOptions(_compilerHandle, options.data(), &str_size),
+                          _functions->vclGetCompilerSupportedOptions(_compilerHandle, options.data(), &str_size),
                           _logHandle);
 
     _logger.debug("Option list size %d, got option list", str_size);
@@ -630,7 +633,7 @@ bool VCLCompilerImpl::is_option_supported(const std::string& option, const std::
         const char* optname_ch = option.c_str();
         const char* optvalue_ch = optValue.has_value() ? optValue.value().c_str() : nullptr;
         THROW_ON_FAIL_FOR_VCL("vclGetCompilerIsOptionSupported",
-                              _api->vclGetCompilerIsOptionSupported(_compilerHandle, optname_ch, optvalue_ch),
+                              _functions->vclGetCompilerIsOptionSupported(_compilerHandle, optname_ch, optvalue_ch),
                               _logHandle);
         return true;
     } catch (const std::exception& e) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
@@ -536,6 +536,11 @@ ov::SupportedOpsMap VCLCompilerImpl::query(const std::shared_ptr<const ov::Model
     UsedVersion usedVersion =
         getUsedVclVersion(VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR, _vclVersion.major, _vclVersion.minor);
     _logger.debug("the finally used vcl version is %d.%d", usedVersion.Major, usedVersion.Minor);
+    checkVclVersion(usedVersion,
+                    _vclVersion.major,
+                    _vclVersion.minor,
+                    VCL_COMPILER_VERSION_MAJOR,
+                    VCL_COMPILER_VERSION_MINOR);
 
     const auto maxOpsetVersion = _compilerProperties.supportedOpsets;
     _logger.info("getSupportedOpsetVersion Max supported version of opset in CiD: %d", maxOpsetVersion);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_impl.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <limits>
 #include <mutex>
+#include <sstream>
+#include <utility>
 
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/npu_private_properties.hpp"
@@ -28,13 +30,13 @@ using vcl_version_utils::checkVclVersion;
 using vcl_version_utils::getUsedVclVersion;
 using vcl_version_utils::UsedVersion;
 
-static inline std::string getLatestVCLLog(vcl_log_handle_t logHandle) {
+static inline std::string getLatestVCLLog(const VCLApi& api, vcl_log_handle_t logHandle) {
     Logger _logger("VCLAPI", Logger::global().level());
     _logger.debug("getLatestVCLLog start");
 
     vcl_version_info_t compilerVersion;
     vcl_version_info_t profilingVersion;
-    vcl_result_t ret = vclGetVersion(&compilerVersion, &profilingVersion);
+    vcl_result_t ret = api.vclGetVersion(&compilerVersion, &profilingVersion);
 
     if (ret != VCL_RESULT_SUCCESS || compilerVersion.major < 3) {
         _logger.warning("Failed to get VCL version: 0x%x", ret);
@@ -44,7 +46,7 @@ static inline std::string getLatestVCLLog(vcl_log_handle_t logHandle) {
     // Get log size
     size_t size = 0;
     // Null graph handle to get error log
-    ret = vclLogHandleGetString(logHandle, &size, nullptr);
+    ret = api.vclLogHandleGetString(logHandle, &size, nullptr);
     if (VCL_RESULT_SUCCESS != ret) {
         return "Failed to get size of latest VCL log";
     }
@@ -56,7 +58,7 @@ static inline std::string getLatestVCLLog(vcl_log_handle_t logHandle) {
     // Get log content
     std::string logContent{};
     logContent.resize(size);
-    ret = vclLogHandleGetString(logHandle, &size, const_cast<char*>(logContent.data()));
+    ret = api.vclLogHandleGetString(logHandle, &size, const_cast<char*>(logContent.data()));
     if (VCL_RESULT_SUCCESS != ret) {
         return "Size of latest error log > 0, failed to get content";
     }
@@ -64,10 +66,11 @@ static inline std::string getLatestVCLLog(vcl_log_handle_t logHandle) {
     return logContent;
 }
 
-static std::optional<std::string> getVCLCompatibilityString(vcl_executable_handle_t executable,
+static std::optional<std::string> getVCLCompatibilityString(const VCLApi& api,
+                                                            vcl_executable_handle_t executable,
                                                             vcl_log_handle_t logHandle) {
     uint64_t compatibilityStringSize = 0;
-    auto result = vclExecutableGetCompatibilityString(executable, nullptr, &compatibilityStringSize);
+    auto result = api.vclExecutableGetCompatibilityString(executable, nullptr, &compatibilityStringSize);
     if (result == VCL_RESULT_ERROR_UNSUPPORTED_FEATURE) {
         return std::nullopt;
     }
@@ -76,20 +79,20 @@ static std::optional<std::string> getVCLCompatibilityString(vcl_executable_handl
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(logHandle));
+                       getLatestVCLLog(api, logHandle));
     }
 
     if (compatibilityStringSize > std::numeric_limits<size_t>::max()) {
         OPENVINO_THROW("Compatibility string size is too large to allocate a local buffer");
     }
     std::string compatibilityString(static_cast<size_t>(compatibilityStringSize), '\0');
-    result = vclExecutableGetCompatibilityString(executable, compatibilityString.data(), &compatibilityStringSize);
+    result = api.vclExecutableGetCompatibilityString(executable, compatibilityString.data(), &compatibilityStringSize);
     if (result != VCL_RESULT_SUCCESS) {
         OPENVINO_THROW("Failed to get compatibility string. vclExecutableGetCompatibilityString result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(logHandle));
+                       getLatestVCLLog(api, logHandle));
     }
     if (compatibilityStringSize > compatibilityString.size()) {
         OPENVINO_THROW("Returned compatibility string size exceeds the allocated buffer size");
@@ -103,31 +106,31 @@ static std::optional<std::string> getVCLCompatibilityString(vcl_executable_handl
     return compatibilityString;
 }
 
-#define THROW_ON_FAIL_FOR_VCL(step, ret, logHandle)     \
-    {                                                   \
-        vcl_result_t result = ret;                      \
-        if (result != VCL_RESULT_SUCCESS) {             \
-            OPENVINO_THROW("Failed to call VCL API : ", \
-                           step,                        \
-                           " result: 0x",               \
-                           std::hex,                    \
-                           result,                      \
-                           " - ",                       \
-                           getLatestVCLLog(logHandle)); \
-        }                                               \
+#define THROW_ON_FAIL_FOR_VCL(step, ret, logHandle)      \
+    {                                                    \
+        vcl_result_t result = ret;                       \
+        if (result != VCL_RESULT_SUCCESS) {              \
+            OPENVINO_THROW("Failed to call VCL API : ",  \
+                           step,                         \
+                           " result: 0x",                \
+                           std::hex,                     \
+                           result,                       \
+                           " - ",                        \
+                           getLatestVCLLog(*_api, logHandle)); \
+        }                                                \
     }
 
-VCLCompilerImpl::VCLCompilerImpl(const std::string& libraryDir,
+VCLCompilerImpl::VCLCompilerImpl(std::shared_ptr<const VCLApi> api,
                                  const std::optional<IDevice::DeviceProperties>& deviceProperties)
-    : _logHandle(nullptr),
+    : _api(std::move(api)),
+      _logHandle(nullptr),
       _logger("VCLCompilerImpl", Logger::global().level()) {
     _logger.debug("VCLCompilerImpl constructor start");
 
-    // Load VCL library
-    (void)VCLApi::getInstance(libraryDir);
+    OPENVINO_ASSERT(_api != nullptr, "VCLCompilerImpl requires a non-null VCLApi instance");
 
     // Initialize the VCL API
-    THROW_ON_FAIL_FOR_VCL("vclGetVersion", vclGetVersion(&_vclVersion, &_vclProfilingVersion), nullptr);
+    THROW_ON_FAIL_FOR_VCL("vclGetVersion", _api->vclGetVersion(&_vclVersion, &_vclProfilingVersion), nullptr);
     _logger.info("Plugin VCL API Version: %d.%d", VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR);
     _logger.info("Plugin VCL Profiling API Version: %d.%d", VCL_PROFILING_VERSION_MAJOR, VCL_PROFILING_VERSION_MINOR);
     _logger.info("Lib VCL Compiler Version: %d.%d", _vclVersion.major, _vclVersion.minor);
@@ -176,10 +179,10 @@ VCLCompilerImpl::VCLCompilerImpl(const std::string& libraryDir,
     }
 
     THROW_ON_FAIL_FOR_VCL("vclCompilerCreate",
-                          vclCompilerCreate(&compilerDesc, &vclDeviceDesc, &_compilerHandle, &_logHandle),
+                          _api->vclCompilerCreate(&compilerDesc, &vclDeviceDesc, &_compilerHandle, &_logHandle),
                           nullptr);
     THROW_ON_FAIL_FOR_VCL("vclCompilerGetProperties",
-                          vclCompilerGetProperties(_compilerHandle, &_compilerProperties),
+                          _api->vclCompilerGetProperties(_compilerHandle, &_compilerProperties),
                           _logHandle);
     _logger.info("VCL Compiler created successfully");
     _logger.info("VCL Compiler Properties: ID: %s, Version: %d.%d, Supported Opsets: %u",
@@ -191,12 +194,12 @@ VCLCompilerImpl::VCLCompilerImpl(const std::string& libraryDir,
 
 VCLCompilerImpl::~VCLCompilerImpl() {
     if (_compilerHandle) {
-        vcl_result_t result = vclCompilerDestroy(_compilerHandle);
+        vcl_result_t result = _api->vclCompilerDestroy(_compilerHandle);
         _compilerHandle = nullptr;
         if (result != VCL_RESULT_SUCCESS) {
             _logger.warning("Failed to destroy VCL compiler: result 0x%x - %s",
                             result,
-                            getLatestVCLLog(_logHandle).c_str());
+                            getLatestVCLLog(*_api, _logHandle).c_str());
         }
     }
 
@@ -207,7 +210,7 @@ VCLCompilerImpl::~VCLCompilerImpl() {
 }
 
 std::shared_ptr<void> VCLCompilerImpl::getLinkedLibrary() const {
-    return VCLApi::getInstance()->getLibrary();
+    return _api->getLibrary();
 }
 
 std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
@@ -280,7 +283,7 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
     vcl_executable_handle_t executable = nullptr;
 
     auto result =
-        vclAllocatedExecutableCreate4(_compilerHandle, exeDesc, allocator.get(), &blob, &blobSize, &executable);
+        _api->vclAllocatedExecutableCreate4(_compilerHandle, exeDesc, allocator.get(), &blob, &blobSize, &executable);
     if (result != VCL_RESULT_SUCCESS) {
         // Check if allocations were performed before throwing exception
         auto tracked_allocations = allocator->m_info;
@@ -288,13 +291,13 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
             allocator->deallocate(allocator.get(), buffer);
         }
         if (executable != nullptr) {
-            vclExecutableDestroy(executable);
+            _api->vclExecutableDestroy(executable);
         }
         OPENVINO_THROW("Compilation failed. vclAllocatedExecutableCreate4 result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(_logHandle));
+                       getLatestVCLLog(*_api, _logHandle));
     }
     OPENVINO_ASSERT(executable != nullptr, "Failed to create VCL executable, executable handle is null");
     OPENVINO_ASSERT(blobSize != 0 && blob != nullptr,
@@ -319,9 +322,9 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
 
     std::optional<std::string> compatibilityString;
     try {
-        compatibilityString = getVCLCompatibilityString(executable, _logHandle);
+        compatibilityString = getVCLCompatibilityString(*_api, executable, _logHandle);
     } catch (...) {
-        vclExecutableDestroy(executable);
+        _api->vclExecutableDestroy(executable);
         throw;
     }
     if (!compatibilityString.has_value()) {
@@ -333,13 +336,13 @@ std::pair<ov::Tensor, std::optional<std::string>> VCLCompilerImpl::compile(
         _logger.debug("Compatibility string from VCL: %s", compatibilityString->c_str());
     }
 
-    result = vclExecutableDestroy(executable);
+    result = _api->vclExecutableDestroy(executable);
     if (result != VCL_RESULT_SUCCESS) {
         OPENVINO_THROW("Failed to destroy VCL executable. vclExecutableDestroy result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(_logHandle));
+                       getLatestVCLLog(*_api, _logHandle));
     }
 
     return std::make_pair<ov::Tensor, std::optional<std::string>>(std::move(alignedBlob),
@@ -407,23 +410,23 @@ std::pair<std::vector<ov::Tensor>, std::optional<std::string>> VCLCompilerImpl::
     auto allocator = std::make_shared<vcl_allocator_2>();
     vcl_executable_handle_t executable = nullptr;
 
-    auto result = vclAllocatedExecutableCreateWSOneShot2(_compilerHandle, exeDesc, allocator.get(), &executable);
+    auto result = _api->vclAllocatedExecutableCreateWSOneShot2(_compilerHandle, exeDesc, allocator.get(), &executable);
     if (result != VCL_RESULT_SUCCESS) {
         if (executable != nullptr) {
-            vclExecutableDestroy(executable);
+            _api->vclExecutableDestroy(executable);
         }
         OPENVINO_THROW("Compilation failed. vclAllocatedExecutableCreateWSOneShot2 result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(_logHandle));
+                       getLatestVCLLog(*_api, _logHandle));
     }
     if (executable == nullptr) {
         OPENVINO_THROW("Failed to create VCL executable, executable handle is null");
     }
 
     if (allocator->m_info.size() == 0) {
-        vclExecutableDestroy(executable);
+        _api->vclExecutableDestroy(executable);
         OPENVINO_THROW("Failed to create VCL executable, blobCount is zero");
     }
 
@@ -436,9 +439,9 @@ std::pair<std::vector<ov::Tensor>, std::optional<std::string>> VCLCompilerImpl::
 
     std::optional<std::string> compatibilityString;
     try {
-        compatibilityString = getVCLCompatibilityString(executable, _logHandle);
+        compatibilityString = getVCLCompatibilityString(*_api, executable, _logHandle);
     } catch (...) {
-        vclExecutableDestroy(executable);
+        _api->vclExecutableDestroy(executable);
         throw;
     }
     if (!compatibilityString.has_value()) {
@@ -449,13 +452,13 @@ std::pair<std::vector<ov::Tensor>, std::optional<std::string>> VCLCompilerImpl::
         _logger.debug("Compatibility string from VCL: %s", compatibilityString->c_str());
     }
 
-    result = vclExecutableDestroy(executable);
+    result = _api->vclExecutableDestroy(executable);
     if (result != VCL_RESULT_SUCCESS) {
         OPENVINO_THROW("Failed to destroy executable. vclExecutableDestroy result: 0x",
                        std::hex,
                        uint64_t(result),
                        " - ",
-                       getLatestVCLLog(_logHandle));
+                       getLatestVCLLog(*_api, _logHandle));
     }
 
     return std::make_pair(std::move(initMainTensors), std::move(compatibilityString));
@@ -480,12 +483,12 @@ std::vector<ov::ProfilingInfo> VCLCompilerImpl::process_profiling_output(const s
     vcl_profiling_input_t profilingInput = {network.data(), network.size(), profData.data(), profData.size()};
     vcl_log_handle_t logHandle;
     THROW_ON_FAIL_FOR_VCL("vclProfilingCreate",
-                          vclProfilingCreate(&profilingInput, &profilingHandle, &logHandle),
+                          _api->vclProfilingCreate(&profilingInput, &profilingHandle, &logHandle),
                           nullptr);
 
     vcl_profiling_properties_t profProperties;
     THROW_ON_FAIL_FOR_VCL("vclProfilingGetProperties",
-                          vclProfilingGetProperties(profilingHandle, &profProperties),
+                          _api->vclProfilingGetProperties(profilingHandle, &profProperties),
                           logHandle);
 
     _logger.info("VCL Profiling Properties: Version: %d.%d",
@@ -498,7 +501,7 @@ std::vector<ov::ProfilingInfo> VCLCompilerImpl::process_profiling_output(const s
     vcl_profiling_output_t profOutput;
     profOutput.data = NULL;
     THROW_ON_FAIL_FOR_VCL("vclGetDecodedProfilingBuffer",
-                          vclGetDecodedProfilingBuffer(profilingHandle, request, &profOutput),
+                          _api->vclGetDecodedProfilingBuffer(profilingHandle, request, &profOutput),
                           logHandle);
     if (profOutput.data == NULL) {
         OPENVINO_THROW("Failed to get VCL profiling output");
@@ -510,7 +513,7 @@ std::vector<ov::ProfilingInfo> VCLCompilerImpl::process_profiling_output(const s
         std::memcpy(layerInfo.data(), profOutput.data, profOutput.size);
     }
 
-    THROW_ON_FAIL_FOR_VCL("vclProfilingDestroy", vclProfilingDestroy(profilingHandle), logHandle);
+    THROW_ON_FAIL_FOR_VCL("vclProfilingDestroy", _api->vclProfilingDestroy(profilingHandle), logHandle);
 
     // Return processed profiling info
     return intel_npu::profiling::convertLayersToIeProfilingInfo(layerInfo);
@@ -561,18 +564,18 @@ ov::SupportedOpsMap VCLCompilerImpl::query(const std::shared_ptr<const ov::Model
     vcl_query_handle_t queryHandle;
     vcl_query_desc_t queryDesc = {serializedIR.buffer.get(), serializedIR.size, buildFlags.c_str(), buildFlags.size()};
     THROW_ON_FAIL_FOR_VCL("vclQueryNetworkCreate",
-                          vclQueryNetworkCreate(_compilerHandle, queryDesc, &queryHandle),
+                          _api->vclQueryNetworkCreate(_compilerHandle, queryDesc, &queryHandle),
                           _logHandle);
 
     uint64_t size = 0;
-    THROW_ON_FAIL_FOR_VCL("vclQueryNetwork", vclQueryNetwork(queryHandle, nullptr, &size), _logHandle);
+    THROW_ON_FAIL_FOR_VCL("vclQueryNetwork", _api->vclQueryNetwork(queryHandle, nullptr, &size), _logHandle);
 
     std::vector<char> supportedLayers(size);
     THROW_ON_FAIL_FOR_VCL("vclQueryNetwork",
-                          vclQueryNetwork(queryHandle, reinterpret_cast<uint8_t*>(supportedLayers.data()), &size),
+                          _api->vclQueryNetwork(queryHandle, reinterpret_cast<uint8_t*>(supportedLayers.data()), &size),
                           _logHandle);
 
-    THROW_ON_FAIL_FOR_VCL("vclQueryNetworkDestroy", vclQueryNetworkDestroy(queryHandle), _logHandle);
+    THROW_ON_FAIL_FOR_VCL("vclQueryNetworkDestroy", _api->vclQueryNetworkDestroy(queryHandle), _logHandle);
 
     const std::string deviceName = "NPU";
     ov::SupportedOpsMap result;
@@ -585,25 +588,38 @@ ov::SupportedOpsMap VCLCompilerImpl::query(const std::shared_ptr<const ov::Model
     return result;
 }
 
-void VCLCompilerImpl::get_supported_options(std::vector<char>& options) const {
+std::vector<std::string> VCLCompilerImpl::get_supported_options() const {
     _logger.debug("get_supported_options start");
     size_t str_size = 0;
     THROW_ON_FAIL_FOR_VCL("vclGetCompilerSupportedOptions",
-                          vclGetCompilerSupportedOptions(_compilerHandle, nullptr, &str_size),
+                          _api->vclGetCompilerSupportedOptions(_compilerHandle, nullptr, &str_size),
                           _logHandle);
 
     if (str_size == 0) {
         _logger.debug("Option list size 0!");
-        return;
+        return {};
     }
 
     _logger.debug("obtain list");
-    options.resize(str_size);
+    std::vector<char> options(str_size);
     THROW_ON_FAIL_FOR_VCL("vclGetCompilerSupportedOptions",
-                          vclGetCompilerSupportedOptions(_compilerHandle, options.data(), &str_size),
+                          _api->vclGetCompilerSupportedOptions(_compilerHandle, options.data(), &str_size),
                           _logHandle);
 
     _logger.debug("Option list size %d, got option list", str_size);
+
+    // VCL hands back a char buffer that may carry trailing NULs. Trimming and tokenising here keeps that
+    // calling convention out of IVCLCompiler.
+    auto trailingNul = std::find(options.begin(), options.end(), '\0');
+    std::string optionsStr(options.begin(), trailingNul);
+
+    std::vector<std::string> result;
+    std::istringstream iss(optionsStr);
+    std::string token;
+    while (iss >> token) {
+        result.push_back(token);
+    }
+    return result;
 }
 
 bool VCLCompilerImpl::is_option_supported(const std::string& option, const std::optional<std::string>& optValue) const {
@@ -611,7 +627,7 @@ bool VCLCompilerImpl::is_option_supported(const std::string& option, const std::
         const char* optname_ch = option.c_str();
         const char* optvalue_ch = optValue.has_value() ? optValue.value().c_str() : nullptr;
         THROW_ON_FAIL_FOR_VCL("vclGetCompilerIsOptionSupported",
-                              vclGetCompilerIsOptionSupported(_compilerHandle, optname_ch, optvalue_ch),
+                              _api->vclGetCompilerIsOptionSupported(_compilerHandle, optname_ch, optvalue_ch),
                               _logHandle);
         return true;
     } catch (const std::exception& e) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
@@ -8,7 +8,6 @@
 #include <iterator>
 #include <ostream>
 
-#include "compiler_impl.hpp"
 #include "intel_npu/common/compiler_adapter_factory.hpp"
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/prefix.hpp"

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -9,6 +9,7 @@
 #include "compiler_impl.hpp"
 #include "intel_npu/config/options.hpp"
 #include "intel_npu/utils/utils.hpp"
+#include "intel_npu/utils/vcl/vcl_api.hpp"
 #include "intel_npu/utils/zero/zero_api.hpp"
 #include "intel_npu/utils/zero/zero_cmd_queue_pool.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
@@ -155,7 +156,7 @@ std::pair<uint64_t, std::optional<std::vector<uint64_t>>> Graph::export_blob(std
 
 std::vector<ov::ProfilingInfo> Graph::process_profiling_output(const std::vector<uint8_t>& profData) const {
     auto ov_lib_path = ov::util::path_to_string(ov::util::get_ov_lib_path());
-    auto compiler = std::make_shared<VCLCompilerImpl>(ov_lib_path);
+    auto compiler = std::make_shared<VCLCompilerImpl>(VCLApi::getInstance(ov_lib_path));
     OPENVINO_ASSERT(compiler != nullptr, "Profiling post-processing requires the NPU plugin compiler library");
 
     std::vector<uint8_t> blob(_blob->get_byte_size());

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -156,7 +156,7 @@ std::pair<uint64_t, std::optional<std::vector<uint64_t>>> Graph::export_blob(std
 
 std::vector<ov::ProfilingInfo> Graph::process_profiling_output(const std::vector<uint8_t>& profData) const {
     auto ov_lib_path = ov::util::path_to_string(ov::util::get_ov_lib_path());
-    auto compiler = std::make_shared<VCLCompilerImpl>(VCLApi::getInstance(ov_lib_path));
+    auto compiler = std::make_shared<VCLCompilerImpl>(VCLLoader::getInstance(ov_lib_path)->sharedFunctions());
     OPENVINO_ASSERT(compiler != nullptr, "Profiling post-processing requires the NPU plugin compiler library");
 
     std::vector<uint8_t> blob(_blob->get_byte_size());

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -44,9 +44,13 @@ PluginCompilerAdapter::PluginCompilerAdapter(const std::shared_ptr<ZeroInitStruc
     _logger.info("Loading PLUGIN compiler");
     try {
         auto ovLibPath = ov::util::path_to_string(ov::util::get_ov_lib_path());
-        auto vclCompilerPtr = std::make_shared<VCLCompilerImpl>(VCLApi::getInstance(ovLibPath), deviceProperties);
+        auto vclLoader = VCLLoader::getInstance(ovLibPath);
+        OPENVINO_ASSERT(vclLoader != nullptr, "VCL loader is nullptr");
+        auto vclCompilerPtr = std::make_shared<VCLCompilerImpl>(vclLoader->sharedFunctions(), deviceProperties);
         OPENVINO_ASSERT(vclCompilerPtr != nullptr, "VCL compiler is nullptr");
-        auto vclLib = vclCompilerPtr->getLinkedLibrary();
+        // Pair the compiler with the library so the .so cannot be unloaded while the compiler
+        // dispatches into it. The compiler itself no longer knows a library is involved.
+        auto vclLib = vclLoader->getLibrary();
         _logger.info("PLUGIN VCL compiler is loading");
         OPENVINO_ASSERT(vclLib != nullptr, "VCL library is nullptr");
         _compiler = ov::SoPtr<VCLCompilerImpl>(vclCompilerPtr, vclLib);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -44,7 +44,7 @@ PluginCompilerAdapter::PluginCompilerAdapter(const std::shared_ptr<ZeroInitStruc
     _logger.info("Loading PLUGIN compiler");
     try {
         auto ovLibPath = ov::util::path_to_string(ov::util::get_ov_lib_path());
-        auto vclCompilerPtr = std::make_shared<VCLCompilerImpl>(ovLibPath, deviceProperties);
+        auto vclCompilerPtr = std::make_shared<VCLCompilerImpl>(VCLApi::getInstance(ovLibPath), deviceProperties);
         OPENVINO_ASSERT(vclCompilerPtr != nullptr, "VCL compiler is nullptr");
         auto vclLib = vclCompilerPtr->getLinkedLibrary();
         _logger.info("PLUGIN VCL compiler is loading");
@@ -287,25 +287,7 @@ uint32_t PluginCompilerAdapter::get_version() const {
 }
 
 std::vector<std::string> PluginCompilerAdapter::get_supported_options() const {
-    std::vector<char> options;
-    _compiler->get_supported_options(options);
-    size_t optionsSize = options.size();
-    while (optionsSize > 0 && options[optionsSize - 1] == '\0') {
-        --optionsSize;
-    }
-    if (optionsSize == 0) {
-        return {};
-    }
-
-    std::string compilerOptionsStr(options.data(), optionsSize);
-    _logger.debug("VCLCompilerImpl return supported_options: %s", compilerOptionsStr.c_str());
-    // vectorize string
-    std::istringstream suppstream(compilerOptionsStr);
-    std::vector<std::string> compilerOpts = {};
-    std::string option;
-    while (suppstream >> option) {
-        compilerOpts.push_back(option);
-    }
+    const std::vector<std::string> compilerOpts = _compiler->get_supported_options();
 
     if (_optionSupportCache) {
         _optionSupportCache->setSupportedOptions(pluginOptionSupportKey, compilerOpts);

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vcl/vcl_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vcl/vcl_api.hpp
@@ -41,7 +41,17 @@ namespace intel_npu {
 
 class VCLApi {
 public:
+    /**
+     * @brief Tag for the non-loading constructor.
+     */
+    struct NoLoad {};
+
     VCLApi(const std::string& library_dir);
+    /**
+     * @brief Builds an instance without loading the compiler library: `lib` stays null and every
+     * entry point is null, so the caller can assign the entry points it needs directly.
+     */
+    explicit VCLApi(NoLoad);
     VCLApi(const VCLApi& other) = delete;
     VCLApi(VCLApi&& other) = delete;
     void operator=(const VCLApi&) = delete;

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vcl/vcl_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vcl/vcl_api.hpp
@@ -32,22 +32,19 @@ namespace intel_npu {
     vcl_symbol_statement(vclExecutableGetCompatibilityString) \
     vcl_symbol_statement(vclGetCompilerSupportedOptions)    \
     vcl_symbol_statement(vclGetCompilerIsOptionSupported)   \
+    vcl_symbol_statement(vclAllocatedExecutableCreateWSOneShot2) \
 
 
 // symbols that may not be supported in older versions of vcl
 #define vcl_weak_symbols_list()                             \
-    vcl_symbol_statement(vclAllocatedExecutableCreate2)     \
-    vcl_symbol_statement(vclAllocatedExecutableCreateWSOneShot2)  // clang-format on
+    vcl_symbol_statement(vclAllocatedExecutableCreate2)  // clang-format on
 
 /**
  * @brief The VCL entry points, as a plain aggregate.
  *
  * Deliberately holds no library handle and does no loading: it is data, not behaviour. Every entry
  * point defaults to null, so a default-constructed table is a legitimate value - an unpopulated
- * table - rather than a half-constructed object. That is what lets tests build one directly with no
- * test-only constructor, tag, or friend declaration. Each field keeps the exact
- * `decltype(&::vclXxx)` type from `vcl.h`, so whatever populates it - `dlsym` in `VCLLoader` or a
- * static function in a test double - is type-checked against the vendor header itself.
+ * table
  */
 struct VCLFunctionTable {
 #define vcl_symbol_statement(vcl_symbol) decltype(&::vcl_symbol) vcl_symbol = nullptr;

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vcl/vcl_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vcl/vcl_api.hpp
@@ -62,6 +62,25 @@ public:
         return lib;
     }
 
+    /**
+     * @brief True when every non-weak entry point resolved.
+     *
+     * Weak symbols are excluded on purpose: they are legitimately null when the loaded library
+     * predates them. Consumers that need the full table assert on this at construction, so a
+     * `NoLoad` instance that was never wired fails with a diagnosable error instead of dispatching
+     * through a null function pointer at the first call. Generated from `vcl_symbols_list()`, so it
+     * cannot drift as the list grows.
+     */
+    bool hasAllRequiredSymbols() const {
+#define vcl_symbol_statement(vcl_symbol) \
+    if (this->vcl_symbol == nullptr) {   \
+        return false;                    \
+    }
+        vcl_symbols_list();
+#undef vcl_symbol_statement
+        return true;
+    }
+
 #define vcl_symbol_statement(vcl_symbol) decltype(&::vcl_symbol) vcl_symbol;
     vcl_symbols_list();
     vcl_weak_symbols_list();
@@ -71,22 +90,5 @@ private:
     std::shared_ptr<void> lib;
     Logger _logger;
 };
-
-#define vcl_symbol_statement(vcl_symbol)                                                                            \
-    template <typename... Args>                                                                                     \
-    inline typename std::invoke_result<decltype(&::vcl_symbol), Args...>::type wrapped_##vcl_symbol(Args... args) { \
-        const auto& ptr = VCLApi::getInstance();                                                                    \
-        if (ptr->vcl_symbol == nullptr) {                                                                           \
-            OPENVINO_THROW("Unsupported vcl_symbol " #vcl_symbol);                                                  \
-        }                                                                                                           \
-        return ptr->vcl_symbol(std::forward<Args>(args)...);                                                        \
-    }
-vcl_symbols_list();
-vcl_weak_symbols_list();
-#undef vcl_symbol_statement
-#define vcl_symbol_statement(vcl_symbol) inline decltype(&::vcl_symbol) vcl_symbol = wrapped_##vcl_symbol;
-vcl_symbols_list();
-vcl_weak_symbols_list();
-#undef vcl_symbol_statement
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vcl/vcl_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/vcl/vcl_api.hpp
@@ -39,37 +39,30 @@ namespace intel_npu {
     vcl_symbol_statement(vclAllocatedExecutableCreate2)     \
     vcl_symbol_statement(vclAllocatedExecutableCreateWSOneShot2)  // clang-format on
 
-class VCLApi {
-public:
-    /**
-     * @brief Tag for the non-loading constructor.
-     */
-    struct NoLoad {};
-
-    VCLApi(const std::string& library_dir);
-    /**
-     * @brief Builds an instance without loading the compiler library: `lib` stays null and every
-     * entry point is null, so the caller can assign the entry points it needs directly.
-     */
-    explicit VCLApi(NoLoad);
-    VCLApi(const VCLApi& other) = delete;
-    VCLApi(VCLApi&& other) = delete;
-    void operator=(const VCLApi&) = delete;
-    void operator=(VCLApi&&) = delete;
-
-    static const std::shared_ptr<VCLApi> getInstance(const std::string& library_dir = std::string());
-    std::shared_ptr<void> getLibrary() const {
-        return lib;
-    }
+/**
+ * @brief The VCL entry points, as a plain aggregate.
+ *
+ * Deliberately holds no library handle and does no loading: it is data, not behaviour. Every entry
+ * point defaults to null, so a default-constructed table is a legitimate value - an unpopulated
+ * table - rather than a half-constructed object. That is what lets tests build one directly with no
+ * test-only constructor, tag, or friend declaration. Each field keeps the exact
+ * `decltype(&::vclXxx)` type from `vcl.h`, so whatever populates it - `dlsym` in `VCLLoader` or a
+ * static function in a test double - is type-checked against the vendor header itself.
+ */
+struct VCLFunctionTable {
+#define vcl_symbol_statement(vcl_symbol) decltype(&::vcl_symbol) vcl_symbol = nullptr;
+    vcl_symbols_list();
+    vcl_weak_symbols_list();
+#undef vcl_symbol_statement
 
     /**
-     * @brief True when every non-weak entry point resolved.
+     * @brief True when every non-weak entry point is populated.
      *
      * Weak symbols are excluded on purpose: they are legitimately null when the loaded library
-     * predates them. Consumers that need the full table assert on this at construction, so a
-     * `NoLoad` instance that was never wired fails with a diagnosable error instead of dispatching
-     * through a null function pointer at the first call. Generated from `vcl_symbols_list()`, so it
-     * cannot drift as the list grows.
+     * predates them. Consumers that need the full table assert on this at construction, so an
+     * unpopulated table fails with a diagnosable error instead of dispatching through a null
+     * function pointer at the first call. Generated from `vcl_symbols_list()`, so it cannot drift
+     * as the list grows.
      */
     bool hasAllRequiredSymbols() const {
 #define vcl_symbol_statement(vcl_symbol) \
@@ -80,13 +73,41 @@ public:
 #undef vcl_symbol_statement
         return true;
     }
+};
 
-#define vcl_symbol_statement(vcl_symbol) decltype(&::vcl_symbol) vcl_symbol;
-    vcl_symbols_list();
-    vcl_weak_symbols_list();
-#undef vcl_symbol_statement
+/**
+ * @brief Owns the loaded VCL compiler library and the function table resolved out of it.
+ *
+ * The loading constructor is private: `getInstance` is the only way to load, so the process cannot
+ * end up with two independently dlopen'd copies of the compiler library.
+ */
+class VCLLoader final : public std::enable_shared_from_this<VCLLoader> {
+public:
+    VCLLoader(const VCLLoader& other) = delete;
+    VCLLoader(VCLLoader&& other) = delete;
+    void operator=(const VCLLoader&) = delete;
+    void operator=(VCLLoader&&) = delete;
+
+    static const std::shared_ptr<const VCLLoader> getInstance(const std::string& library_dir = std::string());
+
+    /**
+     * @brief The function table, sharing this loader's lifetime.
+     *
+     * An aliasing `shared_ptr`, so a holder of the returned table keeps the library loaded without
+     * having to know a library exists.
+     */
+    std::shared_ptr<const VCLFunctionTable> sharedFunctions() const {
+        return {shared_from_this(), &_functions};
+    }
+
+    std::shared_ptr<void> getLibrary() const {
+        return lib;
+    }
 
 private:
+    explicit VCLLoader(const std::string& library_dir);
+
+    VCLFunctionTable _functions;
     std::shared_ptr<void> lib;
     Logger _logger;
 };

--- a/src/plugins/intel_npu/src/utils/src/vcl/vcl_api.cpp
+++ b/src/plugins/intel_npu/src/utils/src/vcl/vcl_api.cpp
@@ -48,6 +48,15 @@ VCLApi::VCLApi(const std::string& library_dir) : _logger("VCLApi", Logger::globa
 #undef vcl_symbol_statement
 }
 
+VCLApi::VCLApi(NoLoad) : _logger("VCLApi", Logger::global().level()) {
+    // `lib` stays null; null every entry point so an unassigned one fails loudly rather than
+    // dispatching through uninitialised memory.
+#define vcl_symbol_statement(vcl_symbol) this->vcl_symbol = nullptr;
+    vcl_symbols_list();
+    vcl_weak_symbols_list();
+#undef vcl_symbol_statement
+}
+
 const std::shared_ptr<VCLApi> VCLApi::getInstance(const std::string& library_dir) {
     static std::mutex mtx;
     std::lock_guard<std::mutex> lock(mtx);

--- a/src/plugins/intel_npu/src/utils/src/vcl/vcl_api.cpp
+++ b/src/plugins/intel_npu/src/utils/src/vcl/vcl_api.cpp
@@ -41,11 +41,6 @@ VCLApi::VCLApi(const std::string& library_dir) : _logger("VCLApi", Logger::globa
     }
     vcl_weak_symbols_list();
 #undef vcl_symbol_statement
-
-#define vcl_symbol_statement(vcl_symbol) vcl_symbol = this->vcl_symbol;
-    vcl_symbols_list();
-    vcl_weak_symbols_list();
-#undef vcl_symbol_statement
 }
 
 VCLApi::VCLApi(NoLoad) : _logger("VCLApi", Logger::global().level()) {

--- a/src/plugins/intel_npu/src/utils/src/vcl/vcl_api.cpp
+++ b/src/plugins/intel_npu/src/utils/src/vcl/vcl_api.cpp
@@ -10,7 +10,7 @@
 #include "openvino/util/shared_object.hpp"
 
 namespace intel_npu {
-VCLApi::VCLApi(const std::string& library_dir) : _logger("VCLApi", Logger::global().level()) {
+VCLLoader::VCLLoader(const std::string& library_dir) : _logger("VCLLoader", Logger::global().level()) {
     const auto baseName = "openvino_intel_npu_compiler_loader";
 
     try {
@@ -24,7 +24,7 @@ VCLApi::VCLApi(const std::string& library_dir) : _logger("VCLApi", Logger::globa
 
     try {
 #define vcl_symbol_statement(vcl_symbol) \
-    this->vcl_symbol = reinterpret_cast<decltype(&::vcl_symbol)>(ov::util::get_symbol(lib, #vcl_symbol));
+    _functions.vcl_symbol = reinterpret_cast<decltype(&::vcl_symbol)>(ov::util::get_symbol(lib, #vcl_symbol));
         vcl_symbols_list();
 #undef vcl_symbol_statement
     } catch (const std::runtime_error& error) {
@@ -32,42 +32,34 @@ VCLApi::VCLApi(const std::string& library_dir) : _logger("VCLApi", Logger::globa
         OPENVINO_THROW(error.what());
     }
 
-#define vcl_symbol_statement(vcl_symbol)                                                                      \
-    try {                                                                                                     \
-        this->vcl_symbol = reinterpret_cast<decltype(&::vcl_symbol)>(ov::util::get_symbol(lib, #vcl_symbol)); \
-    } catch (const std::runtime_error&) {                                                                     \
-        _logger.debug("Failed to get %s from %s", #vcl_symbol, baseName);                                     \
-        this->vcl_symbol = nullptr;                                                                           \
+#define vcl_symbol_statement(vcl_symbol)                                                                           \
+    try {                                                                                                          \
+        _functions.vcl_symbol = reinterpret_cast<decltype(&::vcl_symbol)>(ov::util::get_symbol(lib, #vcl_symbol)); \
+    } catch (const std::runtime_error&) {                                                                          \
+        _logger.debug("Failed to get %s from %s", #vcl_symbol, baseName);                                          \
+        _functions.vcl_symbol = nullptr;                                                                           \
     }
     vcl_weak_symbols_list();
 #undef vcl_symbol_statement
 }
 
-VCLApi::VCLApi(NoLoad) : _logger("VCLApi", Logger::global().level()) {
-    // `lib` stays null; null every entry point so an unassigned one fails loudly rather than
-    // dispatching through uninitialised memory.
-#define vcl_symbol_statement(vcl_symbol) this->vcl_symbol = nullptr;
-    vcl_symbols_list();
-    vcl_weak_symbols_list();
-#undef vcl_symbol_statement
-}
-
-const std::shared_ptr<VCLApi> VCLApi::getInstance(const std::string& library_dir) {
+const std::shared_ptr<const VCLLoader> VCLLoader::getInstance(const std::string& library_dir) {
     static std::mutex mtx;
     std::lock_guard<std::mutex> lock(mtx);
 
     static std::string initialized_dir;
-    static std::shared_ptr<VCLApi> instance = nullptr;
+    static std::shared_ptr<const VCLLoader> instance = nullptr;
 
     if (!instance) {
         if (library_dir.empty()) {
-            OPENVINO_THROW("VCLApi instance has not been loaded yet, and no valid path was provided to load it.");
+            OPENVINO_THROW("VCLLoader instance has not been loaded yet, and no valid path was provided to load it.");
         }
         initialized_dir = library_dir;
-        instance = std::make_shared<VCLApi>(library_dir);
+        // Not make_shared: the loading constructor is private so that this is the only way to load.
+        instance = std::shared_ptr<const VCLLoader>(new VCLLoader(library_dir));
     } else {
         if (!library_dir.empty() && library_dir != initialized_dir) {
-            OPENVINO_THROW("VCLApi has already been initialized with path: '",
+            OPENVINO_THROW("VCLLoader has already been initialized with path: '",
                            initialized_dir,
                            "'. Dynamic switching to a new compiler path: '",
                            library_dir,

--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/vcl_allocator_test.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/vcl_allocator_test.cpp
@@ -38,7 +38,7 @@ protected:
     std::string targetDevice;
     std::shared_ptr<ov::Model> model;
     std::shared_ptr<::intel_npu::vcl_allocator_2> allocator;
-    std::shared_ptr<const ::intel_npu::VCLApi> api;
+    std::shared_ptr<const ::intel_npu::VCLFunctionTable> functions;
 
     void SetUp() override {
         targetDevice = GetParam();
@@ -47,7 +47,7 @@ protected:
 
         try {
             std::string ov_lib_dir = ov::test::utils::getOpenvinoLibDirectory();
-            api = ::intel_npu::VCLApi::getInstance(ov_lib_dir);
+            functions = ::intel_npu::VCLLoader::getInstance(ov_lib_dir)->sharedFunctions();
         } catch (const std::exception&) {
             GTEST_SKIP() << "Couldn't load compiler library";
         }
@@ -56,7 +56,7 @@ protected:
     // Helper struct and function to reduce code duplication
     struct CompilerSetupState {
         // Held so the destructor can reach vclCompilerDestroy, and so the loader outlives the handle.
-        std::shared_ptr<const ::intel_npu::VCLApi> api;
+        std::shared_ptr<const ::intel_npu::VCLFunctionTable> functions;
         std::string buildFlags;
         ::intel_npu::SerializedIR serializedIR;
         vcl_compiler_handle_t compiler = nullptr;
@@ -66,7 +66,7 @@ protected:
         CompilerSetupState(const CompilerSetupState&) = delete;
         CompilerSetupState& operator=(const CompilerSetupState&) = delete;
         CompilerSetupState(CompilerSetupState&& other) noexcept
-            : api(std::move(other.api)),
+            : functions(std::move(other.functions)),
               buildFlags(std::move(other.buildFlags)),
               serializedIR(std::move(other.serializedIR)),
               compiler(other.compiler),
@@ -77,7 +77,7 @@ protected:
         CompilerSetupState& operator=(CompilerSetupState&& other) noexcept {
             if (this != &other) {
                 release();
-                api = std::move(other.api);
+                functions = std::move(other.functions);
                 buildFlags = std::move(other.buildFlags);
                 serializedIR = std::move(other.serializedIR);
                 compiler = other.compiler;
@@ -95,7 +95,7 @@ protected:
     private:
         void release() {
             if (compiler != nullptr) {
-                api->vclCompilerDestroy(compiler);
+                functions->vclCompilerDestroy(compiler);
                 compiler = nullptr;
             }
         }
@@ -103,7 +103,7 @@ protected:
 
     CompilerSetupState createCompilerAndDescriptor() {
         CompilerSetupState state;
-        state.api = api;
+        state.functions = functions;
 
         state.buildFlags = ::intel_npu::compiler_utils::serializeIOInfo(model, true);
 
@@ -117,7 +117,7 @@ protected:
 
         vcl_version_info_t vclVersion = {};
         vcl_version_info_t vclProfilingVersion = {};
-        api->vclGetVersion(&vclVersion, &vclProfilingVersion);
+        functions->vclGetVersion(&vclVersion, &vclProfilingVersion);
 
         vcl_compiler_desc_t compilerDesc = {};
         compilerDesc.version = vclVersion;
@@ -134,7 +134,7 @@ protected:
                                         std::numeric_limits<uint16_t>::max(),
                                         defaultTileCount};
 
-        api->vclCompilerCreate(&compilerDesc, &deviceDesc, &state.compiler, &state.logHandle);
+        functions->vclCompilerCreate(&compilerDesc, &deviceDesc, &state.compiler, &state.logHandle);
 
         if (state.compiler == nullptr) {
             ADD_FAILURE() << "vclCompilerCreate failed";
@@ -143,7 +143,7 @@ protected:
 
         ze_graph_compiler_version_info_t vclVersionInfo = {0, 0};
         vcl_compiler_properties_t compilerProp = {};
-        api->vclCompilerGetProperties(state.compiler, &compilerProp);
+        functions->vclCompilerGetProperties(state.compiler, &compilerProp);
         vclVersionInfo.major = compilerProp.version.major;
         vclVersionInfo.minor = compilerProp.version.minor;
 
@@ -167,7 +167,7 @@ protected:
 
     std::string getCompatibilityString(vcl_executable_handle_t executable) {
         uint64_t compatibilityStringSize = 0;
-        auto result = api->vclExecutableGetCompatibilityString(executable, nullptr, &compatibilityStringSize);
+        auto result = functions->vclExecutableGetCompatibilityString(executable, nullptr, &compatibilityStringSize);
         if (result != VCL_RESULT_SUCCESS || compatibilityStringSize == 0) {
             ADD_FAILURE() << "Failed to get compatibility string size";
             return {};
@@ -178,9 +178,9 @@ protected:
             return {};
         }
         std::vector<char> compatibilityStringBuffer(static_cast<size_t>(compatibilityStringSize), '\0');
-        result = api->vclExecutableGetCompatibilityString(executable,
-                                                          compatibilityStringBuffer.data(),
-                                                          &compatibilityStringSize);
+        result = functions->vclExecutableGetCompatibilityString(executable,
+                                                                compatibilityStringBuffer.data(),
+                                                                &compatibilityStringSize);
         if (result != VCL_RESULT_SUCCESS) {
             ADD_FAILURE() << "Failed to get compatibility string";
             return {};
@@ -210,8 +210,12 @@ TEST_P(VclAllocatorFuncTests, VerifyAllocation) {
                                   setup.buildFlags.c_str(),
                                   setup.buildFlags.size()};
 
-    auto result =
-        api->vclAllocatedExecutableCreate4(setup.compiler, desc, allocator.get(), &blobBuffer, &blobSize, &executable);
+    auto result = functions->vclAllocatedExecutableCreate4(setup.compiler,
+                                                           desc,
+                                                           allocator.get(),
+                                                           &blobBuffer,
+                                                           &blobSize,
+                                                           &executable);
 
     EXPECT_EQ(result, VCL_RESULT_SUCCESS);
     EXPECT_NE(blobBuffer, nullptr);
@@ -229,7 +233,7 @@ TEST_P(VclAllocatorFuncTests, VerifyAllocation) {
                                });
     EXPECT_NE(blobIt, allocator->m_info.end());
 
-    EXPECT_EQ(api->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
+    EXPECT_EQ(functions->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
 }
 
 TEST_P(VclAllocatorFuncTests, VerifyDeallocation) {
@@ -245,8 +249,12 @@ TEST_P(VclAllocatorFuncTests, VerifyDeallocation) {
                                   setup.buildFlags.c_str(),
                                   setup.buildFlags.size()};
 
-    auto result =
-        api->vclAllocatedExecutableCreate4(setup.compiler, desc, allocator.get(), &blobBuffer, &blobSize, &executable);
+    auto result = functions->vclAllocatedExecutableCreate4(setup.compiler,
+                                                           desc,
+                                                           allocator.get(),
+                                                           &blobBuffer,
+                                                           &blobSize,
+                                                           &executable);
 
     EXPECT_EQ(result, VCL_RESULT_SUCCESS);
     ASSERT_NE(executable, nullptr);
@@ -267,7 +275,7 @@ TEST_P(VclAllocatorFuncTests, VerifyDeallocation) {
     EXPECT_EQ(blobIt, allocator->m_info.end());
     EXPECT_EQ(allocator->m_info.size(), 0);
 
-    EXPECT_EQ(api->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
+    EXPECT_EQ(functions->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
 }
 
 TEST_P(VclAllocatorFuncTests, VerifyOwnershipTransferToTensor) {
@@ -283,8 +291,12 @@ TEST_P(VclAllocatorFuncTests, VerifyOwnershipTransferToTensor) {
                                   setup.buildFlags.c_str(),
                                   setup.buildFlags.size()};
 
-    auto result =
-        api->vclAllocatedExecutableCreate4(setup.compiler, desc, allocator.get(), &blobBuffer, &blobSize, &executable);
+    auto result = functions->vclAllocatedExecutableCreate4(setup.compiler,
+                                                           desc,
+                                                           allocator.get(),
+                                                           &blobBuffer,
+                                                           &blobSize,
+                                                           &executable);
 
     EXPECT_EQ(result, VCL_RESULT_SUCCESS);
     ASSERT_NE(executable, nullptr);
@@ -315,7 +327,7 @@ TEST_P(VclAllocatorFuncTests, VerifyOwnershipTransferToTensor) {
     // the tracking info in the allocator should be empty.
     EXPECT_EQ(allocator->m_info.size(), 0);
 
-    EXPECT_EQ(api->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
+    EXPECT_EQ(functions->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
 }
 
 TEST_P(VclAllocatorFuncTests, VerifyOrphanMemoryCleanupOnDestruction) {
@@ -331,8 +343,12 @@ TEST_P(VclAllocatorFuncTests, VerifyOrphanMemoryCleanupOnDestruction) {
                                   setup.buildFlags.c_str(),
                                   setup.buildFlags.size()};
 
-    auto result =
-        api->vclAllocatedExecutableCreate4(setup.compiler, desc, allocator.get(), &blobBuffer, &blobSize, &executable);
+    auto result = functions->vclAllocatedExecutableCreate4(setup.compiler,
+                                                           desc,
+                                                           allocator.get(),
+                                                           &blobBuffer,
+                                                           &blobSize,
+                                                           &executable);
 
     EXPECT_EQ(result, VCL_RESULT_SUCCESS);
     ASSERT_NE(executable, nullptr);
@@ -340,7 +356,7 @@ TEST_P(VclAllocatorFuncTests, VerifyOrphanMemoryCleanupOnDestruction) {
     EXPECT_FALSE(compatibilityString.empty());
     EXPECT_EQ(allocator->m_info.size(), 1);  // 1 allocation: blob
 
-    EXPECT_EQ(api->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
+    EXPECT_EQ(functions->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
 
     // Purpose: Simulate VCL crash or early return where the memory is temporarily tracked as an orphan leak
     // When the allocator goes out of scope and gets destroyed, it should cleanly free all tracked memory

--- a/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/vcl_allocator_test.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/compiler_adapter/vcl_allocator_test.cpp
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <algorithm>
+#include "intel_npu/utils/vcl/vcl_allocator.hpp"
+
 #include <gtest/gtest.h>
+
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -11,7 +14,6 @@
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "intel_npu/utils/utils.hpp"
-#include "intel_npu/utils/vcl/vcl_allocator.hpp"
 #include "intel_npu/utils/vcl/vcl_api.hpp"
 #include "model_serializer.hpp"
 #include "openvino/core/except.hpp"
@@ -36,6 +38,7 @@ protected:
     std::string targetDevice;
     std::shared_ptr<ov::Model> model;
     std::shared_ptr<::intel_npu::vcl_allocator_2> allocator;
+    std::shared_ptr<const ::intel_npu::VCLApi> api;
 
     void SetUp() override {
         targetDevice = GetParam();
@@ -44,7 +47,7 @@ protected:
 
         try {
             std::string ov_lib_dir = ov::test::utils::getOpenvinoLibDirectory();
-            ::intel_npu::VCLApi::getInstance(ov_lib_dir);
+            api = ::intel_npu::VCLApi::getInstance(ov_lib_dir);
         } catch (const std::exception&) {
             GTEST_SKIP() << "Couldn't load compiler library";
         }
@@ -52,6 +55,8 @@ protected:
 
     // Helper struct and function to reduce code duplication
     struct CompilerSetupState {
+        // Held so the destructor can reach vclCompilerDestroy, and so the loader outlives the handle.
+        std::shared_ptr<const ::intel_npu::VCLApi> api;
         std::string buildFlags;
         ::intel_npu::SerializedIR serializedIR;
         vcl_compiler_handle_t compiler = nullptr;
@@ -61,7 +66,8 @@ protected:
         CompilerSetupState(const CompilerSetupState&) = delete;
         CompilerSetupState& operator=(const CompilerSetupState&) = delete;
         CompilerSetupState(CompilerSetupState&& other) noexcept
-            : buildFlags(std::move(other.buildFlags)),
+            : api(std::move(other.api)),
+              buildFlags(std::move(other.buildFlags)),
               serializedIR(std::move(other.serializedIR)),
               compiler(other.compiler),
               logHandle(other.logHandle) {
@@ -71,6 +77,7 @@ protected:
         CompilerSetupState& operator=(CompilerSetupState&& other) noexcept {
             if (this != &other) {
                 release();
+                api = std::move(other.api);
                 buildFlags = std::move(other.buildFlags);
                 serializedIR = std::move(other.serializedIR);
                 compiler = other.compiler;
@@ -88,7 +95,7 @@ protected:
     private:
         void release() {
             if (compiler != nullptr) {
-                ::intel_npu::vclCompilerDestroy(compiler);
+                api->vclCompilerDestroy(compiler);
                 compiler = nullptr;
             }
         }
@@ -96,6 +103,7 @@ protected:
 
     CompilerSetupState createCompilerAndDescriptor() {
         CompilerSetupState state;
+        state.api = api;
 
         state.buildFlags = ::intel_npu::compiler_utils::serializeIOInfo(model, true);
 
@@ -109,7 +117,7 @@ protected:
 
         vcl_version_info_t vclVersion = {};
         vcl_version_info_t vclProfilingVersion = {};
-        ::intel_npu::vclGetVersion(&vclVersion, &vclProfilingVersion);
+        api->vclGetVersion(&vclVersion, &vclProfilingVersion);
 
         vcl_compiler_desc_t compilerDesc = {};
         compilerDesc.version = vclVersion;
@@ -126,7 +134,7 @@ protected:
                                         std::numeric_limits<uint16_t>::max(),
                                         defaultTileCount};
 
-        ::intel_npu::vclCompilerCreate(&compilerDesc, &deviceDesc, &state.compiler, &state.logHandle);
+        api->vclCompilerCreate(&compilerDesc, &deviceDesc, &state.compiler, &state.logHandle);
 
         if (state.compiler == nullptr) {
             ADD_FAILURE() << "vclCompilerCreate failed";
@@ -135,7 +143,7 @@ protected:
 
         ze_graph_compiler_version_info_t vclVersionInfo = {0, 0};
         vcl_compiler_properties_t compilerProp = {};
-        ::intel_npu::vclCompilerGetProperties(state.compiler, &compilerProp);
+        api->vclCompilerGetProperties(state.compiler, &compilerProp);
         vclVersionInfo.major = compilerProp.version.major;
         vclVersionInfo.minor = compilerProp.version.minor;
 
@@ -157,9 +165,9 @@ protected:
         return state;
     }
 
-    static std::string getCompatibilityString(vcl_executable_handle_t executable) {
+    std::string getCompatibilityString(vcl_executable_handle_t executable) {
         uint64_t compatibilityStringSize = 0;
-        auto result = ::intel_npu::vclExecutableGetCompatibilityString(executable, nullptr, &compatibilityStringSize);
+        auto result = api->vclExecutableGetCompatibilityString(executable, nullptr, &compatibilityStringSize);
         if (result != VCL_RESULT_SUCCESS || compatibilityStringSize == 0) {
             ADD_FAILURE() << "Failed to get compatibility string size";
             return {};
@@ -170,9 +178,9 @@ protected:
             return {};
         }
         std::vector<char> compatibilityStringBuffer(static_cast<size_t>(compatibilityStringSize), '\0');
-        result = ::intel_npu::vclExecutableGetCompatibilityString(executable,
-                                                                  compatibilityStringBuffer.data(),
-                                                                  &compatibilityStringSize);
+        result = api->vclExecutableGetCompatibilityString(executable,
+                                                          compatibilityStringBuffer.data(),
+                                                          &compatibilityStringSize);
         if (result != VCL_RESULT_SUCCESS) {
             ADD_FAILURE() << "Failed to get compatibility string";
             return {};
@@ -202,12 +210,8 @@ TEST_P(VclAllocatorFuncTests, VerifyAllocation) {
                                   setup.buildFlags.c_str(),
                                   setup.buildFlags.size()};
 
-    auto result = ::intel_npu::vclAllocatedExecutableCreate4(setup.compiler,
-                                                             desc,
-                                                             allocator.get(),
-                                                             &blobBuffer,
-                                                             &blobSize,
-                                                             &executable);
+    auto result =
+        api->vclAllocatedExecutableCreate4(setup.compiler, desc, allocator.get(), &blobBuffer, &blobSize, &executable);
 
     EXPECT_EQ(result, VCL_RESULT_SUCCESS);
     EXPECT_NE(blobBuffer, nullptr);
@@ -225,7 +229,7 @@ TEST_P(VclAllocatorFuncTests, VerifyAllocation) {
                                });
     EXPECT_NE(blobIt, allocator->m_info.end());
 
-    EXPECT_EQ(::intel_npu::vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
+    EXPECT_EQ(api->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
 }
 
 TEST_P(VclAllocatorFuncTests, VerifyDeallocation) {
@@ -241,12 +245,8 @@ TEST_P(VclAllocatorFuncTests, VerifyDeallocation) {
                                   setup.buildFlags.c_str(),
                                   setup.buildFlags.size()};
 
-    auto result = ::intel_npu::vclAllocatedExecutableCreate4(setup.compiler,
-                                                             desc,
-                                                             allocator.get(),
-                                                             &blobBuffer,
-                                                             &blobSize,
-                                                             &executable);
+    auto result =
+        api->vclAllocatedExecutableCreate4(setup.compiler, desc, allocator.get(), &blobBuffer, &blobSize, &executable);
 
     EXPECT_EQ(result, VCL_RESULT_SUCCESS);
     ASSERT_NE(executable, nullptr);
@@ -267,7 +267,7 @@ TEST_P(VclAllocatorFuncTests, VerifyDeallocation) {
     EXPECT_EQ(blobIt, allocator->m_info.end());
     EXPECT_EQ(allocator->m_info.size(), 0);
 
-    EXPECT_EQ(::intel_npu::vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
+    EXPECT_EQ(api->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
 }
 
 TEST_P(VclAllocatorFuncTests, VerifyOwnershipTransferToTensor) {
@@ -283,12 +283,8 @@ TEST_P(VclAllocatorFuncTests, VerifyOwnershipTransferToTensor) {
                                   setup.buildFlags.c_str(),
                                   setup.buildFlags.size()};
 
-    auto result = ::intel_npu::vclAllocatedExecutableCreate4(setup.compiler,
-                                                             desc,
-                                                             allocator.get(),
-                                                             &blobBuffer,
-                                                             &blobSize,
-                                                             &executable);
+    auto result =
+        api->vclAllocatedExecutableCreate4(setup.compiler, desc, allocator.get(), &blobBuffer, &blobSize, &executable);
 
     EXPECT_EQ(result, VCL_RESULT_SUCCESS);
     ASSERT_NE(executable, nullptr);
@@ -319,7 +315,7 @@ TEST_P(VclAllocatorFuncTests, VerifyOwnershipTransferToTensor) {
     // the tracking info in the allocator should be empty.
     EXPECT_EQ(allocator->m_info.size(), 0);
 
-    EXPECT_EQ(::intel_npu::vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
+    EXPECT_EQ(api->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
 }
 
 TEST_P(VclAllocatorFuncTests, VerifyOrphanMemoryCleanupOnDestruction) {
@@ -335,12 +331,8 @@ TEST_P(VclAllocatorFuncTests, VerifyOrphanMemoryCleanupOnDestruction) {
                                   setup.buildFlags.c_str(),
                                   setup.buildFlags.size()};
 
-    auto result = ::intel_npu::vclAllocatedExecutableCreate4(setup.compiler,
-                                                             desc,
-                                                             allocator.get(),
-                                                             &blobBuffer,
-                                                             &blobSize,
-                                                             &executable);
+    auto result =
+        api->vclAllocatedExecutableCreate4(setup.compiler, desc, allocator.get(), &blobBuffer, &blobSize, &executable);
 
     EXPECT_EQ(result, VCL_RESULT_SUCCESS);
     ASSERT_NE(executable, nullptr);
@@ -348,7 +340,7 @@ TEST_P(VclAllocatorFuncTests, VerifyOrphanMemoryCleanupOnDestruction) {
     EXPECT_FALSE(compatibilityString.empty());
     EXPECT_EQ(allocator->m_info.size(), 1);  // 1 allocation: blob
 
-    EXPECT_EQ(::intel_npu::vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
+    EXPECT_EQ(api->vclExecutableDestroy(executable), VCL_RESULT_SUCCESS);
 
     // Purpose: Simulate VCL crash or early return where the memory is temporarily tracked as an orphan leak
     // When the allocator goes out of scope and gets destroyed, it should cleanly free all tracked memory

--- a/src/plugins/intel_npu/tests/functional/internal/plugin/test_compiler_option_support_helper.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/plugin/test_compiler_option_support_helper.cpp
@@ -43,7 +43,7 @@ size_t countOccurrences(const std::string& haystack, const std::string& needle) 
 }
 
 // Only PluginCompilerAdapter's successful bulk load logs a distinctive, identifiable marker (see
-// "VCLCompilerImpl return supported_options" in plugin_compiler_adapter.cpp). DriverCompilerAdapter has
+// "VCLCompilerImpl return supported_options" in compiler_impl.cpp). DriverCompilerAdapter has
 // no equivalent marker on its success path, so "exactly once" bulk-load checks below only apply to PLUGIN.
 std::string bulkLoadMarkerFor(ov::intel_npu::CompilerType compilerType) {
     return compilerType == ov::intel_npu::CompilerType::PLUGIN ? "VCLCompilerImpl return supported_options" : "";

--- a/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
@@ -61,7 +61,7 @@ struct VCLCompilerImplTest : public ::testing::Test {
 
     std::shared_ptr<VCLCompilerImpl> makeCompiler(
         const std::optional<IDevice::DeviceProperties>& props = std::nullopt) {
-        return std::make_shared<VCLCompilerImpl>(fake.api(), props);
+        return std::make_shared<VCLCompilerImpl>(fake.functions(), props);
     }
 };
 
@@ -140,10 +140,10 @@ TEST_F(VCLCompilerImplTest, NullApiTableIsRejected) {
         ov::Exception);
 }
 
-TEST_F(VCLCompilerImplTest, UnwiredApiTableIsRejected) {
-    // A NoLoad table nobody wired: every entry point is null. Without the hasAllRequiredSymbols
+TEST_F(VCLCompilerImplTest, UnwiredFunctionTableIsRejected) {
+    // A default-constructed table: every entry point is null. Without the hasAllRequiredSymbols
     // guard this would dispatch through a null vclGetVersion instead of throwing.
-    auto unwired = std::make_shared<const intel_npu::VCLApi>(intel_npu::VCLApi::NoLoad{});
+    auto unwired = std::make_shared<const intel_npu::VCLFunctionTable>();
     EXPECT_THROW(
         {
             auto compiler = std::make_shared<VCLCompilerImpl>(unwired);
@@ -156,10 +156,10 @@ TEST_F(VCLCompilerImplTest, MissingWeakSymbolsDoNotBlockConstruction) {
     // The weak symbols are legitimately null against an older compiler library, so the required-
     // symbol guard must ignore them. FakeVcl leaves vclAllocatedExecutableCreate2 null already;
     // null the remaining one so the whole weak list is absent.
-    ASSERT_TRUE(fake.mutableApi()->vclAllocatedExecutableCreate2 == nullptr);
-    fake.mutableApi()->vclAllocatedExecutableCreateWSOneShot2 = nullptr;
+    ASSERT_TRUE(fake.mutableFunctions()->vclAllocatedExecutableCreate2 == nullptr);
+    fake.mutableFunctions()->vclAllocatedExecutableCreateWSOneShot2 = nullptr;
 
-    EXPECT_TRUE(fake.api()->hasAllRequiredSymbols());
+    EXPECT_TRUE(fake.functions()->hasAllRequiredSymbols());
     EXPECT_NO_THROW(makeCompiler());
 }
 

--- a/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
@@ -1,0 +1,691 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "compiler_impl.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "fake_vcl.hpp"
+#include "intel_npu/common/filtered_config.hpp"
+#include "intel_npu/config/options.hpp"
+#include "intel_npu/utils/utils.hpp"
+#include "model_serializer.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "ze_graph_ext_wrappers.hpp"
+
+using ::fake_vcl::FakeVcl;
+using ::intel_npu::FilteredConfig;
+using ::intel_npu::IDevice;
+using ::intel_npu::OptionsDesc;
+using ::intel_npu::VCLCompilerImpl;
+
+namespace {
+
+/// Registers just the options the compiler-in-plugin path reads, so `config.get<>` resolves.
+std::shared_ptr<OptionsDesc> makeOptionsDesc() {
+    auto desc = std::make_shared<OptionsDesc>();
+    desc->add<::intel_npu::MODEL_SERIALIZER_VERSION>();
+    desc->add<::intel_npu::WS_COMPILE_CALL_NUMBER>();
+    return desc;
+}
+
+FilteredConfig makeConfig() {
+    // Registration is all that is needed: compileWsIterative writes WS_COMPILE_CALL_NUMBER via
+    // update(), and MODEL_SERIALIZER_VERSION is read through config.get<>.
+    return FilteredConfig(makeOptionsDesc());
+}
+
+/// A minimal model with one weight, enough for the serializer to produce a real IR.
+std::shared_ptr<ov::Model> makeModel() {
+    auto weights = std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape{5}, std::vector<float>{1.0f});
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{5});
+    input->set_friendly_name("Parameter_0");
+    auto add = std::make_shared<ov::op::v1::Add>(input, weights);
+    add->set_friendly_name("Add_1");
+    return std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input}, "compiler_impl_test_model");
+}
+
+struct VCLCompilerImplTest : public ::testing::Test {
+    FakeVcl fake;
+
+    std::shared_ptr<VCLCompilerImpl> makeCompiler(
+        const std::optional<IDevice::DeviceProperties>& props = std::nullopt) {
+        return std::make_shared<VCLCompilerImpl>(fake.api(), props);
+    }
+};
+
+//
+// --- construction ---
+//
+
+TEST_F(VCLCompilerImplTest, ConstructionQueriesVersionCreatesCompilerAndReadsProperties) {
+    auto compiler = makeCompiler();
+    ASSERT_NE(compiler, nullptr);
+
+    EXPECT_TRUE(fake.called("vclGetVersion"));
+    EXPECT_EQ(fake.callCount("vclCompilerCreate"), 1u);
+    EXPECT_EQ(fake.callCount("vclCompilerGetProperties"), 1u);
+    // vclGetVersion must precede compiler creation: the negotiated version goes into the desc.
+    EXPECT_LT(fake.indexOf("vclGetVersion"), fake.indexOf("vclCompilerCreate"));
+}
+
+TEST_F(VCLCompilerImplTest, ConstructionForwardsTheNegotiatedVersionInTheCompilerDesc) {
+    fake.reportedCompilerVersion = {VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR};
+    auto compiler = makeCompiler();
+
+    ASSERT_EQ(fake.compilerDescs.size(), 1u);
+    EXPECT_EQ(fake.compilerDescs[0].version.major, VCL_COMPILER_VERSION_MAJOR);
+    EXPECT_EQ(fake.compilerDescs[0].version.minor, VCL_COMPILER_VERSION_MINOR);
+}
+
+TEST_F(VCLCompilerImplTest, DevicePropertiesAreForwardedExactly) {
+    IDevice::DeviceProperties props{0x1234u, 7u, 4u};
+    auto compiler = makeCompiler(props);
+
+    ASSERT_EQ(fake.deviceDescs.size(), 1u);
+    const auto& desc = fake.deviceDescs[0];
+    EXPECT_EQ(desc.size, sizeof(vcl_device_desc_t));
+    EXPECT_EQ(desc.deviceID, 0x1234u);
+    EXPECT_EQ(desc.revision, 7u);
+    EXPECT_EQ(desc.tileCount, 4u);
+}
+
+TEST_F(VCLCompilerImplTest, OversizedSubdeviceIdClampsToTheInvalidRevisionSentinel) {
+    constexpr auto sentinel = std::numeric_limits<uint16_t>::max();
+    // Anything at or above the sentinel cannot fit the 16-bit revision field.
+    IDevice::DeviceProperties props{0x1u, static_cast<uint32_t>(sentinel) + 5u, 1u};
+    auto compiler = makeCompiler(props);
+
+    ASSERT_EQ(fake.deviceDescs.size(), 1u);
+    EXPECT_EQ(fake.deviceDescs[0].revision, sentinel);
+}
+
+TEST_F(VCLCompilerImplTest, SubdeviceIdExactlyAtTheSentinelAlsoClamps) {
+    constexpr auto sentinel = std::numeric_limits<uint16_t>::max();
+    IDevice::DeviceProperties props{0x1u, static_cast<uint32_t>(sentinel), 1u};
+    auto compiler = makeCompiler(props);
+
+    ASSERT_EQ(fake.deviceDescs.size(), 1u);
+    EXPECT_EQ(fake.deviceDescs[0].revision, sentinel);
+}
+
+TEST_F(VCLCompilerImplTest, AbsentDevicePropertiesUseDefaultSentinels) {
+    auto compiler = makeCompiler(std::nullopt);
+
+    ASSERT_EQ(fake.deviceDescs.size(), 1u);
+    const auto& desc = fake.deviceDescs[0];
+    EXPECT_EQ(desc.size, sizeof(vcl_device_desc_t));
+    EXPECT_EQ(desc.deviceID, 0x00u);
+    EXPECT_EQ(desc.revision, std::numeric_limits<uint16_t>::max());
+    EXPECT_EQ(desc.tileCount, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(VCLCompilerImplTest, NullApiTableIsRejected) {
+    EXPECT_THROW(
+        {
+            auto compiler = std::make_shared<VCLCompilerImpl>(nullptr);
+            (void)compiler;
+        },
+        ov::Exception);
+}
+
+TEST_F(VCLCompilerImplTest, GetVersionFailureThrows) {
+    fake.failWith("vclGetVersion", VCL_RESULT_ERROR_UNKNOWN);
+    EXPECT_THROW(makeCompiler(), ov::Exception);
+}
+
+TEST_F(VCLCompilerImplTest, CompilerCreateFailureThrowsWithTheVclLogAppended) {
+    fake.logString = "compiler-create-exploded";
+    fake.failWith("vclCompilerCreate", VCL_RESULT_ERROR_OUT_OF_MEMORY);
+
+    try {
+        makeCompiler();
+        FAIL() << "Expected construction to throw";
+    } catch (const ov::Exception& error) {
+        const std::string what = error.what();
+        EXPECT_NE(what.find("vclCompilerCreate"), std::string::npos) << what;
+        EXPECT_NE(what.find("compiler-create-exploded"), std::string::npos) << what;
+    }
+}
+
+TEST_F(VCLCompilerImplTest, CompilerGetPropertiesFailureThrows) {
+    fake.failWith("vclCompilerGetProperties", VCL_RESULT_ERROR_UNKNOWN);
+    EXPECT_THROW(makeCompiler(), ov::Exception);
+}
+
+TEST_F(VCLCompilerImplTest, ConstructionAcceptsALibraryBelowTheFloorAndDefersTheCheck) {
+    // Documents where the version gate actually lives: construction succeeds even for a too-old
+    // library, and the refusal happens on first compile/query (see CompileThrowsWhenTheLibraryIs...).
+    fake.reportedCompilerVersion = {VCL_COMPILER_VERSION_MAJOR - 1, 0};
+    auto compiler = makeCompiler();
+
+    ASSERT_NE(compiler, nullptr);
+    EXPECT_EQ(fake.callCount("vclCompilerCreate"), 1u);
+}
+
+//
+// --- destruction ---
+//
+
+TEST_F(VCLCompilerImplTest, DestructionDestroysTheCompilerExactlyOnce) {
+    {
+        auto compiler = makeCompiler();
+    }
+    EXPECT_EQ(fake.compilerDestroyCount, 1);
+}
+
+TEST_F(VCLCompilerImplTest, DestructionSwallowsCompilerDestroyFailure) {
+    fake.failWith("vclCompilerDestroy", VCL_RESULT_ERROR_UNKNOWN);
+    // A throwing destructor would terminate; the implementation only warns.
+    EXPECT_NO_THROW({ auto compiler = makeCompiler(); });
+    EXPECT_EQ(fake.compilerDestroyCount, 1);
+}
+
+TEST_F(VCLCompilerImplTest, FailedConstructionDoesNotDestroyAnUncreatedCompiler) {
+    fake.failWith("vclCompilerCreate", VCL_RESULT_ERROR_UNKNOWN);
+    EXPECT_THROW(makeCompiler(), ov::Exception);
+    EXPECT_EQ(fake.compilerDestroyCount, 0);
+}
+
+//
+// --- get_version ---
+//
+
+TEST_F(VCLCompilerImplTest, GetVersionPacksTheReportedPropertiesVersion) {
+    fake.propertiesVersion = {9, 3};
+    auto compiler = makeCompiler();
+
+    EXPECT_EQ(compiler->get_version(), ZE_MAKE_VERSION(9, 3));
+    EXPECT_EQ(compiler->get_version() >> 16, 9u);
+    EXPECT_EQ(compiler->get_version() & 0xFFFFu, 3u);
+}
+
+//
+// --- is_option_supported ---
+//
+
+TEST_F(VCLCompilerImplTest, IsOptionSupportedReturnsTrueOnSuccess) {
+    auto compiler = makeCompiler();
+    EXPECT_TRUE(compiler->is_option_supported("SOME_OPTION"));
+}
+
+TEST_F(VCLCompilerImplTest, IsOptionSupportedPassesNullptrWhenNoValueIsGiven) {
+    auto compiler = makeCompiler();
+    compiler->is_option_supported("SOME_OPTION");
+
+    ASSERT_EQ(fake.optionSupportQueries.size(), 1u);
+    EXPECT_EQ(fake.optionSupportQueries[0].first, "SOME_OPTION");
+    EXPECT_FALSE(fake.optionSupportQueries[0].second.has_value());
+}
+
+TEST_F(VCLCompilerImplTest, IsOptionSupportedForwardsTheValueWhenGiven) {
+    auto compiler = makeCompiler();
+    compiler->is_option_supported("SOME_OPTION", std::string("SOME_VALUE"));
+
+    ASSERT_EQ(fake.optionSupportQueries.size(), 1u);
+    EXPECT_EQ(fake.optionSupportQueries[0].first, "SOME_OPTION");
+    ASSERT_TRUE(fake.optionSupportQueries[0].second.has_value());
+    EXPECT_EQ(*fake.optionSupportQueries[0].second, "SOME_VALUE");
+}
+
+TEST_F(VCLCompilerImplTest, IsOptionSupportedSwallowsErrorsAndReportsFalse) {
+    auto compiler = makeCompiler();
+    // The exception is deliberately swallowed: older libraries lack this entry point.
+    fake.failWith("vclGetCompilerIsOptionSupported", VCL_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    EXPECT_FALSE(compiler->is_option_supported("SOME_OPTION"));
+
+    fake.failWith("vclGetCompilerIsOptionSupported", VCL_RESULT_ERROR_UNKNOWN);
+    EXPECT_FALSE(compiler->is_option_supported("SOME_OPTION"));
+}
+
+//
+// --- get_supported_options ---
+//
+
+TEST_F(VCLCompilerImplTest, GetSupportedOptionsUsesTheTwoCallSizeProtocol) {
+    auto compiler = makeCompiler();
+    const auto options = compiler->get_supported_options();
+
+    EXPECT_EQ(fake.callCount("vclGetCompilerSupportedOptions"), 2u);
+    EXPECT_EQ(options, std::vector<std::string>({"OPT_A", "OPT_B", "OPT_C"}));
+}
+
+TEST_F(VCLCompilerImplTest, GetSupportedOptionsReturnsEmptyOnZeroSizeWithoutASecondCall) {
+    fake.supportedOptionsBuffer.clear();
+    auto compiler = makeCompiler();
+    const auto options = compiler->get_supported_options();
+
+    EXPECT_TRUE(options.empty());
+    // Size 0 short-circuits: only the sizing call happens.
+    EXPECT_EQ(fake.callCount("vclGetCompilerSupportedOptions"), 1u);
+}
+
+TEST_F(VCLCompilerImplTest, GetSupportedOptionsTrimsTrailingNulsAndTokenises) {
+    // VCL pads the buffer with NULs; they must not become part of an option name.
+    fake.supportedOptionsBuffer = std::string("OPT_A OPT_B") + std::string(5, '\0');
+    auto compiler = makeCompiler();
+    const auto options = compiler->get_supported_options();
+
+    ASSERT_EQ(options.size(), 2u);
+    EXPECT_EQ(options[0], "OPT_A");
+    EXPECT_EQ(options[1], "OPT_B");
+}
+
+TEST_F(VCLCompilerImplTest, GetSupportedOptionsCollapsesArbitraryWhitespace) {
+    fake.supportedOptionsBuffer = "  OPT_A \t OPT_B \n OPT_C  ";
+    auto compiler = makeCompiler();
+    EXPECT_EQ(compiler->get_supported_options(), std::vector<std::string>({"OPT_A", "OPT_B", "OPT_C"}));
+}
+
+TEST_F(VCLCompilerImplTest, GetSupportedOptionsReturnsEmptyWhenTheBufferIsAllNuls) {
+    fake.supportedOptionsBuffer = std::string(8, '\0');
+    auto compiler = makeCompiler();
+    EXPECT_TRUE(compiler->get_supported_options().empty());
+}
+
+TEST_F(VCLCompilerImplTest, GetSupportedOptionsThrowsWhenTheSizingCallFails) {
+    auto compiler = makeCompiler();
+    fake.failWith("vclGetCompilerSupportedOptions", VCL_RESULT_ERROR_UNKNOWN);
+    EXPECT_THROW(compiler->get_supported_options(), ov::Exception);
+}
+
+//
+// --- process_profiling_output ---
+//
+
+TEST_F(VCLCompilerImplTest, ProcessProfilingOutputFollowsCreateGetDestroyOrdering) {
+    fake.profilingPayload.assign(2 * sizeof(ze_profiling_layer_info), 0);
+    auto compiler = makeCompiler();
+
+    const std::vector<uint8_t> profData{1, 2, 3};
+    const std::vector<uint8_t> network{4, 5, 6, 7};
+    const auto info = compiler->process_profiling_output(profData, network);
+
+    EXPECT_EQ(fake.callCount("vclProfilingCreate"), 1u);
+    EXPECT_EQ(fake.callCount("vclProfilingGetProperties"), 1u);
+    EXPECT_EQ(fake.callCount("vclGetDecodedProfilingBuffer"), 1u);
+    EXPECT_EQ(fake.profilingDestroyCount, 1);
+
+    EXPECT_LT(fake.indexOf("vclProfilingCreate"), fake.indexOf("vclProfilingGetProperties"));
+    EXPECT_LT(fake.indexOf("vclProfilingGetProperties"), fake.indexOf("vclGetDecodedProfilingBuffer"));
+    EXPECT_LT(fake.indexOf("vclGetDecodedProfilingBuffer"), fake.indexOf("vclProfilingDestroy"));
+
+    // One entry per ze_profiling_layer_info in the returned buffer.
+    EXPECT_EQ(info.size(), 2u);
+}
+
+TEST_F(VCLCompilerImplTest, ProcessProfilingOutputSizesByLayerInfoStride) {
+    fake.profilingPayload.assign(5 * sizeof(ze_profiling_layer_info), 0);
+    auto compiler = makeCompiler();
+    EXPECT_EQ(compiler->process_profiling_output({1}, {2}).size(), 5u);
+}
+
+TEST_F(VCLCompilerImplTest, ProcessProfilingOutputThrowsOnNullData) {
+    fake.forceNullProfilingData = true;
+    auto compiler = makeCompiler();
+
+    try {
+        compiler->process_profiling_output({1}, {2});
+        FAIL() << "Expected a throw on NULL profiling data";
+    } catch (const ov::Exception& error) {
+        EXPECT_NE(std::string(error.what()).find("Failed to get VCL profiling output"), std::string::npos);
+    }
+}
+
+TEST_F(VCLCompilerImplTest, ProcessProfilingOutputThrowsWhenCreateFails) {
+    auto compiler = makeCompiler();
+    fake.failWith("vclProfilingCreate", VCL_RESULT_ERROR_UNKNOWN);
+    EXPECT_THROW(compiler->process_profiling_output({1}, {2}), ov::Exception);
+    EXPECT_EQ(fake.profilingDestroyCount, 0);
+}
+
+TEST_F(VCLCompilerImplTest, ProcessProfilingOutputThrowsWhenDestroyFails) {
+    auto compiler = makeCompiler();
+    fake.failWith("vclProfilingDestroy", VCL_RESULT_ERROR_UNKNOWN);
+    EXPECT_THROW(compiler->process_profiling_output({1}, {2}), ov::Exception);
+}
+
+//
+// --- compile ---
+//
+
+TEST_F(VCLCompilerImplTest, CompileProducesABlobAndACompatibilityString) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    const auto [tensor, compatibility] = compiler->compile(makeModel(), config);
+
+    EXPECT_EQ(fake.callCount("vclAllocatedExecutableCreate4"), 1u);
+    EXPECT_GT(tensor.get_byte_size(), 0u);
+    ASSERT_TRUE(compatibility.has_value());
+    EXPECT_EQ(*compatibility, "fake-compat");
+}
+
+TEST_F(VCLCompilerImplTest, CompileBuildFlagsAreIoInfoThenSpaceThenSerializedConfig) {
+    // This is the plugin's actual contract with the compiler; nothing else pins it down.
+    auto compiler = makeCompiler();
+    // compile() stamps the resolved serializer version into a local copy of the config, but only
+    // when the compiler advertises the option. Model a compiler that does not, so the flags are a
+    // pure function of the config the test holds. The stamping branch is covered separately.
+    fake.unsupportedOptions.insert(std::string(ov::intel_npu::model_serializer_version.name()));
+    auto config = makeConfig();
+    const auto model = makeModel();
+
+    const auto [tensor, compatibility] = compiler->compile(model, config);
+    (void)tensor;
+    (void)compatibility;
+
+    ze_graph_compiler_version_info_t compilerVersion{};
+    compilerVersion.major = fake.propertiesVersion.major;
+    compilerVersion.minor = fake.propertiesVersion.minor;
+
+    const auto isSupported = [&compiler](const std::string& name) {
+        return compiler->is_option_supported(name);
+    };
+    const std::string expected = ::intel_npu::compiler_utils::serializeIOInfo(model, true) + " " +
+                                 ::intel_npu::compiler_utils::serializeConfig(config, compilerVersion, isSupported);
+
+    ASSERT_EQ(fake.buildFlags.size(), 1u);
+    EXPECT_EQ(fake.buildFlags[0], expected);
+}
+
+TEST_F(VCLCompilerImplTest, CompileStampsTheResolvedSerializerVersionWhenAdvertised) {
+    // compile() serializes the IR first, then writes back the serializer version it actually used
+    // so the compiler parses the IR the same way. The value is serializeIR's choice, so pin the key.
+    auto compiler = makeCompiler();
+    const auto [tensor, compatibility] = compiler->compile(makeModel(), makeConfig());
+    (void)tensor;
+    (void)compatibility;
+
+    const std::string key = std::string(ov::intel_npu::model_serializer_version.name()) + "=\"";
+    ASSERT_EQ(fake.buildFlags.size(), 1u);
+    EXPECT_NE(fake.buildFlags[0].find(key), std::string::npos);
+}
+
+TEST_F(VCLCompilerImplTest, CompileOmitsTheSerializerVersionWhenNotAdvertised) {
+    // Sending an option the compiler does not know about is a build-flag parse error, so the
+    // write-back must be gated on is_option_supported.
+    auto compiler = makeCompiler();
+    fake.unsupportedOptions.insert(std::string(ov::intel_npu::model_serializer_version.name()));
+
+    const auto [tensor, compatibility] = compiler->compile(makeModel(), makeConfig());
+    (void)tensor;
+    (void)compatibility;
+
+    ASSERT_EQ(fake.buildFlags.size(), 1u);
+    EXPECT_EQ(fake.buildFlags[0].find(ov::intel_npu::model_serializer_version.name()), std::string::npos);
+}
+
+TEST_F(VCLCompilerImplTest, CompileReturnsTheAlignedAllocatorSizeNotTheVclBlobSize) {
+    // VCL reports the logical blob size; the tensor must expose the page-aligned allocation, because
+    // that is what was actually reserved and what the deleter will free.
+    fake.blobPayload.assign(5, 0xAB);
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    const auto [tensor, compatibility] = compiler->compile(makeModel(), config);
+    (void)compatibility;
+
+    const size_t alignedExpected = ::intel_npu::utils::align_size_to_standard_page_size(5);
+    EXPECT_EQ(tensor.get_byte_size(), alignedExpected);
+    EXPECT_NE(tensor.get_byte_size(), 5u);
+    // The payload still lands at the start of the buffer.
+    EXPECT_EQ(static_cast<const uint8_t*>(tensor.data())[0], 0xAB);
+}
+
+TEST_F(VCLCompilerImplTest, CompileDestroysTheExecutableOnTheSuccessPath) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    const auto result = compiler->compile(makeModel(), config);
+    (void)result;
+
+    EXPECT_EQ(fake.executableDestroyCount, 1);
+}
+
+TEST_F(VCLCompilerImplTest, CompileCleansUpAllocationsWhenExecutableCreationFails) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.logString = "create4-failed";
+    fake.failWith("vclAllocatedExecutableCreate4", VCL_RESULT_ERROR_OUT_OF_MEMORY);
+
+    try {
+        compiler->compile(makeModel(), config);
+        FAIL() << "Expected compile to throw";
+    } catch (const ov::Exception& error) {
+        const std::string what = error.what();
+        EXPECT_NE(what.find("vclAllocatedExecutableCreate4"), std::string::npos) << what;
+        EXPECT_NE(what.find("create4-failed"), std::string::npos) << what;
+    }
+}
+
+TEST_F(VCLCompilerImplTest, CompileDestroysTheExecutableWhenTheCompatibilityLookupThrows) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    // A hard failure (not UNSUPPORTED_FEATURE) propagates, but must not leak the executable.
+    fake.failWith("vclExecutableGetCompatibilityString", VCL_RESULT_ERROR_UNKNOWN);
+
+    EXPECT_THROW(compiler->compile(makeModel(), config), ov::Exception);
+    EXPECT_EQ(fake.executableDestroyCount, 1);
+}
+
+TEST_F(VCLCompilerImplTest, CompileTreatsUnsupportedCompatibilityStringAsAbsentNotAnError) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.compatibilityString.reset();  // makes the fake report UNSUPPORTED_FEATURE
+
+    const auto [tensor, compatibility] = compiler->compile(makeModel(), config);
+    (void)tensor;
+
+    EXPECT_FALSE(compatibility.has_value());
+    EXPECT_EQ(fake.executableDestroyCount, 1);
+}
+
+TEST_F(VCLCompilerImplTest, CompileTrimsTheTrailingNulFromTheCompatibilityString) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.compatibilityString = std::string("compat-value");
+
+    const auto [tensor, compatibility] = compiler->compile(makeModel(), config);
+    (void)tensor;
+
+    ASSERT_TRUE(compatibility.has_value());
+    // No embedded NUL should survive into the string.
+    EXPECT_EQ(*compatibility, "compat-value");
+    EXPECT_EQ(compatibility->size(), std::string("compat-value").size());
+}
+
+TEST_F(VCLCompilerImplTest, CompileThrowsOnZeroSizedCompatibilityString) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.compatibilityString = std::string("ignored");
+    fake.compatibilityStringSizeOverride = 0u;
+
+    EXPECT_THROW(compiler->compile(makeModel(), config), ov::Exception);
+    EXPECT_EQ(fake.executableDestroyCount, 1);
+}
+
+TEST_F(VCLCompilerImplTest, CompileThrowsWhenExecutableDestroyFails) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.failWith("vclExecutableDestroy", VCL_RESULT_ERROR_UNKNOWN);
+
+    EXPECT_THROW(compiler->compile(makeModel(), config), ov::Exception);
+}
+
+TEST_F(VCLCompilerImplTest, CompileThrowsWhenTheLibraryIsBelowTheSupportedFloor) {
+    fake.reportedCompilerVersion = {VCL_COMPILER_VERSION_MAJOR - 1, 0};
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    EXPECT_THROW(compiler->compile(makeModel(), config), ov::Exception);
+    // The version gate fires before any executable is created.
+    EXPECT_FALSE(fake.called("vclAllocatedExecutableCreate4"));
+}
+
+//
+// --- compileWsOneShot ---
+//
+
+TEST_F(VCLCompilerImplTest, CompileWsOneShotReturnsOneTensorPerAllocation) {
+    fake.wsBlobSizes = {8, 16, 32};
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    const auto [tensors, compatibility] = compiler->compileWsOneShot(makeModel(), config);
+
+    EXPECT_EQ(fake.callCount("vclAllocatedExecutableCreateWSOneShot2"), 1u);
+    ASSERT_EQ(tensors.size(), 3u);
+    ASSERT_TRUE(compatibility.has_value());
+    EXPECT_EQ(*compatibility, "fake-compat");
+}
+
+TEST_F(VCLCompilerImplTest, CompileWsOneShotOrdersInitSchedulesBeforeMain) {
+    // The adapter consumes the last tensor as the main schedule, so allocation order is load-bearing.
+    fake.wsBlobSizes = {8, 16, 4096 * 3};
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    const auto [tensors, compatibility] = compiler->compileWsOneShot(makeModel(), config);
+    (void)compatibility;
+
+    ASSERT_EQ(tensors.size(), 3u);
+    EXPECT_EQ(tensors.back().get_byte_size(), ::intel_npu::utils::align_size_to_standard_page_size(4096 * 3));
+}
+
+TEST_F(VCLCompilerImplTest, CompileWsOneShotTensorsRemainValidAfterTheCompilerIsGone) {
+    // m_info is cleared so ownership transfers to the tensors; a double free would show up here.
+    fake.wsBlobSizes = {8, 16};
+    std::vector<ov::Tensor> tensors;
+    {
+        auto compiler = makeCompiler();
+        auto config = makeConfig();
+        auto result = compiler->compileWsOneShot(makeModel(), config);
+        tensors = std::move(result.first);
+    }
+    ASSERT_EQ(tensors.size(), 2u);
+    for (auto& tensor : tensors) {
+        ASSERT_NE(tensor.data(), nullptr);
+        // Touch every byte: a freed buffer would trip the allocator or a sanitizer here.
+        std::memset(tensor.data(), 0x5A, tensor.get_byte_size());
+    }
+    tensors.clear();
+}
+
+TEST_F(VCLCompilerImplTest, CompileWsOneShotThrowsAndDestroysExecutableWhenNothingWasAllocated) {
+    fake.wsBlobSizes.clear();  // no allocations -> m_info stays empty
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    try {
+        compiler->compileWsOneShot(makeModel(), config);
+        FAIL() << "Expected compileWsOneShot to throw";
+    } catch (const ov::Exception& error) {
+        EXPECT_NE(std::string(error.what()).find("blobCount is zero"), std::string::npos) << error.what();
+    }
+    EXPECT_EQ(fake.executableDestroyCount, 1);
+}
+
+TEST_F(VCLCompilerImplTest, CompileWsOneShotThrowsWhenCreationFails) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.failWith("vclAllocatedExecutableCreateWSOneShot2", VCL_RESULT_ERROR_UNKNOWN);
+
+    EXPECT_THROW(compiler->compileWsOneShot(makeModel(), config), ov::Exception);
+}
+
+//
+// --- compileWsIterative ---
+//
+
+TEST_F(VCLCompilerImplTest, CompileWsIterativeGoesThroughTheSingleBlobPath) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    const auto [tensor, compatibility] = compiler->compileWsIterative(makeModel(), config, 2);
+    (void)compatibility;
+
+    EXPECT_EQ(fake.callCount("vclAllocatedExecutableCreate4"), 1u);
+    EXPECT_GT(tensor.get_byte_size(), 0u);
+}
+
+//
+// --- query ---
+//
+
+TEST_F(VCLCompilerImplTest, QueryParsesSupportedLayersAndKeysThemToNPU) {
+    const std::string payload = "<Parameter_0><Add_1>";
+    fake.queryResultBuffer.assign(payload.begin(), payload.end());
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    const auto supported = compiler->query(makeModel(), config);
+
+    ASSERT_EQ(supported.size(), 2u);
+    ASSERT_TRUE(supported.count("Parameter_0"));
+    ASSERT_TRUE(supported.count("Add_1"));
+    EXPECT_EQ(supported.at("Parameter_0"), "NPU");
+    EXPECT_EQ(supported.at("Add_1"), "NPU");
+}
+
+TEST_F(VCLCompilerImplTest, QueryUsesTheTwoCallSizeProtocolAndDestroysTheHandle) {
+    const std::string payload = "<Add_1>";
+    fake.queryResultBuffer.assign(payload.begin(), payload.end());
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    const auto supported = compiler->query(makeModel(), config);
+    (void)supported;
+
+    EXPECT_EQ(fake.callCount("vclQueryNetworkCreate"), 1u);
+    EXPECT_EQ(fake.callCount("vclQueryNetwork"), 2u);
+    EXPECT_EQ(fake.queryDestroyCount, 1);
+}
+
+TEST_F(VCLCompilerImplTest, QueryReturnsAnEmptyMapForAnEmptyResult) {
+    fake.queryResultBuffer.clear();
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    EXPECT_TRUE(compiler->query(makeModel(), config).empty());
+}
+
+TEST_F(VCLCompilerImplTest, QueryThrowsWhenCreationFails) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.failWith("vclQueryNetworkCreate", VCL_RESULT_ERROR_INVALID_IR);
+
+    EXPECT_THROW(compiler->query(makeModel(), config), ov::Exception);
+    EXPECT_EQ(fake.queryDestroyCount, 0);
+}
+
+TEST_F(VCLCompilerImplTest, QueryThrowsWhenTheResultFetchFails) {
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.failWith("vclQueryNetwork", VCL_RESULT_ERROR_UNKNOWN);
+
+    EXPECT_THROW(compiler->query(makeModel(), config), ov::Exception);
+}
+
+TEST_F(VCLCompilerImplTest, QueryThrowsWhenDestroyFails) {
+    const std::string payload = "<Add_1>";
+    fake.queryResultBuffer.assign(payload.begin(), payload.end());
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+    fake.failWith("vclQueryNetworkDestroy", VCL_RESULT_ERROR_UNKNOWN);
+
+    EXPECT_THROW(compiler->query(makeModel(), config), ov::Exception);
+}
+
+}  // namespace

--- a/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
@@ -140,6 +140,29 @@ TEST_F(VCLCompilerImplTest, NullApiTableIsRejected) {
         ov::Exception);
 }
 
+TEST_F(VCLCompilerImplTest, UnwiredApiTableIsRejected) {
+    // A NoLoad table nobody wired: every entry point is null. Without the hasAllRequiredSymbols
+    // guard this would dispatch through a null vclGetVersion instead of throwing.
+    auto unwired = std::make_shared<const intel_npu::VCLApi>(intel_npu::VCLApi::NoLoad{});
+    EXPECT_THROW(
+        {
+            auto compiler = std::make_shared<VCLCompilerImpl>(unwired);
+            (void)compiler;
+        },
+        ov::Exception);
+}
+
+TEST_F(VCLCompilerImplTest, MissingWeakSymbolsDoNotBlockConstruction) {
+    // The weak symbols are legitimately null against an older compiler library, so the required-
+    // symbol guard must ignore them. FakeVcl leaves vclAllocatedExecutableCreate2 null already;
+    // null the remaining one so the whole weak list is absent.
+    ASSERT_TRUE(fake.mutableApi()->vclAllocatedExecutableCreate2 == nullptr);
+    fake.mutableApi()->vclAllocatedExecutableCreateWSOneShot2 = nullptr;
+
+    EXPECT_TRUE(fake.api()->hasAllRequiredSymbols());
+    EXPECT_NO_THROW(makeCompiler());
+}
+
 TEST_F(VCLCompilerImplTest, GetVersionFailureThrows) {
     fake.failWith("vclGetVersion", VCL_RESULT_ERROR_UNKNOWN);
     EXPECT_THROW(makeCompiler(), ov::Exception);

--- a/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
@@ -153,14 +153,22 @@ TEST_F(VCLCompilerImplTest, UnwiredFunctionTableIsRejected) {
 }
 
 TEST_F(VCLCompilerImplTest, MissingWeakSymbolsDoNotBlockConstruction) {
-    // The weak symbols are legitimately null against an older compiler library, so the required-
-    // symbol guard must ignore them. FakeVcl leaves vclAllocatedExecutableCreate2 null already;
-    // null the remaining one so the whole weak list is absent.
+    // Weak symbols are legitimately null against an older compiler library, so the required-symbol
+    // guard must ignore them. FakeVcl already leaves the whole weak list null.
     ASSERT_TRUE(fake.mutableFunctions()->vclAllocatedExecutableCreate2 == nullptr);
-    fake.mutableFunctions()->vclAllocatedExecutableCreateWSOneShot2 = nullptr;
 
     EXPECT_TRUE(fake.functions()->hasAllRequiredSymbols());
     EXPECT_NO_THROW(makeCompiler());
+}
+
+TEST_F(VCLCompilerImplTest, MissingRequiredSymbolIsRejected) {
+    // vclAllocatedExecutableCreateWSOneShot2 is required, not weak: compileWsOneShot calls it with
+    // no null guard, so a library lacking it must be refused at construction rather than crashing
+    // on the first weights-separation compile.
+    fake.mutableFunctions()->vclAllocatedExecutableCreateWSOneShot2 = nullptr;
+
+    EXPECT_FALSE(fake.functions()->hasAllRequiredSymbols());
+    EXPECT_THROW(makeCompiler(), ov::Exception);
 }
 
 TEST_F(VCLCompilerImplTest, GetVersionFailureThrows) {
@@ -555,6 +563,18 @@ TEST_F(VCLCompilerImplTest, CompileThrowsWhenTheLibraryIsBelowTheSupportedFloor)
     EXPECT_THROW(compiler->compile(makeModel(), config), ov::Exception);
     // The version gate fires before any executable is created.
     EXPECT_FALSE(fake.called("vclAllocatedExecutableCreate4"));
+}
+
+TEST_F(VCLCompilerImplTest, QueryThrowsWhenTheLibraryIsBelowTheSupportedFloor) {
+    // query() negotiates the version like compile() does, so it must apply the same floor: an
+    // unsupported library would otherwise be asked to parse an IR it cannot understand.
+    fake.reportedCompilerVersion = {VCL_COMPILER_VERSION_MAJOR - 1, 0};
+    auto compiler = makeCompiler();
+    auto config = makeConfig();
+
+    EXPECT_THROW(compiler->query(makeModel(), config), ov::Exception);
+    // The version gate fires before the query handle is created.
+    EXPECT_FALSE(fake.called("vclQueryNetworkCreate"));
 }
 
 //

--- a/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/compiler_impl_test.cpp
@@ -607,25 +607,6 @@ TEST_F(VCLCompilerImplTest, CompileWsOneShotOrdersInitSchedulesBeforeMain) {
     EXPECT_EQ(tensors.back().get_byte_size(), ::intel_npu::utils::align_size_to_standard_page_size(4096 * 3));
 }
 
-TEST_F(VCLCompilerImplTest, CompileWsOneShotTensorsRemainValidAfterTheCompilerIsGone) {
-    // m_info is cleared so ownership transfers to the tensors; a double free would show up here.
-    fake.wsBlobSizes = {8, 16};
-    std::vector<ov::Tensor> tensors;
-    {
-        auto compiler = makeCompiler();
-        auto config = makeConfig();
-        auto result = compiler->compileWsOneShot(makeModel(), config);
-        tensors = std::move(result.first);
-    }
-    ASSERT_EQ(tensors.size(), 2u);
-    for (auto& tensor : tensors) {
-        ASSERT_NE(tensor.data(), nullptr);
-        // Touch every byte: a freed buffer would trip the allocator or a sanitizer here.
-        std::memset(tensor.data(), 0x5A, tensor.get_byte_size());
-    }
-    tensors.clear();
-}
-
 TEST_F(VCLCompilerImplTest, CompileWsOneShotThrowsAndDestroysExecutableWhenNothingWasAllocated) {
     fake.wsBlobSizes.clear();  // no allocations -> m_info stays empty
     auto compiler = makeCompiler();

--- a/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/fake_vcl.hpp
+++ b/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/fake_vcl.hpp
@@ -1,0 +1,560 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "intel_npu/utils/vcl/vcl_api.hpp"
+
+namespace fake_vcl {
+
+//
+// The VCL entry points are plain C function pointers with no user-data parameter, so the fake has to
+// route through a file-static "current instance" pointer. FakeVcl sets it on construction and clears
+// it on destruction, which keeps one fake per test.
+//
+class FakeVcl;
+inline FakeVcl*& current() {
+    static FakeVcl* instance = nullptr;
+    return instance;
+}
+
+/// State objects the opaque VCL handles point at. Never dereferenced by production code, so empty
+/// structs with distinct addresses are enough.
+struct FakeCompilerState {
+    int tag = 1;
+};
+struct FakeExecutableState {
+    int tag = 2;
+};
+struct FakeQueryState {
+    int tag = 3;
+};
+struct FakeProfilingState {
+    int tag = 4;
+};
+struct FakeLogState {
+    int tag = 5;
+};
+
+class FakeVcl {
+public:
+    FakeVcl() {
+        current() = this;
+        _api = std::make_shared<intel_npu::VCLApi>(intel_npu::VCLApi::NoLoad{});
+        wire();
+    }
+
+    ~FakeVcl() {
+        current() = nullptr;
+    }
+
+    FakeVcl(const FakeVcl&) = delete;
+    FakeVcl& operator=(const FakeVcl&) = delete;
+
+    /// The dispatch table to inject into VCLCompilerImpl.
+    std::shared_ptr<const intel_npu::VCLApi> api() const {
+        return _api;
+    }
+    std::shared_ptr<intel_npu::VCLApi> mutableApi() const {
+        return _api;
+    }
+
+    //
+    // --- scripting ---
+    //
+
+    /// Force a specific entry point to fail. Cleared per entry point.
+    void failWith(const std::string& fn, vcl_result_t result) {
+        _results[fn] = result;
+    }
+    void succeed(const std::string& fn) {
+        _results.erase(fn);
+    }
+
+    vcl_result_t resultFor(const std::string& fn) {
+        calls.push_back(fn);
+        const auto it = _results.find(fn);
+        return it == _results.end() ? VCL_RESULT_SUCCESS : it->second;
+    }
+
+    //
+    // --- inputs the fake reports back to production code ---
+    //
+
+    vcl_version_info_t reportedCompilerVersion{VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR};
+    vcl_version_info_t reportedProfilingVersion{VCL_PROFILING_VERSION_MAJOR, VCL_PROFILING_VERSION_MINOR};
+    vcl_version_info_t propertiesVersion{VCL_COMPILER_VERSION_MAJOR, VCL_COMPILER_VERSION_MINOR};
+    uint32_t supportedOpsets = 11;
+    std::string compilerId = "fake-vcl";
+
+    std::string logString = "fake vcl log";
+
+    /// Blob bytes handed back by vclAllocatedExecutableCreate4.
+    std::vector<uint8_t> blobPayload{1, 2, 3, 4, 5};
+    /// Per-blob sizes handed back by vclAllocatedExecutableCreateWSOneShot2 (init schedules, then main).
+    std::vector<size_t> wsBlobSizes{8, 16, 32};
+
+    /// nullopt makes vclExecutableGetCompatibilityString report UNSUPPORTED_FEATURE.
+    std::optional<std::string> compatibilityString = std::string("fake-compat");
+    /// When set, the reported size is used instead of compatibilityString->size() + 1.
+    std::optional<uint64_t> compatibilityStringSizeOverride;
+
+    /// Raw buffer returned by vclGetCompilerSupportedOptions (trailing NULs are meaningful).
+    std::string supportedOptionsBuffer = std::string("OPT_A OPT_B OPT_C");
+
+    /// Options vclGetCompilerIsOptionSupported reports as UNSUPPORTED_FEATURE. Everything else
+    /// follows failWith("vclGetCompilerIsOptionSupported", ...), so a fake can model a compiler
+    /// that advertises most options but not a specific one.
+    std::set<std::string> unsupportedOptions;
+
+    /// Raw buffer returned by vclQueryNetwork.
+    std::vector<char> queryResultBuffer;
+
+    /// Bytes returned by vclGetDecodedProfilingBuffer; nullptr data if empty and forceNullProfData.
+    std::vector<uint8_t> profilingPayload;
+    bool forceNullProfilingData = false;
+
+    //
+    // --- recordings ---
+    //
+
+    std::vector<std::string> calls;
+    std::vector<vcl_device_desc_t> deviceDescs;
+    std::vector<vcl_compiler_desc_t> compilerDescs;
+    /// The build-flags string handed to VCL, per executable-creating call.
+    std::vector<std::string> buildFlags;
+    /// Model IR bytes handed to VCL, per executable-creating call.
+    std::vector<uint64_t> modelIrSizes;
+    std::vector<std::string> queryBuildFlags;
+    /// (option, value) pairs seen by vclGetCompilerIsOptionSupported; value is nullopt for nullptr.
+    std::vector<std::pair<std::string, std::optional<std::string>>> optionSupportQueries;
+
+    int compilerDestroyCount = 0;
+    int executableDestroyCount = 0;
+    int queryDestroyCount = 0;
+    int profilingDestroyCount = 0;
+
+    size_t callCount(const std::string& fn) const {
+        size_t n = 0;
+        for (const auto& c : calls) {
+            if (c == fn) {
+                ++n;
+            }
+        }
+        return n;
+    }
+
+    bool called(const std::string& fn) const {
+        return callCount(fn) > 0;
+    }
+
+    /// Index of the first occurrence of fn in the call log, or npos.
+    size_t indexOf(const std::string& fn) const {
+        for (size_t i = 0; i < calls.size(); ++i) {
+            if (calls[i] == fn) {
+                return i;
+            }
+        }
+        return std::string::npos;
+    }
+
+    // Handle-backing state, kept alive for the fake's lifetime.
+    FakeCompilerState compilerState;
+    FakeExecutableState executableState;
+    FakeQueryState queryState;
+    FakeProfilingState profilingState;
+    FakeLogState logState;
+
+private:
+    void wire();
+
+    std::shared_ptr<intel_npu::VCLApi> _api;
+    std::map<std::string, vcl_result_t> _results;
+};
+
+//
+// --- thunks ---
+//
+
+#define FAKE_GUARD(fn)                                  \
+    FakeVcl* self = current();                          \
+    if (self == nullptr) {                              \
+        return VCL_RESULT_ERROR_UNKNOWN;                \
+    }                                                   \
+    const vcl_result_t scripted = self->resultFor(#fn); \
+    if (scripted != VCL_RESULT_SUCCESS) {               \
+        return scripted;                                \
+    }
+
+inline vcl_result_t VCL_APICALL fake_vclGetVersion(vcl_version_info_t* compilerVersion,
+                                                   vcl_version_info_t* profilingVersion) {
+    FAKE_GUARD(vclGetVersion)
+    if (compilerVersion != nullptr) {
+        *compilerVersion = self->reportedCompilerVersion;
+    }
+    if (profilingVersion != nullptr) {
+        *profilingVersion = self->reportedProfilingVersion;
+    }
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclCompilerCreate(vcl_compiler_desc_t* compilerDesc,
+                                                       vcl_device_desc_t* deviceDesc,
+                                                       vcl_compiler_handle_t* compiler,
+                                                       vcl_log_handle_t* logHandle) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    // Record the descriptors even on the failure path: the test asserts what was forwarded.
+    if (compilerDesc != nullptr) {
+        self->compilerDescs.push_back(*compilerDesc);
+    }
+    if (deviceDesc != nullptr) {
+        self->deviceDescs.push_back(*deviceDesc);
+    }
+    const vcl_result_t scripted = self->resultFor("vclCompilerCreate");
+    if (scripted != VCL_RESULT_SUCCESS) {
+        return scripted;
+    }
+    if (compiler != nullptr) {
+        *compiler = reinterpret_cast<vcl_compiler_handle_t>(&self->compilerState);
+    }
+    if (logHandle != nullptr) {
+        *logHandle = reinterpret_cast<vcl_log_handle_t>(&self->logState);
+    }
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclCompilerDestroy(vcl_compiler_handle_t) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    ++self->compilerDestroyCount;
+    return self->resultFor("vclCompilerDestroy");
+}
+
+inline vcl_result_t VCL_APICALL fake_vclCompilerGetProperties(vcl_compiler_handle_t,
+                                                              vcl_compiler_properties_t* properties) {
+    FAKE_GUARD(vclCompilerGetProperties)
+    if (properties != nullptr) {
+        properties->id = self->compilerId.c_str();
+        properties->version = self->propertiesVersion;
+        properties->supportedOpsets = self->supportedOpsets;
+    }
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclLogHandleGetString(vcl_log_handle_t, size_t* logSize, char* log) {
+    FAKE_GUARD(vclLogHandleGetString)
+    if (logSize == nullptr) {
+        return VCL_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    if (log == nullptr) {
+        *logSize = self->logString.size();
+        return VCL_RESULT_SUCCESS;
+    }
+    std::memcpy(log, self->logString.data(), self->logString.size());
+    *logSize = self->logString.size();
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclAllocatedExecutableCreate4(vcl_compiler_handle_t,
+                                                                   vcl_executable_desc_t desc,
+                                                                   vcl_allocator2_t* allocator,
+                                                                   uint8_t** blobBuffer,
+                                                                   uint64_t* blobSize,
+                                                                   vcl_executable_handle_t* executable) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    if (desc.options != nullptr) {
+        self->buildFlags.emplace_back(desc.options, static_cast<size_t>(desc.optionsSize));
+    }
+    self->modelIrSizes.push_back(desc.modelIRSize);
+
+    const vcl_result_t scripted = self->resultFor("vclAllocatedExecutableCreate4");
+    if (scripted != VCL_RESULT_SUCCESS) {
+        return scripted;
+    }
+    if (allocator == nullptr || blobBuffer == nullptr || blobSize == nullptr) {
+        return VCL_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+
+    const size_t size = self->blobPayload.size();
+    uint8_t* buffer = allocator->allocate(allocator, size);
+    if (buffer == nullptr) {
+        return VCL_RESULT_ERROR_OUT_OF_MEMORY;
+    }
+    std::memcpy(buffer, self->blobPayload.data(), size);
+    *blobBuffer = buffer;
+    *blobSize = size;
+    if (executable != nullptr) {
+        *executable = reinterpret_cast<vcl_executable_handle_t>(&self->executableState);
+    }
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclAllocatedExecutableCreateWSOneShot2(vcl_compiler_handle_t,
+                                                                            vcl_executable_desc_t desc,
+                                                                            vcl_allocator2_t* allocator,
+                                                                            vcl_executable_handle_t* executable) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    if (desc.options != nullptr) {
+        self->buildFlags.emplace_back(desc.options, static_cast<size_t>(desc.optionsSize));
+    }
+    self->modelIrSizes.push_back(desc.modelIRSize);
+
+    const vcl_result_t scripted = self->resultFor("vclAllocatedExecutableCreateWSOneShot2");
+    if (scripted != VCL_RESULT_SUCCESS) {
+        return scripted;
+    }
+    if (allocator == nullptr) {
+        return VCL_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    // One allocation per blob: init schedules first, main last.
+    for (size_t size : self->wsBlobSizes) {
+        uint8_t* buffer = allocator->allocate(allocator, size);
+        if (buffer == nullptr) {
+            return VCL_RESULT_ERROR_OUT_OF_MEMORY;
+        }
+        std::memset(buffer, static_cast<int>(size & 0xFF), size);
+    }
+    if (executable != nullptr) {
+        *executable = reinterpret_cast<vcl_executable_handle_t>(&self->executableState);
+    }
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclExecutableGetCompatibilityString(vcl_executable_handle_t,
+                                                                         char* buffer,
+                                                                         uint64_t* size) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    const vcl_result_t scripted = self->resultFor("vclExecutableGetCompatibilityString");
+    if (scripted != VCL_RESULT_SUCCESS) {
+        return scripted;
+    }
+    if (!self->compatibilityString.has_value()) {
+        return VCL_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+    if (size == nullptr) {
+        return VCL_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    // VCL reports the size including the NUL terminator.
+    const std::string& value = *self->compatibilityString;
+    const uint64_t reported = self->compatibilityStringSizeOverride.value_or(static_cast<uint64_t>(value.size()) + 1u);
+    if (buffer == nullptr) {
+        *size = reported;
+        return VCL_RESULT_SUCCESS;
+    }
+    const size_t toCopy = static_cast<size_t>(reported == 0 ? 0 : reported - 1);
+    std::memcpy(buffer, value.data(), std::min(toCopy, value.size()));
+    if (reported > 0) {
+        buffer[reported - 1] = '\0';
+    }
+    *size = reported;
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclExecutableDestroy(vcl_executable_handle_t) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    ++self->executableDestroyCount;
+    return self->resultFor("vclExecutableDestroy");
+}
+
+inline vcl_result_t VCL_APICALL fake_vclQueryNetworkCreate(vcl_compiler_handle_t,
+                                                           vcl_query_desc_t desc,
+                                                           vcl_query_handle_t* query) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    if (desc.options != nullptr) {
+        self->queryBuildFlags.emplace_back(desc.options, static_cast<size_t>(desc.optionsSize));
+    }
+    const vcl_result_t scripted = self->resultFor("vclQueryNetworkCreate");
+    if (scripted != VCL_RESULT_SUCCESS) {
+        return scripted;
+    }
+    if (query != nullptr) {
+        *query = reinterpret_cast<vcl_query_handle_t>(&self->queryState);
+    }
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclQueryNetwork(vcl_query_handle_t, uint8_t* queryResult, uint64_t* size) {
+    FAKE_GUARD(vclQueryNetwork)
+    if (size == nullptr) {
+        return VCL_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    if (queryResult == nullptr) {
+        *size = self->queryResultBuffer.size();
+        return VCL_RESULT_SUCCESS;
+    }
+    std::memcpy(queryResult, self->queryResultBuffer.data(), self->queryResultBuffer.size());
+    *size = self->queryResultBuffer.size();
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclQueryNetworkDestroy(vcl_query_handle_t) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    ++self->queryDestroyCount;
+    return self->resultFor("vclQueryNetworkDestroy");
+}
+
+inline vcl_result_t VCL_APICALL fake_vclProfilingCreate(p_vcl_profiling_input_t,
+                                                        vcl_profiling_handle_t* profilingHandle,
+                                                        vcl_log_handle_t* logHandle) {
+    FAKE_GUARD(vclProfilingCreate)
+    if (profilingHandle != nullptr) {
+        *profilingHandle = reinterpret_cast<vcl_profiling_handle_t>(&self->profilingState);
+    }
+    if (logHandle != nullptr) {
+        *logHandle = reinterpret_cast<vcl_log_handle_t>(&self->logState);
+    }
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclProfilingGetProperties(vcl_profiling_handle_t,
+                                                               vcl_profiling_properties_t* properties) {
+    FAKE_GUARD(vclProfilingGetProperties)
+    if (properties != nullptr) {
+        properties->version = self->reportedProfilingVersion;
+    }
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclGetDecodedProfilingBuffer(vcl_profiling_handle_t,
+                                                                  vcl_profiling_request_type_t,
+                                                                  p_vcl_profiling_output_t output) {
+    FAKE_GUARD(vclGetDecodedProfilingBuffer)
+    if (output == nullptr) {
+        return VCL_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    if (self->forceNullProfilingData) {
+        output->data = nullptr;
+        output->size = 0;
+        return VCL_RESULT_SUCCESS;
+    }
+    output->data = self->profilingPayload.data();
+    output->size = self->profilingPayload.size();
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclProfilingDestroy(vcl_profiling_handle_t) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    ++self->profilingDestroyCount;
+    return self->resultFor("vclProfilingDestroy");
+}
+
+inline vcl_result_t VCL_APICALL fake_vclGetCompilerSupportedOptions(vcl_compiler_handle_t,
+                                                                    char* result,
+                                                                    uint64_t* size) {
+    FAKE_GUARD(vclGetCompilerSupportedOptions)
+    if (size == nullptr) {
+        return VCL_RESULT_ERROR_INVALID_ARGUMENT;
+    }
+    const std::string& buffer = self->supportedOptionsBuffer;
+    if (result == nullptr) {
+        *size = buffer.size();
+        return VCL_RESULT_SUCCESS;
+    }
+    std::memcpy(result, buffer.data(), buffer.size());
+    *size = buffer.size();
+    return VCL_RESULT_SUCCESS;
+}
+
+inline vcl_result_t VCL_APICALL fake_vclGetCompilerIsOptionSupported(vcl_compiler_handle_t,
+                                                                     const char* option,
+                                                                     const char* value) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    const std::string optionName = option != nullptr ? std::string(option) : std::string();
+    self->optionSupportQueries.emplace_back(
+        optionName,
+        value != nullptr ? std::optional<std::string>(std::string(value)) : std::nullopt);
+    if (self->unsupportedOptions.count(optionName) != 0) {
+        self->calls.push_back("vclGetCompilerIsOptionSupported");
+        return VCL_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+    return self->resultFor("vclGetCompilerIsOptionSupported");
+}
+
+// Entry points the production code under test never calls; wired so a stray call is obvious.
+inline vcl_result_t VCL_APICALL fake_vclExecutableCreate(vcl_compiler_handle_t,
+                                                         vcl_executable_desc_t,
+                                                         vcl_executable_handle_t*) {
+    FakeVcl* self = current();
+    return self == nullptr ? VCL_RESULT_ERROR_UNKNOWN : self->resultFor("vclExecutableCreate");
+}
+
+inline vcl_result_t VCL_APICALL fake_vclExecutableGetSerializableBlob(vcl_executable_handle_t,
+                                                                      uint8_t*,
+                                                                      uint64_t* blobSize) {
+    FakeVcl* self = current();
+    if (self == nullptr) {
+        return VCL_RESULT_ERROR_UNKNOWN;
+    }
+    if (blobSize != nullptr) {
+        *blobSize = 0;
+    }
+    return self->resultFor("vclExecutableGetSerializableBlob");
+}
+
+#undef FAKE_GUARD
+
+inline void FakeVcl::wire() {
+    _api->vclGetVersion = &fake_vclGetVersion;
+    _api->vclCompilerCreate = &fake_vclCompilerCreate;
+    _api->vclCompilerDestroy = &fake_vclCompilerDestroy;
+    _api->vclCompilerGetProperties = &fake_vclCompilerGetProperties;
+    _api->vclQueryNetworkCreate = &fake_vclQueryNetworkCreate;
+    _api->vclQueryNetwork = &fake_vclQueryNetwork;
+    _api->vclQueryNetworkDestroy = &fake_vclQueryNetworkDestroy;
+    _api->vclExecutableCreate = &fake_vclExecutableCreate;
+    _api->vclExecutableDestroy = &fake_vclExecutableDestroy;
+    _api->vclExecutableGetSerializableBlob = &fake_vclExecutableGetSerializableBlob;
+    _api->vclProfilingCreate = &fake_vclProfilingCreate;
+    _api->vclGetDecodedProfilingBuffer = &fake_vclGetDecodedProfilingBuffer;
+    _api->vclProfilingDestroy = &fake_vclProfilingDestroy;
+    _api->vclProfilingGetProperties = &fake_vclProfilingGetProperties;
+    _api->vclLogHandleGetString = &fake_vclLogHandleGetString;
+    _api->vclAllocatedExecutableCreate4 = &fake_vclAllocatedExecutableCreate4;
+    _api->vclExecutableGetCompatibilityString = &fake_vclExecutableGetCompatibilityString;
+    _api->vclGetCompilerSupportedOptions = &fake_vclGetCompilerSupportedOptions;
+    _api->vclGetCompilerIsOptionSupported = &fake_vclGetCompilerIsOptionSupported;
+    _api->vclAllocatedExecutableCreateWSOneShot2 = &fake_vclAllocatedExecutableCreateWSOneShot2;
+    // Weak symbols the production path does not use stay null, matching an older library.
+    _api->vclAllocatedExecutableCreate2 = nullptr;
+}
+
+}  // namespace fake_vcl

--- a/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/fake_vcl.hpp
+++ b/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/fake_vcl.hpp
@@ -50,7 +50,9 @@ class FakeVcl {
 public:
     FakeVcl() {
         current() = this;
-        _api = std::make_shared<intel_npu::VCLApi>(intel_npu::VCLApi::NoLoad{});
+        // A default-constructed table is all-null, which is a legitimate value. No test-only
+        // constructor, tag, or friend declaration is needed to get one.
+        _functions = std::make_shared<intel_npu::VCLFunctionTable>();
         wire();
     }
 
@@ -61,12 +63,13 @@ public:
     FakeVcl(const FakeVcl&) = delete;
     FakeVcl& operator=(const FakeVcl&) = delete;
 
-    /// The dispatch table to inject into VCLCompilerImpl.
-    std::shared_ptr<const intel_npu::VCLApi> api() const {
-        return _api;
+    /// The function table to inject into VCLCompilerImpl.
+    std::shared_ptr<const intel_npu::VCLFunctionTable> functions() const {
+        return _functions;
     }
-    std::shared_ptr<intel_npu::VCLApi> mutableApi() const {
-        return _api;
+    /// Same table, writable, for tests that need to null an entry point out.
+    std::shared_ptr<intel_npu::VCLFunctionTable> mutableFunctions() const {
+        return _functions;
     }
 
     //
@@ -178,7 +181,7 @@ public:
 private:
     void wire();
 
-    std::shared_ptr<intel_npu::VCLApi> _api;
+    std::shared_ptr<intel_npu::VCLFunctionTable> _functions;
     std::map<std::string, vcl_result_t> _results;
 };
 
@@ -533,28 +536,28 @@ inline vcl_result_t VCL_APICALL fake_vclExecutableGetSerializableBlob(vcl_execut
 #undef FAKE_GUARD
 
 inline void FakeVcl::wire() {
-    _api->vclGetVersion = &fake_vclGetVersion;
-    _api->vclCompilerCreate = &fake_vclCompilerCreate;
-    _api->vclCompilerDestroy = &fake_vclCompilerDestroy;
-    _api->vclCompilerGetProperties = &fake_vclCompilerGetProperties;
-    _api->vclQueryNetworkCreate = &fake_vclQueryNetworkCreate;
-    _api->vclQueryNetwork = &fake_vclQueryNetwork;
-    _api->vclQueryNetworkDestroy = &fake_vclQueryNetworkDestroy;
-    _api->vclExecutableCreate = &fake_vclExecutableCreate;
-    _api->vclExecutableDestroy = &fake_vclExecutableDestroy;
-    _api->vclExecutableGetSerializableBlob = &fake_vclExecutableGetSerializableBlob;
-    _api->vclProfilingCreate = &fake_vclProfilingCreate;
-    _api->vclGetDecodedProfilingBuffer = &fake_vclGetDecodedProfilingBuffer;
-    _api->vclProfilingDestroy = &fake_vclProfilingDestroy;
-    _api->vclProfilingGetProperties = &fake_vclProfilingGetProperties;
-    _api->vclLogHandleGetString = &fake_vclLogHandleGetString;
-    _api->vclAllocatedExecutableCreate4 = &fake_vclAllocatedExecutableCreate4;
-    _api->vclExecutableGetCompatibilityString = &fake_vclExecutableGetCompatibilityString;
-    _api->vclGetCompilerSupportedOptions = &fake_vclGetCompilerSupportedOptions;
-    _api->vclGetCompilerIsOptionSupported = &fake_vclGetCompilerIsOptionSupported;
-    _api->vclAllocatedExecutableCreateWSOneShot2 = &fake_vclAllocatedExecutableCreateWSOneShot2;
+    _functions->vclGetVersion = &fake_vclGetVersion;
+    _functions->vclCompilerCreate = &fake_vclCompilerCreate;
+    _functions->vclCompilerDestroy = &fake_vclCompilerDestroy;
+    _functions->vclCompilerGetProperties = &fake_vclCompilerGetProperties;
+    _functions->vclQueryNetworkCreate = &fake_vclQueryNetworkCreate;
+    _functions->vclQueryNetwork = &fake_vclQueryNetwork;
+    _functions->vclQueryNetworkDestroy = &fake_vclQueryNetworkDestroy;
+    _functions->vclExecutableCreate = &fake_vclExecutableCreate;
+    _functions->vclExecutableDestroy = &fake_vclExecutableDestroy;
+    _functions->vclExecutableGetSerializableBlob = &fake_vclExecutableGetSerializableBlob;
+    _functions->vclProfilingCreate = &fake_vclProfilingCreate;
+    _functions->vclGetDecodedProfilingBuffer = &fake_vclGetDecodedProfilingBuffer;
+    _functions->vclProfilingDestroy = &fake_vclProfilingDestroy;
+    _functions->vclProfilingGetProperties = &fake_vclProfilingGetProperties;
+    _functions->vclLogHandleGetString = &fake_vclLogHandleGetString;
+    _functions->vclAllocatedExecutableCreate4 = &fake_vclAllocatedExecutableCreate4;
+    _functions->vclExecutableGetCompatibilityString = &fake_vclExecutableGetCompatibilityString;
+    _functions->vclGetCompilerSupportedOptions = &fake_vclGetCompilerSupportedOptions;
+    _functions->vclGetCompilerIsOptionSupported = &fake_vclGetCompilerIsOptionSupported;
+    _functions->vclAllocatedExecutableCreateWSOneShot2 = &fake_vclAllocatedExecutableCreateWSOneShot2;
     // Weak symbols the production path does not use stay null, matching an older library.
-    _api->vclAllocatedExecutableCreate2 = nullptr;
+    _functions->vclAllocatedExecutableCreate2 = nullptr;
 }
 
 }  // namespace fake_vcl

--- a/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/vcl_version_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/compiler_adapter/vcl_version_test.cpp
@@ -1,0 +1,113 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "intel_npu/utils/vcl/vcl.h"
+#include "openvino/core/except.hpp"
+#include "vcl_version_utils.hpp"
+
+namespace {
+
+using ::intel_npu::vcl_version_utils::checkVclVersion;
+using ::intel_npu::vcl_version_utils::getUsedVclVersion;
+using ::intel_npu::vcl_version_utils::UsedVersion;
+
+// The floor the plugin was built against.
+constexpr uint16_t kFloorMajor = VCL_COMPILER_VERSION_MAJOR;
+constexpr uint16_t kFloorMinor = VCL_COMPILER_VERSION_MINOR;
+
+// Convenience wrapper: negotiate against the real plugin floor, then validate.
+void negotiateAndCheck(uint16_t loadedMajor, uint16_t loadedMinor) {
+    const UsedVersion used = getUsedVclVersion(kFloorMajor, kFloorMinor, loadedMajor, loadedMinor);
+    checkVclVersion(used, loadedMajor, loadedMinor, kFloorMajor, kFloorMinor);
+}
+
+//
+// getUsedVclVersion — version negotiation
+//
+
+TEST(VclVersionTests, SameMajorTakesTheLowerMinor) {
+    // Plugin minor is the lower one.
+    EXPECT_EQ(getUsedVclVersion(7, 10, 7, 20).Major, 7);
+    EXPECT_EQ(getUsedVclVersion(7, 10, 7, 20).Minor, 10);
+
+    // Loaded minor is the lower one.
+    EXPECT_EQ(getUsedVclVersion(7, 20, 7, 10).Major, 7);
+    EXPECT_EQ(getUsedVclVersion(7, 20, 7, 10).Minor, 10);
+}
+
+TEST(VclVersionTests, SameMajorAndMinorIsUnchanged) {
+    const UsedVersion used = getUsedVclVersion(7, 10, 7, 10);
+    EXPECT_EQ(used.Major, 7);
+    EXPECT_EQ(used.Minor, 10);
+}
+
+TEST(VclVersionTests, PluginMajorNewerThanLibraryDowngradesToLibrary) {
+    // Plugin 9.3 against library 7.20 -> speak the library's 7.20, minor included.
+    const UsedVersion used = getUsedVclVersion(9, 3, 7, 20);
+    EXPECT_EQ(used.Major, 7);
+    EXPECT_EQ(used.Minor, 20);
+}
+
+TEST(VclVersionTests, PluginMajorOlderThanLibraryKeepsPluginVersion) {
+    // Plugin 7.10 against library 9.3 -> keep 7.10; the library is expected to be
+    // backward compatible.
+    const UsedVersion used = getUsedVclVersion(7, 10, 9, 3);
+    EXPECT_EQ(used.Major, 7);
+    EXPECT_EQ(used.Minor, 10);
+}
+
+//
+// checkVclVersion — floor enforcement
+//
+
+TEST(VclVersionTests, VersionAtTheFloorIsAccepted) {
+    EXPECT_NO_THROW(checkVclVersion(UsedVersion{7, 10}, 7, 10, 7, 10));
+}
+
+TEST(VclVersionTests, VersionAboveTheFloorIsAccepted) {
+    EXPECT_NO_THROW(checkVclVersion(UsedVersion{7, 11}, 7, 11, 7, 10));
+    EXPECT_NO_THROW(checkVclVersion(UsedVersion{8, 0}, 8, 0, 7, 10));
+}
+
+TEST(VclVersionTests, MinorBelowTheFloorThrows) {
+    EXPECT_THROW(checkVclVersion(UsedVersion{7, 9}, 7, 9, 7, 10), ov::Exception);
+}
+
+TEST(VclVersionTests, MajorBelowTheFloorThrows) {
+    EXPECT_THROW(checkVclVersion(UsedVersion{6, 99}, 6, 99, 7, 10), ov::Exception);
+}
+
+TEST(VclVersionTests, ThrowMessageReportsLoadedAndRequiredVersions) {
+    try {
+        checkVclVersion(UsedVersion{6, 1}, 6, 1, 7, 10);
+        FAIL() << "Expected checkVclVersion to throw";
+    } catch (const ov::Exception& error) {
+        const std::string what = error.what();
+        EXPECT_NE(what.find("Unsupported VCL version: 6.1"), std::string::npos) << what;
+        EXPECT_NE(what.find("please use VCL 7.10 or later"), std::string::npos) << what;
+    }
+}
+
+//
+// Negotiation and enforcement together, against the real plugin floor
+//
+
+TEST(VclVersionTests, LibraryOlderThanTheFloorIsRejected) {
+    // Negotiation downgrades to the library's version, which then fails the floor check.
+    ASSERT_GT(kFloorMinor, 0u) << "test assumes a non-zero plugin floor minor";
+    EXPECT_THROW(negotiateAndCheck(kFloorMajor, static_cast<uint16_t>(kFloorMinor - 1)), ov::Exception);
+    EXPECT_THROW(negotiateAndCheck(static_cast<uint16_t>(kFloorMajor - 1), 99), ov::Exception);
+}
+
+TEST(VclVersionTests, LibraryAtOrNewerThanTheFloorIsAccepted) {
+    EXPECT_NO_THROW(negotiateAndCheck(kFloorMajor, kFloorMinor));
+    EXPECT_NO_THROW(negotiateAndCheck(kFloorMajor, static_cast<uint16_t>(kFloorMinor + 1)));
+    EXPECT_NO_THROW(negotiateAndCheck(static_cast<uint16_t>(kFloorMajor + 1), 0));
+}
+
+}  // namespace


### PR DESCRIPTION
`VCLApi` is split into a `VCLFunctionTable` (data: the entry points) and a `VCLLoader` (the loaded
library), and `VCLCompilerImpl` receives the table by injection instead of reaching for a
process-wide singleton. The process-wide `intel_npu::vclXxx` wrappers are gone. `VCLCompilerImpl` is
unit-testable with **no driver, no compiler library, and no NPU present**, and no test-only
construction path exists anywhere. 68 new tests.

`PluginCompilerAdapter` still depends on `VCLCompilerImpl` concretely — extracting `IVCLCompiler`
and moving the adapter onto it is deliberately left to a follow-up.

**Notable things now pinned down that nothing verified before:**
- The build-flags string handed to the compiler is exactly `serializeIOInfo(model, true) + " " + serializeConfig(...)`. This is the plugin's entire contract with the compiler; a swapped order or missing separator previously produced a mis-compiled blob rather than an error.
- The serializer-version write-back is gated on `is_option_supported`: `compile` stamps the version `serializeIR` actually chose into a local config copy, but only when the compiler advertises `NPU_MODEL_SERIALIZER_VERSION`. Both sides of that gate are now covered — sending the option to a compiler that does not know it is a build-flag parse error.
- `compile` returns the **page-aligned allocator size**, not VCL's logical `blobSize` — the aligned value is what was actually reserved, so reporting the smaller logical size would under-report the buffer to every downstream consumer of the tensor.
- `compileWsOneShot` ordering: init schedules first, main last. `PluginCompilerAdapter` consumes the last tensor via `pop_back`, so this is load-bearing.
- The `uint32_t` to `uint16_t` revision narrowing clamps at `>= 0xFFFF` — without the guard, `subdeviceId = 0x10004` would wrap to `4` and claim a **valid** revision.
- `is_option_supported` swallows **any** error (both `UNSUPPORTED_FEATURE` and `UNKNOWN` are tested) because it is called from inside serialization callbacks where a throw would abort compilation.