### PR TITLE
Fix/onnx pad wrap mode

### DIFF
--- a/src/core/include/openvino/op/util/attr_types.hpp
+++ b/src/core/include/openvino/op/util/attr_types.hpp
@@ -15,7 +15,7 @@
 namespace ov {
 namespace op {
 /// \brief Modes for the `Pad` operator.
-enum class PadMode { CONSTANT = 0, EDGE, REFLECT, SYMMETRIC };
+enum class PadMode { CONSTANT = 0, EDGE, REFLECT, SYMMETRIC, WRAP };
 
 OPENVINO_API
 std::ostream& operator<<(std::ostream& s, const PadMode& type);

--- a/src/core/reference/src/op/pad.cpp
+++ b/src/core/reference/src/op/pad.cpp
@@ -161,6 +161,22 @@ struct SymmetricAndReflectPad : PadBase {
     int axis_correction{};
 };
 
+struct WrapPad : PadBase {
+    using PadBase::PadBase;
+
+    const Coordinate* transform_to_input_data_coord(const Coordinate& out_coord) const override {
+        assert(out_coord.size() == coord.size());
+        for (size_t i = 0; i != coord.size(); ++i) {
+            const auto shape_dim = static_cast<std::ptrdiff_t>(data_shape[i]);
+            const auto sc = static_cast<std::ptrdiff_t>(out_coord[i]);
+            const auto cc = sc - padding_begin.at(i);
+            // Python-style modulo: always yields a non-negative result
+            coord[i] = static_cast<size_t>(((cc % shape_dim) + shape_dim) % shape_dim);
+        }
+        return std::addressof(coord);
+    }
+};
+
 void pad(const char* data,
          const char* pad_value,
          char* out,
@@ -184,6 +200,11 @@ void pad(const char* data,
     case op::PadMode::REFLECT:
     case op::PadMode::SYMMETRIC: {
         impl::SymmetricAndReflectPad
+            pad{data, pad_value, out, elem_size, data_shape, out_shape, padding_below, padding_above, pad_mode};
+        pad.run();
+    } break;
+    case op::PadMode::WRAP: {
+        impl::WrapPad
             pad{data, pad_value, out, elem_size, data_shape, out_shape, padding_below, padding_above, pad_mode};
         pad.run();
     } break;

--- a/src/core/shape_inference/include/pad_shape_inference.hpp
+++ b/src/core/shape_inference/include/pad_shape_inference.hpp
@@ -90,6 +90,11 @@ std::vector<TRShape> shape_infer(const util::PadBase* op,
                                               "REFLECT padding mode requires an input of dimension "
                                               "of at least 2 at each "
                                               "spatial axis.");
+                        NODE_VALIDATION_CHECK(op,
+                                              pad_mode != op::PadMode::WRAP || dim_lb >= 1,
+                                              "WRAP padding mode requires an input of dimension of "
+                                              "at least 1 at each "
+                                              "spatial axis.");
                     }
                     NODE_SHAPE_INFER_CHECK(
                         op,

--- a/src/core/src/op/util/attr_types.cpp
+++ b/src/core/src/op/util/attr_types.cpp
@@ -17,7 +17,8 @@ OPENVINO_API EnumNames<ov::op::PadMode>& EnumNames<ov::op::PadMode>::get() {
                                                         {{"constant", ov::op::PadMode::CONSTANT},
                                                          {"edge", ov::op::PadMode::EDGE},
                                                          {"reflect", ov::op::PadMode::REFLECT},
-                                                         {"symmetric", ov::op::PadMode::SYMMETRIC}});
+                                                         {"symmetric", ov::op::PadMode::SYMMETRIC},
+                                                         {"wrap", ov::op::PadMode::WRAP}});
     return enum_names;
 }
 

--- a/src/frontends/onnx/frontend/src/op/pad.cpp
+++ b/src/frontends/onnx/frontend/src/op/pad.cpp
@@ -27,6 +27,8 @@ ov::op::PadMode get_pad_mode(std::string mode) {
         pad_mode = ov::op::PadMode::REFLECT;
     } else if (mode == "edge") {
         pad_mode = ov::op::PadMode::EDGE;
+    } else if (mode == "wrap") {
+        pad_mode = ov::op::PadMode::WRAP;
     } else {
         OPENVINO_THROW("Unsupported padding mode: [" + mode + "]");
     }

--- a/src/frontends/onnx/tests/models/pad_wrap.prototxt
+++ b/src/frontends/onnx/tests/models/pad_wrap.prototxt
@@ -1,0 +1,60 @@
+ir_version: 9
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "pads"
+    output: "y"
+    op_type: "Pad"
+    attribute {
+      name: "mode"
+      s: "wrap"
+      type: STRING
+    }
+  }
+  name: "test_wrap_pad"
+  initializer {
+    dims: 8
+    data_type: 7
+    int64_data: 0
+    int64_data: 0
+    int64_data: 1
+    int64_data: 1
+    int64_data: 0
+    int64_data: 0
+    int64_data: 1
+    int64_data: 1
+    name: "pads"
+  }
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 1 }
+          dim { dim_value: 1 }
+          dim { dim_value: 3 }
+          dim { dim_value: 3 }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 1 }
+          dim { dim_value: 1 }
+          dim { dim_value: 5 }
+          dim { dim_value: 5 }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 19
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -4155,6 +4155,34 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_pad_constant_negative_begin_end) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_pad_wrap) {
+    // Regression test for GitHub issue #37772:
+    // ONNX Pad with mode="wrap" (opset 19+) was rejected by the ONNX frontend.
+    // Circular/toroidal padding: values wrap around from the opposite edge.
+    const auto model = convert_model("pad_wrap.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    // Input: arange(9, dtype=float32).reshape(1, 1, 3, 3)
+    // [[[[0, 1, 2],
+    //    [3, 4, 5],
+    //    [6, 7, 8]]]]
+    test_case.add_input<float>({0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f});
+
+    // Expected output matches onnxruntime with pads=[0,0,1,1, 0,0,1,1]:
+    // [[[[8, 6, 7, 8, 6],
+    //    [2, 0, 1, 2, 0],
+    //    [5, 3, 4, 5, 3],
+    //    [8, 6, 7, 8, 6],
+    //    [2, 0, 1, 2, 0]]]]
+    test_case.add_expected_output<float>(Shape{1, 1, 5, 5},
+                                         {8.f, 6.f, 7.f, 8.f, 6.f,
+                                          2.f, 0.f, 1.f, 2.f, 0.f,
+                                          5.f, 3.f, 4.f, 5.f, 3.f,
+                                          8.f, 6.f, 7.f, 8.f, 6.f,
+                                          2.f, 0.f, 1.f, 2.f, 0.f});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_pow_float32_float32) {
     const auto model = convert_model("pow_float32_float32.onnx");
     auto test_case = ov::test::TestCase(model, s_device);


### PR DESCRIPTION
### Details:
 - Add `WRAP` to `PadMode` enum in core IR (`attr_types.hpp`, `attr_types.cpp`)
 - Implement circular/toroidal coordinate mapping in reference pad (`WrapPad` struct using Python-style modulo)
 - Add shape inference validation for `WRAP` mode (dimension ≥ 1 per axis)
 - Map ONNX string `"wrap"` → `PadMode::WRAP` in the ONNX frontend `get_pad_mode()`
 - Add opset-19 test model `pad_wrap.prototxt` and regression test `onnx_model_pad_wrap`

### Tickets:
 - #37772

### AI Assistance:
 - *AI assistance used: yes*
 - AI was used to identify affected files.