### PR TITLE
cabelo@opensuse.org - Native OpenVINO

### DIFF
--- a/docs/articles_en/about-openvino/release-notes-openvino/system-requirements.rst
+++ b/docs/articles_en/about-openvino/release-notes-openvino/system-requirements.rst
@@ -37,7 +37,7 @@ CPU
       * Ubuntu 22.04 long-term support (LTS), 64-bit (Kernel 5.15+)
       * macOS 12.6 and above, ARM64
       * Red Hat Enterprise Linux (RHEL) 8 and 9, 64-bit
-      * openSUSE Tumbleweed, 64-bit and ARM64
+      * openSUSE Tumbleweed, Leap 16.0 and Leap 16.1 64-bit and ARM64
       * Ubuntu 22.04 ARM64
 
 GPU
@@ -64,6 +64,7 @@ GPU
       * Ubuntu 24.04 long-term support (LTS), 64-bit
       * Ubuntu 22.04 long-term support (LTS), 64-bit
       * Red Hat Enterprise Linux (RHEL) 8 and 9, 64-bit
+      * openSUSE Tumbleweed, Leap 16.0 and Leap 16.1 64-bit and ARM64
 
    .. tab-item:: Additional considerations
 
@@ -87,6 +88,7 @@ Intel® Neural Processing Unit
 
       * Ubuntu 24.04 long-term support (LTS), 64-bit (preview support)
       * Ubuntu 22.04 long-term support (LTS), 64-bit
+      * openSUSE Tumbleweed, Leap 16.0 and Leap 16.1 64-bit and ARM64
       * Windows 11, 64-bit (22H2 and later)
 
    .. tab-item:: Additional considerations
@@ -106,6 +108,7 @@ Operating systems and developer environment
 
       * Ubuntu 24.04 with Linux kernel 6.8+
       * Ubuntu 22.04 with Linux kernel 5.15+
+      * openSUSE Tumbleweed, Leap 16.0 and Leap 16.1 64-bit and ARM64
       * Red Hat Enterprise Linux 9.3-9.4 with Linux kernel 5.4
 
       Build environment components:
@@ -321,7 +324,7 @@ to learn more about the release types.
          .. tab-item:: Linux
             :sync: linux
 
-            OpenVINO RPM packages are compatible with and can be run on openSUSE Tumbleweed only.
+            OpenVINO RPM packages are compatible with and can be run on openSUSE Tumbleweed, Leap 16.0 and Leap 16.1.
 
             Software:
 


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*

### AI Assistance:
 - *AI assistance used: no *
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*

Work carried out under the openSUSE Innovator initiative brings the next generation of Intel's Artificial Intelligence stack to Tumbleweed, Leap 16.0, and Leap 16.1, while also resulting in an upstream contribution to the Intel NPU driver.

As an Intel Innovator and member of the openSUSE Innovator initiative, I remain committed to bringing the openSUSE ecosystem closer to the latest technologies in Artificial Intelligence and heterogeneous computing.

In this latest work cycle, the Intel Linux NPU driver version 1.35.0 was made available for openSUSE Tumbleweed, openSUSE Leap 16.0, and openSUSE Leap 16.1. This provides users of these versions with access to the infrastructure needed to utilize the NPU found in the new generations of Intel® Core™ Ultra processors.

## Evidences:
- NEWS: 
  + https://news.opensuse.org/2026/08/31/NPU-openVINO/

- Repository: 
  + https://software.opensuse.org/package/linux-npu-driver
  + https://software.opensuse.org/package/openvino

- A humble contribution to the NPU drive:
  + https://github.com/intel/linux-npu-driver/pull/142

- Test on my machine:
<img width="1366" height="1284" alt="fina2l" src="https://github.com/user-attachments/assets/33bebca1-6676-4936-9983-07d96f5811a1" />

Thanks for the support @michalzx