### PR TITLE
[GPU] fix timm perf regression

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_imad.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_imad.cl
@@ -222,7 +222,7 @@ KERNEL (fused_convolution_eltwise_gpu_imad)(
                     uint valid_ifm_in_pack_input = (kd + 1) * PACK <= FILTER_IFM_NUM ? PACK : (FILTER_IFM_NUM % PACK);
                     for (uint v = 0; v < valid_ifm_in_pack_input; v++) {
                         int f_addr = ((feature_location + v) / FSV + INPUT0_PAD_BEFORE_FEATURE_NUM / FSV) * \
-                                      INPUT0_FEATURE_PITCH * FSV  + (feature_location + v) % FSV;
+                                      INPUT0_FEATURE_PITCH * FSV + (feature_location + v) % FSV;
                         input_int8_arr[v] = conv_input[in_addr + f_addr];
                     }
                     for (uint v = valid_ifm_in_pack_input; v < PACK; v++) {
@@ -239,7 +239,7 @@ KERNEL (fused_convolution_eltwise_gpu_imad)(
                     #endif
                         in[reg] = *(__global PACKED_TYPE*)(conv_input + in_addr);
                         in_addr += (INPUT0_SIZE_X + IWPAD) * 16;
-                 #endif
+                #endif
             #else
                 #ifdef BLOCK_LOAD_INPUTS
                     in[reg] = AS_PACKED_TYPE(_sub_group_block_read((const __global uint*) &conv_input[in_addr]));
@@ -267,17 +267,6 @@ KERNEL (fused_convolution_eltwise_gpu_imad)(
             for(int pf = 0; pf < NUM_FILTERS; pf++) {
                 w[pf] = weights[weight_addr];
                 weight_addr += SIMD_SIZE;
-            }
-        #endif
-
-        #if FILTER_IFM_NUM % PACK != 0
-            if ((kd + 1) * PACK >= ALIGN(FILTER_IFM_NUM, PACK)) {
-                for (int pf = 0; pf < NUM_FILTERS; pf++) {
-                    FILTER_TYPE* w_p = (FILTER_TYPE*)&w[pf];
-                    unroll_for (uint in_f = FILTER_IFM_NUM % PACK; in_f < PACK; in_f++) {
-                        w_p[in_f] = 0;
-                    }
-                }
             }
         #endif
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights.cl
@@ -563,6 +563,18 @@ KERNEL (reorder_weights)(const __global INPUT0_TYPE* input, __global OUTPUT_TYPE
     const unsigned z = (zyx / OUTPUT_SIZE_X) / OUTPUT_SIZE_Y;
 #endif
 
+#if !REORDER_ROTATE
+    uint output_idx = FUNC_CALL(get_output_index)(g, o, i, z, y, x);
+#else
+    uint output_idx = FUNC_CALL(get_output_index)(g, o, i, OUTPUT_SIZE_Z - z - 1, OUTPUT_SIZE_Y - y - 1, OUTPUT_SIZE_X - x - 1);
+#endif
+#if IMAD_ISV4_PADDING
+    if (i >= OUTPUT_IFM_NUM) {
+        output[output_idx] = (OUTPUT_TYPE)0;
+        return;
+    }
+#endif
+
 #if OUTPUT_GROUPS_NUM > 1 //  Add grouped macro instead this check
     uint8 ir = RESHAPE_WEIGHT_DIMS_WITH_GROUPS(OUTPUT, INPUT0, g, o, i, 0, z, y, x);
 #else
@@ -570,11 +582,6 @@ KERNEL (reorder_weights)(const __global INPUT0_TYPE* input, __global OUTPUT_TYPE
 #endif
 
     uint input_idx = FUNC_CALL(get_input_index)(ir.s0,ir.s1,ir.s2,ir.s4,ir.s5,ir.s6);
-#if !REORDER_ROTATE
-    uint output_idx = FUNC_CALL(get_output_index)(g, o, i, z, y, x);
-#else
-    uint output_idx = FUNC_CALL(get_output_index)(g, o, i, OUTPUT_SIZE_Z - z - 1, OUTPUT_SIZE_Y - y - 1, OUTPUT_SIZE_X - x - 1);
-#endif
 #ifdef BF16_INPUT
     output[output_idx] = TO_OUTPUT_TYPE(_convert_as_bfloat16_float(input[input_idx]));
 #else

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_kernel.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_kernel.cpp
@@ -37,7 +37,29 @@ JitConstants ReorderWeightsKernel::GetJitConstants(const reorder_weights_params&
     if ( params.input.GetDType() == WeightsType::BF16 ) {
         jit.AddConstant(MakeJitConstant("BF16_INPUT", true));
     }
+
+    const auto output_layout = params.output.GetLayout();
+    const bool has_imad_isv4_padding =
+        (output_layout == WeightsLayout::os_is_yx_osv16_isv4 ||
+         output_layout == WeightsLayout::g_os_is_yx_osv16_isv4) &&
+        params.output.IFM().v % 4 != 0;
+    jit.AddConstant(MakeJitConstant("IMAD_ISV4_PADDING", has_imad_isv4_padding));
+
     return jit;
+}
+
+ReorderWeightsKernel::DispatchData ReorderWeightsKernel::SetDefault(const reorder_weights_params& params) const {
+    auto dispatch_data = ReorderKernelBase::SetDefault(params);
+    const auto output_layout = params.output.GetLayout();
+
+    if ((output_layout == WeightsLayout::os_is_yx_osv16_isv4 ||
+         output_layout == WeightsLayout::g_os_is_yx_osv16_isv4) &&
+        params.output.IFM().v % 4 != 0) {
+        dispatch_data.gws[1] = Align(params.output.IFM().v, size_t{4});
+        dispatch_data.lws = GetOptimalLocalWorkGroupSizes(dispatch_data.gws, params.engineInfo);
+    }
+
+    return dispatch_data;
 }
 
 KernelsPriority ReorderWeightsKernel::GetKernelsPriority(const Params& /*params*/) const {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_kernel.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_kernel.h
@@ -12,6 +12,7 @@ public:
     ReorderWeightsKernel() : ReorderKernelBase("reorder_weights") {}
     ~ReorderWeightsKernel() override = default;
     JitConstants GetJitConstants(const reorder_weights_params& params) const override;
+    DispatchData SetDefault(const reorder_weights_params& params) const override;
     KernelsData GetKernelsData(const Params& params) const override;
     KernelsPriority GetKernelsPriority(const Params& params) const override;
     ParamsKey GetSupportedKey() const override;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -7954,6 +7954,8 @@ INSTANTIATE_TEST_SUITE_P(convolution_grouped_fsv4_fsv16,
 
                             // Format: b_fs_yx_fsv16
                             TestParamType_grouped_convolution_gpu(12, 12, 1, 96, 96, 3, 3, 1, 32, 1, 1, true, true, true, format::b_fs_yx_fsv16, ""),
+                            TestParamType_grouped_convolution_gpu(8, 8, 1, 16, 16, 3, 3, 1, 16, 1, 1, true, true, true, format::b_fs_yx_fsv16, "convolution_gpu_imad"),
+                            TestParamType_grouped_convolution_gpu(8, 8, 1, 80, 16, 3, 3, 1, 16, 1, 1, true, true, true, format::b_fs_yx_fsv16, "convolution_gpu_imad"),
                             TestParamType_grouped_convolution_gpu(4, 4, 1, 8, 16, 3, 3, 1, 2, 1, 1, true, true, true, format::b_fs_yx_fsv16, ""),
                             TestParamType_grouped_convolution_gpu(7, 7, 1, 8, 4, 3, 3, 1, 4, 1, 1, true, true, true, format::b_fs_yx_fsv16, ""),
                             TestParamType_grouped_convolution_gpu(5, 5, 1, 34, 12, 3, 3, 1, 2, 1, 1, true, true, true, format::b_fs_yx_fsv16, ""),


### PR DESCRIPTION
### Details:
 - fix performance regression caused by using per-lane access (to avoid OOB on xe2+ GPU) on iGPU (xe-lp)

### Tickets:
 - *CVS-187303*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI root cause and human validate the solution.*