### PR TITLE
[BUG FIX] Fix performance regression on PTL

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -292,7 +292,8 @@ bool is_all_core_auto_case_low_tolerance_zero_adds_profile(const ov::MemBandwidt
 void determine_tbb_partitioner_and_threads(Config& config,
                                            const std::vector<std::vector<int>>& proc_type_table,
                                            const ov::MemBandwidthPressure& tolerance,
-                                           bool int8_intensive) {
+                                           bool int8_intensive,
+                                           int num_streams) {
     if (config.tbbPartitioner != TbbPartitioner::NONE) {
         return;
     }
@@ -313,7 +314,8 @@ void determine_tbb_partitioner_and_threads(Config& config,
         }
     }
 
-    if (has_lp_ecores && (is_all_core_auto_case_high_lp_share_relaxed_profile(tolerance, lp_ecore_share) ||
+    if (num_streams == 1 &&
+        has_lp_ecores && (is_all_core_auto_case_high_lp_share_relaxed_profile(tolerance, lp_ecore_share) ||
                           is_all_core_auto_case_high_lp_share_vision_profile(tolerance, lp_ecore_share) ||
                           is_all_core_auto_case_high_lp_share_residual_vision_profile(tolerance, lp_ecore_share) ||
                           is_all_core_auto_case_low_tolerance_dense_conv_profile(tolerance) ||
@@ -1221,7 +1223,8 @@ void configure_x86_hybrid_threads(Config& config,
                                   const std::vector<std::vector<int>>& proc_type_table,
                                   const ov::MemBandwidthPressure& tolerance,
                                   bool int8_intensive,
-                                  bool is_LLM) {
+                                  bool is_LLM,
+                                  int num_streams) {
     const int main_cores = proc_type_table[0][MAIN_CORE_PROC];
     const int efficient_cores = proc_type_table[0][EFFICIENT_CORE_PROC];
     const int lp_efficient_cores = proc_type_table[0][LP_EFFICIENT_CORE_PROC];
@@ -1235,7 +1238,7 @@ void configure_x86_hybrid_threads(Config& config,
             config.modelPreferThreadsLatency = main_cores;
         } else {
             config.modelPreferThreadsLatency = main_cores + efficient_cores;
-            determine_tbb_partitioner_and_threads(config, proc_type_table, tolerance, int8_intensive);
+            determine_tbb_partitioner_and_threads(config, proc_type_table, tolerance, int8_intensive, num_streams);
         }
     } else {
         // Fall back to default latency preference logic
@@ -1363,7 +1366,12 @@ int get_model_prefer_threads(const int num_streams,
         const int lp_efficient_cores = proc_type_table[0][LP_EFFICIENT_CORE_PROC];
 
         if (efficient_cores > 0 && main_cores > 0) {
-            configure_x86_hybrid_threads(config, proc_type_table, networkToleranceForLowCache, int8_intensive, is_LLM);
+            configure_x86_hybrid_threads(config,
+                                         proc_type_table,
+                                         networkToleranceForLowCache,
+                                         int8_intensive,
+                                         is_LLM,
+                                         num_streams);
         } else if (efficient_cores == 0 && main_cores * 2 <= lp_efficient_cores) {
             configure_x86_hybrid_lp_threads(config, proc_type_table, networkToleranceForLowCache);
         } else {

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -314,14 +314,14 @@ void determine_tbb_partitioner_and_threads(Config& config,
         }
     }
 
-    if (num_streams == 1 &&
-        has_lp_ecores && (is_all_core_auto_case_high_lp_share_relaxed_profile(tolerance, lp_ecore_share) ||
-                          is_all_core_auto_case_high_lp_share_vision_profile(tolerance, lp_ecore_share) ||
-                          is_all_core_auto_case_high_lp_share_residual_vision_profile(tolerance, lp_ecore_share) ||
-                          is_all_core_auto_case_low_tolerance_dense_conv_profile(tolerance) ||
-                          is_all_core_auto_case_low_tolerance_zero_adds_profile(tolerance) ||
-                          (is_all_core_auto_case(tolerance) &&
-                           !is_all_core_auto_case_small_conv_exclusion_profile(tolerance, lp_ecore_share)))) {
+    if (num_streams == 1 && has_lp_ecores &&
+        (is_all_core_auto_case_high_lp_share_relaxed_profile(tolerance, lp_ecore_share) ||
+         is_all_core_auto_case_high_lp_share_vision_profile(tolerance, lp_ecore_share) ||
+         is_all_core_auto_case_high_lp_share_residual_vision_profile(tolerance, lp_ecore_share) ||
+         is_all_core_auto_case_low_tolerance_dense_conv_profile(tolerance) ||
+         is_all_core_auto_case_low_tolerance_zero_adds_profile(tolerance) ||
+         (is_all_core_auto_case(tolerance) &&
+          !is_all_core_auto_case_small_conv_exclusion_profile(tolerance, lp_ecore_share)))) {
         config.modelPreferThreadsLatency = proc_type_table[0][MAIN_CORE_PROC] +
                                            proc_type_table[0][EFFICIENT_CORE_PROC] +
                                            proc_type_table[0][LP_EFFICIENT_CORE_PROC];

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.hpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.hpp
@@ -147,7 +147,8 @@ void configure_x86_hybrid_threads(Config& config,
                                   const std::vector<std::vector<int>>& proc_type_table,
                                   const ov::MemBandwidthPressure& tolerance,
                                   bool int8_intensive,
-                                  bool is_LLM);
+                                  bool is_LLM,
+                                  int num_streams = 1);
 
 void configure_x86_hybrid_lp_threads(Config& config,
                                      const std::vector<std::vector<int>>& proc_type_table,

--- a/src/plugins/intel_cpu/tests/unit/streams_info/model_prefer_threads.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/model_prefer_threads.cpp
@@ -300,6 +300,29 @@ TEST_F(ModelPreferThreadsIntegrationTest, direct_x86_hybrid_high_lp_share_relaxe
     EXPECT_EQ(config.tbbPartitioner, TbbPartitioner::AUTO);
 }
 
+TEST_F(ModelPreferThreadsIntegrationTest, direct_x86_hybrid_multiple_streams_skip_all_core_auto_case) {
+    std::vector<std::vector<int>> proc_type_table = {{16, 4, 8, 4, 0, 0, 0}};
+    const auto tolerance = MemBandwidthPressureBuilder{}
+                               .total_gemms(0)
+                               .total_convs(20)
+                               .total_light_convs(13)
+                               .ratio_compute_convs(0.29f)
+                               .ratio_mem_limited_convs(0.15f)
+                               .ratio_mem_limited_gemms(0.0f)
+                               .ratio_mem_limited_adds(0.4f)
+                               .max_mem_tolerance(0.2f)
+                               .build();
+
+    Config single_stream_config;
+    configure_x86_hybrid_threads(single_stream_config, proc_type_table, tolerance, false, false, 1);
+    EXPECT_EQ(single_stream_config.tbbPartitioner, TbbPartitioner::AUTO);
+
+    Config multiple_streams_config;
+    configure_x86_hybrid_threads(multiple_streams_config, proc_type_table, tolerance, false, false, 2);
+    EXPECT_EQ(multiple_streams_config.modelPreferThreadsLatency, 12);
+    EXPECT_EQ(multiple_streams_config.tbbPartitioner, TbbPartitioner::STATIC);
+}
+
 TEST_F(ModelPreferThreadsIntegrationTest, direct_x86_hybrid_low_lp_share_keeps_main_and_efficient_auto_case) {
     Config config;
     std::vector<std::vector<int>> proc_type_table = {{28, 8, 16, 4, 0, 0, 0}};


### PR DESCRIPTION
### Details:
 - *Performance regression due to setting tbb_partitioner from static to auto with throughput mode*

### Tickets:
 - *CVS-193124*
### Performance data:
<img width="568" height="76" alt="image" src="https://github.com/user-attachments/assets/98fca029-f2ce-4074-a34e-84d3f1e49afe" />

Fix the performance issues of the following models:
<img width="521" height="277" alt="image" src="https://github.com/user-attachments/assets/1b87e3ba-1cfe-43c7-89ea-3ab58a020b75" />


### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
