### PR TITLE
[GPU] Support OneHot with non-constant on_value/off_value

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
@@ -20,8 +20,11 @@ static void CreateOneHotOpGeneric(ProgramBuilder& p, const std::shared_ptr<ov::o
     auto on_value_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
     auto off_value_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(3));
 
-    OPENVINO_ASSERT(on_value_node != nullptr || off_value_node != nullptr || depth_value_node != nullptr,
-                    "[GPU] Unsupported on/off/depth nodes type in ",
+    // A non-constant depth is handled below by the two input primitive variant,
+    // but on/off are read as compile time values right away, so they must be constants.
+    // Non-constant ones are expected to have been rewritten into a mask + Select by DecomposeOneHotNonConstValues.
+    OPENVINO_ASSERT(on_value_node != nullptr && off_value_node != nullptr,
+                    "[GPU] Unsupported on/off nodes type in ",
                     op->get_friendly_name(),
                     " (",
                     op->get_type_name(),

--- a/src/plugins/intel_gpu/src/plugin/transformations/decompose_one_hot_non_const_values.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/decompose_one_hot_non_const_values.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "decompose_one_hot_non_const_values.hpp"
+
+#include <memory>
+
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/util/one_hot_base.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+namespace ov::intel_gpu {
+
+DecomposeOneHotNonConstValues::DecomposeOneHotNonConstValues() {
+    using namespace ov::pass::pattern;
+
+    // OneHotBase is the parent of both v1::OneHot and v16::OneHot, so this matches either version.
+    auto one_hot_m = wrap_type<ov::op::util::OneHotBase>();
+
+    ov::matcher_pass_callback callback = [this](Matcher& m) {
+        auto one_hot = ov::as_type_ptr<ov::op::util::OneHotBase>(m.get_match_root());
+        if (!one_hot || transformation_callback(one_hot))
+            return false;
+
+        const auto on_value = one_hot->input_value(2);
+        const auto off_value = one_hot->input_value(3);
+
+        // Compile time values are baked into the kernel by the one_hot primitive, leave them alone.
+        if (ov::is_type<ov::op::v0::Constant>(on_value.get_node()) &&
+            ov::is_type<ov::op::v0::Constant>(off_value.get_node()))
+            return false;
+
+        auto mask_on = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{}, true);
+        auto mask_off = std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{}, false);
+        // Cloning keeps the axis and, for v16, the negative indices mode.
+        auto mask = one_hot->clone_with_new_inputs({one_hot->input_value(0),
+                                                    one_hot->input_value(1),
+                                                    mask_on,
+                                                    mask_off});
+        mask->set_friendly_name(one_hot->get_friendly_name() + "/mask");
+
+        // on/off are scalars by the op specification, so the Select keeps the OneHot shape and type.
+        auto select = std::make_shared<ov::op::v1::Select>(mask, on_value, off_value);
+        select->set_friendly_name(one_hot->get_friendly_name());
+
+        ov::copy_runtime_info(one_hot, {mask_on, mask_off, mask, select});
+        ov::replace_node(one_hot, select);
+        return true;
+    };
+
+    auto m = std::make_shared<Matcher>(one_hot_m, "DecomposeOneHotNonConstValues");
+    register_matcher(m, callback);
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/decompose_one_hot_non_const_values.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/decompose_one_hot_non_const_values.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov::intel_gpu {
+
+/**
+ * @brief Decomposes OneHot (v1/v16) whose on_value/off_value are not Constants.
+ *
+ * The cldnn one_hot primitive bakes on/off into the OpenCL kernel as jit constants,
+ * so it can only handle compile time values.
+ * ONNX exports of `Tensor.repeat(...)` build the repeats vector with a OneHot,
+ * and its on_value comes from a ShapeOf chain, which is a genuine runtime value.
+ *
+ * Such a OneHot is rewritten as a boolean mask plus a Select:
+ *     OneHot(idx, depth, on, off)  ->  Select(OneHot(idx, depth, true, false), on, off)
+ *
+ * on_value/off_value are scalars by the op specification,
+ * so the Select output shape and type match the original ones.
+ * When indices and depth are constants the mask is folded away and only the Select remains,
+ * which already has a CPU implementation for shape_of subgraphs.
+ */
+class DecomposeOneHotNonConstValues : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("DecomposeOneHotNonConstValuesGPU");
+    DecomposeOneHotNonConstValues();
+};
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/decompose_one_hot_non_const_values.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/decompose_one_hot_non_const_values.hpp
@@ -9,24 +9,15 @@
 namespace ov::intel_gpu {
 
 /**
- * @brief Decomposes OneHot (v1/v16) whose on_value/off_value are not Constants.
+ * @brief Decomposes OneHot (v1/v16) with non-Constant on_value/off_value.
  *
- * The cldnn one_hot primitive bakes on/off into the OpenCL kernel as jit constants,
- * so it can only handle compile time values.
- * ONNX exports of `Tensor.repeat(...)` build the repeats vector with a OneHot,
- * and its on_value comes from a ShapeOf chain, which is a genuine runtime value.
- *
- * Such a OneHot is rewritten as a boolean mask plus a Select:
+ * The cldnn one_hot primitive bakes on/off values into the kernel as jit constants,
+ * so they must be known at compile time. Rewrite such a OneHot as a mask plus a Select:
  *     OneHot(idx, depth, on, off)  ->  Select(OneHot(idx, depth, true, false), on, off)
- *
- * on_value/off_value are scalars by the op specification,
- * so the Select output shape and type match the original ones.
- * When indices and depth are constants the mask is folded away and only the Select remains,
- * which already has a CPU implementation for shape_of subgraphs.
  */
 class DecomposeOneHotNonConstValues : public ov::pass::MatcherPass {
 public:
-    OPENVINO_MATCHER_PASS_RTTI("DecomposeOneHotNonConstValuesGPU");
+    OPENVINO_MATCHER_PASS_RTTI("DecomposeOneHotNonConstValues");
     DecomposeOneHotNonConstValues();
 };
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -90,6 +90,7 @@
 #include "transformations/common_optimizations/moe_op_fusion.hpp"
 #include "transformations/op_conversions/convert_gather_matmul_to_compressed.hpp"
 #include "plugin/transformations/convert_stridedslices_to_variadicsplit.hpp"
+#include "plugin/transformations/decompose_one_hot_non_const_values.hpp"
 #include "plugin/transformations/decompose_reduce_scalar_output.hpp"
 #include "plugin/transformations/dynamic_quantize_fully_connected.hpp"
 #include "plugin/transformations/fc_convert_fusion.hpp"
@@ -776,6 +777,12 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                                                           keep_precision_sensitive_in_fp32_1,
                                                           convert_input_output_precision,
                                                           store_original_precision_as_rt_attribute);
+
+        // The one_hot primitive takes on/off as compile time values,
+        // so OneHot ops fed by a runtime scalar are turned into a boolean mask + Select.
+        // This runs right before "CommonOptimizations",
+        // whose ConstantFolding folds the mask away when indices and depth are constants.
+        manager.register_pass<ov::intel_gpu::DecomposeOneHotNonConstValues>();
 
         manager.register_pass<ov::pass::CommonOptimizations>();
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/decompose_one_hot_non_const_values_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/decompose_one_hot_non_const_values_test.cpp
@@ -1,0 +1,149 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <openvino/core/model.hpp>
+#include <openvino/pass/manager.hpp>
+#include <plugin/transformations/decompose_one_hot_non_const_values.hpp>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/one_hot.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/squeeze.hpp"
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+namespace {
+
+using NegativeIndicesMode = ov::op::v16::OneHot::NegativeIndicesMode;
+
+std::shared_ptr<ov::op::v0::Constant> bool_const(bool value) {
+    return std::make_shared<ov::op::v0::Constant>(ov::element::boolean, ov::Shape{}, value);
+}
+
+// on_value taken from the shape of a dynamic tensor, as in the ONNX export of `x.repeat(1, N)`.
+ov::Output<ov::Node> shape_scalar(const ov::Output<ov::Node>& data) {
+    auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(data, ov::element::i32);
+    auto axes = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {0});
+    return std::make_shared<ov::op::v0::Squeeze>(shape_of, axes);
+}
+
+}  // namespace
+
+TEST_F(TransformationTestsF, DecomposeOneHotNonConstOnValueV16) {
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    {
+        auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1});
+        auto on = shape_scalar(data);
+        auto indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto depth = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {2});
+        auto off = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {1});
+        auto one_hot =
+            std::make_shared<ov::op::v16::OneHot>(indices, depth, on, off, 1, NegativeIndicesMode::NORMALIZE);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{one_hot}, ov::ParameterVector{data});
+        manager.register_pass<DecomposeOneHotNonConstValues>();
+    }
+    {
+        auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1});
+        auto on = shape_scalar(data);
+        auto indices = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto depth = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {2});
+        auto off = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {1});
+        auto mask = std::make_shared<ov::op::v16::OneHot>(indices,
+                                                          depth,
+                                                          bool_const(true),
+                                                          bool_const(false),
+                                                          1,
+                                                          NegativeIndicesMode::NORMALIZE);
+        auto select = std::make_shared<ov::op::v1::Select>(mask, on, off);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{data});
+    }
+}
+
+TEST_F(TransformationTestsF, DecomposeOneHotNonConstOffValueV1) {
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    {
+        auto indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+        auto off = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{});
+        auto depth = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {4});
+        auto on = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {5.0f});
+        auto one_hot = std::make_shared<ov::op::v1::OneHot>(indices, depth, on, off, 1);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{one_hot}, ov::ParameterVector{indices, off});
+        manager.register_pass<DecomposeOneHotNonConstValues>();
+    }
+    {
+        auto indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+        auto off = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{});
+        auto depth = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {4});
+        auto on = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {5.0f});
+        auto mask = std::make_shared<ov::op::v1::OneHot>(indices, depth, bool_const(true), bool_const(false), 1);
+        auto select = std::make_shared<ov::op::v1::Select>(mask, on, off);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{indices, off});
+    }
+}
+
+TEST_F(TransformationTestsF, DecomposeOneHotNonConstOnAndOffValuesV16IgnoreNegative) {
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    {
+        auto indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1, -1});
+        auto on = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{});
+        auto off = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{});
+        auto depth = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {3});
+        auto one_hot = std::make_shared<ov::op::v16::OneHot>(indices,
+                                                             depth,
+                                                             on,
+                                                             off,
+                                                             2,
+                                                             NegativeIndicesMode::IGNORE_NEGATIVE);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{one_hot}, ov::ParameterVector{indices, on, off});
+        manager.register_pass<DecomposeOneHotNonConstValues>();
+    }
+    {
+        auto indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1, -1});
+        auto on = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{});
+        auto off = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{});
+        auto depth = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {3});
+        auto mask = std::make_shared<ov::op::v16::OneHot>(indices,
+                                                          depth,
+                                                          bool_const(true),
+                                                          bool_const(false),
+                                                          2,
+                                                          NegativeIndicesMode::IGNORE_NEGATIVE);
+        auto select = std::make_shared<ov::op::v1::Select>(mask, on, off);
+
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{select}, ov::ParameterVector{indices, on, off});
+    }
+}
+
+// Constant on/off are handled by the one_hot primitive itself, the pass must leave them alone.
+TEST_F(TransformationTestsF, DecomposeOneHotConstValuesIsNoop) {
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    {
+        auto indices = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1});
+        auto depth = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {3});
+        auto on = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f});
+        auto off = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {0.0f});
+        auto one_hot = std::make_shared<ov::op::v1::OneHot>(indices, depth, on, off, 1);
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{one_hot}, ov::ParameterVector{indices});
+        manager.register_pass<DecomposeOneHotNonConstValues>();
+    }
+    // model_ref is intentionally left unset: the model must stay as it is.
+}


### PR DESCRIPTION
## Issue
- Compiling `detectron_COCO-Detection_faster_rcnn_R_50_FPN_1x` (ONNX, FP32) on GPU fails at the `OneHot`.

## Root cause
- The GPU plugin has always assumed all inputs of `OneHot` are constants, 
- However, one of the inputs, `on_value` is non-constant type, so this model cannot be compiled.
<img width="629" height="321" alt="image" src="https://github.com/user-attachments/assets/adf52edf-ca5c-473a-9072-3be2c2659ffc" />

## Solution
- Add a GPU transformation, `DecomposeOneHotNonConstValues`, that splits the `OneHot` into the part that decides 1) where the hot positions are and the part that decides 2) which values to write:
```
OneHot(idx, depth, on, off)  ->  Select(OneHot(idx, depth, true, false), on, off)
```
- The mask OneHot now always has constant on/off, so it fits the existing primitive, and the runtime value is moved to `Select`, which reads all of its inputs from buffers. 
- `clone_with_new_inputs()` keeps `axis` and the `negative_indices_mode`, and `on_value`/`off_value` are scalars by the op specification, so the `Select` output shape and type match the original ones.
- The pass runs right before `CommonOptimizations`, whose `ConstantFolding` folds the mask away when `indices` and `depth` are constants.
- For this model only the `Select` remains, and it already has a CPU implementation registered for shape_of subgraphs, so no GPU kernel is built for it.

## Ticket
- CVS-193530