### PR TITLE
[GPU] Fall back to OCL for oneDNN concat with more than 512 inputs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.cpp
@@ -30,8 +30,8 @@ protected:
         int input_idx = DNNL_ARG_MULTIPLE_SRC;
         for (size_t i = 0; i < instance.inputs_memory_count(); i++) {
             auto& input = instance.input_memory(i);
-            auto offset = onednn::get_offset(instance.get_input_layout(i), _pd.dnnl::primitive_desc_base::src_desc(static_cast<uint8_t>(i)));
-            args.insert({input_idx++, input.get_onednn_memory(_pd.dnnl::primitive_desc_base::src_desc(static_cast<uint8_t>(i)), offset)});
+            auto offset = onednn::get_offset(instance.get_input_layout(i), _pd.dnnl::primitive_desc_base::src_desc(static_cast<int>(i)));
+            args.insert({input_idx++, input.get_onednn_memory(_pd.dnnl::primitive_desc_base::src_desc(static_cast<int>(i)), offset)});
         }
 
         {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
@@ -30,7 +30,7 @@ struct ConcatenationImplementationManager : public ImplementationManager {
         static_assert(DNNL_ARG_MULTIPLE_SRC % (2 * max_onednn_inputs) == 0,
                       "the first colliding source index equals the flag value only while the "
                       "DNNL_ARG_MULTIPLE_SRC base leaves that bit and all lower bits clear");
-        if (node.get_dependencies().size() > max_onednn_inputs)
+        if (node.get_inputs_count() > max_onednn_inputs)
             return false;
 
         static const std::vector<ov::element::Type_t> supported_types = { ov::element::f16, ov::element::bf16, ov::element::u8, ov::element::i8 };

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
@@ -23,6 +23,16 @@ struct ConcatenationImplementationManager : public ImplementationManager {
         if (!info.supports_immad || info.arch == gpu_arch::unknown || !config.get_use_onednn())
             return false;
 
+        // oneDNN classifies DNNL_ARG_MULTIPLE_SRC + i as an attribute argument once i sets the
+        // DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS bit, so a concat with more sources than that bit's
+        // value fails oneDNN's argument count check at execution time.
+        constexpr size_t max_onednn_inputs = DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS;
+        static_assert(DNNL_ARG_MULTIPLE_SRC % (2 * max_onednn_inputs) == 0,
+                      "the first colliding source index equals the flag value only while the "
+                      "DNNL_ARG_MULTIPLE_SRC base leaves that bit and all lower bits clear");
+        if (node.get_dependencies().size() > max_onednn_inputs)
+            return false;
+
         static const std::vector<ov::element::Type_t> supported_types = { ov::element::f16, ov::element::bf16, ov::element::u8, ov::element::i8 };
         static const std::vector<format::type> supported_in_fmts = {
             format::any,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -1722,6 +1722,77 @@ TEST(concat_gpu_onednn, basic_input_types) {
     }
 }
 
+// oneDNN counts DNNL_ARG_MULTIPLE_SRC + i (i >= 512) as an attribute argument because the arg id
+// bit-collides with DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS (512), so executing a concat with more
+// than 512 inputs is rejected with "could not execute a primitive".
+static void run_concat_onednn_many_inputs(const std::vector<int32_t>& input_features, impl_types expected_impl) {
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_immad)
+        GTEST_SKIP() << "Skipping oneDNN concat test: device does not support IMMAD";
+
+    constexpr int32_t spatial_size = 2;
+    constexpr size_t elems_per_feature = spatial_size * spatial_size;
+
+    topology topology;
+    std::vector<input_info> concat_inputs;
+    std::vector<memory::ptr> input_mems;
+    int32_t total_features = 0;
+    for (size_t i = 0; i < input_features.size(); ++i) {
+        auto id = "input" + std::to_string(i);
+        layout in_layout = { data_types::f16, format::bfyx, tensor{ 1, input_features[i], spatial_size, spatial_size } };
+        auto mem = engine.allocate_memory(in_layout);
+        set_values(mem, VF<ov::float16>(in_layout.count(), ov::float16(static_cast<float>(i))));
+        topology.add(input_layout(id, in_layout));
+        concat_inputs.emplace_back(id);
+        input_mems.push_back(mem);
+        total_features += input_features[i];
+    }
+    topology.add(concatenation("concat", concat_inputs, 1, data_types::f16));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::custom_outputs(std::vector<std::string>{ "concat" }));
+
+    network network(engine, topology, config);
+    for (size_t i = 0; i < input_mems.size(); ++i)
+        network.set_input_data("input" + std::to_string(i), input_mems[i]);
+
+    auto impl = network.get_primitive("concat")->get_impl();
+    ASSERT_TRUE(impl != nullptr);
+    ASSERT_TRUE(impl->m_manager != nullptr);
+    EXPECT_EQ(impl->m_manager->get_impl_type(), expected_impl);
+
+    std::map<primitive_id, network_output> outputs;
+    ASSERT_NO_THROW(outputs = network.execute());
+
+    auto output_memory = outputs.at("concat").get_memory();
+    ASSERT_EQ(output_memory->get_layout().feature(), total_features);
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(output_memory, get_test_stream());
+    size_t offset = 0;
+    for (size_t i = 0; i < input_features.size(); ++i) {
+        const size_t elems = static_cast<size_t>(input_features[i]) * elems_per_feature;
+        for (size_t e = 0; e < elems; ++e, ++offset) {
+            ASSERT_EQ(static_cast<float>(output_ptr[offset]), static_cast<float>(i)) << "input " << i;
+        }
+    }
+}
+
+TEST(concat_gpu_onednn, max_supported_input_count_uses_onednn) {
+    ASSERT_NO_FATAL_FAILURE(run_concat_onednn_many_inputs(std::vector<int32_t>(512, 1), impl_types::onednn));
+}
+
+TEST(concat_gpu_onednn, above_max_input_count_falls_back_to_ocl) {
+    ASSERT_NO_FATAL_FAILURE(run_concat_onednn_many_inputs(std::vector<int32_t>(513, 1), impl_types::ocl));
+}
+
+// Wide concat whose sources do not all share one layout, so oneDNN source descriptors must be
+// indexed past 255 correctly.
+TEST(concat_gpu_onednn, varying_input_shapes_across_index_255) {
+    std::vector<int32_t> input_features(300, 1);
+    std::fill(input_features.begin() + 256, input_features.end(), 3);
+    ASSERT_NO_FATAL_FAILURE(run_concat_onednn_many_inputs(input_features, impl_types::onednn));
+}
+
 TEST(concat_gpu_onednn, impl_selection_unaligned_feature_axis) {
     auto& engine = get_test_engine();
     if (!engine.get_device_info().supports_immad)


### PR DESCRIPTION
### Details:

A concat source is passed to oneDNN as `DNNL_ARG_MULTIPLE_SRC + i`. In `cvt_primitive_args()` oneDNN decides whether an execution argument is an *attribute* argument with a **bitwise AND** against the attribute flag macros:

```cpp
extra_inputs += (arg & DNNL_ARG_ATTR_ZERO_POINTS)              // 8192
             || (arg & DNNL_ARG_ATTR_SCALES)                   // 4096
             || (arg & DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS)   //  512  <-- collides
             || ...;
```

`DNNL_ARG_MULTIPLE_SRC` is `1024`, so for `i >= 512` the id `1024 + i` has the `512` bit set and a genuine source is also counted in `extra_inputs`. The final check `n_inputs == pd->n_inputs() + extra_inputs` then fails for **every concat with more than 512 inputs**, and the GPU plugin reports it as `could not execute a primitive`.

This affects real topologies: `ssd-resnet101-fpn-oid` (FP16) contains two 601-input `Concat` nodes produced by the TF Object Detection post-processor (`MultiClassNonMaxSuppression/Concatenate/concat`; Open Images has 601 classes). The model compiles and then fails on the first inference:

```
Exception from src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h:559:
could not execute a primitive

onednn_verbose,v1,primitive,exec:check,primitive,
  bad number of inputs (expected 690 got 601),src/common/primitive_exec_types.cpp:142
```

(601 sources, indices 512..600 miscounted → `extra_inputs = 89` → `601 + 89 = 690`.)

**Changes**

- `concatenation_onednn.hpp`: reject the oneDNN concat implementation when the node has   more than `DNNL_ARG_ATTR_PRECOMPUTED_REDUCTIONS` (512) inputs, so implementation selection falls back to the OCL concat kernel, which has no such limit.
- `concatenation_onednn.cpp`: `primitive_desc_base::src_desc()` takes an `int`, but the source index was cast to `uint8_t`, so a concat with more than 256 inputs asked for the descriptor of input `i - 256`.
- `concatenation_gpu_test.cpp`: boundary coverage at 512 / 513 inputs plus a wide concat whose sources do not all share one layout. All three assert the selected implementation type and the concatenated values.

**Note on the proper fix**

The real defect is in oneDNN: `concat_pd_t::arg_usage()` classifies these ids with a correct *range* test, while `cvt_primitive_args()` uses a *bitwise* test on the same ids.
`DNNL_ARG_ATTR_SCALES` (4096) and `DNNL_ARG_ATTR_ZERO_POINTS` (8192) carry the same latent defect. A separate ticket has been filed with oneDNN; this PR is the plugin-side workaround until that lands. Reverting it once oneDNN is fixed will restore the oneDNN concat path for wide nodes (measured slightly faster than the OCL fallback).

**Validation** (Intel Arc A770, `--device_suffix=1`)
- `ov_gpu_unit_tests --gtest_filter='concat_gpu_onednn.*'` — 8/8 pass
- `ov_gpu_unit_tests --gtest_filter='*concat*'` — 550/550 pass
- `ssd-resnet101-fpn-oid` FP16 `benchmark_app -d GPU` — runs (24 iterations), previously   threw on the first inference

### Tickets:
 - 193526

### AI Assistance:
 - AI assistance used: yes
 - AI: find root-cause & fix
 - Human: review
