### PR TITLE
[GPU] Fix ScatterNDUpdate negative index normalization

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/scatter_nd_update_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/scatter_nd_update_opt.cl
@@ -78,6 +78,14 @@ KERNEL(scatter_nd_update_opt)(OPTIONAL_SHAPE_INFO_ARG
     uint target_coord[INDICES_MAX_DIM];
     uint g_coord[INDICES_MAX_DIM] = { INPUT2_ORDER };
 
+#if INPUT0_DIMS <= 4
+    const uint data_dim[INPUT0_DIMS] = {INPUT0_BATCH_NUM, INPUT0_FEATURE_NUM, INPUT0_SIZE_Y, INPUT0_SIZE_X};
+#elif INPUT0_DIMS == 5
+    const uint data_dim[INPUT0_DIMS] = {INPUT0_BATCH_NUM, INPUT0_FEATURE_NUM, INPUT0_SIZE_Z, INPUT0_SIZE_Y, INPUT0_SIZE_X};
+#elif INPUT0_DIMS == 6
+    const uint data_dim[INPUT0_DIMS] = {INPUT0_BATCH_NUM, INPUT0_FEATURE_NUM, INPUT0_SIZE_W, INPUT0_SIZE_Z, INPUT0_SIZE_Y, INPUT0_SIZE_X};
+#endif
+
 #if INPUT1_LENGTH == 1 && INDICES_RANK == 1
     for (uint i = 0; i < OUTPUT_DIMS; ++i) {
         target_coord[i] = g_coord[i];
@@ -90,7 +98,7 @@ KERNEL(scatter_nd_update_opt)(OPTIONAL_SHAPE_INFO_ARG
     for (uint i = 0; i < INDICES_LAST_DIM; ++i) {
         indices_coord[INDICES_RANK - 1] = i;
         int indices_val = indices[GET_INDICES_INDEX(INPUT1_ORDER)];
-        target_coord[i] = indices_val + (INPUT0_DIMS * (indices_val < 0));
+        target_coord[i] = indices_val < 0 ? indices_val + (int)data_dim[i] : indices_val;
     }
 
     for (uint i = INDICES_LAST_DIM; i < OUTPUT_DIMS; ++i) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_nd_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_nd_update_gpu_test.cpp
@@ -507,7 +507,7 @@ TEST(scatter_nd_update_gpu_fp16_test16, data3_indice4_update3_dynamic) {
     auto input2_layout = layout{ ov::PartialShape::dynamic(4), data_types::i32, format::bfyx };
     auto input3_layout = layout{ ov::PartialShape::dynamic(3), data_types::f16, format::bfyx };
 
-    auto input1 = engine.allocate_memory({ { 2, 3, 3 }, data_types::f16, format::bfyx }); // data
+    auto input1 = engine.allocate_memory({ { 2, 2, 3 }, data_types::f16, format::bfyx }); // data
     auto input2 = engine.allocate_memory({ { 2, 1, 1, 3 }, data_types::i32, format::bfyx }); // Indexes
     auto input3 = engine.allocate_memory({ { 2, 1, 1 }, data_types::f16, format::bfyx }); // Updates
 
@@ -515,9 +515,7 @@ TEST(scatter_nd_update_gpu_fp16_test16, data3_indice4_update3_dynamic) {
         // 0
         ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
         ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
-        ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
         // 1
-        ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
         ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
         ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
     });
@@ -533,10 +531,8 @@ TEST(scatter_nd_update_gpu_fp16_test16, data3_indice4_update3_dynamic) {
     std::vector<float> expected_results = {
         // 0
         ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
-        ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
         ov::float16(1.f), ov::float16(2.f), ov::float16(1.f),
         // 1
-        ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
         ov::float16(1.f), ov::float16(2.f), ov::float16(3.f),
         ov::float16(1.f), ov::float16(2.f), ov::float16(-1.f),
     };


### PR DESCRIPTION
### Details:
 - Fix negative-index normalization in the optimized GPU ScatterNDUpdate kernel. Each negative coordinate is now adjusted by its indexed dimension size instead of the input tensor rank.
 - Strengthen the existing GPU regression test with an indexed dimension whose size differs from the tensor rank. The previous rank-3/size-3 case could not detect the incorrect formula.
 - Root cause: for an input shaped `[1, 2, 512, 1025]`, a feature index of `-1` was converted to `3` using rank `4`, instead of the valid coordinate `1` using feature size `2`. The resulting out-of-bounds GPU write caused `CL_DEVICE_NOT_AVAILABLE` on Xe3.
 - Validation: Intel GPU plugin build and full OpenVINO Release build passed. The original LED model completed 39 iterations normally. With CLIntercept call logging and `FinishAfterEnqueue` enabled, the formerly failing kernel completed 19 launches with `CL_SUCCESS` and the log contained no OpenCL failures.

### Tickets:
 - 193527

### AI Assistance:
 - AI assistance used: yes
 - GitHub Copilot assisted with CLI log analysis, root-cause identification, implementation, and patch preparation. The change was validated locally on Xe3 with the full Release build, the original model workload, and CLIntercept forced synchronization.