### PR TITLE
[LPT] Deduplicate dequantization output precision handling in tests, enable f16 where it passes

### DIFF
--- a/src/common/low_precision_transformations/tests/concat_with_fq_tranformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_fq_tranformation.cpp
@@ -110,14 +110,8 @@ public:
         const ov::PartialShape shape = std::get<1>(GetParam());
         ConcatTransformationTestValues testValues = std::get<2>(GetParam());
 
-        // dequantization output precision depends on input precision
-        // to avoid huge amount of tests cases let's define dequantization output precision as input precision
-        if (!testValues.actual.dequantization1.multiply.empty()) {
-            testValues.actual.dequantization1.multiply.outPrecision = precision;
-        }
-        if (!testValues.actual.dequantization2.multiply.empty()) {
-            testValues.actual.dequantization2.multiply.outPrecision = precision;
-        }
+        setDequantizationOutPrecision(testValues.actual.dequantization1, precision);
+        setDequantizationOutPrecision(testValues.actual.dequantization2, precision);
         actualFunction = ov::builder::subgraph::ConcatFunction::get(precision,
                                                                         shape,
                                                                         testValues.actual.fakeQuantize1,
@@ -162,11 +156,7 @@ public:
             standaloneCleanupManager.run_passes(actualFunction);
         }
 
-        // dequantization output precision depends on input precision
-        // to avoid huge amount of tests cases let's define dequantization output precision as input precision
-        if (!testValues.result.dequantizationAfter.multiply.empty()) {
-            testValues.result.dequantizationAfter.multiply.outPrecision = precision;
-        }
+        setDequantizationOutPrecision(testValues.result.dequantizationAfter, precision);
 
         if (!testValues.params.updatePrecisions && (precision == ov::element::f32) &&
             !testValues.result.dequantizationAfter.convert.empty()) {

--- a/src/common/low_precision_transformations/tests/concat_with_intermediate_reshape_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_intermediate_reshape_transformation.cpp
@@ -69,6 +69,7 @@ public:
     void SetUp() override {
         const ov::element::Type precision = std::get<0>(GetParam());
         TestValues testValues = std::get<1>(GetParam());
+        setDequantizationOutPrecision(testValues.result.dequantizationAfter, precision);
 
         actualFunction = ov::builder::subgraph::ConcatFunction::getOriginalWithIntermediateReshape(
             precision,
@@ -114,7 +115,7 @@ TEST_P(ConcatWithIntermediateReshapeTransformation, CompareFunctions) {
 
 const std::vector<ov::element::Type> precisions = {
         ov::element::f32,
-        // ov::element::f16
+        ov::element::f16
 };
 
 const std::vector<TestValues> testValues = {

--- a/src/common/low_precision_transformations/tests/concat_with_not_quantized_parent_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_with_not_quantized_parent_transformation.cpp
@@ -130,14 +130,8 @@ public:
         const std::pair<ov::Shape, ov::Shape> shapes = std::get<1>(GetParam());
         ConcatWithNotQuantizedParentTransformationTestValues testValues = std::get<2>(GetParam());
 
-        // dequantization output precision depends on input precision
-        // to avoid huge amount of tests cases let's define dequantization output precision as input precision
-        if (!testValues.actual.dequantization1.multiply.empty()) {
-            testValues.actual.dequantization1.multiply.outPrecision = precision;
-        }
-        if (!testValues.actual.dequantization2.multiply.empty()) {
-            testValues.actual.dequantization2.multiply.outPrecision = precision;
-        }
+        setDequantizationOutPrecision(testValues.actual.dequantization1, precision);
+        setDequantizationOutPrecision(testValues.actual.dequantization2, precision);
 
         actualFunction = ov::builder::subgraph::ConcatFunction::get(
             precision,
@@ -197,9 +191,7 @@ public:
             standaloneCleanupManager.run_passes(actualFunction);
         }
 
-        if (!testValues.result.dequantizationAfter.multiply.empty()) {
-            testValues.result.dequantizationAfter.multiply.outPrecision = precision;
-        }
+        setDequantizationOutPrecision(testValues.result.dequantizationAfter, precision);
 
         if (!testValues.params.updatePrecisions &&
             (precision == ov::element::f32) &&

--- a/src/common/low_precision_transformations/tests/layer_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/layer_transformation.cpp
@@ -160,6 +160,13 @@ ov::builder::subgraph::DequantizationOperations LayerTransformation::toDequantiz
     return ov::builder::subgraph::DequantizationOperations(convert, subtract, multiply);
 }
 
+void LayerTransformation::setDequantizationOutPrecision(ov::builder::subgraph::DequantizationOperations& dequantization,
+                                                        const ov::element::Type& modelPrecision) {
+    if (!dequantization.multiply.empty()) {
+        dequantization.multiply.outPrecision = modelPrecision;
+    }
+}
+
 bool LayerTransformation::allNamesAreUnique(const std::shared_ptr<ov::Model>& model) {
     const auto& ops = model->get_ops();
     std::set<std::string> opNames;

--- a/src/common/low_precision_transformations/tests/layer_transformation.hpp
+++ b/src/common/low_precision_transformations/tests/layer_transformation.hpp
@@ -64,7 +64,7 @@ public:
     static ov::builder::subgraph::DequantizationOperations toDequantizationOperations(
         const ov::pass::low_precision::FakeQuantizeDequantization& dequantization);
 
-    // LPT computes dequantization in deqPrecision (f32) but restores the model precision on the
+    // LPT computes dequantization in deqPrecision (f32 by default) but restores the model precision on the
     // dequantization Multiply output, so reference expectations have to follow the model precision.
     static void setDequantizationOutPrecision(ov::builder::subgraph::DequantizationOperations& dequantization,
                                               const ov::element::Type& modelPrecision);

--- a/src/common/low_precision_transformations/tests/layer_transformation.hpp
+++ b/src/common/low_precision_transformations/tests/layer_transformation.hpp
@@ -64,6 +64,11 @@ public:
     static ov::builder::subgraph::DequantizationOperations toDequantizationOperations(
         const ov::pass::low_precision::FakeQuantizeDequantization& dequantization);
 
+    // LPT computes dequantization in deqPrecision (f32) but restores the model precision on the
+    // dequantization Multiply output, so reference expectations have to follow the model precision.
+    static void setDequantizationOutPrecision(ov::builder::subgraph::DequantizationOperations& dequantization,
+                                              const ov::element::Type& modelPrecision);
+
     static bool allNamesAreUnique(const std::shared_ptr<ov::Model>& model);
 
     template <class Operation>

--- a/src/common/low_precision_transformations/tests/markup_avg_pool_precisions_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/markup_avg_pool_precisions_transformation.cpp
@@ -142,7 +142,7 @@ TEST_P(MarkupAvgPoolPrecisionsTransformation, CompareFunctions) {
 
 const std::vector<ov::element::Type> precisions = {
     ov::element::f32,
-    // ov::element::f16
+    ov::element::f16
 };
 
 const std::vector<std::string> additionalLayer = {

--- a/src/common/low_precision_transformations/tests/recurrent_cell_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/recurrent_cell_transformation.cpp
@@ -127,11 +127,7 @@ public:
         clenup_transformer.commonGraphRewrite->add_matcher<ov::pass::low_precision::FuseMultiplyToFakeQuantizeTransformation>(params);
         clenup_transformer.transform(actualFunction);
 
-        // dequantization output precision depends on input precision
-        // to avoid huge amount of tests cases let's define dequantization output precision as input precision
-        if (!testValues.result.dequantizationAfter.multiply.empty()) {
-            testValues.result.dequantizationAfter.multiply.outPrecision = precision;
-        }
+        setDequantizationOutPrecision(testValues.result.dequantizationAfter, precision);
 
         referenceFunction =
             ov::builder::subgraph::RecurrentCellFunction::get(precision,


### PR DESCRIPTION
### Details:
 - LPT computes dequantization in `deqPrecision` (f32) but restores the model precision on the dequantization `Multiply` output, which is built as `TypeRelaxed<Multiply>`. Reference models in the unit tests did not model this, so their expectations only ever matched f32 models.
 - Three test files worked around it by patching `multiply.outPrecision` inline, each with its own copy of the same three lines (6 copies in total). `multiply_transformation.cpp` already solves the same problem more generally with an `element::dynamic` sentinel.
 - Extracted the rule into `LayerTransformation::setDequantizationOutPrecision` and routed the 6 copies through it.
 - `ov::element::f16` was commented out of the `precisions` vector in 17 test files with no reason recorded anywhere. Enabled it in the two files where the rule above is sufficient to make it pass (`markup_avg_pool_precisions_transformation.cpp`, `concat_with_intermediate_reshape_transformation.cpp`), which adds 13 test cases.
 - The remaining 15 files are left untouched. Their f16 expectations need further work and the causes differ per suite, so no blanket reason comment was added - an unverified reason would be worse than none.
 - Validation: `ov_lp_transformations_tests` on x64 Linux Release, 3682 -> 3695 tests, all passing. Not validated on other platforms.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - GitHub Copilot was used to investigate why f16 was disabled across the LPT unit tests, to identify the root cause by dumping and comparing actual vs reference graph element types, and to apply the deduplication. Human validation: reviewed the diff, and built and ran `ov_lp_transformations_tests` locally before and after, confirming the test count increases by exactly the enabled f16 cases and that no previously passing test regresses.