### PR TITLE
Support aten::histc in PyTorch frontend

### DIFF
--- a/src/frontends/pytorch/src/op/histc.cpp
+++ b/src/frontends/pytorch/src/op/histc.cpp
@@ -1,0 +1,145 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/convert_like.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/floor.hpp"
+#include "openvino/op/greater.hpp"
+#include "openvino/op/greater_eq.hpp"
+#include "openvino/op/less_eq.hpp"
+#include "openvino/op/logical_and.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
+#include "openvino/op/reduce_max.hpp"
+#include "openvino/op/reduce_min.hpp"
+#include "openvino/op/reduce_prod.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/scatter_elements_update.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/subtract.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+namespace {
+Output<Node> input_or_const(const NodeContext& context, size_t idx, const Output<Node>& default_value) {
+    if (context.get_input_size() > idx && !context.input_is_none(idx)) {
+        return context.get_input(idx);
+    }
+    return default_value;
+}
+}  // namespace
+
+OutputVector translate_histc(const NodeContext& context) {
+    // aten::histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
+    // aten::histc.out(..., Tensor(a!) out) -> Tensor(a!)
+    num_inputs_check(context, 1, 5);
+    auto input = context.get_input(0);
+    const auto orig_type = input.get_element_type();
+
+    if (orig_type.is_static() && !orig_type.is_real()) {
+        input = context.mark_node(std::make_shared<v0::Convert>(input, element::f32));
+    }
+
+    auto bins = input_or_const(context, 1, context.mark_node(v0::Constant::create(element::i64, Shape{}, {100})));
+    auto min_val = input_or_const(context, 2, context.mark_node(v0::Constant::create(element::f32, Shape{}, {0})));
+    auto max_val = input_or_const(context, 3, context.mark_node(v0::Constant::create(element::f32, Shape{}, {0})));
+
+    auto minus_one = context.mark_node(v0::Constant::create(element::i64, Shape{1}, {-1}));
+    auto flat = context.mark_node(std::make_shared<v1::Reshape>(input, minus_one, false));
+    min_val = context.mark_node(std::make_shared<v1::ConvertLike>(min_val, flat));
+    max_val = context.mark_node(std::make_shared<v1::ConvertLike>(max_val, flat));
+
+    auto reduce_axes = context.mark_node(v0::Constant::create(element::i64, Shape{1}, {0}));
+    auto data_min = context.mark_node(std::make_shared<v1::ReduceMin>(flat, reduce_axes, false));
+    auto data_max = context.mark_node(std::make_shared<v1::ReduceMax>(flat, reduce_axes, false));
+    auto numel = context.mark_node(
+        std::make_shared<v1::ReduceProd>(context.mark_node(std::make_shared<v3::ShapeOf>(flat, element::i64)),
+                                         reduce_axes,
+                                         false));
+    auto has_data = context.mark_node(
+        std::make_shared<v1::Greater>(numel, context.mark_node(v0::Constant::create(element::i64, Shape{}, {0}))));
+    auto min_eq_max = context.mark_node(std::make_shared<v1::Equal>(min_val, max_val));
+    auto infer_range = context.mark_node(std::make_shared<v1::LogicalAnd>(min_eq_max, has_data));
+    auto left = context.mark_node(std::make_shared<v1::Select>(infer_range, data_min, min_val));
+    auto right = context.mark_node(std::make_shared<v1::Select>(infer_range, data_max, max_val));
+
+    // When the range is still empty (constant input or empty tensor), expand by ±1 like PyTorch histc.
+    auto still_eq = context.mark_node(std::make_shared<v1::Equal>(left, right));
+    auto one = context.mark_node(
+        std::make_shared<v1::ConvertLike>(context.mark_node(v0::Constant::create(element::f32, Shape{}, {1})), left));
+    left = context.mark_node(
+        std::make_shared<v1::Select>(still_eq, context.mark_node(std::make_shared<v1::Subtract>(left, one)), left));
+    right = context.mark_node(
+        std::make_shared<v1::Select>(still_eq, context.mark_node(std::make_shared<v1::Add>(right, one)), right));
+
+    auto bins_f = context.mark_node(std::make_shared<v1::ConvertLike>(bins, flat));
+    auto width = context.mark_node(
+        std::make_shared<v1::Divide>(context.mark_node(std::make_shared<v1::Subtract>(right, left)), bins_f));
+    auto pos = context.mark_node(std::make_shared<v0::Floor>(context.mark_node(
+        std::make_shared<v1::Divide>(context.mark_node(std::make_shared<v1::Subtract>(flat, left)), width))));
+
+    auto zero_f = context.mark_node(
+        std::make_shared<v1::ConvertLike>(context.mark_node(v0::Constant::create(element::f32, Shape{}, {0})), flat));
+    auto last_bin_f = context.mark_node(
+        std::make_shared<v1::ConvertLike>(context.mark_node(std::make_shared<v1::Subtract>(
+                                              context.mark_node(std::make_shared<v0::Convert>(bins, element::i64)),
+                                              context.mark_node(v0::Constant::create(element::i64, Shape{}, {1})))),
+                                          flat));
+    auto clamped = context.mark_node(
+        std::make_shared<v1::Minimum>(context.mark_node(std::make_shared<v1::Maximum>(pos, zero_f)), last_bin_f));
+
+    auto in_range = context.mark_node(
+        std::make_shared<v1::LogicalAnd>(context.mark_node(std::make_shared<v1::GreaterEqual>(flat, left)),
+                                         context.mark_node(std::make_shared<v1::LessEqual>(flat, right))));
+    auto safe_pos = context.mark_node(std::make_shared<v1::Select>(in_range, clamped, zero_f));
+    auto bin_idx = context.mark_node(std::make_shared<v0::Convert>(safe_pos, element::i64));
+
+    auto flat_shape = context.mark_node(std::make_shared<v3::ShapeOf>(flat, element::i64));
+    auto ones = context.mark_node(
+        std::make_shared<v3::Broadcast>(context.mark_node(std::make_shared<v1::ConvertLike>(
+                                            context.mark_node(v0::Constant::create(element::f32, Shape{}, {1})),
+                                            flat)),
+                                        flat_shape));
+    auto updates = context.mark_node(std::make_shared<v1::Select>(in_range, ones, zero_f));
+
+    auto hist_shape = context.mark_node(
+        std::make_shared<v1::Reshape>(context.mark_node(std::make_shared<v0::Convert>(bins, element::i64)),
+                                      context.mark_node(v0::Constant::create(element::i64, Shape{1}, {1})),
+                                      false));
+    auto histogram = context.mark_node(std::make_shared<v3::Broadcast>(zero_f, hist_shape));
+    auto axis = context.mark_node(v0::Constant::create(element::i64, Shape{}, {0}));
+    auto result =
+        context.mark_node(std::make_shared<v12::ScatterElementsUpdate>(histogram,
+                                                                       bin_idx,
+                                                                       updates,
+                                                                       axis,
+                                                                       v12::ScatterElementsUpdate::Reduction::SUM));
+
+    if (orig_type.is_static() && orig_type.is_real() && orig_type != result->get_element_type()) {
+        result = context.mark_node(std::make_shared<v0::Convert>(result, orig_type));
+    }
+
+    if (context.get_input_size() > 4 && !context.input_is_none(4)) {
+        context.mutate_input(4, result);
+    }
+    return {result};
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -132,6 +132,7 @@ OP_CONVERTER(translate_group_norm);
 OP_CONVERTER(translate_gru);
 OP_CONVERTER(translate_hann_window);
 OP_CONVERTER(translate_hardtanh);
+OP_CONVERTER(translate_histc);
 OP_CONVERTER(translate_hstack);
 OP_CONVERTER(translate_if);
 OP_CONVERTER(translate_cond_fx);
@@ -577,6 +578,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::hardsigmoid", op::quantizable_op<op::translate_1to1_match_1_inputs<opset10::HSigmoid>>},
         {"aten::hardswish", op::quantizable_op<op::translate_1to1_match_1_inputs<opset10::HSwish>>},
         {"aten::hardtanh", op::quantizable_op<op::translate_hardtanh>},
+        {"aten::histc", op::translate_histc},
         {"aten::hstack", op::translate_hstack},
         {"aten::im2col", op::translate_im2col},
         {"aten::imag", common_translators::translate_imag},
@@ -1006,6 +1008,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.hardswish_.default", op::inplace_op<op::translate_1to1_match_1_inputs<opset10::HSwish>>},
         {"aten.hardtanh.default", op::translate_hardtanh},
         {"aten.hardtanh_.default", op::inplace_op<op::translate_hardtanh>},
+        {"aten.histc.default", op::translate_histc},
         {"aten.index.Tensor", op::translate_index_fx},
         {"aten._unsafe_index.Tensor", op::translate_index_fx},
         {"aten.index_select.default", op::translate_index_select},

--- a/tests/layer_tests/pytorch_tests/test_histc.py
+++ b/tests/layer_tests/pytorch_tests/test_histc.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestHistc(PytorchLayerTest):
+
+    def _prepare_input(self, input_data, input_dtype):
+        return (np.array(input_data, dtype=input_dtype),)
+
+    def create_model(self, bins, min_val, max_val):
+        class aten_histc(torch.nn.Module):
+            def __init__(self, bins, min_val, max_val):
+                super().__init__()
+                self.bins = bins
+                self.min_val = min_val
+                self.max_val = max_val
+
+            def forward(self, x):
+                return torch.histc(x, bins=self.bins, min=self.min_val, max=self.max_val)
+
+        return aten_histc(bins, min_val, max_val), "aten::histc"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize(
+        "input_data,bins,min_val,max_val,input_dtype",
+        [
+            # basic histogram, explicit bins/min/max
+            ([1.0, 2.0, 1.0], 4, 0.0, 3.0, np.float32),
+            # value exactly equal to min / max; last bin includes max
+            ([0.0, 1.0, 2.0, 3.0], 3, 0.0, 3.0, np.float32),
+            ([3.0], 3, 0.0, 3.0, np.float32),
+            ([0.0], 3, 0.0, 3.0, np.float32),
+            # values below min / above max are excluded
+            ([-1.0, 0.0, 1.0, 2.0], 2, 0.0, 2.0, np.float32),
+            ([0.0, 1.0, 2.0, 3.0], 2, 0.0, 2.0, np.float32),
+            # multiple bin counts
+            ([1.0, 2.0, 3.0], 1, 0.0, 3.0, np.float32),
+            ([1.0, 2.0, 3.0, 4.0], 10, 1.0, 4.0, np.float32),
+            # negative and mixed-sign values
+            ([-3.0, -1.0, 0.0, 2.0], 5, -3.0, 2.0, np.float32),
+            ([-2.0, -0.5, 0.0, 1.5, 4.0], 4, -2.0, 2.0, np.float32),
+            # automatic range: min == max == 0 infers from data
+            ([1.0, 2.0, 3.0, 4.0], 4, 0.0, 0.0, np.float32),
+            # automatic range on a constant tensor expands by ±1
+            ([5.0, 5.0, 5.0], 4, 0.0, 0.0, np.float32),
+            # min == max != 0 also infers from data (PyTorch histc)
+            ([1.0, 2.0, 3.0], 4, 5.0, 5.0, np.float32),
+            # 2D is flattened
+            ([[1.0, 2.0], [3.0, 4.0]], 4, 1.0, 4.0, np.float32),
+            # float64
+            ([1.0, 2.0, 3.0], 3, 1.0, 3.0, np.float64),
+            # NaN / Inf are excluded
+            ([np.nan, 2.0, 3.0], 2, 1.0, 4.0, np.float32),
+            ([np.inf, 2.0, 3.0], 2, 1.0, 4.0, np.float32),
+            ([-np.inf, 2.0, 3.0], 2, 1.0, 4.0, np.float32),
+        ],
+    )
+    def test_histc(self, input_data, bins, min_val, max_val, input_dtype, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(bins, min_val, max_val),
+            ie_device,
+            precision,
+            ir_version,
+            trace_model=True,
+            dynamic_shapes=False,
+            kwargs_to_prepare_input={"input_data": input_data, "input_dtype": input_dtype},
+        )
+
+
+class TestHistcDefaultBins(PytorchLayerTest):
+    """Default bins=100 with min=max=0 (auto range)."""
+
+    def _prepare_input(self, input_data):
+        return (np.array(input_data, dtype=np.float32),)
+
+    def create_model(self):
+        class aten_histc_default(torch.nn.Module):
+            def forward(self, x):
+                return torch.histc(x)
+
+        return aten_histc_default(), "aten::histc"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    def test_histc_default_bins(self, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(),
+            ie_device,
+            precision,
+            ir_version,
+            trace_model=True,
+            dynamic_shapes=False,
+            kwargs_to_prepare_input={"input_data": [0.0, 50.0, 100.0]},
+        )

--- a/tests/layer_tests/pytorch_tests/test_histc.py
+++ b/tests/layer_tests/pytorch_tests/test_histc.py
@@ -56,6 +56,11 @@ class TestHistc(PytorchLayerTest):
             ([[1.0, 2.0], [3.0, 4.0]], 4, 1.0, 4.0, np.float32),
             # float64
             ([1.0, 2.0, 3.0], 3, 1.0, 3.0, np.float64),
+            # integer inputs (should convert to float)
+            ([1, 2, 3], 3, 1, 3, np.int32),
+            ([0, 5, 10], 3, 0, 10, np.int64),
+            # single bin
+            ([1.0, 2.0, 3.0], 1, 0.0, 3.0, np.float32),
             # NaN / Inf are excluded
             ([np.nan, 2.0, 3.0], 2, 1.0, 4.0, np.float32),
             ([np.inf, 2.0, 3.0], 2, 1.0, 4.0, np.float32),


### PR DESCRIPTION
## Summary

Add PyTorch frontend support for `aten::histc`.

## Changes

- implement `aten::histc` translation
- register the ATen operator (TorchScript and FX)
- add frontend tests covering normal and boundary behavior

## Validation

Local targeted OpenVINO build (macOS arm64, CPU plugin + PyTorch frontend + Python wheel), then:

```
cd tests/layer_tests
export TEST_DEVICE=CPU
export TEST_PRECISION=FP32
python -m pytest pytorch_tests/test_histc.py -v
```

Result: **19 passed**

```
export TEST_PRECISION=FP16
python -m pytest pytorch_tests/test_histc.py -q
```

Result: **19 passed**

Repeated `test_histc.py` three additional times (FP32): **19 passed** each run.

Regression:

```
export TEST_PRECISION=FP32
python -m pytest pytorch_tests/test_bincount.py -q
```

Result: **24 passed**

clang-format (Google/OpenVINO src style) was applied to `histc.cpp`. clang-tidy-18 was not run (toolchain is AppleClang; repo requires clang-tidy-18).

## Issue

Fixes #29699

### Tickets:
 - 188841

### AI Assistance:
 - AI assistance used: yes
 - Cursor Grok was used to inspect prior closed PRs, PyTorch `histc` source, and neighboring translators, then draft the translator/tests. Human validation: local wheel build, CPU FP32/FP16 layer tests against PyTorch 2.13.0, and review of bin-boundary semantics (`max` inclusive, out-of-range excluded, min==max range inference).