### PR TITLE
[GPU] fix MOE OTD low performance in dGPU

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/ops/moe_offload_constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/moe_offload_constant.cpp
@@ -62,7 +62,11 @@ PartialUploadDesc try_prepare_partial_upload(ProgramBuilder& p,
     desc.upload_shape[0] = std::min<size_t>(const_shape[0], resident_expert_num);
 
     auto upload_layout = cldnn::layout(desc.upload_shape, out_dtype, const_format);
-    auto upload_mem = p.get_engine().allocate_memory(upload_layout, false);
+    const auto use_device_memory = p.get_engine().get_device_info().dev_type == cldnn::device_type::discrete_gpu &&
+                                   p.get_engine().supports_allocation(cldnn::allocation_type::usm_device);
+    auto upload_mem = use_device_memory
+                          ? p.get_engine().allocate_memory(upload_layout, cldnn::allocation_type::usm_device, false)
+                          : p.get_engine().allocate_memory(upload_layout, false);
     // Reinterpret the smaller physical allocation as the full constant layout so the
     // graph sees the expected shape/layout. This is safe because:
     // 1. constant.cpp marks this data node with skip_device_transfer=true (partial_upload.enabled),


### PR DESCRIPTION
### Description

This PR improves MoE expert-weight offloading performance on discrete GPUs.

Previously, partially resident expert weights were allocated in host USM because the OTD constants skip the normal host-to-device transfer. As a result, GPU kernels repeatedly accessed expert weights across PCIe.

The updated allocation logic uses device USM when running on a discrete GPU that supports it. Other devices retain the existing allocation fallback.

### Performance

Test configuration:

- Model: Qwen3-30B-A3B
- Device: Intel Xe Graphics RI discrete GPU
- Offload ratio: 20%
- Prompt: `Explain why the sky is blue in one sentence.`
- Input length: 11 tokens
- Output length: 64 tokens
- Runs: 1 warm-up + 3 measured iterations
- Decoding: greedy

| Metric | Before | After |
|---|---:|---:|
| Throughput | 9.01 tokens/s | 51.40 tokens/s |
| TPOT | 111.04 ms/token | 19.46 ms/token |

This provides approximately a **5.7x throughput improvement**.

Correctness was verified using three prompts with 64 generated tokens each. All 192 token IDs and decoded outputs matched the non-offloaded baseline exactly.

### Tickets

CVS-193785