### PR TITLE
[GGUF] Simplify weight tensor handling

### DIFF
--- a/src/frontends/gguf/src/builder/blocks/qkv_repack.cpp
+++ b/src/frontends/gguf/src/builder/blocks/qkv_repack.cpp
@@ -5,7 +5,6 @@
 #include "builder/blocks/qkv_repack.hpp"
 
 #include <array>
-#include <unordered_map>
 
 #include "quant/weights.hpp"
 
@@ -13,23 +12,6 @@ namespace ov {
 namespace frontend {
 namespace gguf {
 namespace blocks {
-
-namespace {
-
-// Re-key the sliced tensors from "<src_base>.<part>.weight" to "<dst_base>.weight" so
-// emit_weight_op's sub-key extraction (weight/scales/zp) and translate_weight's make_weight_node
-// see the node's own base name.
-std::unordered_map<std::string, ov::Tensor> rekey(const std::unordered_map<std::string, ov::Tensor>& extracted,
-                                                  const std::string& dst_base) {
-    std::unordered_map<std::string, ov::Tensor> out;
-    for (const auto& kv : extracted) {
-        auto dot = kv.first.rfind('.');
-        out[dst_base + "." + kv.first.substr(dot + 1)] = kv.second;
-    }
-    return out;
-}
-
-}  // namespace
 
 void register_fused_qkv(GraphEmitter& e, const DecoderConfig& cfg, int il) {
     const std::string p = "blk." + std::to_string(il) + ".";
@@ -39,8 +21,7 @@ void register_fused_qkv(GraphEmitter& e, const DecoderConfig& cfg, int il) {
     const std::array<std::string, 3> names = {p + "attn_q.weight", p + "attn_k.weight", p + "attn_v.weight"};
     const std::array<int64_t, 3> rows = {(int64_t)n_q, (int64_t)n_kv, (int64_t)n_kv};
     for (size_t i = 0; i < 3; ++i) {
-        const std::string base = p + "attn_" + std::string(1, "qkv"[i]);  // blk.N.attn_q etc.
-        e.emit_weight_op(names[i], rekey(parts[i].extracted, base), parts[i].qtype, ps({1, 1, rows[i], cfg.n_embd}));
+        e.emit_weight_op(names[i], parts[i].tensors, parts[i].qtype, ps({1, 1, rows[i], cfg.n_embd}));
     }
 
     // Some fused-QKV archs (e.g. phi-3) also carry a single attn_qkv.bias; split it into
@@ -59,11 +40,9 @@ void register_qwen35_q_gate(GraphEmitter& e, const DecoderConfig& cfg, int il) {
     const std::string p = "blk." + std::to_string(il) + ".";
     auto parts = split_interleaved_q_gate(p + "attn_q", e.weights(), e.qtypes(), static_cast<size_t>(cfg.head_size));
     const std::array<std::string, 2> names = {p + "attn_q.weight", p + "attn_gate.weight"};
-    const std::array<std::string, 2> suffix = {"q", "gate"};
     const int64_t rows = static_cast<int64_t>(cfg.n_head) * cfg.head_size;
     for (size_t i = 0; i < 2; ++i) {
-        const std::string base = p + "attn_" + suffix[i];
-        e.emit_weight_op(names[i], rekey(parts[i].extracted, base), parts[i].qtype, ps({1, 1, rows, cfg.n_embd}));
+        e.emit_weight_op(names[i], parts[i].tensors, parts[i].qtype, ps({1, 1, rows, cfg.n_embd}));
     }
 }
 

--- a/src/frontends/gguf/src/builder/graph_emitter.cpp
+++ b/src/frontends/gguf/src/builder/graph_emitter.cpp
@@ -22,6 +22,20 @@ std::string strip_weight_suffix(const std::string& name) {
     return ends_with_weight ? name.substr(0, name.size() - suffix.size()) : name;
 }
 
+WeightTensors find_weight_tensors(const std::unordered_map<std::string, ov::Tensor>& weights, const std::string& base) {
+    WeightTensors tensors;
+    if (auto it = weights.find(base + ".weight"); it != weights.end()) {
+        tensors.weight = it->second;
+    }
+    if (auto it = weights.find(base + ".scales"); it != weights.end()) {
+        tensors.scales = it->second;
+    }
+    if (auto it = weights.find(base + ".zp"); it != weights.end()) {
+        tensors.zero_point = it->second;
+    }
+    return tensors;
+}
+
 }  // namespace
 
 GraphEmitter::GraphEmitter(std::unordered_map<std::string, ov::Tensor>& weights,
@@ -127,7 +141,7 @@ void GraphEmitter::add_extra_input_node(const std::string& name, const std::shar
 }
 
 void GraphEmitter::emit_weight_op(const std::string& node_name,
-                                  const std::unordered_map<std::string, ov::Tensor>& extracted,
+                                  const WeightTensors& tensors,
                                   GgufTensorType qtype,
                                   const ov::PartialShape& shape_4d) {
     if (m_emitted_weights.count(node_name)) {
@@ -141,15 +155,16 @@ void GraphEmitter::emit_weight_op(const std::string& node_name,
     op.output_name = node_name;
     op.output_shape = shape_4d;
     op.output_type = ov::element::f32;
-    // translate_weight rebuilds the make_weight_node(base, weights, qtypes) inputs from these:
+    // translate_weight reads these into a WeightTensors payload:
     // "gguf.blob.<sub>" -> extracted tensor (<sub> in {weight, scales, zp}), and the qtype id.
     op.attributes["gguf_weight"] = true;  // marks this GGML_OP_NONE leaf as a weight
     op.attributes["gguf_qtype"] = static_cast<int>(qtype);
-    for (const auto& kv : extracted) {
-        const std::string& full = kv.first;  // "<base>.weight" / ".scales" / ".zp"
-        auto dot = full.rfind('.');
-        std::string sub = (dot == std::string::npos) ? full : full.substr(dot + 1);
-        op.attributes["gguf.blob." + sub] = kv.second;
+    op.attributes["gguf.blob.weight"] = tensors.weight;
+    if (tensors.scales) {
+        op.attributes["gguf.blob.scales"] = tensors.scales;
+    }
+    if (tensors.zero_point) {
+        op.attributes["gguf.blob.zp"] = tensors.zero_point;
     }
     m_graph->nodes.push_back(std::move(op));
 
@@ -163,14 +178,7 @@ void GraphEmitter::add_weight(const std::string& ggml_name) {
     }
     const std::string base = strip_weight_suffix(ggml_name);
 
-    // Collect the parser's extracted tensors for this weight (weight [+ scales [+ zp]]).
-    std::unordered_map<std::string, ov::Tensor> extracted;
-    for (const char* sub : {".weight", ".scales", ".zp"}) {
-        auto it = m_weights.find(base + sub);
-        if (it != m_weights.end()) {
-            extracted[base + sub] = it->second;
-        }
-    }
+    auto tensors = find_weight_tensors(m_weights, base);
     GgufTensorType qtype = GGUF_TYPE_F16;
     if (auto it = m_qtypes.find(base + ".qtype"); it != m_qtypes.end()) {
         qtype = it->second;
@@ -184,21 +192,14 @@ void GraphEmitter::add_weight(const std::string& ggml_name) {
         rows = s.size() >= 1 ? static_cast<int64_t>(s[0]) : 1;
         cols = s.size() >= 2 ? static_cast<int64_t>(s[1]) : 1;
     }
-    emit_weight_op(ggml_name, extracted, qtype, ov::PartialShape({1, 1, rows, cols}));
+    emit_weight_op(ggml_name, tensors, qtype, ov::PartialShape({1, 1, rows, cols}));
 }
 
 void GraphEmitter::add_weight_from(const std::string& node_name, const std::string& src_base) {
     if (m_emitted_weights.count(node_name)) {
         return;
     }
-    const std::string dst_base = strip_weight_suffix(node_name);
-    std::unordered_map<std::string, ov::Tensor> extracted;
-    for (const char* sub : {".weight", ".scales", ".zp"}) {
-        auto it = m_weights.find(src_base + sub);
-        if (it != m_weights.end()) {
-            extracted[dst_base + sub] = it->second;
-        }
-    }
+    auto tensors = find_weight_tensors(m_weights, src_base);
     GgufTensorType qtype = GGUF_TYPE_F16;
     if (auto it = m_qtypes.find(src_base + ".qtype"); it != m_qtypes.end()) {
         qtype = it->second;
@@ -209,7 +210,7 @@ void GraphEmitter::add_weight_from(const std::string& node_name, const std::stri
         rows = s.size() >= 1 ? static_cast<int64_t>(s[0]) : 1;
         cols = s.size() >= 2 ? static_cast<int64_t>(s[1]) : 1;
     }
-    emit_weight_op(node_name, extracted, qtype, ov::PartialShape({1, 1, rows, cols}));
+    emit_weight_op(node_name, tensors, qtype, ov::PartialShape({1, 1, rows, cols}));
 }
 
 void GraphEmitter::add_named_weight(const std::string& ggml_name) {
@@ -224,15 +225,12 @@ void GraphEmitter::add_named_weight(const std::string& ggml_name) {
     GgufTensorType qtype = w.get_element_type() == ov::element::f32    ? GGUF_TYPE_F32
                            : w.get_element_type() == ov::element::bf16 ? GGUF_TYPE_BF16
                                                                        : GGUF_TYPE_F16;
-    // emit_weight_op re-keys by the last '.'; a bias ends in ".bias", so key it as ".weight"
-    // explicitly (make_weight_node's plain-Constant path reads "<base>.weight").
-    std::unordered_map<std::string, ov::Tensor> extracted{{ggml_name + ".weight", w}};
     const auto& s = w.get_shape();
     int64_t n = s.empty() ? 1 : static_cast<int64_t>(s[0]);
     // 2-D plain weights (qwen35's ssm_conv1d, OV [conv_dim, d_conv]) keep both extents;
     // 1-D ones (biases, norm scales) are the common case and stay a trailing vector.
     const ov::PartialShape shape = s.size() == 2 ? ps({1, 1, n, static_cast<int64_t>(s[1])}) : ps({1, 1, 1, n});
-    emit_weight_op(ggml_name, extracted, qtype, shape);
+    emit_weight_op(ggml_name, {w, {}, {}}, qtype, shape);
 }
 
 }  // namespace gguf

--- a/src/frontends/gguf/src/builder/graph_emitter.hpp
+++ b/src/frontends/gguf/src/builder/graph_emitter.hpp
@@ -18,6 +18,7 @@
 #include "openvino/op/parameter.hpp"
 #include "openvino/runtime/tensor.hpp"
 #include "quant/gguf.hpp"
+#include "quant/weights.hpp"
 
 namespace ov {
 namespace frontend {
@@ -109,15 +110,14 @@ public:
 
     // Emit a weight as a GGML_OP_NONE leaf node carrying the parser's already-extracted tensors
     // (`<base>.weight` [+ `.scales` [+ `.zp`]] + qtype) as node attributes. translate_weight
-    // rebuilds the weights/qtypes maps from these attributes and calls make_weight_node(base,
-    // weights, qtypes). Routing weights through GGML_OP_NONE makes that the single weight-loading
+    // rebuilds a WeightTensors payload from these attributes and calls make_weight_node.
+    // Routing weights through GGML_OP_NONE makes that the single weight-loading
     // API, shared with the llama.cpp cgraph decoder (which marks the same leaf with raw ggml bytes
     // instead), and keeps the compressed decompression subgraph -- built lazily in translate_weight
     // during the walk -- rather than materializing an ov::Node eagerly here.
-    // `node_name` is the tensor name translators reference (the GGML_OP_NONE output);
-    // `extracted` maps "<base>.weight"/".scales"/".zp" -> tensor; `qtype` is the ggml type.
+    // `node_name` is the tensor name translators reference (the GGML_OP_NONE output).
     void emit_weight_op(const std::string& node_name,
-                        const std::unordered_map<std::string, ov::Tensor>& extracted,
+                        const WeightTensors& tensors,
                         GgufTensorType qtype,
                         const ov::PartialShape& shape_4d);
 

--- a/src/frontends/gguf/src/op/weight.cpp
+++ b/src/frontends/gguf/src/op/weight.cpp
@@ -5,7 +5,6 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <unordered_map>
 #include <vector>
 
 #include "node_context.hpp"
@@ -27,9 +26,9 @@ namespace op {
 //
 //   1. Native .gguf builder path: the parser already extracted the weight into OpenVINO tensors
 //      (weight [+ scales [+ zp]]); the node carries them as attributes "gguf.blob.<sub>" plus the
-//      quant type id "gguf_qtype" (and marker "gguf_weight"). We rebuild the make_weight_node(
-//      base, weights, qtypes) inputs and call that overload -- the exact dequant path the builder
-//      used before, unchanged numerics, and it handles fused-QKV parts / MoE experts uniformly.
+//      quant type id "gguf_qtype" (and marker "gguf_weight"). We pass the tensors directly to
+//      make_weight_node -- the exact dequant path the builder used before, unchanged numerics,
+//      and it handles fused-QKV parts / MoE experts uniformly.
 //
 //   2. llama.cpp cgraph path: the node carries the raw ggml bytes in "data" plus the ggml type
 //      name "quant_type"; make_weight_node(data, quant_type, shape) re-extracts and builds. This
@@ -40,21 +39,14 @@ namespace op {
 OutputVector translate_weight(const NodeContext& context) {
     // Path 1: pre-extracted tensors from the native builder.
     if (context.get_attribute<bool>("gguf_weight", false)) {
-        const std::string base = "weight";
-        std::unordered_map<std::string, ov::Tensor> weights;
-        for (const char* sub : {"weight", "scales", "zp"}) {
-            // scales/zp are absent for plain/symmetric types -> defaulted get_attribute (empty
-            // tensor) so the missing-key Any doesn't throw.
-            auto blob = context.get_attribute<ov::Tensor>(std::string("gguf.blob.") + sub, ov::Tensor());
-            if (blob) {
-                weights[base + "." + sub] = blob;
-            }
-        }
-        FRONT_END_OP_CONVERSION_CHECK(weights.count(base + ".weight"),
-                                      "GGML_OP_NONE weight leaf has no 'gguf.blob.weight' attribute");
+        WeightTensors tensors{
+            context.get_attribute<ov::Tensor>("gguf.blob.weight", ov::Tensor()),
+            context.get_attribute<ov::Tensor>("gguf.blob.scales", ov::Tensor()),
+            context.get_attribute<ov::Tensor>("gguf.blob.zp", ov::Tensor()),
+        };
+        FRONT_END_OP_CONVERSION_CHECK(tensors.weight, "GGML_OP_NONE weight leaf has no 'gguf.blob.weight' attribute");
         auto qtype = static_cast<GgufTensorType>(context.get_attribute<int>("gguf_qtype"));
-        std::unordered_map<std::string, GgufTensorType> qtypes{{base + ".qtype", qtype}};
-        auto node = make_weight_node(base, weights, qtypes);
+        auto node = make_weight_node(tensors, qtype, context.get_name());
         return rename_outputs_with_suffix({node}, context.get_name());
     }
 

--- a/src/frontends/gguf/src/quant/gguf.cpp
+++ b/src/frontends/gguf/src/quant/gguf.cpp
@@ -500,8 +500,8 @@ GGUFLoad get_gguf_data(const std::string& file) {
             return {w_bytes, s_nelems * sizeof(uint16_t), 0};  // symmetric: no zp
         }
 
-        // Weights: i8 or u8 stored in byte arrays (not u32-packed anymore for sym; u32 only for 4-bit).
-        // 4-bit types: Q4_0(i4 in u32), Q4_1(u4 in u32), Q4_K(u4 in u32).
+        // Weights: i8 or u8 stored in byte arrays (u32 only for asymmetric 4-bit).
+        // 4-bit types: Q4_0(i4), Q4_1(u4 in u32), Q4_K(u4 in u32).
         // 8-bit types: Q8_0(i8), Q5_0(i8), Q5_1(i8), Q5_K(i8), Q6_K(i8).
         const bool is_4bit = (ti.type == GGUF_TYPE_Q4_0 || ti.type == GGUF_TYPE_Q4_1 || ti.type == GGUF_TYPE_Q4_K);
         uint64_t weights_per_byte = is_4bit ? 2 : 1;
@@ -611,20 +611,18 @@ GGUFLoad get_gguf_data(const std::string& file) {
             auto [wb, sb, bb] = quant_sizes(ti);
             char* buf_ptr = quant_buf->get_ptr<char>();
             auto shape = get_shape(tensor);
-            auto weights_shape = shape;
-            weights_shape.back() /= 8;  // u32 packs 8 i4 nibbles
             auto scale_shape = shape;
             scale_shape.back() /= 32;
 
             std::shared_ptr<void> so_buf(quant_buf);
-            ov::Tensor w_view(ov::element::u32, weights_shape, static_cast<void*>(buf_ptr + quant_offset));
+            ov::Tensor w_view(ov::element::i4, shape, static_cast<void*>(buf_ptr + quant_offset));
             ov::Tensor weights(w_view, so_buf);
             quant_offset += wb;
             ov::Tensor s_view(ov::element::f16, scale_shape, static_cast<void*>(buf_ptr + quant_offset));
             ov::Tensor scales(s_view, so_buf);
             quant_offset += sb;
 
-            gguf_fill_q4_0(tensor, weights, scales);
+            gguf_fill_sym(tensor, weights, scales);
             mapped->hint_evict(abs_off, tensor.bsize);
 
             arrays.emplace(name, std::move(weights));

--- a/src/frontends/gguf/src/quant/gguf.hpp
+++ b/src/frontends/gguf/src/quant/gguf.hpp
@@ -95,12 +95,8 @@ using GGUFLoad = std::tuple<std::unordered_map<std::string, GGUFMetaData>,
                             std::shared_ptr<ov::MappedMemory>,
                             std::shared_ptr<ov::AlignedBuffer>>;
 
-// Fill pre-allocated i4 weights (u32-packed, XORed for i4 sign) and f16 scales from a
-// Q4_0 tensor. No bias: Q4_0 is symmetric (zp = -8*scale is implicit, not stored).
-void gguf_fill_q4_0(const GgufTensor& tensor, ov::Tensor& weights, ov::Tensor& scales);
-
 // Fill pre-allocated weights and f16 scales from a symmetric GGUF tensor
-// (Q8_0/Q5_0/Q6_K: i8 weights; Q3_K: i4 weights packed as u8).
+// (Q8_0/Q5_0/Q6_K: i8 weights; Q4_0/Q3_K: i4 weights packed as u8).
 // No zero-point: the center value is subtracted during unpacking so weights are centered at 0.
 void gguf_fill_sym(const GgufTensor& tensor, ov::Tensor& weights, ov::Tensor& scales);
 

--- a/src/frontends/gguf/src/quant/gguf_quants.cpp
+++ b/src/frontends/gguf/src/quant/gguf_quants.cpp
@@ -621,10 +621,10 @@ void gguf_fill_mxfp4(const GgufTensor& tensor, ov::Tensor& weights, ov::Tensor& 
     });
 }
 
-// Q4_0 symmetric: same block layout as Q4_0 but XORs each packed byte with 0x88 to
+// Q4_0 symmetric: unpack each GGML block and XOR every packed byte with 0x88 to
 // flip the MSB of every nibble, converting u4 [0..15] to i4 [-8..7] in-place. No bias
 // tensor is produced (zp is exactly -8 * scale = a fixed shift, not per-element).
-void gguf_fill_q4_0(const GgufTensor& tensor, ov::Tensor& weights_arr, ov::Tensor& scales_arr) {
+static void fill_q4_0(const GgufTensor& tensor, ov::Tensor& weights_arr, ov::Tensor& scales_arr) {
     const uint64_t bytes_per_block = 18;
     auto data = static_cast<const uint8_t*>(tensor.weights_data);
     auto weights = static_cast<uint8_t*>(weights_arr.data());
@@ -684,10 +684,12 @@ void gguf_fill_q2_0(const GgufTensor& tensor, ov::Tensor& weights_arr, ov::Tenso
     });
 }
 
-// Symmetric types (Q8_0, Q5_0, Q6_K, Q3_K): fill weights + scales (f16), no zero-point.
+// Symmetric types (Q4_0, Q8_0, Q5_0, Q6_K, Q3_K): fill weights + scales (f16), no zero-point.
 // Q8_K uses f32 scales and is handled by a separate overload dispatched on tensor.type.
 void gguf_fill_sym(const GgufTensor& tensor, ov::Tensor& weights, ov::Tensor& scales) {
-    if (tensor.type == GGUF_TYPE_Q8_0) {
+    if (tensor.type == GGUF_TYPE_Q4_0) {
+        fill_q4_0(tensor, weights, scales);
+    } else if (tensor.type == GGUF_TYPE_Q8_0) {
         fill_q8_0(tensor, weights, scales);
     } else if (tensor.type == GGUF_TYPE_Q5_0) {
         fill_q5_0(tensor, weights, scales);

--- a/src/frontends/gguf/src/quant/weights.cpp
+++ b/src/frontends/gguf/src/quant/weights.cpp
@@ -536,8 +536,12 @@ std::shared_ptr<ov::Node> make_weight_node(const WeightTensors& tensors,
                                            GgufTensorType qtype,
                                            const std::string& name) {
     OPENVINO_ASSERT(tensors.weight, "[GGUF] missing weight tensor: ", name);
+    const auto format = get_weight_format(qtype);
+    OPENVINO_ASSERT(!format.has_scales || tensors.scales, "[GGUF] missing scales tensor: ", name);
+    OPENVINO_ASSERT(!format.has_zero_point || tensors.zero_point, "[GGUF] missing zero-point tensor: ", name);
+
     std::shared_ptr<ov::Node> node;
-    switch (get_weight_format(qtype).layout) {
+    switch (format.layout) {
     case WeightLayout::MXFP4:
         node = make_mxfp4(tensors);
         break;
@@ -643,7 +647,8 @@ std::array<FusedQkvPart, 3> split_fused_qkv_extracted(const std::string& base,
                                                              std::make_pair(n_q + n_k, total_rows)};
     std::array<FusedQkvPart, 3> out;
     for (size_t i = 0; i < 3; ++i) {
-        const auto [r0, r1] = ranges[i];
+        const size_t r0 = ranges[i].first;
+        const size_t r1 = ranges[i].second;
         out[i] = make_split_part(qtype, format, weights, base, [&](const ov::Tensor& t) {
             return slice_rows(t, r0, r1);
         });

--- a/src/frontends/gguf/src/quant/weights.cpp
+++ b/src/frontends/gguf/src/quant/weights.cpp
@@ -670,28 +670,21 @@ std::array<FusedQkvPart, 2> split_interleaved_q_gate(const std::string& base,
                                                      const std::unordered_map<std::string, ov::Tensor>& weights,
                                                      const std::unordered_map<std::string, GgufTensorType>& qtypes,
                                                      size_t head_dim) {
-    GgufTensorType qtype = GGUF_TYPE_F16;
-    if (auto it = qtypes.find(base + ".qtype"); it != qtypes.end()) {
-        qtype = it->second;
-    }
+    const GgufTensorType qtype = lookup_qtype(base, qtypes);
     const auto format = get_weight_format(qtype);
 
-    const ov::Tensor& w = get(weights, base + ".weight");
     const size_t block = 2 * head_dim;
-    OPENVINO_ASSERT(w.get_shape()[0] % block == 0, "[GGUF] interleaved q/gate row mismatch for ", base);
+    OPENVINO_ASSERT(get(weights, base + ".weight").get_shape()[0] % block == 0,
+                    "[GGUF] interleaved q/gate row mismatch for ",
+                    base);
 
     const std::array<size_t, 2> offsets = {0, head_dim};
 
     std::array<FusedQkvPart, 2> out;
     for (size_t i = 0; i < 2; ++i) {
-        out[i].qtype = qtype;
-        out[i].tensors.weight = gather_rows_strided(w, block, head_dim, offsets[i]);
-        if (format.has_scales) {
-            out[i].tensors.scales = gather_rows_strided(get(weights, base + ".scales"), block, head_dim, offsets[i]);
-        }
-        if (format.has_zero_point) {
-            out[i].tensors.zero_point = gather_rows_strided(get(weights, base + ".zp"), block, head_dim, offsets[i]);
-        }
+        out[i] = make_split_part(qtype, format, weights, base, [&](const ov::Tensor& t) {
+            return gather_rows_strided(t, block, head_dim, offsets[i]);
+        });
     }
     return out;
 }

--- a/src/frontends/gguf/src/quant/weights.cpp
+++ b/src/frontends/gguf/src/quant/weights.cpp
@@ -37,6 +37,51 @@ namespace gguf {
 
 namespace {
 
+enum class WeightLayout { PLAIN, MXFP4, SYMMETRIC_I4, SYMMETRIC_I8, ASYMMETRIC_I2, ASYMMETRIC_I4, ASYMMETRIC_I8 };
+
+enum class FillKind { NONE, MXFP4, SYMMETRIC, ASYMMETRIC, Q2_0 };
+
+struct WeightFormat {
+    WeightLayout layout;
+    FillKind fill;
+    size_t group_size;
+    bool has_scales;
+    bool has_zero_point;
+};
+
+WeightFormat get_weight_format(GgufTensorType qtype) {
+    switch (qtype) {
+    case GGUF_TYPE_MXFP4:
+        return {WeightLayout::MXFP4, FillKind::MXFP4, 32, false, false};
+    case GGUF_TYPE_Q4_0:
+        return {WeightLayout::SYMMETRIC_I4, FillKind::SYMMETRIC, 32, true, false};
+    case GGUF_TYPE_Q3_K:
+        return {WeightLayout::SYMMETRIC_I4, FillKind::SYMMETRIC, 16, true, false};
+    case GGUF_TYPE_Q5_0:
+    case GGUF_TYPE_Q8_0:
+        return {WeightLayout::SYMMETRIC_I8, FillKind::SYMMETRIC, 32, true, false};
+    case GGUF_TYPE_Q6_K:
+        return {WeightLayout::SYMMETRIC_I8, FillKind::SYMMETRIC, 16, true, false};
+    case GGUF_TYPE_Q8_K:
+        return {WeightLayout::SYMMETRIC_I8, FillKind::NONE, 0, false, false};
+    case GGUF_TYPE_Q2_K:
+        return {WeightLayout::ASYMMETRIC_I2, FillKind::ASYMMETRIC, 16, true, true};
+    case GGUF_TYPE_Q2_0:
+        return {WeightLayout::ASYMMETRIC_I2, FillKind::Q2_0, 64, true, true};
+    case GGUF_TYPE_Q4_1:
+    case GGUF_TYPE_Q4_K:
+        return {WeightLayout::ASYMMETRIC_I4, FillKind::ASYMMETRIC, 32, true, true};
+    case GGUF_TYPE_Q5_1:
+    case GGUF_TYPE_Q5_K:
+        return {WeightLayout::ASYMMETRIC_I8, FillKind::ASYMMETRIC, 32, true, true};
+    case GGUF_TYPE_F16:
+    case GGUF_TYPE_F32:
+    case GGUF_TYPE_BF16:
+    default:
+        return {WeightLayout::PLAIN, FillKind::NONE, 0, false, false};
+    }
+}
+
 const ov::Tensor& get(const std::unordered_map<std::string, ov::Tensor>& weights, const std::string& key) {
     auto it = weights.find(key);
     OPENVINO_ASSERT(it != weights.end(), "[GGUF] missing weight tensor: ", key);
@@ -111,42 +156,12 @@ std::shared_ptr<ov::op::v0::Constant> make_compressed_weight_constant(ov::elemen
                                                   std::make_shared<ov::Tensor>(weight));
 }
 
-// Q4_0 symmetric: i4 weights (XOR-converted from u4) + f16 scale, no zero-point.
-// Emits: Multiply(Convert(i4_const, f16), scale) [-> Reshape] via low_precision_dequantize.
-std::shared_ptr<ov::Node> make_q4_0(const std::string& name,
-                                    const std::unordered_map<std::string, ov::Tensor>& weights) {
-    ov::Tensor weight = get(weights, name + ".weight");  // u32-packed i4 nibbles
-    ov::Tensor scales = get(weights, name + ".scales");
-
-    ov::Shape orig_shape = weight.get_shape();
-    orig_shape.back() *= sizeof(uint32_t) / sizeof(uint8_t) * 2;  // u32 packs 8 i4
-    const size_t num_groups = scales.get_shape().back();
-    const size_t group_size = orig_shape.back() / num_groups;
-
-    auto grouped_shape = grouped_weight_shape(orig_shape, num_groups, group_size);
-    auto scale_shape = per_group_shape(orig_shape, num_groups);
-    scales.set_shape(scale_shape);
-
-    auto weights_node = make_compressed_weight_constant(ov::element::i4, grouped_shape, weight);
-    auto scales_node = std::make_shared<ov::op::v0::Constant>(scales);
-    auto final_shape_node =
-        std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{orig_shape.size()}, orig_shape);
-
-    auto result = ov::decomposition::low_precision_dequantize(weights_node->output(0),
-                                                              scales_node->output(0),
-                                                              {},
-                                                              final_shape_node->output(0));
-    return std::make_shared<ov::op::v0::Convert>(result, ov::element::f32);
-}
-
 // Symmetric 8-bit (Q8_0, Q5_0, Q6_K): i8 weights (pre-centered) + per-group f16 scale.
 // Q6_K uses explicit f32 arithmetic to preserve the reference dequantization accuracy; the other
 // formats use the compressed-weight decomposition.
-std::shared_ptr<ov::Node> make_sym_int8(const std::string& name,
-                                        const std::unordered_map<std::string, ov::Tensor>& weights,
-                                        GgufTensorType qtype) {
-    ov::Tensor weight = get(weights, name + ".weight");  // i8 byte per element
-    ov::Tensor scales = get(weights, name + ".scales");
+std::shared_ptr<ov::Node> make_sym_int8(const WeightTensors& tensors, GgufTensorType qtype) {
+    ov::Tensor weight = tensors.weight;  // i8 byte per element
+    ov::Tensor scales = tensors.scales;
 
     const ov::Shape& orig_shape = weight.get_shape();
     const size_t num_groups = scales.get_shape().back();
@@ -177,11 +192,10 @@ std::shared_ptr<ov::Node> make_sym_int8(const std::string& name,
 
 // 4-bit asymmetric (Q4_1/Q4_K): u4 weights + per-group scale and zero-point. Fractional f16
 // zero-points use explicit f32 dequantization; exact integer zero-points keep the compressed path.
-std::shared_ptr<ov::Node> make_int4(const std::string& name,
-                                    const std::unordered_map<std::string, ov::Tensor>& weights) {
-    ov::Tensor weight = get(weights, name + ".weight");  // u32-packed u4
-    ov::Tensor scales = get(weights, name + ".scales");
-    ov::Tensor zp_t = get(weights, name + ".zp");
+std::shared_ptr<ov::Node> make_int4(const WeightTensors& tensors) {
+    ov::Tensor weight = tensors.weight;  // u32-packed u4
+    ov::Tensor scales = tensors.scales;
+    ov::Tensor zp_t = tensors.zero_point;
 
     ov::Shape orig_shape = weight.get_shape();
     orig_shape.back() *= sizeof(uint32_t) / sizeof(uint8_t) * 2;  // u32 packs 8 u4
@@ -217,10 +231,9 @@ std::shared_ptr<ov::Node> make_int4(const std::string& name,
 
 // Symmetric 4-bit (Q3_K): i4 weights (centered [-4..3]) + per-group f16 scale. No zero-point.
 // Emits: Multiply(Convert(i4_const, f16), scale) [-> Reshape].
-std::shared_ptr<ov::Node> make_sym_int4(const std::string& name,
-                                        const std::unordered_map<std::string, ov::Tensor>& weights) {
-    ov::Tensor weight = get(weights, name + ".weight");  // i4 packed, 2 per byte
-    ov::Tensor scales = get(weights, name + ".scales");
+std::shared_ptr<ov::Node> make_sym_int4(const WeightTensors& tensors) {
+    ov::Tensor weight = tensors.weight;  // i4 packed, 2 per byte
+    ov::Tensor scales = tensors.scales;
 
     const ov::Shape& orig_shape = weight.get_shape();
     const size_t num_groups = scales.get_shape().back();
@@ -244,11 +257,10 @@ std::shared_ptr<ov::Node> make_sym_int4(const std::string& name,
 
 // Asymmetric 2-bit (Q2_K): u2 weights (raw [0..3]) + per-group f16 scale + u8 zp.
 // Emits: Multiply(Subtract(Convert(u2_const, f16), zp_u8), scale) [-> Reshape].
-std::shared_ptr<ov::Node> make_int2(const std::string& name,
-                                    const std::unordered_map<std::string, ov::Tensor>& weights) {
-    ov::Tensor weight = get(weights, name + ".weight");  // u2 packed, 4 per byte
-    ov::Tensor scales = get(weights, name + ".scales");
-    ov::Tensor zp_t = get(weights, name + ".zp");  // u8 integer zero-points
+std::shared_ptr<ov::Node> make_int2(const WeightTensors& tensors) {
+    ov::Tensor weight = tensors.weight;  // u2 packed, 4 per byte
+    ov::Tensor scales = tensors.scales;
+    ov::Tensor zp_t = tensors.zero_point;  // u8 integer zero-points
 
     const ov::Shape& orig_shape = weight.get_shape();
     const size_t num_groups = scales.get_shape().back();
@@ -274,11 +286,10 @@ std::shared_ptr<ov::Node> make_int2(const std::string& name,
 
 // Asymmetric 8-bit (Q5_K): i8 weights (raw 5-bit value, not centered) + f16 scales + u8 zp.
 // Emits: Multiply(Subtract(Convert(i8_const, f16), zp_u8), scale) [-> Reshape].
-std::shared_ptr<ov::Node> make_asym_int8(const std::string& name,
-                                         const std::unordered_map<std::string, ov::Tensor>& weights) {
-    ov::Tensor weight = get(weights, name + ".weight");  // i8 byte per element
-    ov::Tensor scales = get(weights, name + ".scales");
-    ov::Tensor zp_t = get(weights, name + ".zp");  // u8 integer zero-points
+std::shared_ptr<ov::Node> make_asym_int8(const WeightTensors& tensors) {
+    ov::Tensor weight = tensors.weight;  // i8 byte per element
+    ov::Tensor scales = tensors.scales;
+    ov::Tensor zp_t = tensors.zero_point;  // u8 integer zero-points
 
     const ov::Shape& orig_shape = weight.get_shape();
     const size_t num_groups = scales.get_shape().back();
@@ -314,10 +325,9 @@ std::shared_ptr<ov::Node> make_asym_int8(const std::string& name,
 // MXFP4 (gpt-oss): native compressed weights = f4e2m1 weight * f8e8m0 per-32 scale, both
 // kept compressed so the CPU plugin decompresses on the fly (no host f16 expansion). The
 // parser already deinterleaved into natural order; here we just build the subgraph.
-std::shared_ptr<ov::Node> make_mxfp4(const std::string& base,
-                                     const std::unordered_map<std::string, ov::Tensor>& weights) {
-    ov::Tensor weight = get(weights, base + ".weight");  // f4e2m1 [.., cols]
-    ov::Tensor scales = get(weights, base + ".scales");  // f8e8m0 [.., groups]
+std::shared_ptr<ov::Node> make_mxfp4(const WeightTensors& tensors) {
+    ov::Tensor weight = tensors.weight;  // f4e2m1 [.., cols]
+    ov::Tensor scales = tensors.scales;  // f8e8m0 [.., groups]
 
     ov::Shape orig_shape = weight.get_shape();
     size_t rows = 1;
@@ -398,19 +408,15 @@ std::shared_ptr<ov::Node> requantize_q8_0_channelwise(const std::vector<float>& 
 
 // Dequantize the gguf_fill_* output (i8, i4, u2, or u32-packed u4 weights + per-group f16 scale
 // and optional f16 zero-point) to row-major f32: f32 = (w - zp) * scale, grouped along cols.
-std::vector<float> dequant_extracted_to_f32(const std::unordered_map<std::string, ov::Tensor>& w,
-                                            const std::string& base,
-                                            size_t rows,
-                                            size_t cols) {
-    const ov::Tensor& weight = get(w, base + ".weight");
-    const ov::Tensor& scales = get(w, base + ".scales");
+std::vector<float> dequant_extracted_to_f32(const WeightTensors& tensors, size_t rows, size_t cols) {
+    const ov::Tensor& weight = tensors.weight;
+    const ov::Tensor& scales = tensors.scales;
     const size_t num_groups = scales.get_shape().back();
     const size_t group = cols / num_groups;
     const auto* s = scales.data<ov::float16>();
 
-    auto zp_it = w.find(base + ".zp");
-    const bool has_zp = zp_it != w.end();
-    const ov::float16* z = has_zp ? zp_it->second.data<ov::float16>() : nullptr;
+    const bool has_zp = static_cast<bool>(tensors.zero_point);
+    const ov::float16* z = has_zp ? tensors.zero_point.data<ov::float16>() : nullptr;
 
     const auto et = weight.get_element_type();
     std::vector<float> out(rows * cols);
@@ -521,49 +527,33 @@ ov::element::Type gguf_zero_point_type(const std::string& name, GgufTensorType q
     return (integer_zp && !needs_q8_0_c_requant(name, qtype)) ? ov::element::u8 : ov::element::f16;
 }
 
-std::shared_ptr<ov::Node> make_weight_node(const std::string& base,
-                                           const std::unordered_map<std::string, ov::Tensor>& weights,
-                                           const std::unordered_map<std::string, GgufTensorType>& qtypes) {
-    GgufTensorType qtype = GGUF_TYPE_F16;
-    if (auto it = qtypes.find(base + ".qtype"); it != qtypes.end()) {
-        qtype = it->second;
-    }
-
+std::shared_ptr<ov::Node> make_weight_node(const WeightTensors& tensors,
+                                           GgufTensorType qtype,
+                                           const std::string& name) {
+    OPENVINO_ASSERT(tensors.weight, "[GGUF] missing weight tensor: ", name);
     std::shared_ptr<ov::Node> node;
-    switch (qtype) {
-    case GGUF_TYPE_MXFP4:
-        node = make_mxfp4(base, weights);
+    switch (get_weight_format(qtype).layout) {
+    case WeightLayout::MXFP4:
+        node = make_mxfp4(tensors);
         break;
-    case GGUF_TYPE_Q4_0:
-        node = make_q4_0(base, weights);
+    case WeightLayout::ASYMMETRIC_I4:
+        node = make_int4(tensors);
         break;
-    case GGUF_TYPE_Q4_1:
-    case GGUF_TYPE_Q4_K:
-        node = make_int4(base, weights);
+    case WeightLayout::ASYMMETRIC_I2:
+        node = make_int2(tensors);
         break;
-    case GGUF_TYPE_Q2_K:
-    case GGUF_TYPE_Q2_0:
-        node = make_int2(base, weights);
+    case WeightLayout::ASYMMETRIC_I8:
+        node = make_asym_int8(tensors);
         break;
-    case GGUF_TYPE_Q5_K:
-    case GGUF_TYPE_Q5_1:
-        node = make_asym_int8(base, weights);
+    case WeightLayout::SYMMETRIC_I4:
+        node = make_sym_int4(tensors);
         break;
-    case GGUF_TYPE_Q3_K:
-        node = make_sym_int4(base, weights);
+    case WeightLayout::SYMMETRIC_I8:
+        node = make_sym_int8(tensors, qtype);
         break;
-    case GGUF_TYPE_Q5_0:
-    case GGUF_TYPE_Q8_0:
-    case GGUF_TYPE_Q6_K:
-    case GGUF_TYPE_Q8_K:
-        node = make_sym_int8(base, weights, qtype);
-        break;
-    case GGUF_TYPE_F16:
-    case GGUF_TYPE_F32:
-    case GGUF_TYPE_BF16:
-    default: {
+    case WeightLayout::PLAIN: {
         // Non-quantized weight: a plain Constant (converted to f32 for the translators).
-        ov::Tensor w = get(weights, base + ".weight");
+        ov::Tensor w = tensors.weight;
         auto cnst = std::make_shared<ov::op::v0::Constant>(w);
         node = (w.get_element_type() == ov::element::f32)
                    ? std::static_pointer_cast<ov::Node>(cnst)
@@ -571,7 +561,7 @@ std::shared_ptr<ov::Node> make_weight_node(const std::string& base,
         break;
     }
     }
-    node->set_friendly_name(base + ".weight");
+    node->set_friendly_name(name);
     return node;
 }
 
@@ -613,12 +603,7 @@ std::array<FusedQkvPart, 3> split_fused_qkv_extracted(const std::string& base,
     if (auto it = qtypes.find(base + ".qtype"); it != qtypes.end()) {
         qtype = it->second;
     }
-    const bool has_scales = qtype == GGUF_TYPE_Q4_0 || qtype == GGUF_TYPE_Q4_1 || qtype == GGUF_TYPE_Q4_K ||
-                            qtype == GGUF_TYPE_Q5_0 || qtype == GGUF_TYPE_Q5_1 || qtype == GGUF_TYPE_Q8_0 ||
-                            qtype == GGUF_TYPE_Q2_K || qtype == GGUF_TYPE_Q3_K || qtype == GGUF_TYPE_Q5_K ||
-                            qtype == GGUF_TYPE_Q6_K || qtype == GGUF_TYPE_Q2_0;
-    const bool has_zp = qtype == GGUF_TYPE_Q4_1 || qtype == GGUF_TYPE_Q4_K || qtype == GGUF_TYPE_Q5_K ||
-                        qtype == GGUF_TYPE_Q5_1 || qtype == GGUF_TYPE_Q2_K || qtype == GGUF_TYPE_Q2_0;
+    const auto format = get_weight_format(qtype);
 
     const ov::Tensor& w = get(weights, base + ".weight");
     const size_t total_rows = w.get_shape()[0];
@@ -627,18 +612,16 @@ std::array<FusedQkvPart, 3> split_fused_qkv_extracted(const std::string& base,
     const std::array<std::pair<size_t, size_t>, 3> ranges = {std::make_pair(size_t(0), n_q),
                                                              std::make_pair(n_q, n_q + n_k),
                                                              std::make_pair(n_q + n_k, total_rows)};
-    const std::array<std::string, 3> parts = {base + ".q", base + ".k", base + ".v"};
-
     std::array<FusedQkvPart, 3> out;
     for (size_t i = 0; i < 3; ++i) {
         const auto [r0, r1] = ranges[i];
         out[i].qtype = qtype;
-        out[i].extracted[parts[i] + ".weight"] = slice_rows(w, r0, r1);
-        if (has_scales) {
-            out[i].extracted[parts[i] + ".scales"] = slice_rows(get(weights, base + ".scales"), r0, r1);
+        out[i].tensors.weight = slice_rows(w, r0, r1);
+        if (format.has_scales) {
+            out[i].tensors.scales = slice_rows(get(weights, base + ".scales"), r0, r1);
         }
-        if (has_zp) {
-            out[i].extracted[parts[i] + ".zp"] = slice_rows(get(weights, base + ".zp"), r0, r1);
+        if (format.has_zero_point) {
+            out[i].tensors.zero_point = slice_rows(get(weights, base + ".zp"), r0, r1);
         }
     }
     return out;
@@ -667,31 +650,23 @@ std::array<FusedQkvPart, 2> split_interleaved_q_gate(const std::string& base,
     if (auto it = qtypes.find(base + ".qtype"); it != qtypes.end()) {
         qtype = it->second;
     }
-    const bool has_scales = qtype == GGUF_TYPE_Q4_0 || qtype == GGUF_TYPE_Q4_1 || qtype == GGUF_TYPE_Q4_K ||
-                            qtype == GGUF_TYPE_Q5_0 || qtype == GGUF_TYPE_Q5_1 || qtype == GGUF_TYPE_Q8_0 ||
-                            qtype == GGUF_TYPE_Q2_K || qtype == GGUF_TYPE_Q3_K || qtype == GGUF_TYPE_Q5_K ||
-                            qtype == GGUF_TYPE_Q6_K || qtype == GGUF_TYPE_Q2_0;
-    const bool has_zp = qtype == GGUF_TYPE_Q4_1 || qtype == GGUF_TYPE_Q4_K || qtype == GGUF_TYPE_Q5_K ||
-                        qtype == GGUF_TYPE_Q5_1 || qtype == GGUF_TYPE_Q2_K || qtype == GGUF_TYPE_Q2_0;
+    const auto format = get_weight_format(qtype);
 
     const ov::Tensor& w = get(weights, base + ".weight");
     const size_t block = 2 * head_dim;
     OPENVINO_ASSERT(w.get_shape()[0] % block == 0, "[GGUF] interleaved q/gate row mismatch for ", base);
 
-    const std::array<std::string, 2> parts = {base + ".q", base + ".gate"};
     const std::array<size_t, 2> offsets = {0, head_dim};
 
     std::array<FusedQkvPart, 2> out;
     for (size_t i = 0; i < 2; ++i) {
         out[i].qtype = qtype;
-        out[i].extracted[parts[i] + ".weight"] = gather_rows_strided(w, block, head_dim, offsets[i]);
-        if (has_scales) {
-            out[i].extracted[parts[i] + ".scales"] =
-                gather_rows_strided(get(weights, base + ".scales"), block, head_dim, offsets[i]);
+        out[i].tensors.weight = gather_rows_strided(w, block, head_dim, offsets[i]);
+        if (format.has_scales) {
+            out[i].tensors.scales = gather_rows_strided(get(weights, base + ".scales"), block, head_dim, offsets[i]);
         }
-        if (has_zp) {
-            out[i].extracted[parts[i] + ".zp"] =
-                gather_rows_strided(get(weights, base + ".zp"), block, head_dim, offsets[i]);
+        if (format.has_zero_point) {
+            out[i].tensors.zero_point = gather_rows_strided(get(weights, base + ".zp"), block, head_dim, offsets[i]);
         }
     }
     return out;
@@ -707,8 +682,6 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
     const size_t rows = logical_shape[0];
     const size_t cols = logical_shape[1];
     const GgufTensorType qtype = gguf_type_from_name(quant_type);
-
-    const std::string base = "weight";
 
     if (qtype == GGUF_TYPE_Q4_1 || qtype == GGUF_TYPE_Q5_1) {
         ov::Tensor decoded(ov::element::f32, logical_shape);
@@ -744,9 +717,7 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
                                : qtype == GGUF_TYPE_F16 ? ov::element::f16
                                                         : ov::element::bf16;
         ov::Tensor typed(et, logical_shape, data.data());
-        std::unordered_map<std::string, ov::Tensor> w{{base + ".weight", typed}};
-        std::unordered_map<std::string, GgufTensorType> q{{base + ".qtype", qtype}};
-        return make_weight_node(base, w, q);
+        return make_weight_node({typed, {}, {}}, qtype, name);
     }
 
     // Quantized weights: run the matching fill function to extract weights/scales/zp into
@@ -764,8 +735,7 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
         return cols / block;
     };
 
-    std::unordered_map<std::string, ov::Tensor> w;
-    std::unordered_map<std::string, GgufTensorType> q{{base + ".qtype", qtype}};
+    WeightTensors tensors;
 
     // Asymmetric zero-points. The CPU plugin only folds the dequant into the MatMul when the
     // zp is an INTEGER (u8) low-precision constant; a fractional f16 zp leaves a standalone
@@ -796,105 +766,58 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
                                                        qtype,
                                                        rq_weights.data<int8_t>(),
                                                        rq_scales.data<ov::float16>());
-        OPENVINO_ASSERT(ok, "[GGUF] faithful K-quant requant failed for ", base);
+        OPENVINO_ASSERT(ok, "[GGUF] faithful K-quant requant failed for ", name);
         return build_q8_0_c_node(rq_weights, rq_scales, rows, cols);
     }
 
-    switch (qtype) {
-    case GGUF_TYPE_MXFP4: {
+    const auto format = get_weight_format(qtype);
+    switch (format.fill) {
+    case FillKind::MXFP4: {
         // 2D here means a bare MXFP4 tensor from the llama.cpp cgraph path (e.g. test-backend-ops
         // op tests), not a stored MoE expert weight -- those stay rank>2 and are intercepted
         // earlier in translate_weight() to keep them packed for MUL_MAT_ID.
         ov::Tensor weights(ov::element::f4e2m1, ov::Shape{rows, cols});
         ov::Tensor scales(ov::element::f8e8m0, ov::Shape{rows, sub_blocks_per_row(32)});
         gguf_fill_mxfp4(tensor, weights, scales);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
+        tensors.weight = weights;
+        tensors.scales = scales;
         break;
     }
-    case GGUF_TYPE_Q4_0: {
-        ov::Tensor weights(ov::element::u32, ov::Shape{rows, cols / 8});
-        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(32)});
-        gguf_fill_q4_0(tensor, weights, scales);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
-        break;
-    }
-    case GGUF_TYPE_Q5_0:
-    case GGUF_TYPE_Q8_0: {
-        // Symmetric, i8 weights + f16 scales (group 32).
-        ov::Tensor weights(ov::element::i8, ov::Shape{rows, cols});
-        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(32)});
+    case FillKind::SYMMETRIC: {
+        const auto weight_type = format.layout == WeightLayout::SYMMETRIC_I4 ? ov::element::i4 : ov::element::i8;
+        ov::Tensor weights(weight_type, ov::Shape{rows, cols});
+        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(format.group_size)});
         gguf_fill_sym(tensor, weights, scales);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
+        tensors.weight = weights;
+        tensors.scales = scales;
         break;
     }
-    case GGUF_TYPE_Q6_K: {
-        // Symmetric, i8 weights + f16 scales (group 16).
-        ov::Tensor weights(ov::element::i8, ov::Shape{rows, cols});
-        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(16)});
-        gguf_fill_sym(tensor, weights, scales);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
-        break;
-    }
-    case GGUF_TYPE_Q3_K: {
-        // Symmetric, i4 weights (2/byte) + f16 scales (group 16).
-        ov::Tensor weights(ov::element::i4, ov::Shape{rows, cols});
-        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(16)});
-        gguf_fill_sym(tensor, weights, scales);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
-        break;
-    }
-    case GGUF_TYPE_Q4_1:
-    case GGUF_TYPE_Q4_K: {
-        // Asymmetric 4-bit: u32-packed u4 weights + f16 scales + zp (group 32).
-        ov::Tensor weights(ov::element::u32, ov::Shape{rows, cols / 8});
-        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(32)});
-        ov::Tensor zp(zp_type, ov::Shape{rows, sub_blocks_per_row(32)});
+    case FillKind::ASYMMETRIC: {
+        const bool packed_u4 = format.layout == WeightLayout::ASYMMETRIC_I4;
+        const auto weight_type = packed_u4                                      ? ov::element::u32
+                                 : format.layout == WeightLayout::ASYMMETRIC_I2 ? ov::element::u2
+                                                                                : ov::element::i8;
+        ov::Tensor weights(weight_type, ov::Shape{rows, packed_u4 ? cols / 8 : cols});
+        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(format.group_size)});
+        ov::Tensor zp(zp_type, scales.get_shape());
         gguf_fill_asym(tensor, weights, scales, zp);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
-        w[base + ".zp"] = zp;
+        tensors.weight = weights;
+        tensors.scales = scales;
+        tensors.zero_point = zp;
         break;
     }
-    case GGUF_TYPE_Q5_1:
-    case GGUF_TYPE_Q5_K: {
-        // Asymmetric 8-bit weights + f16 scales + zp (group 32).
-        ov::Tensor weights(ov::element::i8, ov::Shape{rows, cols});
-        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(32)});
-        ov::Tensor zp(zp_type, ov::Shape{rows, sub_blocks_per_row(32)});
-        gguf_fill_asym(tensor, weights, scales, zp);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
-        w[base + ".zp"] = zp;
-        break;
-    }
-    case GGUF_TYPE_Q2_K: {
-        // Asymmetric 2-bit weights (u2) + f16 scales + zp (group 16).
-        ov::Tensor weights(ov::element::u2, ov::Shape{rows, cols});
-        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(16)});
-        ov::Tensor zp(zp_type, ov::Shape{rows, sub_blocks_per_row(16)});
-        gguf_fill_asym(tensor, weights, scales, zp);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
-        w[base + ".zp"] = zp;
-        break;
-    }
-    case GGUF_TYPE_Q2_0: {
+    case FillKind::Q2_0: {
         // Ternary: u2 weights + f16 scales + a zero-point that is the constant 1 (group 64).
         ov::Tensor weights(ov::element::u2, ov::Shape{rows, cols});
-        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(64)});
+        ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(format.group_size)});
         ov::Tensor zp(zp_type, ov::Shape{rows, sub_blocks_per_row(64)});
         gguf_fill_q2_0(tensor, weights, scales, zp);
-        w[base + ".weight"] = weights;
-        w[base + ".scales"] = scales;
-        w[base + ".zp"] = zp;
+        tensors.weight = weights;
+        tensors.scales = scales;
+        tensors.zero_point = zp;
         break;
     }
-    default:
+    case FillKind::NONE:
         OPENVINO_THROW("[GGUF] unsupported weight quant type: ", quant_type);
     }
 
@@ -902,11 +825,11 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
     // above already handled Q4_K/Q5_K/Q6_K, so here reproduce the backend's channel-wise Q8_0_C by
     // dequantizing to f32 from the extracted tensors, then re-quantizing.
     if (requant) {
-        auto f32 = dequant_extracted_to_f32(w, base, rows, cols);
+        auto f32 = dequant_extracted_to_f32(tensors, rows, cols);
         return requantize_q8_0_channelwise(f32, rows, cols);
     }
 
-    return make_weight_node(base, w, q);
+    return make_weight_node(tensors, qtype, name);
 }
 
 }  // namespace gguf

--- a/src/frontends/gguf/src/quant/weights.cpp
+++ b/src/frontends/gguf/src/quant/weights.cpp
@@ -47,38 +47,43 @@ struct WeightFormat {
     size_t group_size;
     bool has_scales;
     bool has_zero_point;
+    // Element type gguf_fill_* writes the weight blob as, and whether it's u32-packed (8
+    // sub-byte elements per word) rather than one element per byte. Only meaningful for
+    // FillKind::MXFP4/SYMMETRIC/ASYMMETRIC/Q2_0 -- the raw-bytes make_weight_node() overload.
+    ov::element::Type weight_element_type;
+    bool packed_u32;
 };
 
 WeightFormat get_weight_format(GgufTensorType qtype) {
     switch (qtype) {
     case GGUF_TYPE_MXFP4:
-        return {WeightLayout::MXFP4, FillKind::MXFP4, 32, false, false};
+        return {WeightLayout::MXFP4, FillKind::MXFP4, 32, true, false, ov::element::f4e2m1, false};
     case GGUF_TYPE_Q4_0:
-        return {WeightLayout::SYMMETRIC_I4, FillKind::SYMMETRIC, 32, true, false};
+        return {WeightLayout::SYMMETRIC_I4, FillKind::SYMMETRIC, 32, true, false, ov::element::i4, false};
     case GGUF_TYPE_Q3_K:
-        return {WeightLayout::SYMMETRIC_I4, FillKind::SYMMETRIC, 16, true, false};
+        return {WeightLayout::SYMMETRIC_I4, FillKind::SYMMETRIC, 16, true, false, ov::element::i4, false};
     case GGUF_TYPE_Q5_0:
     case GGUF_TYPE_Q8_0:
-        return {WeightLayout::SYMMETRIC_I8, FillKind::SYMMETRIC, 32, true, false};
+        return {WeightLayout::SYMMETRIC_I8, FillKind::SYMMETRIC, 32, true, false, ov::element::i8, false};
     case GGUF_TYPE_Q6_K:
-        return {WeightLayout::SYMMETRIC_I8, FillKind::SYMMETRIC, 16, true, false};
+        return {WeightLayout::SYMMETRIC_I8, FillKind::SYMMETRIC, 16, true, false, ov::element::i8, false};
     case GGUF_TYPE_Q8_K:
-        return {WeightLayout::SYMMETRIC_I8, FillKind::NONE, 0, false, false};
+        return {WeightLayout::SYMMETRIC_I8, FillKind::NONE, 256, true, false, ov::element::i8, false};
     case GGUF_TYPE_Q2_K:
-        return {WeightLayout::ASYMMETRIC_I2, FillKind::ASYMMETRIC, 16, true, true};
+        return {WeightLayout::ASYMMETRIC_I2, FillKind::ASYMMETRIC, 16, true, true, ov::element::u2, false};
     case GGUF_TYPE_Q2_0:
-        return {WeightLayout::ASYMMETRIC_I2, FillKind::Q2_0, 64, true, true};
+        return {WeightLayout::ASYMMETRIC_I2, FillKind::Q2_0, 64, true, true, ov::element::u2, false};
     case GGUF_TYPE_Q4_1:
     case GGUF_TYPE_Q4_K:
-        return {WeightLayout::ASYMMETRIC_I4, FillKind::ASYMMETRIC, 32, true, true};
+        return {WeightLayout::ASYMMETRIC_I4, FillKind::ASYMMETRIC, 32, true, true, ov::element::u32, true};
     case GGUF_TYPE_Q5_1:
     case GGUF_TYPE_Q5_K:
-        return {WeightLayout::ASYMMETRIC_I8, FillKind::ASYMMETRIC, 32, true, true};
+        return {WeightLayout::ASYMMETRIC_I8, FillKind::ASYMMETRIC, 32, true, true, ov::element::i8, false};
     case GGUF_TYPE_F16:
     case GGUF_TYPE_F32:
     case GGUF_TYPE_BF16:
     default:
-        return {WeightLayout::PLAIN, FillKind::NONE, 0, false, false};
+        return {WeightLayout::PLAIN, FillKind::NONE, 0, false, false, ov::element::dynamic, false};
     }
 }
 
@@ -593,20 +598,44 @@ GgufTensorType gguf_type_from_name(const std::string& quant_type) {
     return it->second;
 }
 
+GgufTensorType lookup_qtype(const std::string& base, const std::unordered_map<std::string, GgufTensorType>& qtypes) {
+    GgufTensorType qtype = GGUF_TYPE_F16;
+    if (auto it = qtypes.find(base + ".qtype"); it != qtypes.end()) {
+        qtype = it->second;
+    }
+    return qtype;
+}
+
+// Build one split-off part by applying `slice` (a row-range or strided-gather extractor) to
+// the weight and, if present for this qtype's format, the scales and zero-point.
+template <typename SliceFn>
+FusedQkvPart make_split_part(GgufTensorType qtype,
+                             const WeightFormat& format,
+                             const std::unordered_map<std::string, ov::Tensor>& weights,
+                             const std::string& base,
+                             const SliceFn& slice) {
+    FusedQkvPart part;
+    part.qtype = qtype;
+    part.tensors.weight = slice(get(weights, base + ".weight"));
+    if (format.has_scales) {
+        part.tensors.scales = slice(get(weights, base + ".scales"));
+    }
+    if (format.has_zero_point) {
+        part.tensors.zero_point = slice(get(weights, base + ".zp"));
+    }
+    return part;
+}
+
 std::array<FusedQkvPart, 3> split_fused_qkv_extracted(const std::string& base,
                                                       const std::unordered_map<std::string, ov::Tensor>& weights,
                                                       const std::unordered_map<std::string, GgufTensorType>& qtypes,
                                                       size_t n_q,
                                                       size_t n_k,
                                                       size_t n_v) {
-    GgufTensorType qtype = GGUF_TYPE_F16;
-    if (auto it = qtypes.find(base + ".qtype"); it != qtypes.end()) {
-        qtype = it->second;
-    }
+    const GgufTensorType qtype = lookup_qtype(base, qtypes);
     const auto format = get_weight_format(qtype);
 
-    const ov::Tensor& w = get(weights, base + ".weight");
-    const size_t total_rows = w.get_shape()[0];
+    const size_t total_rows = get(weights, base + ".weight").get_shape()[0];
     OPENVINO_ASSERT(n_q + n_k + n_v == total_rows, "[GGUF] fused qkv row mismatch for ", base);
 
     const std::array<std::pair<size_t, size_t>, 3> ranges = {std::make_pair(size_t(0), n_q),
@@ -615,14 +644,9 @@ std::array<FusedQkvPart, 3> split_fused_qkv_extracted(const std::string& base,
     std::array<FusedQkvPart, 3> out;
     for (size_t i = 0; i < 3; ++i) {
         const auto [r0, r1] = ranges[i];
-        out[i].qtype = qtype;
-        out[i].tensors.weight = slice_rows(w, r0, r1);
-        if (format.has_scales) {
-            out[i].tensors.scales = slice_rows(get(weights, base + ".scales"), r0, r1);
-        }
-        if (format.has_zero_point) {
-            out[i].tensors.zero_point = slice_rows(get(weights, base + ".zp"), r0, r1);
-        }
+        out[i] = make_split_part(qtype, format, weights, base, [&](const ov::Tensor& t) {
+            return slice_rows(t, r0, r1);
+        });
     }
     return out;
 }
@@ -776,16 +800,15 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
         // 2D here means a bare MXFP4 tensor from the llama.cpp cgraph path (e.g. test-backend-ops
         // op tests), not a stored MoE expert weight -- those stay rank>2 and are intercepted
         // earlier in translate_weight() to keep them packed for MUL_MAT_ID.
-        ov::Tensor weights(ov::element::f4e2m1, ov::Shape{rows, cols});
-        ov::Tensor scales(ov::element::f8e8m0, ov::Shape{rows, sub_blocks_per_row(32)});
+        ov::Tensor weights(format.weight_element_type, ov::Shape{rows, cols});
+        ov::Tensor scales(ov::element::f8e8m0, ov::Shape{rows, sub_blocks_per_row(format.group_size)});
         gguf_fill_mxfp4(tensor, weights, scales);
         tensors.weight = weights;
         tensors.scales = scales;
         break;
     }
     case FillKind::SYMMETRIC: {
-        const auto weight_type = format.layout == WeightLayout::SYMMETRIC_I4 ? ov::element::i4 : ov::element::i8;
-        ov::Tensor weights(weight_type, ov::Shape{rows, cols});
+        ov::Tensor weights(format.weight_element_type, ov::Shape{rows, cols});
         ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(format.group_size)});
         gguf_fill_sym(tensor, weights, scales);
         tensors.weight = weights;
@@ -793,11 +816,7 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
         break;
     }
     case FillKind::ASYMMETRIC: {
-        const bool packed_u4 = format.layout == WeightLayout::ASYMMETRIC_I4;
-        const auto weight_type = packed_u4                                      ? ov::element::u32
-                                 : format.layout == WeightLayout::ASYMMETRIC_I2 ? ov::element::u2
-                                                                                : ov::element::i8;
-        ov::Tensor weights(weight_type, ov::Shape{rows, packed_u4 ? cols / 8 : cols});
+        ov::Tensor weights(format.weight_element_type, ov::Shape{rows, format.packed_u32 ? cols / 8 : cols});
         ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(format.group_size)});
         ov::Tensor zp(zp_type, scales.get_shape());
         gguf_fill_asym(tensor, weights, scales, zp);
@@ -808,9 +827,9 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
     }
     case FillKind::Q2_0: {
         // Ternary: u2 weights + f16 scales + a zero-point that is the constant 1 (group 64).
-        ov::Tensor weights(ov::element::u2, ov::Shape{rows, cols});
+        ov::Tensor weights(format.weight_element_type, ov::Shape{rows, cols});
         ov::Tensor scales(ov::element::f16, ov::Shape{rows, sub_blocks_per_row(format.group_size)});
-        ov::Tensor zp(zp_type, ov::Shape{rows, sub_blocks_per_row(64)});
+        ov::Tensor zp(zp_type, scales.get_shape());
         gguf_fill_q2_0(tensor, weights, scales, zp);
         tensors.weight = weights;
         tensors.scales = scales;

--- a/src/frontends/gguf/src/quant/weights.hpp
+++ b/src/frontends/gguf/src/quant/weights.hpp
@@ -43,18 +43,21 @@ enum class LossyWeightApproximation {
 // the approximation is actually PERFORMED, not where its parameters are queried.
 void notify_lossy_weight_approximation(LossyWeightApproximation kind);
 
-// Build the OpenVINO node for a GGUF weight with base name `base` (the tensor name without
-// the trailing ".weight", e.g. "blk.0.attn_q" or "token_embd"). Quantized weights become a
+// The tensors extracted from one GGUF weight. `scales` and `zero_point` are empty for formats
+// that do not use them.
+struct WeightTensors {
+    ov::Tensor weight;
+    ov::Tensor scales;
+    ov::Tensor zero_point;
+};
+
+// Build the OpenVINO node for one extracted GGUF weight. Quantized weights become a
 // low-bitness compressed subgraph (u4/u8 weights + zero-point + f16 scale, Convert ->
 // Subtract -> Multiply -> Reshape), matching what the cgraph path produces; F16/F32 weights
 // become a plain Constant. The returned node's output is f32 and feeds the translators.
-//
-// `weights` holds the parser output (tensors by gguf name; quantized tensors expanded to
-// "<base>.weight" + "<base>.scales" + "<base>.biases"). `qtypes` maps "<base>.qtype" ->
-// GgufTensorType.
-std::shared_ptr<ov::Node> make_weight_node(const std::string& base,
-                                           const std::unordered_map<std::string, ov::Tensor>& weights,
-                                           const std::unordered_map<std::string, GgufTensorType>& qtypes);
+std::shared_ptr<ov::Node> make_weight_node(const WeightTensors& tensors,
+                                           GgufTensorType qtype,
+                                           const std::string& name = "weight");
 
 // Build the OpenVINO weight node directly from the raw GGUF weight bytes, as provided by a
 // decoder (e.g. wrapping llama.cpp's tensor->data). `data` holds the bytes exactly as ggml
@@ -75,18 +78,16 @@ std::shared_ptr<ov::Node> make_weight_node(const ov::Tensor& data,
 // Map a ggml quant type name (e.g. "Q4_K") to its GgufTensorType id. Throws if unknown.
 GgufTensorType gguf_type_from_name(const std::string& quant_type);
 
-// One split part of a fused attn_qkv weight: the extracted tensors keyed as "<part>.weight"
-// [+ ".scales" [+ ".zp"]] plus the shared quant type. Used by the GGUF builder to emit a
+// One split part of a fused attn_qkv weight: its extracted tensors and shared quant type.
+// Used by the GGUF builder to emit a
 // GGML_OP_NONE weight leaf per q/k/v part (routing them through translate_weight like any other
 // weight) instead of building the decompression nodes eagerly.
 struct FusedQkvPart {
-    std::unordered_map<std::string, ov::Tensor> extracted;
+    WeightTensors tensors;
     GgufTensorType qtype = GGUF_TYPE_F16;
 };
 
-// Row-slice a fused `<base>` attn_qkv weight into q/k/v extracted-tensor sub-maps (no OV nodes).
-// The returned parts' tensors are keyed "<base>.q.weight"/".scales"/".zp" etc. Same slicing as
-// make_fused_qkv_weights, but returns the extracted payload for GGML_OP_NONE emission.
+// Row-slice a fused `<base>` attn_qkv weight into q/k/v tensor payloads (no OV nodes).
 std::array<FusedQkvPart, 3> split_fused_qkv_extracted(const std::string& base,
                                                       const std::unordered_map<std::string, ov::Tensor>& weights,
                                                       const std::unordered_map<std::string, GgufTensorType>& qtypes,
@@ -105,7 +106,7 @@ std::array<ov::Tensor, 3> split_fused_qkv_bias(const std::string& base,
 
 // De-interleave a qwen35 `<base>` attn_q weight, which packs the query and the attention output
 // gate per head as [q_h0 | gate_h0 | q_h1 | gate_h1 | ...], into two plain projections.
-// Returns {query, gate}, keyed "<base>.q.*" and "<base>.gate.*".
+// Returns {query, gate}.
 std::array<FusedQkvPart, 2> split_interleaved_q_gate(const std::string& base,
                                                      const std::unordered_map<std::string, ov::Tensor>& weights,
                                                      const std::unordered_map<std::string, GgufTensorType>& qtypes,

--- a/src/frontends/gguf/tests/test_weights.cpp
+++ b/src/frontends/gguf/tests/test_weights.cpp
@@ -286,3 +286,13 @@ TEST(GGUFFusedQkvWeight, PreservesScalesForMxfp4AndQ8K) {
     check(ov::frontend::gguf::GGUF_TYPE_MXFP4, ov::element::f4e2m1, ov::element::f8e8m0, 8);
     check(ov::frontend::gguf::GGUF_TYPE_Q8_K, ov::element::i8, ov::element::f32, 1);
 }
+
+TEST(GGUFWeight, RejectsMissingAuxiliaryTensors) {
+    using namespace ov::frontend::gguf;
+
+    WeightTensors without_scales{ov::Tensor(ov::element::i4, {1, 32}), {}, {}};
+    EXPECT_THROW(make_weight_node(without_scales, GGUF_TYPE_Q4_0), ov::Exception);
+
+    WeightTensors without_zero_point{ov::Tensor(ov::element::u32, {1, 4}), ov::Tensor(ov::element::f16, {1, 1}), {}};
+    EXPECT_THROW(make_weight_node(without_zero_point, GGUF_TYPE_Q4_K), ov::Exception);
+}

--- a/src/frontends/gguf/tests/test_weights.cpp
+++ b/src/frontends/gguf/tests/test_weights.cpp
@@ -256,3 +256,33 @@ TEST(GGUFFusedQkvBias, SplitsIntoExpectedRanges) {
         EXPECT_FLOAT_EQ(parts[2].data<float>()[i], static_cast<float>(n_q + n_k + i));
     }
 }
+
+TEST(GGUFFusedQkvWeight, PreservesScalesForMxfp4AndQ8K) {
+    const auto check = [](ov::frontend::gguf::GgufTensorType qtype,
+                          const ov::element::Type& weight_type,
+                          const ov::element::Type& scale_type,
+                          size_t groups) {
+        constexpr size_t rows = 6;
+        constexpr size_t cols = 256;
+        std::unordered_map<std::string, ov::Tensor> weights{
+            {"fused.weight", ov::Tensor(weight_type, {rows, cols})},
+            {"fused.scales", ov::Tensor(scale_type, {rows, groups})},
+        };
+        std::unordered_map<std::string, ov::frontend::gguf::GgufTensorType> qtypes{{"fused.qtype", qtype}};
+
+        auto qkv = ov::frontend::gguf::split_fused_qkv_extracted("fused", weights, qtypes, 2, 2, 2);
+        for (const auto& part : qkv) {
+            ASSERT_TRUE(part.tensors.scales);
+            EXPECT_EQ(part.tensors.scales.get_shape(), (ov::Shape{2, groups}));
+        }
+
+        auto q_gate = ov::frontend::gguf::split_interleaved_q_gate("fused", weights, qtypes, 1);
+        for (const auto& part : q_gate) {
+            ASSERT_TRUE(part.tensors.scales);
+            EXPECT_EQ(part.tensors.scales.get_shape(), (ov::Shape{3, groups}));
+        }
+    };
+
+    check(ov::frontend::gguf::GGUF_TYPE_MXFP4, ov::element::f4e2m1, ov::element::f8e8m0, 8);
+    check(ov::frontend::gguf::GGUF_TYPE_Q8_K, ov::element::i8, ov::element::f32, 1);
+}


### PR DESCRIPTION
### Details:
 - Replace string-keyed per-weight maps with a typed `WeightTensors` payload.
 - Centralize quantization format traits and route Q4_0 through the shared symmetric-i4 path.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - AI helped implement the refactoring and address review feedback. The changes were validated with the GGUF frontend build, clang-format target, and all 255 GGUF frontend tests.