### PR TITLE
[GPU] disable quantization for depthwise convolution layers

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/remove_fq_before_dw_conv.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/remove_fq_before_dw_conv.cpp
@@ -1,0 +1,251 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "remove_fq_before_dw_conv.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/group_conv.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/mvn.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+namespace ov::intel_gpu {
+
+namespace {
+
+constexpr size_t channel_axis = 1;
+constexpr size_t max_bridge_operations = 2;
+constexpr size_t max_depthwise_kernel_elements = 9;
+
+bool has_supported_depthwise_shape(const std::shared_ptr<ov::op::v1::GroupConvolution>& convolution) {
+    const auto& data_shape = convolution->get_input_partial_shape(0);
+    const auto& weights_shape = convolution->get_input_partial_shape(1);
+    const auto& output_shape = convolution->get_output_partial_shape(0);
+    if (!data_shape[channel_axis].is_static() || !weights_shape.is_static() || !output_shape[channel_axis].is_static()) {
+        return false;
+    }
+
+    if (data_shape.size() != 4 || weights_shape.size() != 5 || output_shape.size() != 4) {
+        return false;
+    }
+
+    const size_t groups = weights_shape[0].get_length();
+    if (groups <= 1 || weights_shape[1] != 1 || weights_shape[2] != 1 || data_shape[channel_axis] != groups || output_shape[channel_axis] != groups) {
+        return false;
+    }
+
+    const size_t kernel_y = weights_shape[3].get_length();
+    const size_t kernel_x = weights_shape[4].get_length();
+    return kernel_y > 0 && kernel_x > 0 && kernel_y <= max_depthwise_kernel_elements && kernel_x <= max_depthwise_kernel_elements &&
+           kernel_y * kernel_x <= max_depthwise_kernel_elements;
+}
+
+bool has_channelwise_fake_quantize(const std::shared_ptr<ov::op::v0::FakeQuantize>& fake_quantize, const std::shared_ptr<ov::op::v1::GroupConvolution>& convolution) {
+    if (convolution->get_input_partial_shape(0)[channel_axis].is_dynamic()) {
+        return false;
+    }
+    size_t channels = convolution->get_input_partial_shape(0)[channel_axis].get_length();
+
+    const ov::Shape expected_shape{1, channels, 1, 1};
+    for (size_t index = 1; index < fake_quantize->get_input_size(); ++index) {
+        const auto constant = ov::as_type_ptr<ov::op::v0::Constant>(fake_quantize->get_input_node_shared_ptr(index));
+        if (constant == nullptr || constant->get_shape() != expected_shape) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool has_channelwise_int8_weights(const std::shared_ptr<ov::op::v1::GroupConvolution>& convolution) {
+    const auto multiply = ov::as_type_ptr<ov::op::v1::Multiply>(convolution->get_input_node_shared_ptr(1));
+    if (multiply == nullptr) {
+        return false;
+    }
+
+    const auto weights_shape = convolution->get_input_partial_shape(1);
+    const ov::PartialShape expected_scale_shape{weights_shape[0], 1, 1, 1, 1};
+    for (size_t scale_index = 0; scale_index < 2; ++scale_index) {
+        const auto scale = ov::as_type_ptr<ov::op::v0::Constant>(multiply->get_input_node_shared_ptr(scale_index));
+        const auto convert = ov::as_type_ptr<ov::op::v0::Convert>(multiply->get_input_node_shared_ptr(1 - scale_index));
+        if (scale == nullptr || scale->get_output_partial_shape(0) != expected_scale_shape || convert == nullptr) {
+            continue;
+        }
+
+        const auto weights = ov::as_type_ptr<ov::op::v0::Constant>(convert->get_input_node_shared_ptr(0));
+        if (weights == nullptr || weights->get_output_partial_shape(0) != weights_shape) {
+            continue;
+        }
+
+        const auto weights_type = weights->get_element_type();
+        if (weights_type == ov::element::i8 || weights_type == ov::element::u8) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::optional<size_t> get_transposed_channel_axis(const std::shared_ptr<ov::op::v1::Transpose>& transpose, size_t current_channel_axis) {
+    const auto rank = transpose->get_input_partial_shape(0).rank();
+    if (rank.is_dynamic() || rank.get_length() <= 0 || static_cast<uint64_t>(rank.get_length()) > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+        return std::nullopt;
+    }
+
+    const auto order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+    if (order == nullptr) {
+        return std::nullopt;
+    }
+
+    const int64_t rank_value = rank.get_length();
+    const auto order_values = order->cast_vector<int64_t>();
+    if (order_values.size() != static_cast<size_t>(rank_value) || current_channel_axis >= order_values.size()) {
+        return std::nullopt;
+    }
+
+    std::vector<bool> visited_axes(order_values.size(), false);
+    std::optional<size_t> new_channel_axis;
+    for (size_t output_axis = 0; output_axis < order_values.size(); ++output_axis) {
+        int64_t input_axis = order_values[output_axis];
+        if (input_axis < 0) {
+            input_axis += rank_value;
+        }
+        if (input_axis < 0 || input_axis >= rank_value || visited_axes[static_cast<size_t>(input_axis)]) {
+            return std::nullopt;
+        }
+
+        visited_axes[static_cast<size_t>(input_axis)] = true;
+        if (static_cast<size_t>(input_axis) == current_channel_axis) {
+            new_channel_axis = output_axis;
+        }
+    }
+
+    return new_channel_axis;
+}
+
+bool mvn_reduces_channel(const std::shared_ptr<ov::Node>& node, size_t current_channel_axis) {
+    const auto rank = node->get_input_partial_shape(0).rank();
+    if (rank.is_dynamic() || rank.get_length() <= 0 || static_cast<uint64_t>(rank.get_length()) > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+        current_channel_axis >= static_cast<size_t>(rank.get_length())) {
+        return false;
+    }
+
+    if (const auto mvn = ov::as_type_ptr<ov::op::v0::MVN>(node)) {
+        return mvn->get_reduction_axes().count(current_channel_axis) != 0;
+    }
+
+    const auto mvn = ov::as_type_ptr<ov::op::v6::MVN>(node);
+    if (mvn == nullptr) {
+        return false;
+    }
+
+    const auto axes = ov::as_type_ptr<ov::op::v0::Constant>(mvn->get_input_node_shared_ptr(1));
+    if (axes == nullptr) {
+        return false;
+    }
+
+    const int64_t rank_value = rank.get_length();
+    for (int64_t axis : axes->cast_vector<int64_t>()) {
+        if (axis < 0) {
+            axis += rank_value;
+        }
+        if (axis < 0 || axis >= rank_value) {
+            return false;
+        }
+        if (static_cast<size_t>(axis) == current_channel_axis) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool has_mvn_dequantization_barrier(const ov::Output<ov::Node>& output, size_t current_channel_axis, size_t bridge_operations = 0) {
+    for (const auto& target_input : output.get_target_inputs()) {
+        const auto consumer = target_input.get_node()->shared_from_this();
+        if (target_input.get_index() == 0 && mvn_reduces_channel(consumer, current_channel_axis)) {
+            return true;
+        }
+
+        if (bridge_operations >= max_bridge_operations) {
+            continue;
+        }
+
+        if (const auto add = ov::as_type_ptr<ov::op::v1::Add>(consumer)) {
+            const size_t data_index = target_input.get_index();
+            if (data_index >= add->get_input_size()) {
+                continue;
+            }
+
+            const size_t other_index = 1 - data_index;
+            if (ov::is_type<ov::op::v0::Constant>(add->get_input_node_shared_ptr(other_index)) &&
+                has_mvn_dequantization_barrier(add->output(0), current_channel_axis, bridge_operations + 1)) {
+                return true;
+            }
+        } else if (const auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(consumer)) {
+            if (target_input.get_index() != 0) {
+                continue;
+            }
+
+            const auto transposed_channel_axis = get_transposed_channel_axis(transpose, current_channel_axis);
+            if (transposed_channel_axis.has_value() && has_mvn_dequantization_barrier(transpose->output(0), *transposed_channel_axis, bridge_operations + 1)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+}  // namespace
+
+RemoveFakeQuantizeBeforeDepthwiseConv::RemoveFakeQuantizeBeforeDepthwiseConv() {
+    auto group_convolution_pattern = ov::pass::pattern::wrap_type<ov::op::v1::GroupConvolution>();
+
+    ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& matcher) {
+        const auto group_convolution = ov::as_type_ptr<ov::op::v1::GroupConvolution>(matcher.get_match_root());
+        if (group_convolution == nullptr || !has_supported_depthwise_shape(group_convolution)) {
+            return false;
+        }
+
+        const auto fake_quantize = ov::as_type_ptr<ov::op::v0::FakeQuantize>(group_convolution->get_input_node_shared_ptr(0));
+        if (fake_quantize == nullptr || !has_channelwise_fake_quantize(fake_quantize, group_convolution) ||
+            !has_channelwise_int8_weights(group_convolution)) {
+            return false;
+        }
+
+        const auto fq_consumers = fake_quantize->output(0).get_target_inputs();
+        if (fq_consumers.size() != 1) {
+            return false;
+        }
+
+        const auto& fq_consumer = *fq_consumers.begin();
+        if (fq_consumer.get_node() != group_convolution.get() || fq_consumer.get_index() != 0) {
+            return false;
+        }
+
+        const auto fq_data = fake_quantize->input_value(0);
+        if (fq_data.get_target_inputs().size() < 2 || !has_mvn_dequantization_barrier(group_convolution->output(0), channel_axis)) {
+            return false;
+        }
+
+        group_convolution->input(0).replace_source_output(fq_data);
+        return true;
+    };
+
+    auto matcher = std::make_shared<ov::pass::pattern::Matcher>(group_convolution_pattern, "RemoveFakeQuantizeBeforeDepthwiseConv");
+    register_matcher(matcher, callback);
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/remove_fq_before_dw_conv.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/remove_fq_before_dw_conv.cpp
@@ -204,7 +204,9 @@ bool has_mvn_dequantization_barrier(const ov::Output<ov::Node>& output, size_t c
                 continue;
             }
             return false;
-        } else if (const auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(consumer)) {
+        }
+
+        if (const auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(consumer)) {
             if (target_input.get_index() != 0) {
                 return false;
             }
@@ -214,9 +216,9 @@ bool has_mvn_dequantization_barrier(const ov::Output<ov::Node>& output, size_t c
                 continue;
             }
             return false;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     return true;

--- a/src/plugins/intel_gpu/src/plugin/transformations/remove_fq_before_dw_conv.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/remove_fq_before_dw_conv.cpp
@@ -32,11 +32,11 @@ bool has_supported_depthwise_shape(const std::shared_ptr<ov::op::v1::GroupConvol
     const auto& data_shape = convolution->get_input_partial_shape(0);
     const auto& weights_shape = convolution->get_input_partial_shape(1);
     const auto& output_shape = convolution->get_output_partial_shape(0);
-    if (!data_shape[channel_axis].is_static() || !weights_shape.is_static() || !output_shape[channel_axis].is_static()) {
+    if (data_shape.rank() != 4 || weights_shape.rank() != 5 || output_shape.rank() != 4) {
         return false;
     }
 
-    if (data_shape.size() != 4 || weights_shape.size() != 5 || output_shape.size() != 4) {
+    if (!data_shape[channel_axis].is_static() || !weights_shape.is_static() || !output_shape[channel_axis].is_static()) {
         return false;
     }
 
@@ -51,11 +51,13 @@ bool has_supported_depthwise_shape(const std::shared_ptr<ov::op::v1::GroupConvol
            kernel_y * kernel_x <= max_depthwise_kernel_elements;
 }
 
+// Precondition: data_shape.rank() == 4 and channel dimension is static, checked by has_supported_depthwise_shape.
 bool has_channelwise_fake_quantize(const std::shared_ptr<ov::op::v0::FakeQuantize>& fake_quantize, const std::shared_ptr<ov::op::v1::GroupConvolution>& convolution) {
-    if (convolution->get_input_partial_shape(0)[channel_axis].is_dynamic()) {
+    const auto& data_shape = convolution->get_input_partial_shape(0);
+    if (data_shape.rank() != 4 || data_shape[channel_axis].is_dynamic()) {
         return false;
     }
-    size_t channels = convolution->get_input_partial_shape(0)[channel_axis].get_length();
+    size_t channels = data_shape[channel_axis].get_length();
 
     const ov::Shape expected_shape{1, channels, 1, 1};
     for (size_t index = 1; index < fake_quantize->get_input_size(); ++index) {
@@ -75,6 +77,9 @@ bool has_channelwise_int8_weights(const std::shared_ptr<ov::op::v1::GroupConvolu
     }
 
     const auto weights_shape = convolution->get_input_partial_shape(1);
+    if (weights_shape.rank() != 5) {
+        return false;
+    }
     const ov::PartialShape expected_scale_shape{weights_shape[0], 1, 1, 1, 1};
     for (size_t scale_index = 0; scale_index < 2; ++scale_index) {
         const auto scale = ov::as_type_ptr<ov::op::v0::Constant>(multiply->get_input_node_shared_ptr(scale_index));
@@ -172,40 +177,49 @@ bool mvn_reduces_channel(const std::shared_ptr<ov::Node>& node, size_t current_c
 }
 
 bool has_mvn_dequantization_barrier(const ov::Output<ov::Node>& output, size_t current_channel_axis, size_t bridge_operations = 0) {
-    for (const auto& target_input : output.get_target_inputs()) {
+    const auto target_inputs = output.get_target_inputs();
+    if (target_inputs.empty()) {
+        return false;
+    }
+
+    for (const auto& target_input : target_inputs) {
         const auto consumer = target_input.get_node()->shared_from_this();
         if (target_input.get_index() == 0 && mvn_reduces_channel(consumer, current_channel_axis)) {
-            return true;
+            continue;
         }
 
         if (bridge_operations >= max_bridge_operations) {
-            continue;
+            return false;
         }
 
         if (const auto add = ov::as_type_ptr<ov::op::v1::Add>(consumer)) {
             const size_t data_index = target_input.get_index();
             if (data_index >= add->get_input_size()) {
-                continue;
+                return false;
             }
 
             const size_t other_index = 1 - data_index;
             if (ov::is_type<ov::op::v0::Constant>(add->get_input_node_shared_ptr(other_index)) &&
                 has_mvn_dequantization_barrier(add->output(0), current_channel_axis, bridge_operations + 1)) {
-                return true;
+                continue;
             }
+            return false;
         } else if (const auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(consumer)) {
             if (target_input.get_index() != 0) {
-                continue;
+                return false;
             }
 
             const auto transposed_channel_axis = get_transposed_channel_axis(transpose, current_channel_axis);
             if (transposed_channel_axis.has_value() && has_mvn_dequantization_barrier(transpose->output(0), *transposed_channel_axis, bridge_operations + 1)) {
-                return true;
+                continue;
             }
+            return false;
+        } else {
+            return false;
         }
     }
 
-    return false;
+    return true;
 }
 
 }  // namespace

--- a/src/plugins/intel_gpu/src/plugin/transformations/remove_fq_before_dw_conv.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/remove_fq_before_dw_conv.hpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+
+namespace ov::intel_gpu {
+
+class RemoveFakeQuantizeBeforeDepthwiseConv : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("RemoveFakeQuantizeBeforeDepthwiseConv");
+    RemoveFakeQuantizeBeforeDepthwiseConv();
+};
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -116,6 +116,7 @@
 #include "plugin/transformations/optimize_subsequent_reshapes.hpp"
 #include "plugin/transformations/print_model_statistics.hpp"
 #include "plugin/transformations/reduce_fc_dimensions.hpp"
+#include "plugin/transformations/remove_fq_before_dw_conv.hpp"
 #include "plugin/transformations/sink_reshape.hpp"
 #include "plugin/transformations/transpose_fusion.hpp"
 #include "plugin/transformations/sdpa_transpose_fusion.hpp"
@@ -1345,6 +1346,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                        ov::is_type<ov::op::v1::Convolution>(first_dep) ||
                        ov::is_type<ov::op::v1::Convolution>(second_dep);
         });
+
+        if (enableInt8 && infer_precision == ov::element::f16) {
+            manager.register_pass<RemoveFakeQuantizeBeforeDepthwiseConv>();
+        }
 
         manager.run_passes(func);
     }

--- a/src/plugins/intel_gpu/tests/unit/transformations/remove_fq_before_dw_conv_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/remove_fq_before_dw_conv_test.cpp
@@ -214,7 +214,7 @@ TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeWithFloatingPoi
 TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForDynamicShape) {
     GraphOptions options;
     options.dynamic_spatial_shape = true;
-    run_pass_and_check(options, false);
+    run_pass_and_check(options, true);
 }
 
 }  // namespace ov::test::intel_gpu

--- a/src/plugins/intel_gpu/tests/unit/transformations/remove_fq_before_dw_conv_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/remove_fq_before_dw_conv_test.cpp
@@ -1,0 +1,220 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plugin/transformations/remove_fq_before_dw_conv.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "openvino/core/model.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/group_conv.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/mvn.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/pass/manager.hpp"
+
+namespace ov::test::intel_gpu {
+
+namespace {
+
+struct GraphOptions {
+    bool shared_parent = true;
+    bool shared_fake_quantize = false;
+    bool with_mvn = true;
+    bool mvn_reduces_channel = true;
+    bool channelwise_fake_quantize = true;
+    bool constant_fake_quantize_bounds = true;
+    bool quantized_weights = true;
+    bool dynamic_spatial_shape = false;
+    size_t groups = 8;
+    size_t input_channels_per_group = 1;
+    size_t output_channels_per_group = 1;
+    size_t kernel_size = 3;
+};
+
+struct TestGraph {
+    std::shared_ptr<ov::Model> model;
+    std::shared_ptr<ov::op::v0::Relu> parent;
+    std::shared_ptr<ov::op::v0::FakeQuantize> fake_quantize;
+    std::shared_ptr<ov::op::v1::GroupConvolution> convolution;
+    std::shared_ptr<ov::Node> weights;
+    std::shared_ptr<ov::op::v0::Relu> parent_consumer;
+};
+
+TestGraph make_test_graph(const GraphOptions& options) {
+    const size_t in_channels = options.groups * options.input_channels_per_group;
+    const size_t output_channels = options.groups * options.output_channels_per_group;
+    const ov::PartialShape data_shape = options.dynamic_spatial_shape ? ov::PartialShape{1, ov::Dimension::value_type(in_channels), -1, -1} : ov::PartialShape{1, ov::Dimension::value_type(in_channels), 8, 8};
+
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, data_shape);
+    auto parent = std::make_shared<ov::op::v0::Relu>(input);
+    ov::ParameterVector parameters{input};
+
+    const ov::Shape fq_shape = options.channelwise_fake_quantize ? ov::Shape{1, in_channels, 1, 1} : ov::Shape{};
+    auto make_fq_bound = [&](float value) -> ov::Output<ov::Node> {
+        if (options.constant_fake_quantize_bounds) {
+            return ov::op::v0::Constant::create(ov::element::f16, fq_shape, {value});
+        }
+
+        auto parameter = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, fq_shape);
+        parameters.push_back(parameter);
+        return parameter;
+    };
+
+    auto fake_quantize =
+        std::make_shared<ov::op::v0::FakeQuantize>(parent, make_fq_bound(-1.f), make_fq_bound(1.f), make_fq_bound(-128.f), make_fq_bound(127.f), 256);
+
+    const ov::Shape weights_shape{options.groups,
+                                  options.output_channels_per_group,
+                                  options.input_channels_per_group,
+                                  options.kernel_size,
+                                  options.kernel_size};
+    std::shared_ptr<ov::Node> weights;
+    if (options.quantized_weights) {
+        auto compressed_weights = ov::op::v0::Constant::create(ov::element::i8, weights_shape, {1});
+        auto convert = std::make_shared<ov::op::v0::Convert>(compressed_weights, ov::element::f16);
+        auto scale = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{options.groups, options.output_channels_per_group, 1, 1, 1}, {0.1f});
+        weights = std::make_shared<ov::op::v1::Multiply>(convert, scale);
+    } else {
+        weights = ov::op::v0::Constant::create(ov::element::f16, weights_shape, {0.1f});
+    }
+
+    const auto padding = static_cast<ptrdiff_t>(options.kernel_size / 2);
+    auto convolution = std::make_shared<ov::op::v1::GroupConvolution>(fake_quantize,
+                                                                      weights,
+                                                                      ov::Strides{1, 1},
+                                                                      ov::CoordinateDiff{padding, padding},
+                                                                      ov::CoordinateDiff{padding, padding},
+                                                                      ov::Strides{1, 1});
+    auto bias = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1, output_channels, 1, 1}, {0.f});
+    auto add = std::make_shared<ov::op::v1::Add>(convolution, bias);
+    auto order = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 3, 1});
+    auto transpose = std::make_shared<ov::op::v1::Transpose>(add, order);
+
+    std::shared_ptr<ov::Node> main_output = transpose;
+    if (options.with_mvn) {
+        const std::vector<int64_t> axes_values = options.mvn_reduces_channel ? std::vector<int64_t>{-1} : std::vector<int64_t>{1};
+        auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, axes_values);
+        main_output = std::make_shared<ov::op::v6::MVN>(transpose, axes, true, 1e-6f, ov::op::MVNEpsMode::INSIDE_SQRT);
+    }
+
+    ov::OutputVector outputs{main_output};
+    std::shared_ptr<ov::op::v0::Relu> parent_consumer;
+    if (options.shared_parent) {
+        parent_consumer = std::make_shared<ov::op::v0::Relu>(parent);
+        outputs.push_back(parent_consumer);
+    }
+    if (options.shared_fake_quantize) {
+        outputs.push_back(std::make_shared<ov::op::v0::Relu>(fake_quantize));
+    }
+
+    return {std::make_shared<ov::Model>(outputs, parameters), parent, fake_quantize, convolution, weights, parent_consumer};
+}
+
+void run_pass_and_check(const GraphOptions& options, bool expect_removal) {
+    auto graph = make_test_graph(options);
+
+    ov::pass::Manager manager;
+    manager.register_pass<ov::intel_gpu::RemoveFakeQuantizeBeforeDepthwiseConv>();
+    manager.run_passes(graph.model);
+
+    EXPECT_EQ(graph.convolution->get_input_node_shared_ptr(1), graph.weights);
+    if (expect_removal) {
+        EXPECT_EQ(graph.convolution->get_input_node_shared_ptr(0), graph.parent);
+        EXPECT_TRUE(graph.fake_quantize->output(0).get_target_inputs().empty());
+        const auto ordered_ops = graph.model->get_ordered_ops();
+        EXPECT_TRUE(std::none_of(ordered_ops.begin(), ordered_ops.end(), [](const std::shared_ptr<ov::Node>& node) {
+            return ov::is_type<ov::op::v0::FakeQuantize>(node);
+        }));
+        ASSERT_NE(graph.parent_consumer, nullptr);
+        EXPECT_EQ(graph.parent_consumer->get_input_node_shared_ptr(0), graph.parent);
+    } else {
+        EXPECT_EQ(graph.convolution->get_input_node_shared_ptr(0), graph.fake_quantize);
+    }
+}
+
+}  // namespace
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, RemovesMatchingFakeQuantize) {
+    run_pass_and_check(GraphOptions{}, true);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForSingleConsumerParent) {
+    GraphOptions options;
+    options.shared_parent = false;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsSharedFakeQuantize) {
+    GraphOptions options;
+    options.shared_fake_quantize = true;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForNonDepthwiseConvolution) {
+    GraphOptions options;
+    options.groups = 4;
+    options.input_channels_per_group = 2;
+    options.output_channels_per_group = 2;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForChannelMultiplier) {
+    GraphOptions options;
+    options.output_channels_per_group = 2;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForLargeKernel) {
+    GraphOptions options;
+    options.kernel_size = 5;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeWithoutMvn) {
+    GraphOptions options;
+    options.with_mvn = false;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeWhenMvnDoesNotReduceChannel) {
+    GraphOptions options;
+    options.mvn_reduces_channel = false;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsPerTensorFakeQuantize) {
+    GraphOptions options;
+    options.channelwise_fake_quantize = false;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeWithDynamicBounds) {
+    GraphOptions options;
+    options.constant_fake_quantize_bounds = false;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeWithFloatingPointWeights) {
+    GraphOptions options;
+    options.quantized_weights = false;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForDynamicShape) {
+    GraphOptions options;
+    options.dynamic_spatial_shape = true;
+    run_pass_and_check(options, false);
+}
+
+}  // namespace ov::test::intel_gpu

--- a/src/plugins/intel_gpu/tests/unit/transformations/remove_fq_before_dw_conv_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/remove_fq_before_dw_conv_test.cpp
@@ -211,7 +211,7 @@ TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeWithFloatingPoi
     run_pass_and_check(options, false);
 }
 
-TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForDynamicShape) {
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, RemovesFakeQuantizeForDynamicShape) {
     GraphOptions options;
     options.dynamic_spatial_shape = true;
     run_pass_and_check(options, true);

--- a/src/plugins/intel_gpu/tests/unit/transformations/remove_fq_before_dw_conv_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/remove_fq_before_dw_conv_test.cpp
@@ -30,12 +30,14 @@ namespace {
 struct GraphOptions {
     bool shared_parent = true;
     bool shared_fake_quantize = false;
+    bool shared_convolution = false;
     bool with_mvn = true;
     bool mvn_reduces_channel = true;
     bool channelwise_fake_quantize = true;
     bool constant_fake_quantize_bounds = true;
     bool quantized_weights = true;
     bool dynamic_spatial_shape = false;
+    bool dynamic_rank = false;
     size_t groups = 8;
     size_t input_channels_per_group = 1;
     size_t output_channels_per_group = 1;
@@ -54,7 +56,10 @@ struct TestGraph {
 TestGraph make_test_graph(const GraphOptions& options) {
     const size_t in_channels = options.groups * options.input_channels_per_group;
     const size_t output_channels = options.groups * options.output_channels_per_group;
-    const ov::PartialShape data_shape = options.dynamic_spatial_shape ? ov::PartialShape{1, ov::Dimension::value_type(in_channels), -1, -1} : ov::PartialShape{1, ov::Dimension::value_type(in_channels), 8, 8};
+    const ov::PartialShape data_shape = options.dynamic_rank
+                                            ? ov::PartialShape::dynamic()
+                                            : (options.dynamic_spatial_shape ? ov::PartialShape{1, ov::Dimension::value_type(in_channels), -1, -1}
+                                                                             : ov::PartialShape{1, ov::Dimension::value_type(in_channels), 8, 8});
 
     auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, data_shape);
     auto parent = std::make_shared<ov::op::v0::Relu>(input);
@@ -116,6 +121,9 @@ TestGraph make_test_graph(const GraphOptions& options) {
     }
     if (options.shared_fake_quantize) {
         outputs.push_back(std::make_shared<ov::op::v0::Relu>(fake_quantize));
+    }
+    if (options.shared_convolution) {
+        outputs.push_back(std::make_shared<ov::op::v0::Relu>(convolution));
     }
 
     return {std::make_shared<ov::Model>(outputs, parameters), parent, fake_quantize, convolution, weights, parent_consumer};
@@ -215,6 +223,18 @@ TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, RemovesFakeQuantizeForDynamicSha
     GraphOptions options;
     options.dynamic_spatial_shape = true;
     run_pass_and_check(options, true);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForDynamicRank) {
+    GraphOptions options;
+    options.dynamic_rank = true;
+    run_pass_and_check(options, false);
+}
+
+TEST(RemoveFakeQuantizeBeforeDepthwiseConvTest, KeepsFakeQuantizeForBranchingConvolutionOutput) {
+    GraphOptions options;
+    options.shared_convolution = true;
+    run_pass_and_check(options, false);
 }
 
 }  // namespace ov::test::intel_gpu


### PR DESCRIPTION
### Details:
- In the case of INT8-quantized depthwise convolutions, the overhead of a non-fused quantization layer could exceed the performance gains achieved by executing the convolution in INT8 instead of FP16.
  - The newly added transformation is applied only when
    - Small, memory-bound INT8 depthwise convolution
    - Channel-wise activation FakeQuantize with INT8/UINT8 weights
    - Multiple consumers of the FakeQuantize parent, requiring branch-local quantization
    - All convolution output paths reaching a channel-reducing MVN
- This PR aims to improve overall performance by disabling quantization in such cases.

### Tickets:
 - 193541

### AI Assistance:
 - *AI assistance used: yes*