### PR TITLE
[GPU] Hold weak references in remote context memory cache (backport to 2026.4 release)

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
@@ -102,7 +102,8 @@ private:
     ContextType m_type;
     std::string m_device_name;
     static const size_t cache_capacity = 100;
-    cldnn::LruCache<size_t, cldnn::memory::ptr> m_memory_cache = cldnn::LruCache<size_t, cldnn::memory::ptr>(cache_capacity);
+    cldnn::LruCache<size_t, std::weak_ptr<cldnn::memory>> m_memory_cache =
+        cldnn::LruCache<size_t, std::weak_ptr<cldnn::memory>>(cache_capacity);
     std::mutex m_cache_mutex;
 
     bool m_is_initialized = false;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/lru_cache.hpp
@@ -96,6 +96,23 @@ public:
     }
 
     /**
+     * @brief Remove the entry associated with a key
+     *
+     * @param key
+     * @return true if any value associated with the key was existed and removed
+     * @return false otherwise
+     */
+    bool erase(const Key& key) {
+        auto iter = _key_map.find(key);
+        if (iter == _key_map.end())
+            return false;
+
+        _lru_data_list.erase(iter->second);
+        _key_map.erase(iter);
+        return true;
+    }
+
+    /**
      * @brief Remove all entries
      *
      */
@@ -204,6 +221,11 @@ public:
     Value get(const Key& key) {
         std::lock_guard<std::mutex> lock(_mutex);
         return parent::get(key);
+    }
+
+    bool erase(const Key& key) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return parent::erase(key);
     }
 
     void set_remove_item_callback(FuncRemoveItem callback) {

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -251,15 +251,18 @@ const std::string& RemoteContextImpl::get_device_name() const {
 
 cldnn::memory::ptr RemoteContextImpl::try_get_cached_memory(size_t hash) {
     std::lock_guard<std::mutex> lock(m_cache_mutex);
-    if (m_memory_cache.has(hash))
-        return m_memory_cache.get(hash).lock();
+    if (!m_memory_cache.has(hash))
+        return nullptr;
 
+    if (auto memory = m_memory_cache.get(hash).lock())
+        return memory;
+
+    // The last tensor which wrapped that memory is gone, so the entry is erased instead of being kept as the most recently used one
+    m_memory_cache.erase(hash);
     return nullptr;
 }
 
 void RemoteContextImpl::add_to_cache(size_t hash, cldnn::memory::ptr memory) {
-    if (!memory)
-        return;
     std::lock_guard<std::mutex> lock(m_cache_mutex);
     m_memory_cache.add(hash, memory);
 }

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -252,12 +252,14 @@ const std::string& RemoteContextImpl::get_device_name() const {
 cldnn::memory::ptr RemoteContextImpl::try_get_cached_memory(size_t hash) {
     std::lock_guard<std::mutex> lock(m_cache_mutex);
     if (m_memory_cache.has(hash))
-        return m_memory_cache.get(hash);
+        return m_memory_cache.get(hash).lock();
 
     return nullptr;
 }
 
 void RemoteContextImpl::add_to_cache(size_t hash, cldnn::memory::ptr memory) {
+    if (!memory)
+        return;
     std::lock_guard<std::mutex> lock(m_cache_mutex);
     m_memory_cache.add(hash, memory);
 }

--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -453,7 +453,7 @@ void RemoteTensorImpl::allocate() {
     update_properties();
     update_strides();
 
-    if (enable_caching)
+    if (enable_caching && m_memory_object)
         context->add_to_cache(m_hash, m_memory_object);
 }
 

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/ocl_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/ocl_remote_tensor_tests.cpp
@@ -8,6 +8,12 @@
 #include <filesystem>
 #include <fstream>
 
+#if !defined(_WIN32)
+# include <fcntl.h>
+# include <sys/mman.h>
+# include <unistd.h>
+#endif
+
 #include "openvino/core/preprocess/pre_post_process.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/constant.hpp"
@@ -3107,6 +3113,155 @@ TEST(GpuRemoteTensorFromCpu, smoke_allocAlignedCPUMemory) {
     ov::util::aligned_free(input_ptr);
     ov::util::aligned_free(output_ptr);
 }
+
+TEST(GpuRemoteTensorFromCpu, smoke_reuseImportOfSameCPUMemory) {
+    ov::Core core;
+    std::string target_device = ov::test::utils::DEVICE_GPU;
+    uint32_t cacheline_size = core.get_property(target_device, ov::intel_gpu::cacheline_size);
+    ASSERT_GT(cacheline_size, 0u);
+    const ov::Shape shape{cacheline_size / sizeof(float)};
+    const size_t byte_size = ov::shape_size(shape) * sizeof(float);
+    auto ctx = core.get_default_context(target_device).as<ov::intel_gpu::ocl::ClContext>();
+    void* input_ptr = ov::util::aligned_alloc(byte_size, cacheline_size);
+
+    {
+        auto first_tensor =
+            ctx.create_tensor(ov::element::f32,
+                              shape,
+                              ov::intel_gpu::VirtualAddressMemory(input_ptr, static_cast<int64_t>(byte_size)));
+        auto second_tensor =
+            ctx.create_tensor(ov::element::f32,
+                              shape,
+                              ov::intel_gpu::VirtualAddressMemory(input_ptr, static_cast<int64_t>(byte_size)));
+
+        // Both tensors are alive, so the second import is expected to be served from the context memory cache.
+        EXPECT_EQ(first_tensor.get(), second_tensor.get());
+    }
+
+    ov::util::aligned_free(input_ptr);
+}
+
+#if !defined(_WIN32)
+// Regression test for a cached host pointer import which outlived every tensor that wrapped it: once the
+// application maps another file over the same virtual address range, the cache key repeats
+// (pointer, size, access mode, shape and element type are all unchanged), so a context lifetime entry
+// would hand out the buffer imported for the previous file instead of importing the new one.
+class GpuRemoteTensorFromRecycledMapping : public ::testing::Test {
+protected:
+    // Page aligned pointer and a size which is a multiple of any device cacheline size, as host pointer import requires
+    static constexpr size_t buffer_size = 64 * 1024;
+
+    std::filesystem::path m_first_file;
+    std::filesystem::path m_second_file;
+    void* m_mapping = nullptr;
+    void* m_output_ptr = nullptr;
+
+    void SetUp() override {
+        const auto prefix = ov::test::utils::generateTestFilePrefix();
+        m_first_file = prefix + "_first.bin";
+        m_second_file = prefix + "_second.bin";
+    }
+
+    void TearDown() override {
+        if (m_mapping != nullptr)
+            munmap(m_mapping, buffer_size);
+        if (m_output_ptr != nullptr)
+            ov::util::aligned_free(m_output_ptr);
+        std::error_code ec;
+        std::filesystem::remove(m_first_file, ec);
+        std::filesystem::remove(m_second_file, ec);
+    }
+
+    static void write_file(const std::filesystem::path& path, const std::vector<float>& values) {
+        std::ofstream file(path, std::ios::binary);
+        file.write(reinterpret_cast<const char*>(values.data()), values.size() * sizeof(float));
+    }
+
+    // MAP_FIXED replaces the previously mapped file at the very same address atomically, so the pointer the import
+    // is keyed on is guaranteed to be reused and there is no unmapped gap in between.
+    void map_over_reservation(const std::filesystem::path& path) {
+        const int fd = open(path.c_str(), O_RDWR);
+        ASSERT_NE(fd, -1);
+        void* ptr = mmap(m_mapping, buffer_size, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_PRIVATE, fd, 0);
+        close(fd);
+        ASSERT_NE(ptr, MAP_FAILED);
+        ASSERT_EQ(ptr, m_mapping);
+    }
+};
+
+TEST_F(GpuRemoteTensorFromRecycledMapping, smoke_remappedFileIsNotServedFromCache) {
+    ov::Core core;
+    std::string target_device = ov::test::utils::DEVICE_GPU;
+    const ov::Shape shape{buffer_size / sizeof(float)};
+    const size_t element_count = ov::shape_size(shape);
+
+    std::vector<float> first_values(element_count);
+    std::vector<float> second_values(element_count);
+    for (size_t i = 0; i < element_count; ++i) {
+        first_values[i] = static_cast<float>(i + 1);
+        second_values[i] = -static_cast<float>(i + 1);
+    }
+    write_file(m_first_file, first_values);
+    write_file(m_second_file, second_values);
+
+    // Reserve the range once, so both files can be mapped at exactly the same address
+    m_mapping = mmap(nullptr, buffer_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(m_mapping, MAP_FAILED);
+
+    uint32_t cacheline_size = core.get_property(target_device, ov::intel_gpu::cacheline_size);
+    ASSERT_GT(cacheline_size, 0u);
+    ASSERT_EQ(buffer_size % cacheline_size, 0u);
+    auto ctx = core.get_default_context(target_device).as<ov::intel_gpu::ocl::ClContext>();
+    m_output_ptr = ov::util::aligned_alloc(buffer_size, cacheline_size);
+
+    // The mapping is imported with CL_MEM_USE_HOST_PTR, so a host side read may return the content of the currently
+    // mapped file even when the device still sees the pages of the previously mapped one.
+    auto copy_mapping_on_device = [&]() {
+        std::fill_n(static_cast<float*>(m_output_ptr), element_count, 0.0f);
+        auto input_tensor = ctx.create_tensor(
+            ov::element::f32,
+            shape,
+            ov::intel_gpu::VirtualAddressMemory(m_mapping,
+                                                static_cast<int64_t>(buffer_size),
+                                                ov::intel_gpu::AccessMode::READ));
+        auto output_tensor =
+            ctx.create_tensor(ov::element::f32,
+                              shape,
+                              ov::intel_gpu::VirtualAddressMemory(m_output_ptr, static_cast<int64_t>(buffer_size)));
+
+        auto model = make_copy_model(shape);
+        auto compiled = core.compile_model(model, ctx);
+        auto infer_req = compiled.create_infer_request();
+        infer_req.set_tensor(compiled.input(), input_tensor);
+        infer_req.set_tensor(compiled.output(), output_tensor);
+        infer_req.infer();
+
+        const auto* output_values = static_cast<const float*>(m_output_ptr);
+        return std::vector<float>(output_values, output_values + element_count);
+    };
+
+    ASSERT_NO_FATAL_FAILURE(map_over_reservation(m_first_file));
+    const auto first_result = copy_mapping_on_device();
+    for (size_t i = 0; i < element_count; ++i) {
+        ASSERT_FLOAT_EQ(first_result[i], first_values[i]) << "Mismatch at index " << i;
+    }
+
+    ASSERT_NO_FATAL_FAILURE(map_over_reservation(m_second_file));
+    const auto second_result = copy_mapping_on_device();
+    for (size_t i = 0; i < element_count; ++i) {
+        ASSERT_FLOAT_EQ(second_result[i], second_values[i]) << "Mismatch at index " << i;
+    }
+
+    // Finally drop the mapping the entries were keyed on while keeping the address reserved and inaccessible.
+    ASSERT_NE(mmap(m_mapping, buffer_size, PROT_NONE, MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0), MAP_FAILED);
+    ASSERT_THROW(ctx.create_tensor(ov::element::f32,
+                                   shape,
+                                   ov::intel_gpu::VirtualAddressMemory(m_mapping,
+                                                                       static_cast<int64_t>(buffer_size),
+                                                                       ov::intel_gpu::AccessMode::READ)),
+                 ov::Exception);
+}
+#endif  // !defined(_WIN32)
 
 
 using MmapFileMemoryParams = std::tuple<std::size_t, std::size_t>;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/lru_caches_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/lru_caches_gpu_test.cpp
@@ -53,6 +53,30 @@ TEST(lru_cache, basic_data_type)
     }
 }
 
+TEST(lru_cache, erase)
+{
+    const size_t cap = 4;
+    LruCache<int, int> ca(cap);
+
+    for (int i = 1; i <= static_cast<int>(cap); i++) {
+        ca.add(i, i + 10);
+    }
+    ASSERT_EQ(ca.get_all_keys(), std::vector<int>({4, 3, 2, 1}));
+
+    ASSERT_FALSE(ca.erase(cap + 1));
+    ASSERT_EQ(ca.size(), cap);
+
+    ASSERT_TRUE(ca.erase(3));
+    ASSERT_FALSE(ca.has(3));
+    ASSERT_EQ(ca.size(), cap - 1);
+    ASSERT_EQ(ca.get_all_keys(), std::vector<int>({4, 2, 1}));
+
+    // Erasing an entry which has just been touched leaves the order of the remaining ones untouched
+    ca.get(1);
+    ASSERT_TRUE(ca.erase(1));
+    ASSERT_EQ(ca.get_all_keys(), std::vector<int>({4, 2}));
+}
+
 class lru_cache_test_data {
 public:
     lru_cache_test_data(int a, int b, int c) : x(a), y(b), z(c) {


### PR DESCRIPTION
### Details:
**Backport of https://github.com/openvinotoolkit/openvino/pull/37807 to 2026.4 release**

 - `RemoteContextImpl` caches imported external memory in an LRU cache (`m_memory_cache`, capacity 100) keyed by a hash of (mem handle, shared buffer handle, host pointer + size + access, surface id, plane, shape, element type). Entries were strong `cldnn::memory::ptr`, owned by the context, so an entry outlived every tensor that wrapped the external object it was keyed on.
 - For `BT_CPU_VA` the key is a raw host virtual address. When an application maps file A, imports it, then destroys the tensor, the inter request and the model and unmaps file A, the cache entry survives. If the OS then hands the address back for file B of the same size, every key component repeats and the import is served from the cache instead of being redone.

### Root cause:
 - A cached import is safe only when the key uniquely and stably identifies the imported object for the entry's lifetime. A context-lifetime entry cannot satisfy that for a recyclable key; it stays reachable after every user of the underlying object is gone, which is exactly when the key becomes free to be reissued to a different object.
 - Whether a stale hit corrupts data is driver-specific. On Windows the import pins the pages behind the original mapping, so the stale buffer keeps feeding the previous file's weights - that is the reported failure. On Linux /915/xe, `CL_MEM_USE_HOST_PTR | CL_MEM_FORCE_HOST_MEMORY_INTEL` resolves the virtual range (userptr + MMU notifier re-fault), so the same stale hit happens to read the newly mapped content and is benign. The unsound lifetime is common to both; only the visible symptom differs.

### The fix:
 - `m_memory_cache` now holds `std::weak_ptr<cldnn::memory>`. A hit therefore requires that some live memory object still wraps the external object, so an entry can never outlive its last user.

### Behavior changes:
 - Importing a DMA-buf fd transfers ownership to the driver, and releasing the `cl_mem` closes the descriptor. A strong cache entry used to keep the fd alive, so re-importing the same fd after the tensor was destroyed accidentally succeeded; it now fails with `CL_INVALID_MEM_OBJECT (-38)`, the same as with caching disabled. Correct usage passes a fresh descriptor per import.
 - Expired entries are not pruned explicitly - `cldnn::LruCache` has no `erase()`, and a miss in `allocate()` is always followed by add_to_cache() with the same key, which overwrites the value in place. Up to `cache_capacity` expired entries can occupy the cache and evict live ones; the only cost is a re-import.

### Tests:
 - `GpuRemoteTensorFromRecycledMapping.smoke_remappedFileIsNotServedFromCache` reproduces the recycled address deterministically with `MAP_FIXED`.

### Tickets:
 - CVS-192956