### PR TITLE
[PyTorch FE] Support aten::hypot operator

### DIFF
--- a/src/frontends/pytorch/src/op/hypot.cpp
+++ b/src/frontends/pytorch/src/op/hypot.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/sqrt.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_hypot(const NodeContext& context) {
+    // hypot(input, other, *) -> Tensor : elementwise sqrt(input^2 + other^2), with broadcasting.
+    num_inputs_check(context, 2, 2);
+    Output<Node> lhs;
+    Output<Node> rhs;
+    std::tie(lhs, rhs) = get_inputs_with_promoted_types(context, 0, 1);
+
+    const auto lhs_squared = context.mark_node(std::make_shared<v1::Multiply>(lhs, lhs));
+    const auto rhs_squared = context.mark_node(std::make_shared<v1::Multiply>(rhs, rhs));
+    const auto sum_of_squares = context.mark_node(std::make_shared<v1::Add>(lhs_squared, rhs_squared));
+    const auto result = context.mark_node(std::make_shared<v0::Sqrt>(sum_of_squares));
+
+    return {result};
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -133,6 +133,7 @@ OP_CONVERTER(translate_gru);
 OP_CONVERTER(translate_hann_window);
 OP_CONVERTER(translate_hardtanh);
 OP_CONVERTER(translate_hstack);
+OP_CONVERTER(translate_hypot);
 OP_CONVERTER(translate_if);
 OP_CONVERTER(translate_cond_fx);
 OP_CONVERTER(translate_im2col);
@@ -578,6 +579,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::hardswish", op::quantizable_op<op::translate_1to1_match_1_inputs<opset10::HSwish>>},
         {"aten::hardtanh", op::quantizable_op<op::translate_hardtanh>},
         {"aten::hstack", op::translate_hstack},
+        {"aten::hypot", op::translate_hypot},
         {"aten::im2col", op::translate_im2col},
         {"aten::imag", common_translators::translate_imag},
         // aten::index - Supported in limited set of patterns
@@ -1006,6 +1008,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.hardswish_.default", op::inplace_op<op::translate_1to1_match_1_inputs<opset10::HSwish>>},
         {"aten.hardtanh.default", op::translate_hardtanh},
         {"aten.hardtanh_.default", op::inplace_op<op::translate_hardtanh>},
+        {"aten.hypot.default", op::translate_hypot},
         {"aten.index.Tensor", op::translate_index_fx},
         {"aten._unsafe_index.Tensor", op::translate_index_fx},
         {"aten.index_select.default", op::translate_index_select},

--- a/tests/layer_tests/pytorch_tests/test_hypot.py
+++ b/tests/layer_tests/pytorch_tests/test_hypot.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+@pytest.mark.parametrize("input_shape_rhs", [
+    [2, 5, 3, 4],
+    [1, 5, 3, 4],
+    [1]
+])
+class TestHypot(PytorchLayerTest):
+
+    def _prepare_input(self):
+        return (self.random.randn(2, 5, 3, 4), self.input_rhs)
+
+    def create_model(self):
+
+        class aten_hypot(torch.nn.Module):
+            def forward(self, lhs, rhs):
+                return torch.hypot(lhs, rhs)
+
+        return aten_hypot(), "aten::hypot"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    @pytest.mark.precommit_fx_backend
+    def test_hypot(self, ie_device, precision, ir_version, input_shape_rhs):
+        self.input_rhs = self.random.randn(*input_shape_rhs)
+        self._test(*self.create_model(), ie_device, precision, ir_version,
+                   use_convert_model=True, fx_kind="aten.hypot")
+
+
+class TestHypotTypes(PytorchLayerTest):
+
+    def _prepare_input(self):
+        return (self.random.randn(*self.lhs_shape, dtype=self.lhs_type),
+                self.random.randn(*self.rhs_shape, dtype=self.rhs_type))
+
+    def create_model(self, lhs_type, rhs_type):
+
+        class aten_hypot(torch.nn.Module):
+            def __init__(self, lhs_type, rhs_type):
+                super().__init__()
+                self.lhs_type = lhs_type
+                self.rhs_type = rhs_type
+
+            def forward(self, lhs, rhs):
+                return torch.hypot(lhs.to(self.lhs_type), rhs.to(self.rhs_type))
+
+        return aten_hypot(lhs_type, rhs_type), "aten::hypot"
+
+    @pytest.mark.parametrize(("lhs_type", "rhs_type"),
+                             [[torch.float16, torch.float32],
+                              [torch.float32, torch.float64],
+                              [torch.float16, torch.float64],
+                              [torch.float32, torch.float32]])
+    @pytest.mark.parametrize(("lhs_shape", "rhs_shape"), [([2, 3], [2, 3]),
+                                                          ([2, 3], [1, 3]),
+                                                          ([3, 2, 3], [2, 3])])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    def test_hypot_types(self, ie_device, precision, ir_version, lhs_type, lhs_shape, rhs_type, rhs_shape):
+        self.lhs_type = lhs_type
+        self.lhs_shape = lhs_shape
+        self.rhs_type = rhs_type
+        self.rhs_shape = rhs_shape
+        self._test(*self.create_model(lhs_type, rhs_type),
+                   ie_device, precision, ir_version, freeze_model=False, trace_model=True, fx_kind="aten.hypot")
+
+
+class TestHypotValues(PytorchLayerTest):
+    # Pythagorean triples plus negative and zero legs give exact, easy-to-verify results:
+    # (3,4)->5, (5,12)->13, (8,15)->17, (-6,8)->10, (0,0)->0.
+    def _prepare_input(self):
+        return (np.array([3.0, 5.0, 8.0, -6.0, 0.0], dtype=np.float32),
+                np.array([4.0, 12.0, 15.0, 8.0, 0.0], dtype=np.float32))
+
+    def create_model(self):
+
+        class aten_hypot(torch.nn.Module):
+            def forward(self, lhs, rhs):
+                return torch.hypot(lhs, rhs)
+
+        return aten_hypot(), "aten::hypot"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    def test_hypot_values(self, ie_device, precision, ir_version):
+        self._test(*self.create_model(), ie_device, precision, ir_version, fx_kind="aten.hypot")


### PR DESCRIPTION
### Details:
 - Add PyTorch frontend support for aten::hypot, translating it to
   sqrt(input^2 + other^2) with numpy-style broadcasting and input type
   promotion.
 - Register the op for both the TorchScript (aten::hypot) and
   torch.export/FX (aten.hypot.default) paths.
 - Add layer tests covering broadcasting, fp16/fp32/fp64 type promotion,
   and exact-value cases (Pythagorean triples, negative and zero legs).

### Tickets:
 - #37824

### AI Assistance:
 - AI assistance used: yes
 - Claude (Claude Code) was used to implement the aten::hypot translator,
   register it in op_table.cpp for the TorchScript and FX paths, and write
   the layer tests.
 - Human validation: built the openvino_pytorch_frontend target locally
   with MSVC (compiles and links cleanly); ran
   tests/layer_tests/pytorch_tests/test_hypot.py — the frontend-conversion
   tests pass (type promotion across fp16/fp32/fp64 and exact Pythagorean
   values), and output matches torch.hypot.
