### PR TITLE
[GPU][Coverity] Fix Coverity DIVIDE_BY_ZERO in selective_ssm JIT kernel generators

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_selective_ssm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_selective_ssm.cpp
@@ -190,7 +190,8 @@ protected:
         jit.make("SSM_STATE_SIZE", state_size);
         jit.make("SSM_SUBGROUP_SIZE", subgroup_size);
         jit.make("SSM_HEAD_DIM_BLOCK", head_dim_block);
-        jit.make("SSM_STATE_ITERATIONS", cldnn::ceil_div(state_size, subgroup_size));
+        // get_subgroup_size() returns 0 for unsupported devices; the clamp only keeps the divisor defined.
+        jit.make("SSM_STATE_ITERATIONS", cldnn::ceil_div(state_size, std::max<size_t>(subgroup_size, 1)));
         jit.make("SSM_PAGED", true);
         jit.make("SSM_JIT_PRECOMPUTE_DA", PrecomputeDA);
         jit.make("SSM_JIT_USE_SLM", Kind == selective_ssm_jit::device_kind::discrete && use_discrete_slm(params));

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_selective_ssm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_selective_ssm.cpp
@@ -242,7 +242,8 @@ protected:
 
             const auto& seq_shape = params.get_input_layout(6).get_partial_shape();
             const size_t sequences = seq_shape[0].get_length() > 0 ? seq_shape[0].get_length() - 1 : 0;
-            kd.params.workGroups.global = {std::max<size_t>(cldnn::ceil_div(head_dim, head_dim_block), 1) * subgroup_size,
+            // get_head_dim_block() returns 0 for unsupported configurations; the clamp only keeps the divisor defined.
+            kd.params.workGroups.global = {std::max<size_t>(cldnn::ceil_div(head_dim, std::max<size_t>(head_dim_block, 1)), 1) * subgroup_size,
                                            std::max<size_t>(num_heads, 1),
                                            std::max<size_t>(sequences, 1)};
         }};

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/selective_ssm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/selective_ssm.cpp
@@ -138,7 +138,8 @@ protected:
                                                                                 private_values_budget,
                                                                                 discrete_target);
 
-            kd.params.workGroups.global = {cldnn::ceil_div(head_dim, head_dim_block) * subgroup_size, num_heads, batch};
+            // get_head_dim_block() returns 0 for unsupported configurations; the clamp only keeps the divisor defined.
+            kd.params.workGroups.global = {cldnn::ceil_div(head_dim, std::max<size_t>(head_dim_block, 1)) * subgroup_size, num_heads, batch};
             kd.params.workGroups.local = {subgroup_size, 1, 1};
             kd.params.scalars.clear();
             cldnn::scalar_desc sequence_desc;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/selective_ssm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/selective_ssm.cpp
@@ -94,7 +94,8 @@ protected:
         jit.make("SSM_STATE_SIZE", state_size);
         jit.make("SSM_SUBGROUP_SIZE", subgroup_size);
         jit.make("SSM_HEAD_DIM_BLOCK", head_dim_block);
-        jit.make("SSM_STATE_ITERATIONS", cldnn::ceil_div(state_size, subgroup_size));
+        // get_subgroup_size() returns 0 for unsupported devices; the clamp only keeps the divisor defined.
+        jit.make("SSM_STATE_ITERATIONS", cldnn::ceil_div(state_size, std::max<size_t>(subgroup_size, 1)));
         jit.make("SSM_PAGED", false);
         jit.make("SSM_JIT_PRECOMPUTE_DA", false);
         jit.make("SSM_JIT_USE_SLM", Kind == selective_ssm_jit::device_kind::discrete && use_discrete_slm(params));


### PR DESCRIPTION
### Details:
 - Coverity reported 4 `DIVIDE_BY_ZERO` defects (CID 2550257, 2550335, 2550292, 2550297) in the
   selective_ssm / paged_selective_ssm JIT kernel generators.
 - `get_subgroup_size()` and `get_head_dim_block()` return `0` for unsupported devices/configurations,
   and both are used as the divisor of `cldnn::ceil_div()`.
 - Clamped **only the divisor** with `std::max<size_t>(x, 1)` at the four division sites.
 - No behavioral change: the raw values are still exported as `SSM_SUBGROUP_SIZE` /
   `SSM_HEAD_DIM_BLOCK`, and `validate_*_selective_ssm_jit()` already rejects the zero case during
   implementation selection. No asserts were added, so the existing selection/fallback logic is intact.

### Tickets:
 - 193882

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
