### PR TITLE
feat: add support for aten::uniform_

### DIFF
--- a/src/frontends/pytorch/src/op/rand.cpp
+++ b/src/frontends/pytorch/src/op/rand.cpp
@@ -351,14 +351,14 @@ OutputVector translate_uniform_(const NodeContext& context) {
     auto dtype = element::f32;
 
     Output<Node> low;
-    if (context.get_input_size() > 1 && !context.input_is_none(1)) {
+    if (!context.input_is_none(1)) {
         low = context.get_input(1);
     } else {
         low = context.mark_node(v0::Constant::create(dtype, Shape{}, {0.0f}));
     }
 
     Output<Node> high;
-    if (context.get_input_size() > 2 && !context.input_is_none(2)) {
+    if (!context.input_is_none(2)) {
         high = context.get_input(2);
     } else {
         high = context.mark_node(v0::Constant::create(dtype, Shape{}, {1.0f}));
@@ -368,7 +368,7 @@ OutputVector translate_uniform_(const NodeContext& context) {
     high = context.mark_node(std::make_shared<v0::Convert>(high, dtype));
 
     uint64_t global_seed = 0;
-    if (context.get_input_size() > 3 && !context.input_is_none(3)) {
+    if (!context.input_is_none(3)) {
         auto gen_const = as_type_ptr<v0::Constant>(context.get_input(3).get_node_shared_ptr());
         if (gen_const) {
             auto seed = gen_const->cast_vector<uint64_t>();

--- a/src/frontends/pytorch/src/op/rand.cpp
+++ b/src/frontends/pytorch/src/op/rand.cpp
@@ -343,7 +343,55 @@ OutputVector translate_normal(const NodeContext& context) {
     }
 }
 
+OutputVector translate_uniform_(const NodeContext& context) {
+    // aten::uniform_(Tensor(a!) self, float from=0., float to=1., *, Generator? generator=None) -> Tensor(a!)
+    num_inputs_check(context, 1, 4);
+    auto inp_tensor = context.get_input(0);
+    auto sizes = context.mark_node(std::make_shared<v3::ShapeOf>(inp_tensor, element::i32));
+    auto dtype = element::f32;
+
+    Output<Node> low;
+    if (context.get_input_size() > 1 && !context.input_is_none(1)) {
+        low = context.get_input(1);
+    } else {
+        low = context.mark_node(v0::Constant::create(dtype, Shape{}, {0.0f}));
+    }
+
+    Output<Node> high;
+    if (context.get_input_size() > 2 && !context.input_is_none(2)) {
+        high = context.get_input(2);
+    } else {
+        high = context.mark_node(v0::Constant::create(dtype, Shape{}, {1.0f}));
+    }
+
+    low = context.mark_node(std::make_shared<v0::Convert>(low, dtype));
+    high = context.mark_node(std::make_shared<v0::Convert>(high, dtype));
+
+    uint64_t global_seed = 0;
+    if (context.get_input_size() > 3 && !context.input_is_none(3)) {
+        auto gen_const = as_type_ptr<v0::Constant>(context.get_input(3).get_node_shared_ptr());
+        if (gen_const) {
+            auto seed = gen_const->cast_vector<uint64_t>();
+            if (!seed.empty()) {
+                global_seed = seed[0];
+            }
+        }
+    }
+
+    auto res = context.mark_node(std::make_shared<v8::RandomUniform>(sizes,
+                                                                     low,
+                                                                     high,
+                                                                     dtype,
+                                                                     global_seed,
+                                                                     0,
+                                                                     PhiloxAlignment::PYTORCH));
+    res = context.mark_node(std::make_shared<v1::ConvertLike>(res, inp_tensor));
+    context.mutate_input(0, res);
+    return {res};
+}
+
 }  // namespace op
 }  // namespace pytorch
 }  // namespace frontend
 }  // namespace ov
+

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -282,6 +282,7 @@ OP_CONVERTER(translate_tuple_index);
 OP_CONVERTER(translate_tuple_unpack);
 OP_CONVERTER(translate_unflatten);
 OP_CONVERTER(translate_unfold);
+OP_CONVERTER(translate_uniform_);
 OP_CONVERTER(translate_unique2);
 OP_CONVERTER(translate_upsample_bicubic2d);
 OP_CONVERTER(translate_upsample_bilinear2d);
@@ -793,6 +794,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         // aten::unbind - Supported in limited set of patterns
         {"aten::unflatten", op::translate_unflatten},
         {"aten::unfold", op::translate_unfold},
+        {"aten::uniform_", op::translate_uniform_},
         // aten::unsafe_chunk - Supported in limited set of patterns
         {"aten::unsqueeze", common_translators::translate_unsqueeze},
         {"aten::unsqueeze_copy", common_translators::translate_unsqueeze},
@@ -1161,6 +1163,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.triu.default", op::translate_triu},
         {"aten.unbind.int", op::translate_unbind_int_fx},
         {"aten.unfold.default", op::translate_unfold},
+        {"aten.uniform_.default", op::translate_uniform_},
         {"aten.unsqueeze.default", common_translators::translate_unsqueeze},
         {"aten.unsqueeze_copy.default", op::translate_1to1_match_2_inputs<opset10::Unsqueeze>},
         {"aten.upsample_bicubic2d.default", op::translate_upsample_bicubic2d},

--- a/tests/layer_tests/pytorch_tests/test_uniform.py
+++ b/tests/layer_tests/pytorch_tests/test_uniform.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+pytestmark = pytest.mark.filterwarnings("ignore::torch.jit.TracerWarning")
+
+
+class TestInplaceUniform(PytorchLayerTest):
+    def _prepare_input(self):
+        return (np.random.randn(1, 3, 224, 224).astype(np.float32),)
+
+    def create_model(self, from_val, to_val):
+        class aten_uniform(torch.nn.Module):
+            def __init__(self, from_val, to_val):
+                super().__init__()
+                self.from_val = from_val
+                self.to_val = to_val
+
+            def forward(self, x):
+                x = x.to(torch.float32)
+                if self.from_val is None and self.to_val is None:
+                    return x.uniform_(), x
+                return x.uniform_(self.from_val, self.to_val), x
+
+        return aten_uniform(from_val, to_val), "aten::uniform_"
+
+    @pytest.mark.parametrize("from_val,to_val", [
+        (None, None),
+        (0.0, 1.0),
+        (-5.0, 5.0),
+        (10.0, 20.0),
+    ])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_fx_backend
+    def test_inplace_uniform(self, from_val, to_val, ie_device, precision, ir_version):
+        self._test(*self.create_model(from_val, to_val),
+                   ie_device, precision, ir_version, custom_eps=1e30)
+
+
+class TestUniformStatistics:
+    class aten_uniform(torch.nn.Module):
+        def __init__(self, from_val, to_val):
+            super().__init__()
+            self.from_val = from_val
+            self.to_val = to_val
+
+        def forward(self, x):
+            return x.uniform_(self.from_val, self.to_val)
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.parametrize("from_val,to_val,size", [
+        (0.0, 1.0, (100000,)),
+        (-5.0, 5.0, (10000, 10)),
+        (10.0, 20.0, (100000,)),
+    ])
+    def test_uniform_statistics(self, from_val, to_val, size, ie_device, precision):
+        import numpy.testing as npt
+        import openvino as ov
+
+        fw_model = self.aten_uniform(from_val, to_val)
+        example_input = (torch.zeros(size, dtype=torch.float32),)
+        input_size = [size]
+
+        ov_model = ov.convert_model(input_model=fw_model, example_input=example_input, input=input_size)
+        if ie_device == "GPU" and precision == "FP32":
+            config = {"INFERENCE_PRECISION_HINT": "f32"}
+        else:
+            config = {}
+        compiled_model = ov.Core().compile_model(ov_model, ie_device, config)
+
+        ov_res = compiled_model(example_input)[0]
+
+        # Check bounds
+        assert np.all(ov_res >= from_val) and np.all(ov_res <= to_val)
+
+        # Check mean property of uniform distribution: mean ≈ (from + to) / 2
+        expected_mean = (from_val + to_val) / 2.0
+        npt.assert_allclose(np.mean(ov_res), expected_mean, atol=0.1, rtol=0.1)


### PR DESCRIPTION
### Details:
 - Added support for the pytorch in-place uniform distribution operator (`aten::uniform_`)
 - `aten::uniform_ ` fills the input tensor in-place with numbers sampled from a uniform distribution over [from, to).

### Tickets:
 - closes : #29716 

### AI Assistance:
 - *AI assistance used: yes*
 - AI assistance was used to understand how similar pattern are used and generate code for test file also to navigate and understand the code base better.