### PR TITLE
[RFC] int8 attention path for narrow ViT encoders on Intel iGPU and CPU

### DIFF
--- a/src/common/snippets/src/lowered/pass/solve_buffer_memory.cpp
+++ b/src/common/snippets/src/lowered/pass/solve_buffer_memory.cpp
@@ -105,7 +105,22 @@ std::vector<ov::MemorySolver::Box> SolveBufferMemory::init_boxes(const Buffers& 
                 }
             }
         }
-        OPENVINO_ASSERT(e_start <= e_finish, "Incorrect life time of buffer!");
+        if (e_start > e_finish) {
+            std::string msg = "buffer " + buffer_expr->get_node()->get_friendly_name() + " cluster " +
+                              std::to_string(cluster_id) + " start " + std::to_string(e_start) + " finish " +
+                              std::to_string(e_finish);
+            for (const auto& buffer_in : buffer_expr->get_input_port_connectors()) {
+                msg += "\n  src: " + buffer_in->get_source().get_expr()->get_node()->get_friendly_name() + " #" +
+                       std::to_string(casted_execution_number(buffer_in->get_source().get_expr()));
+            }
+            for (const auto& buffer_out : buffer_expr->get_output_port_connectors()) {
+                for (const auto& consumer : buffer_out->get_consumers()) {
+                    msg += "\n  dst: " + consumer.get_expr()->get_node()->get_friendly_name() + " #" +
+                           std::to_string(casted_execution_number(consumer.get_expr()));
+                }
+            }
+            OPENVINO_THROW("Incorrect life time of buffer! ", msg);
+        }
 
         auto buffer_size = static_cast<int64_t>(buffer_expr->get_byte_size());
         box.size = std::max(buffer_size, box.size);

--- a/src/common/snippets/src/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/pass/softmax_decomposition.cpp
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <memory>
+#include <cstdlib>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -22,6 +24,7 @@
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "snippets/itt.hpp"
 #include "snippets/lowered/port_descriptor.hpp"
+#include "snippets/op/brgemm.hpp"
 #include "snippets/op/powerstatic.hpp"
 #include "snippets/op/reduce.hpp"
 #include "snippets/utils/utils.hpp"
@@ -49,15 +52,37 @@ SoftmaxDecomposition::SoftmaxDecomposition() {
         const auto normalized_axis = static_cast<size_t>(*axis);
 
         const auto& softmax_input = softmax->input_value(0);
-        const auto reduce_max = std::make_shared<ov::snippets::op::ReduceMax>(softmax_input, normalized_axis);
-        ov::snippets::op::ReduceBase::compute_and_set_reduce_subtensors(reduce_max);
-        const auto subtract = std::make_shared<ov::op::v1::Subtract>(softmax_input, reduce_max);
-        const auto exp = std::make_shared<ov::op::v0::Exp>(subtract);
+        // veesion: OV_SNIPPETS_SOFTMAX=nomax lowers softmax as exp(x)/sum(exp(x)) rather than
+        // the max-shifted form. It is the same function; the shift exists only to keep exp()
+        // from overflowing, and it costs a whole extra pass over the score tile -- the max of
+        // a row is needed before its first exp, so the ReduceMax loop cannot fuse into the
+        // exp loop -- plus a subtract per element. Safe while the logits stay below ~88.
+        const char* softmax_mode = std::getenv("OV_SNIPPETS_SOFTMAX");
+        std::string mode = softmax_mode == nullptr ? std::string() : std::string(softmax_mode);
+        const char* noexp_env = std::getenv("OV_SNIPPETS_NOEXP");
+        if (noexp_env != nullptr && noexp_env[0] != '\0') {
+            mode = "noexp";  // separate variable: the candidate pins OV_SNIPPETS_SOFTMAX at import
+        }
+        const bool shift_by_max = mode != "nomax" && mode != "noexp";
 
-        const auto reduce_sum = std::make_shared<ov::snippets::op::ReduceSum>(exp, normalized_axis);
-        ov::snippets::op::ReduceBase::compute_and_set_reduce_subtensors(reduce_sum);
-        const auto power = std::make_shared<ov::snippets::op::PowerStatic>(reduce_sum, -1.F);
-        const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, power);
+        ov::NodeVector decomposed;
+        ov::Output<ov::Node> exp_input = softmax_input;
+        if (shift_by_max) {
+            const auto reduce_max = std::make_shared<ov::snippets::op::ReduceMax>(softmax_input, normalized_axis);
+            ov::snippets::op::ReduceBase::compute_and_set_reduce_subtensors(reduce_max);
+            const auto subtract = std::make_shared<ov::op::v1::Subtract>(softmax_input, reduce_max);
+            exp_input = subtract;
+            decomposed.insert(decomposed.end(), {reduce_max, subtract});
+        }
+        // veesion: OV_SNIPPETS_SOFTMAX=noexp swaps the exponential for a squaring, which is one
+        // vmulps over the same tile in the same loop. It computes the wrong function and exists
+        // only to price the exp against the rest of the fused softmax.
+        std::shared_ptr<ov::Node> exp;
+        if (mode == "noexp") {
+            exp = std::make_shared<ov::snippets::op::PowerStatic>(exp_input, 2.F);
+        } else {
+            exp = std::make_shared<ov::op::v0::Exp>(exp_input);
+        }
 
         OPENVINO_ASSERT(normalized_axis < rank, "Softmax has incorrect axis");
         std::vector<size_t> subtensor(rank, 1);
@@ -65,10 +90,90 @@ SoftmaxDecomposition::SoftmaxDecomposition() {
             subtensor[i] = utils::get_full_dim_value();
         }
 
-        lowered::PortDescriptorUtils::set_port_descriptor(power->input(0), subtensor);
-        lowered::PortDescriptorUtils::set_port_descriptor(power->output(0), std::move(subtensor));
+        // veesion: OV_SNIPPETS_SOFTMAX=defer applies the 1/rowsum to the OUTPUT of the matmul
+        // that consumes the softmax, rather than to the softmax itself. softmax(s) @ V is
+        // identically (exp(s - rowmax) @ V) / rowsum, an exact reassociation, and it changes
+        // what a quantiser sees: the deferred operand peaks at exactly 1.0 on every row by
+        // construction, so a fixed u8 grid is fully used whatever a row's peakedness. A
+        // per-tensor grid on the normalised probabilities cannot manage that -- real attention
+        // rows differ in peak by orders of magnitude and the global max starves the flat ones.
+        // Both loops are blocked over the same M dimension, so the row sums are still live.
+        std::shared_ptr<ov::snippets::op::Brgemm> consumer;
+        if (mode == "defer") {
+            std::shared_ptr<ov::Node> cursor = softmax;
+            for (size_t hop = 0; hop < 16 && !consumer; ++hop) {
+                const auto& targets = cursor->get_output_target_inputs(0);
+                if (targets.size() != 1) {
+                    break;
+                }
+                const auto& target = *targets.begin();
+                auto next = target.get_node()->shared_from_this();
+                if (auto brgemm = ov::as_type_ptr<ov::snippets::op::Brgemm>(next)) {
+                    if (target.get_index() == 0) {
+                        consumer = brgemm;
+                    }
+                    break;
+                }
+                cursor = next;
+            }
+            OPENVINO_ASSERT(consumer, "OV_SNIPPETS_SOFTMAX=defer found no Brgemm consuming the softmax");
+        }
+        // Deferring only pays when the matmul is int8: the point is to hand the quantiser an
+        // operand that peaks at 1.0 by construction. On an f32 matmul it is pure loss -- and it
+        // also walks into a FuseLoops soundness gap, where a loop whose only consumer sits in
+        // the loop below can be hoisted above the expression that produces its input.
+        // Deferring is only expressible when the matmul is int8, and not for the reason one would
+        // guess. FuseTransposeBrgemm runs before this pass, so on f32 it has already folded the
+        // output transpose into the Brgemm: the product comes out as [B, M, H, K] while the row
+        // sums are [B, H, M, 1], and the two do not broadcast. The int8 path keeps an explicit
+        // Transpose -- the FakeQuantize on v blocks the fold -- so there the layouts still agree.
+        // Rescaling in the folded layout would need the row sums permuted by the same perm, i.e. a
+        // Transpose emitted after TransposeDecomposition has already run. It is not worth it: the
+        // multiplies saved are 1000*1000*9*12 = 108M/clip, ~0.5 ms of 90, and they sit fused in the
+        // exp loop where they are close to free.
+        const bool deferred = consumer && consumer->output(0).get_element_type() == ov::element::i32;
 
-        copy_runtime_info(softmax, {reduce_max, subtract, exp, reduce_sum, power, multiply});
+        // Iteration 26 tried summing the QUANTISED operand instead of exp, on the theory that the
+        // rounded-away tail biases every row downwards. It is much worse (rel 0.50 vs 0.14, and the
+        // centred component decorrelates entirely), and the best-fit global scale stays near 1, so
+        // the extra f32 consumer on the u8 tensor perturbs the int8 lowering rather than the ratio.
+        const auto reduce_sum = std::make_shared<ov::snippets::op::ReduceSum>(exp, normalized_axis);
+        ov::snippets::op::ReduceBase::compute_and_set_reduce_subtensors(reduce_sum);
+        const auto power = std::make_shared<ov::snippets::op::PowerStatic>(reduce_sum, -1.F);
+        lowered::PortDescriptorUtils::set_port_descriptor(power->input(0), subtensor);
+        lowered::PortDescriptorUtils::set_port_descriptor(power->output(0), subtensor);
+
+        if (deferred) {
+            // An int8 Brgemm accumulates in i32 and the conversion back to real arithmetic is a
+            // separate node, so anchor the rescale on the first real-typed value downstream
+            // rather than on the accumulator itself.
+            ov::Output<ov::Node> anchor = consumer->output(0);
+            for (size_t hop = 0; hop < 8 && !anchor.get_element_type().is_real(); ++hop) {
+                const auto& targets = anchor.get_target_inputs();
+                if (targets.size() != 1) {
+                    break;
+                }
+                anchor = targets.begin()->get_node()->output(0);
+            }
+            OPENVINO_ASSERT(anchor.get_element_type().is_real(),
+                            "OV_SNIPPETS_SOFTMAX=defer found no real-typed value after the Brgemm");
+            // Nothing downstream of the Brgemm depends on the row sums any more, so a plain
+            // topological sort is free to schedule the ReduceSum after the Brgemm -- which forces
+            // the exp tile to be re-read in a second pass and inverts the buffer lifetimes. Pin it.
+            consumer->add_control_dependency(power);
+            const auto sinks = anchor.get_target_inputs();
+            const auto rescale = std::make_shared<ov::op::v1::Multiply>(anchor, power);
+            for (const auto& sink : sinks) {
+                sink.replace_source_output(rescale->output(0));
+            }
+            decomposed.insert(decomposed.end(), {exp, reduce_sum, power, rescale});
+            copy_runtime_info(softmax, decomposed);
+            return ov::replace_node_update_name(softmax, exp);
+        }
+
+        const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, power);
+        decomposed.insert(decomposed.end(), {exp, reduce_sum, power, multiply});
+        copy_runtime_info(softmax, decomposed);
         return ov::replace_node_update_name(softmax, multiply);
     };
 

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -122,7 +122,19 @@ RoPEFusionFlux::RoPEFusionFlux(bool num_heads_transposed) {
     auto opt_squeeze_1 = pattern::optional<opset1::Squeeze>({x1_1_neg, -1});
     auto opt_unsqueeze = pattern::optional<opset1::Unsqueeze>({opt_squeeze_1, -1});
 
-    auto x2 = pattern::wrap_type<opset1::Concat>({opt_unsqueeze, split->output(0)}, {{"axis", -1}});
+    // By the time this pass runs, earlier passes have already rewritten Squeeze/Unsqueeze into
+    // Reshape, so the two optional slots above can never match a torch unbind+stack spelling
+    // and the matcher silently declined -- leaving a 12-node elementwise chain per RoPE. Accept
+    // the squeeze-then-unsqueeze round trip in its Reshape form too, pinned by shape so a
+    // genuine reshape cannot slip through: rank 4, then rank 5 with a unit tail.
+    auto opt_reshape_sq =
+        pattern::optional<opset1::Reshape>({opt_unsqueeze, pattern::any_input()},
+                                           pattern::shape_matches("[" + num_heads_pattern + ", ?]"));
+    auto opt_reshape_unsq =
+        pattern::optional<opset1::Reshape>({opt_reshape_sq, pattern::any_input()},
+                                           pattern::shape_matches("[" + num_heads_pattern + ", ?, 1]"));
+
+    auto x2 = pattern::wrap_type<opset1::Concat>({opt_reshape_unsq, split->output(0)}, {{"axis", -1}});
     auto x3 = pattern::wrap_type<opset1::Reshape>({x2, pattern::any_input()},
                                                   pattern::shape_matches("[" + num_heads_pattern + ", head_size]"));
 

--- a/src/core/src/op/scaled_dot_product_attention.cpp
+++ b/src/core/src/op/scaled_dot_product_attention.cpp
@@ -60,6 +60,11 @@ void op::v13::ScaledDotProductAttention::validate_and_infer_types() {
     }
     for (size_t i = 1; i < input_size; i++) {
         const auto& element_type = get_input_element_type(i);
+        // An s8 key or value is a legal input for an integer micro-SDPA: the codes are
+        // dequantized by the scale input, so the output type still follows the query.
+        if ((i == 1 || i == 2) && element_type == element::i8) {
+            continue;
+        }
         if (i == 3 && (element_type == element::boolean || causal)) {
             // Skip checking attention_mask in loop when boolean or skipped to not affect merged dtype.
             continue;

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
@@ -2086,16 +2086,69 @@ void jit_negative_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
 }
 
 /// EXP ///
+// veesion: OV_CPU_FAST_EXP=1 replaces the stock exp with 2^(x*log2e) evaluated as a degree-4
+// Taylor series on the fraction (max abs error 4.4e-5 on the reduced range). It drops the
+// denormal-underflow mask and blend, clamping in the log2 domain instead, which removes a
+// 2-uop vblendvps and a vcmpps on avx2. Behaviour differs from the stock emitter only below
+// exp(-87) and above exp(87), where it saturates rather than flushing to zero / inf.
+static bool fast_exp_enabled() {
+    const char* v = std::getenv("OV_CPU_FAST_EXP");
+    return v != nullptr && v[0] != '\0';
+}
+
+// veesion: degree of the polynomial approximating 2^f on f in [-0.5, 0.5]. The stock fast path
+// is a degree-4 Taylor series; degrees 2 and 3 use minimax coefficients instead, whose max
+// relative error is 1.73e-3 and 7.49e-5 -- against a u8 softmax grid step of 1/510 = 1.96e-3,
+// and most of even that cancels because the same approximation feeds the row sum it is divided
+// by. Each degree dropped removes one vfmadd213ps of fourteen instructions.
+static int fast_exp_degree() {
+    const char* v = std::getenv("OV_CPU_EXP_DEG");
+    const int d = v ? std::atoi(v) : 4;
+    return (d >= 1 && d <= 4) ? d : 4;
+}
+
+// veesion: multiplying the polynomial by 2^n is the same as adding n to its exponent field, and
+// the polynomial's value is always in [0.7, 1.5] so the field is 126 or 127 and the add cannot
+// carry out of it. That trades a 4-cycle vmulps on the FMA ports -- the one resource this
+// emitter is actually bound by -- for a 1-cycle vpaddd on the integer ports, and drops the
+// exponent_bias add on the side path since the bias is now already in the polynomial's field.
+// Bit-exact with the multiply everywhere the lower clamp holds n >= -126.
+static bool fast_exp_shift() {
+    const char* v = std::getenv("OV_CPU_EXP_SHIFT");
+    return v != nullptr && v[0] == '1';
+}
+
+// Drops the vminps that clamps the log2-domain argument to +126. Every exp in this model takes a
+// non-positive argument -- softmax subtracts the row max, gelu's erf takes -x*x/2 -- so the
+// upper clamp can never fire. The lower clamp stays: without it an argument below -126 shifts a
+// negative exponent field and returns a large negative float rather than zero.
+static bool fast_exp_nomin() {
+    const char* v = std::getenv("OV_CPU_EXP_NOMIN");
+    return v != nullptr && v[0] == '1';
+}
+
 jit_exp_emitter::jit_exp_emitter(x64::jit_generator_t* host, x64::cpu_isa_t host_isa, ov::element::Type exec_prc)
     : jit_emitter(host, host_isa, exec_prc) {
     prepare_table();
+}
+
+// veesion: the fast path opens with `f = x * log2e`, which sits at the head of a serial
+// latency chain (mul -> max -> round -> sub -> poly -> mul). When the only producer of x is a
+// scale that the caller controls -- as in this model's softmax, where q is pre-multiplied by
+// the q@k dequant scale -- log2e can be folded into that scale for free and this multiply
+// deleted outright. Applied only through the node constructor, so jit_erf_emitter's private
+// exp (whose argument is -x*x/2, not a scaled input) keeps its multiply.
+static bool fast_exp_nolog2e() {
+    const char* v = std::getenv("OV_CPU_EXP_NOLOG2E");
+    return v != nullptr && v[0] == '1';
 }
 
 jit_exp_emitter::jit_exp_emitter(x64::jit_generator_t* host,
                                  x64::cpu_isa_t host_isa,
                                  [[maybe_unused]] const std::shared_ptr<ov::Node>& node,
                                  ov::element::Type exec_prc)
-    : jit_emitter(host, host_isa, exec_prc) {
+    : jit_emitter(host, host_isa, exec_prc),
+      m_skip_log2e(fast_exp_nolog2e()) {
     prepare_table();
 }
 
@@ -2125,6 +2178,69 @@ void jit_exp_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
     auto vmm_src = Vmm(in_vec_idxs[0]);
     auto vmm_dst = Vmm(out_vec_idxs[0]);
+
+    if (fast_exp_enabled()) {
+        auto vmm_f = Vmm(aux_vec_idxs[0]);
+        auto vmm_scale = Vmm(aux_vec_idxs[1]);
+        // veesion: the clamps below sit in front of the round, on the serial chain
+        // mul -> min -> max -> round -> sub -> poly -> mul. They can be moved behind it: fast_hi
+        // and fast_lo are the integers +-126, so clamp-then-round and round-then-clamp agree
+        // exactly, and the move takes 8 cycles off a 36-cycle chain at identical instruction
+        // count. Iteration 58 built that and measured it 1.5% SLOWER, ahead in none of four
+        // paired rounds; dropping the vminps outright (OV_CPU_EXP_NOMIN) measured exactly zero.
+        // Yet deg4 -> deg2, which drops two vfmadd213ps, is worth 4.8%. What this emitter is
+        // bound by is its FMA-port operations alone, at roughly 4 cycles each; min, max, round
+        // and the integer side path are free. Only removing an FMA-port op pays here.
+        const bool shift_scale = fast_exp_shift();
+        if (m_skip_log2e) {
+            if (!fast_exp_nomin()) {
+                h->uni_vminps(vmm_f, vmm_src, table_val("fast_hi"));
+                h->uni_vmaxps(vmm_f, vmm_f, table_val("fast_lo"));
+            } else {
+                h->uni_vmaxps(vmm_f, vmm_src, table_val("fast_lo"));
+            }
+        } else {
+            h->uni_vmulps(vmm_f, vmm_src, table_val("log2ef"));
+            if (!fast_exp_nomin()) {
+                h->uni_vminps(vmm_f, vmm_f, table_val("fast_hi"));
+            }
+            h->uni_vmaxps(vmm_f, vmm_f, table_val("fast_lo"));
+        }
+        const auto _op_near = 0U;
+        h->uni_vroundps(vmm_scale, vmm_f, _op_near);
+        h->uni_vsubps(vmm_f, vmm_f, vmm_scale);
+        h->uni_vcvtps2dq(vmm_scale, vmm_scale);
+        if (!shift_scale) {
+            h->uni_vpaddd(vmm_scale, vmm_scale, table_val("exponent_bias"));
+        }
+        h->uni_vpslld(vmm_scale, vmm_scale, 23);
+        const int deg = fast_exp_degree();
+        if (deg == 4) {
+            h->uni_vmovups(vmm_dst, table_val("fast_c4"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("fast_c3"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("fast_c2"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("fast_c1"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("one"));
+        } else if (deg == 3) {
+            h->uni_vmovups(vmm_dst, table_val("mm3_c3"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("mm3_c2"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("mm3_c1"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("mm3_c0"));
+        } else if (deg == 2) {
+            h->uni_vmovups(vmm_dst, table_val("mm2_c2"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("mm2_c1"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("mm2_c0"));
+        } else {
+            h->uni_vmovups(vmm_dst, table_val("mm1_c1"));
+            h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("mm1_c0"));
+        }
+        if (shift_scale) {
+            h->uni_vpaddd(vmm_dst, vmm_dst, vmm_scale);
+        } else {
+            h->uni_vmulps(vmm_dst, vmm_dst, vmm_scale);
+        }
+        return;
+    }
 
     Vmm vmm_mask = need_vmm_mask() ? Vmm(aux_vec_idxs[0]) : Vmm();
     auto vmm_aux0 = Vmm(aux_vec_idxs[0 + static_cast<size_t>(need_vmm_mask())]);
@@ -2205,9 +2321,34 @@ void jit_exp_emitter::register_table_entries() {
     push_arg_entry_of("ln_flt_max_f", 0x42b17218, true);
     push_arg_entry_of("ln_flt_min_f", 0xc2aeac50, true);
     push_arg_entry_of("exponent_bias", 0x0000007f, true);
+
+    push_arg_entry_of("fast_c1", 0x3f317218, true);  // ln2
+    push_arg_entry_of("fast_c2", 0x3e75fdf0, true);  // ln2^2/2
+    push_arg_entry_of("fast_c3", 0x3d635847, true);  // ln2^3/6
+    push_arg_entry_of("fast_c4", 0x3c1d955b, true);  // ln2^4/24
+    push_arg_entry_of("fast_hi", 0x42fc0000, true);  // +126, clamped in the log2 domain
+    push_arg_entry_of("fast_lo", 0xc2fc0000, true);  // -126
+
+    // Minimax fits of 2^f on [-0.5, 0.5], relative error 7.49e-5 (degree 3) and 1.73e-3
+    // (degree 2). The leading coefficient is not exactly 1, so unlike the Taylor form these
+    // cannot reuse "one" as the final addend.
+    push_arg_entry_of("mm3_c0", 0x3f7ffb4a, true);  // 0.99992810f
+    push_arg_entry_of("mm3_c1", 0x3f31798d, true);  // 0.69326097f
+    push_arg_entry_of("mm3_c2", 0x3e786ef2, true);  // 0.24261072f
+    push_arg_entry_of("mm3_c3", 0x3d61fb67, true);  // 0.05517140f
+    push_arg_entry_of("mm2_c0", 0x3f800e84, true);  // 1.00044300f
+    push_arg_entry_of("mm2_c1", 0x3f3414eb, true);  // 0.70344418f
+    push_arg_entry_of("mm2_c2", 0x3e74260d, true);  // 0.23842640f
+    // Degree 1, relative error 2.98e-2 -- fifteen times the u8 softmax grid step, so this is only
+    // viable if the goldens say the error cancels through the softmax normalisation.
+    push_arg_entry_of("mm1_c0", 0x3f83b6bc, true);  // 1.02901416f
+    push_arg_entry_of("mm1_c1", 0x3f2f9e4c, true);  // 0.68600918f
 }
 
 size_t jit_exp_emitter::aux_vecs_count() const {
+    if (fast_exp_enabled()) {
+        return 2;
+    }
     return need_vmm_mask() ? 3 : 2;
 }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.hpp
@@ -654,6 +654,11 @@ private:
 
     void register_table_entries() override;
     size_t aux_vecs_count() const override;
+
+    // veesion: caller has already folded log2(e) into an upstream scale, so the emitter's own
+    // leading multiply would be redundant. Only ever set for a graph Exp, never for the copy
+    // jit_erf_emitter owns.
+    bool m_skip_log2e{false};
 };
 
 class jit_erf_emitter : public jit_emitter {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.cpp
@@ -118,9 +118,16 @@ std::set<std::vector<element::Type>> jit_brgemm_emitter::get_supported_precision
                                     dnnl::impl::cpu::x64::avx2_vnni_2)) {
             supported_types.insert(form_precisions({element::bf16, element::bf16}));
         }
+        // veesion: avx2_vnni_2 is a superset of avx2_vnni and executes vpdpbusd, so it takes a
+        // u8 A operand. Omitting it here left {i8, i8} as the only int8 pair on this ISA, and
+        // PropagatePrecision then inserted a SATURATING u8->i8 convert on A while BrgemmConfig
+        // kept src_dt=u8: every operand byte above 127 was silently clamped. On int8 MHA that is
+        // the softmax operand, so any attention probability over 127/255 was truncated to
+        // 127/255 -- measured directly, and worth ~0.35 relative error on a peaked row.
         if (snippets::utils::any_of(config.isa(),
                                     dnnl::impl::cpu::x64::avx512_core_vnni,
-                                    dnnl::impl::cpu::x64::avx2_vnni)) {
+                                    dnnl::impl::cpu::x64::avx2_vnni,
+                                    dnnl::impl::cpu::x64::avx2_vnni_2)) {
             supported_types.insert(form_precisions({element::u8, element::i8}));
         }
         if (config.isa() == dnnl::impl::cpu::x64::avx2_vnni_2) {

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -2221,7 +2221,7 @@ bool ScaledDotProductAttention::isSupportedOperation(const std::shared_ptr<const
             }
         }
         // using mha should be better for static shapes
-        if (!op->is_dynamic()) {
+        if (!op->is_dynamic() && std::getenv("OV_CPU_KEEP_SDPA") == nullptr) {
             errorMessage = "Only run in dynamic mode";
             return false;
         }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/fuse_brgemm_cpu_postops.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/fuse_brgemm_cpu_postops.cpp
@@ -6,6 +6,7 @@
 
 #include <common/c_types_map.hpp>
 #include <cstddef>
+#include <cstdlib>
 #include <limits>
 #include <memory>
 #include <set>
@@ -292,6 +293,17 @@ ov::pass::pattern::op::Predicate pass::FuseBinaryEltwise::binary_input_predicate
     "binary_input_predicate"};
 
 bool pass::FuseBinaryEltwise::can_be_fused(const std::shared_ptr<const ov::Node>& node) {
+    // veesion: fusing a per-OC binary operand into an int8 BrgemmCPU inside a fused MHA body
+    // corrupts the result, and not by the operand's value: clamping the operand to an exact
+    // zero -- an Add that provably changes nothing -- still moves the model output by 8.9%
+    // relative at depth 2, while the same graph with the Add left as an ordinary in-loop
+    // eltwise reproduces the unfused reference to 0.0. So enabling the post-op selects a
+    // different, wrong brgemm path rather than mis-addressing the operand; the operand's
+    // pointer bookkeeping (address regs -> external_ptrs) is compacted consistently on both
+    // sides. Nothing in this model wants a binary post-op, so refuse it by default.
+    if (std::getenv("OV_BRGEMM_BINARY_POSTOP") == nullptr) {
+        return false;
+    }
     if (!ov::is_type_any_of<ov::op::v1::Multiply,
                             ov::op::v1::Add,
                             ov::op::v1::Subtract,

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.cpp
@@ -5,6 +5,7 @@
 #include "brgemm_cpu_blocking.hpp"
 
 #include <cassert>
+#include <cstdlib>
 #include <cstddef>
 #include <iterator>
 #include <memory>
@@ -115,9 +116,14 @@ std::tuple<size_t, size_t, size_t> BrgemmCPUBlocking::get_blocking_params(
 
     const auto [m, n, k] = get_brgemm_dimensions(brgemm_expr);
 
-    const auto default_m_blk = 32;
-    const auto default_n_blk = 64;
-    const auto default_k_blk = !ov::snippets::utils::is_dynamic_value(k) && k > 1024 ? 1024 : 512;
+    const auto env_blk = [](const char* name, size_t fallback) {
+        const char* v = std::getenv(name);
+        return v != nullptr ? static_cast<size_t>(std::atoi(v)) : fallback;
+    };
+    const auto default_m_blk = env_blk("OV_SNIPPETS_M_BLK", 32);
+    const auto default_n_blk = env_blk("OV_SNIPPETS_N_BLK", 64);
+    const auto default_k_blk =
+        env_blk("OV_SNIPPETS_K_BLK", !ov::snippets::utils::is_dynamic_value(k) && k > 1024 ? 1024 : 512);
 
     size_t m_blk = get_corrected_blk_size_by_dim(m, default_m_blk);
     size_t n_blk =

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -124,6 +124,7 @@
 #include "transformations/op_conversions/mvn6_decomposition.hpp"
 #include "transformations/op_conversions/normalize_l2_decomposition.hpp"
 #include "transformations/op_conversions/rnn_cell_decomposition.hpp"
+#include "transformations/op_conversions/scaled_dot_product_attention_decomposition.hpp"
 #include "transformations/op_conversions/simplify_ctc_greedy_decoder_seq_len.hpp"
 #include "transformations/op_conversions/softmax_decomposition.hpp"
 #include "transformations/op_conversions/softsign_decomposition.hpp"
@@ -872,6 +873,12 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_DISABLE_PASS_COMMON(manager, ov::pass::ConvertScatterNDUpdate15ToScatterNDUpdate3);
     CPU_DISABLE_PASS_COMMON(manager, ov::pass::ConvertSliceScatter);
     CPU_DISABLE_PASS_COMMON(manager, ov::pass::SDPAFusion);
+    // CommonOptimizations decomposes every v13::SDPA into MatMul/Softmax/MatMul, so the
+    // plugin's own blocked ScaledDotProductAttention node is unreachable for a plain
+    // (non-KV-cache) encoder. Keeping the node is opt-in while it is being evaluated.
+    if (std::getenv("OV_CPU_KEEP_SDPA") != nullptr) {
+        CPU_DISABLE_PASS_COMMON(manager, ov::pass::ScaledDotProductAttentionDecomposition);
+    }
     CPU_DISABLE_PASS_X64(manager, ov::pass::HSigmoidDecomposition);
     CPU_DISABLE_PASS_ARM64(manager, ov::pass::HSigmoidDecomposition);
 

--- a/src/plugins/intel_gpu/include/intel_gpu/op/sdpa.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/sdpa.hpp
@@ -28,6 +28,16 @@ public:
          const std::vector<int64_t>& order_out,
          const ov::element::Type output_type = ov::element::dynamic);
 
+    /// Overload that takes Q unrotated plus a trailing (cos, sin) pair of inputs.
+    SDPA(const OutputVector& inputs,
+         const bool is_causal,
+         const std::vector<int64_t>& order_q,
+         const std::vector<int64_t>& order_k,
+         const std::vector<int64_t>& order_v,
+         const std::vector<int64_t>& order_out,
+         const ov::element::Type output_type,
+         bool rope_q);
+
     SDPA(const OutputVector& inputs,
          const bool is_causal,
          const std::vector<int64_t>& order_q,
@@ -52,6 +62,10 @@ public:
     ov::element::Type get_output_type() const { return m_output_type; }
 
     bool get_kv_compressed() const { return m_compressed; }
+
+    /// Q arrives unrotated; the last two inputs carry the interleaved RoPE cos/sin table
+    /// (batch, tokens, head_size) and the SDPA kernel rotates Q while staging it.
+    bool get_rope_q() const { return m_rope_q; }
     QuantizationAttribute get_quantization_attrs() const { return m_quantization_attrs; }
     size_t get_compression_inputs_num() const;
 
@@ -70,6 +84,7 @@ protected:
     ov::element::Type m_output_type;
 
     bool m_compressed = false;
+    bool m_rope_q = false;
     QuantizationAttribute m_quantization_attrs = {};
 };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp
@@ -41,17 +41,22 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
                                  const std::vector<int64_t>& input_v_transpose_order = {},
                                  const std::vector<int64_t>& output_transpose_order = {},
                                  const QuantizationAttributes& quantization_attributes = {},
-                                 bool is_kv_compressed = false)
+                                 bool is_kv_compressed = false,
+                                 bool has_rope_q = false)
         : primitive_base(id, inputs)
         , is_causal(is_causal)
         , indirect_axis(indirect_axis)
         , is_kv_compressed(is_kv_compressed)
+        , has_rope_q(has_rope_q)
         , quantization_attributes(quantization_attributes)
         , input_q_transpose_order(input_q_transpose_order)
         , input_k_transpose_order(input_k_transpose_order)
         , input_v_transpose_order(input_v_transpose_order)
         , output_transpose_order(output_transpose_order) {
             auto data_inputs_num = inputs.size();
+            if (has_rope_q) {
+                data_inputs_num -= 2;  // rope cos/sin table, appended last
+            }
             if (indirect_axis != -1) {
                 data_inputs_num--;
             }
@@ -74,6 +79,9 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
     int64_t indirect_axis = -1;
 
     bool is_kv_compressed = false;
+    /// Q arrives unrotated and the last two inputs hold the interleaved RoPE cos/sin table,
+    /// laid out (batch, tokens, head_size); the SDPA kernel rotates Q as it stages it.
+    bool has_rope_q = false;
     QuantizationAttributes quantization_attributes;
 
     std::vector<int64_t> input_q_transpose_order;
@@ -104,6 +112,7 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
             seed = hash_combine(seed, scale_val.value());
         }
         seed = hash_combine(seed, is_kv_compressed);
+        seed = hash_combine(seed, has_rope_q);
         seed = hash_range(seed, quantization_attributes.scales_zp_output_order.begin(), quantization_attributes.scales_zp_output_order.end());
         seed = hash_range(seed, quantization_attributes.group_sizes.begin(), quantization_attributes.group_sizes.end());
         seed = hash_combine(seed, quantization_attributes.quantization_type);
@@ -133,6 +142,7 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
                attn_mask_val == rhs_casted.attn_mask_val &&
                scale_val == rhs_casted.scale_val &&
                is_kv_compressed == rhs_casted.is_kv_compressed &&
+               has_rope_q == rhs_casted.has_rope_q &&
                quantization_attributes.scales_zp_output_order == rhs_casted.quantization_attributes.scales_zp_output_order &&
                quantization_attributes.output_storage_type == rhs_casted.quantization_attributes.output_storage_type &&
                quantization_attributes.group_sizes == rhs_casted.quantization_attributes.group_sizes &&
@@ -146,6 +156,7 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
         primitive_base<scaled_dot_product_attention>::save(ob);
         ob << is_causal;
         ob << is_kv_compressed;
+        ob << has_rope_q;
         ob << has_attn_mask_input;
         ob << has_scale_input;
         ob << has_sink_input;
@@ -175,6 +186,7 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
         primitive_base<scaled_dot_product_attention>::load(ib);
         ib >> is_causal;
         ib >> is_kv_compressed;
+        ib >> has_rope_q;
         ib >> has_attn_mask_input;
         ib >> has_scale_input;
         ib >> has_sink_input;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -22,6 +22,7 @@
 #include "permute_inst.h"
 #include "reshape_inst.h"
 #include "softmax_inst.h"
+#include "scaled_dot_product_attention_inst.h"
 #include "resample_inst.h"
 #include "depth_to_space_inst.h"
 #include "fully_connected_inst.h"
@@ -52,6 +53,7 @@
 #include <string>
 #include <utility>
 #include <deque>
+#include <iostream>
 #ifdef ENABLE_ONEDNN_FOR_GPU
 #include <impls/onednn/utils.hpp>
 #endif
@@ -1023,6 +1025,21 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             should_fuse |= input_data.is_type<softmax>() &&
                            input_data.as<softmax>().get_primitive()->dimension == 1 &&
                            quantize_node.has_per_tensor_values();
+
+            // veesion: fuse the per-tensor scale_shift_opt quantizer into micro-SDPA so the
+            // kernel stores i8 directly and the standalone quantize pass disappears. The
+            // micro kernel implements the epilogue itself; only i8 output with a real
+            // per-tensor output range qualifies. Default off upstream.
+            if (std::getenv("OV_SDPA_OUT_I8") != nullptr) {
+                if (input_data.is_type<scaled_dot_product_attention>() && std::getenv("OV_SDPA_OUT_I8_DEBUG"))
+                    std::cerr << "[veesion] sdpa-out-i8 fuse candidate " << quantize_node.id()
+                              << " out_dt=" << static_cast<int>(out_dt) << " per_tensor=" << quantize_node.has_per_tensor_values()
+                              << " lo=" << quantize_node.get_output_lo_val() << " hi=" << quantize_node.get_output_hi_val() << std::endl;
+                should_fuse |= input_data.is_type<scaled_dot_product_attention>() &&
+                               quantize_node.has_per_tensor_values() &&
+                               quantize_node.get_output_lo_val() < quantize_node.get_output_hi_val() &&
+                               out_dt == data_types::i8;
+            }
 
             should_fuse |= input_data.is_type<broadcast>() && broadcast_supports_fusings(input_data.as<broadcast>());
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -23,6 +23,7 @@
 #include "group_normalization_inst.h"
 #include "mvn_inst.h"
 #include "rms_inst.h"
+#include "rope_inst.h"
 
 #include <vector>
 #include <list>
@@ -459,7 +460,11 @@ void remove_redundant_reorders::run(program& p) {
                  input.is_type<fully_connected>() ||
                  input.is_type<concatenation>() || input.is_type<depth_to_space>() || input.is_type<region_yolo>() ||
                  input.is_type<detection_output>() || input.is_type<gather>() || input.is_type<broadcast>() ||
-                 input.is_type<select>() || input.is_type<eltwise>() || input.is_type<rms>()) && !input.is_constant();
+                 input.is_type<select>() || input.is_type<eltwise>() || input.is_type<rms>() ||
+                 // veesion: RoPE feeding an s8 SDPA K. rope_opt already stores through
+                 // TO_OUTPUT_TYPE, so narrowing in the rotation's own store removes a whole
+                 // 18 MB read / 9 MB write pass. OV_ROPE_I8=0 disables it for A/B.
+                 (input.is_type<rope>() && std::getenv("OV_ROPE_I8") == nullptr)) && !input.is_constant();
             if (!same_data_type && !allowed_dt_conversion_fuse)
                 continue;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cl
@@ -7,6 +7,12 @@
 #define INPUT_VEC_TYPE  MAKE_VECTOR_TYPE(INPUT0_TYPE, VEC_SIZE)
 #define OUTPUT_VEC_TYPE MAKE_VECTOR_TYPE(OUTPUT_TYPE, VEC_SIZE)
 
+// veesion: an s8 output narrows SDPA's K inside the rotation's own store, which removes a whole
+// f16 read / i8 write pass over an 18 MB tensor. Only the interleaved bodies implement it.
+#if defined(OUTPUT_I8) && !defined(RotateInterleaved) && !defined(ROPE_CONTIG)
+#   error "rope_opt.cl - an i8 output is only implemented for the interleaved rotation"
+#endif
+
 #define UNPACK_FLOAT_VEC_1(outputv, input1, input2) \
     outputv.s0 = convert_float(input1.s0);          \
     outputv.s1 = convert_float(input1.s2);          \
@@ -439,6 +445,9 @@ uint cos_sin_p = p;
 #endif
 
 #ifdef RotateInterleaved
+#if defined(OUTPUT_I8) && VEC_SIZE != 16
+#   error "rope_opt.cl - an i8 output is only wired for the VEC_SIZE 16 interleaved body"
+#endif
 KERNEL(rope_opt)(
     OPTIONAL_SHAPE_INFO_ARG const __global INPUT0_TYPE* input,
     const __global INPUT1_TYPE* cos,
@@ -447,10 +456,19 @@ KERNEL(rope_opt)(
 #if VEC_SIZE != 1 && VEC_SIZE != 8 && VEC_SIZE != 16
 #   error "rope_opt.cl - VEC_SIZE must be one of {1, 8, 16}"
 #endif
+#ifdef REVERSED_GWS
+    // dim0 carries the rotary/head index, which is the contiguous axis of a bfyx tensor, so
+    // consecutive lanes of a subgroup read consecutive VEC_SIZE chunks of the same row.
+    const uint b = get_global_id(2);
+    const uint h = get_global_id(1);
+    const uint p = ((uint)get_global_id(0) * VEC_SIZE) / HALF_ROTARY_NDIMS;
+    const uint r = 2 * (((uint)get_global_id(0) * VEC_SIZE) % HALF_ROTARY_NDIMS);
+#else
     const uint b = get_global_id(0);
     const uint h = get_global_id(1);
     const uint p = ((uint)get_global_id(2) * VEC_SIZE) / HALF_ROTARY_NDIMS;
     const uint r = 2 * (((uint)get_global_id(2) * VEC_SIZE) % HALF_ROTARY_NDIMS);
+#endif
 
 #ifdef ENABLE_TRANSPOSE
     uint input_idx = INPUT0_GET_INDEX(b, p, h, 0);
@@ -526,8 +544,14 @@ KERNEL(rope_opt)(
     PACK_HALF16_VEC_1(outputv1, out1, out2);
     PACK_HALF16_VEC_2(outputv2, out1, out2);
 
+#ifdef OUTPUT_I8
+    // output_idx + r is a multiple of 2*VEC_SIZE, so both char16 stores stay naturally aligned.
+    *(char16*)(output + output_idx + r) = convert_char16_sat_rte(outputv1);
+    *(char16*)(output + output_idx + r + VEC_SIZE) = convert_char16_sat_rte(outputv2);
+#else
     *(half16*)(output + output_idx + r) = outputv1;
     *(half16*)(output + output_idx + r + VEC_SIZE) = outputv2;
+#endif
 #endif
 }
 #endif
@@ -632,6 +656,60 @@ KERNEL(rope_opt)(
 
     *(half16*)(output + output_idx + r) = outputv1;
     *(half16*)(output + output_idx + r + VEC_SIZE) = outputv2;
+#endif
+}
+#endif
+
+#ifdef ROPE_CONTIG
+// Flat-dispatch interleaved RoPE for a fully packed bfyx tensor.
+//
+// The REVERSED_GWS body above gives each work item two VEC_SIZE loads that are 32 B apart, so
+// consecutive lanes are VEC_SIZE*2 elements apart and the compiler cannot lower either load to
+// a subgroup block read -- it issues two scattered messages that touch every cache line twice.
+// Here lane i owns exactly one contiguous run of VEC_SIZE elements, so the address is
+// base + lane*VEC_SIZE and the rotation pairs (2j, 2j+1) both live inside that run. The pairing
+// therefore becomes an in-register swap of adjacent components, which is a source-region swizzle
+// on Gen, and both the load and the store are block-shaped.
+//
+// Requires: rotary_ndims == head_size, a power of two, a row of HEAD_COUNT*ROTARY_NDIMS
+// elements, and no padding anywhere. rope_opt.cpp checks all of that before enabling this.
+KERNEL(rope_opt)(
+    OPTIONAL_SHAPE_INFO_ARG const __global INPUT0_TYPE* input,
+    const __global INPUT1_TYPE* cos,
+    const __global INPUT2_TYPE* sin,
+    __global OUTPUT_TYPE* output) {
+    const uint elem = (uint)get_global_id(0) * VEC_SIZE;
+    // elem / (HEAD_COUNT*ROTARY_NDIMS) is the flattened (batch, token) index; the offset inside
+    // the head is elem % ROTARY_NDIMS because ROTARY_NDIMS divides the row width.
+    const uint cs = (elem / (HEAD_COUNT * ROTARY_NDIMS)) * ROTARY_NDIMS + (elem & (ROTARY_NDIMS - 1));
+
+    INPUT_VEC_TYPE v = *(const INPUT_VEC_TYPE*)(input + elem);
+#ifdef ROPE_CONTIG_COPY
+#ifdef OUTPUT_I8
+    *(OUTPUT_VEC_TYPE*)(output + elem) = CAT(CAT(convert_char, VEC_SIZE), _sat_rte)(v);
+#else
+    *(OUTPUT_VEC_TYPE*)(output + elem) = v;
+#endif
+#else
+    INPUT_VEC_TYPE c = *(const INPUT_VEC_TYPE*)(cos + cs);
+    INPUT_VEC_TYPE s = *(const INPUT_VEC_TYPE*)(sin + cs);
+#if VEC_SIZE == 16
+    INPUT_VEC_TYPE sw = (INPUT_VEC_TYPE)(v.s1, v.s0, v.s3, v.s2, v.s5, v.s4, v.s7, v.s6,
+                                         v.s9, v.s8, v.sb, v.sa, v.sd, v.sc, v.sf, v.se);
+    const INPUT_VEC_TYPE sgn = (INPUT_VEC_TYPE)(-1, 1, -1, 1, -1, 1, -1, 1,
+                                                -1, 1, -1, 1, -1, 1, -1, 1);
+#elif VEC_SIZE == 8
+    INPUT_VEC_TYPE sw = (INPUT_VEC_TYPE)(v.s1, v.s0, v.s3, v.s2, v.s5, v.s4, v.s7, v.s6);
+    const INPUT_VEC_TYPE sgn = (INPUT_VEC_TYPE)(-1, 1, -1, 1, -1, 1, -1, 1);
+#else
+#   error "rope_opt.cl - ROPE_CONTIG needs VEC_SIZE 8 or 16"
+#endif
+#ifdef OUTPUT_I8
+    *(OUTPUT_VEC_TYPE*)(output + elem) =
+        CAT(CAT(convert_char, VEC_SIZE), _sat_rte)(c * v + (sgn * s) * sw);
+#else
+    *(OUTPUT_VEC_TYPE*)(output + elem) = c * v + (sgn * s) * sw;
+#endif
 #endif
 }
 #endif

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.cpp
@@ -3,6 +3,8 @@
 //
 #include "rope_opt.hpp"
 
+#include <sstream>
+
 #include "common_utils/dispatch_utils.hpp"
 #include "common_utils/jitter.hpp"
 #include "intel_gpu/primitives/rope.hpp"
@@ -45,7 +47,97 @@ size_t get_vec_size(const RuntimeParams& params) {
         }
     }
 
+    // Debug hook: OV_ROPE_VEC forces the per-work-item vector width. The kernel only has
+    // bodies for 1, 8 and 16, and rotary_ndims must stay divisible by 2*vec_size.
+    if (const char* s = std::getenv("OV_ROPE_VEC")) {
+        size_t v = static_cast<size_t>(std::atoi(s));
+        if ((v == 1 || v == 8 || v == 16) && desc->config.rotary_ndims % (2 * v) == 0) {
+            vec_size = v;
+        }
+    }
+
     return vec_size;
+}
+
+// The interleaved dispatch normally puts BATCH on gws dim 0, which is the largest stride of a
+// bfyx tensor, so a subgroup's lanes land on unrelated cache lines. Reversing dims 0 and 2 puts
+// the rotary/head index -- the contiguous axis -- on the fast dimension instead.
+static bool interleaved_reversed_gws(const RuntimeParams& params) {
+    if (std::getenv("OV_ROPE_NO_REVERSE") != nullptr) {
+        return false;
+    }
+    auto desc = params.typed_desc<rope>();
+    const auto& cfg = desc->config;
+    return cfg.is_interleaved && !cfg.is_qwen && !cfg.is_chatglm && !cfg.is_ltx_video && !cfg.support_3d_rope;
+}
+
+// Upstream reverses the rotate-half dispatch only at vec_size 1, so a vectorised rotate-half
+// keeps BATCH on the fast dimension and its subgroups straddle whole tensors. The reversal is
+// just as valid vectorised: the kernel already reads b from gws dim 2 under REVERSED_GWS.
+static bool half_reversed_gws(const RuntimeParams& params, size_t vec_size) {
+    if (std::getenv("OV_ROPE_NO_HALF_REVERSE") != nullptr) {
+        return false;
+    }
+    auto desc = params.typed_desc<rope>();
+    const auto& cfg = desc->config;
+    return !cfg.is_interleaved && vec_size > 1 && !cfg.is_qwen && !cfg.is_chatglm && !cfg.is_ltx_video && !cfg.support_3d_rope;
+}
+
+// A packed bfyx tensor whose rows are HEAD_COUNT * ROTARY_NDIMS wide can be walked as one flat
+// run of VEC_SIZE-element chunks, which is the only lane->address mapping the compiler lowers to
+// a subgroup block read. Returns 0 when that is not legal here, otherwise the flat gws.
+//
+// Measured neutral against the default REVERSED_GWS path, so it is off unless explicitly asked for.
+// OV_ROPE_CONTIG: unset/0 = off, 1 = on, "copy" = on but drop the rotation (bandwidth ablation).
+static size_t interleaved_contig_gws(const RuntimeParams& params, size_t vec_size) {
+    const char* mode = std::getenv("OV_ROPE_CONTIG");
+    if (mode == nullptr || std::string(mode) == "0") {
+        return 0;
+    }
+    auto desc = params.typed_desc<rope>();
+    const auto& cfg = desc->config;
+    if (!cfg.is_interleaved || cfg.is_qwen || cfg.is_chatglm || cfg.is_ltx_video || cfg.support_3d_rope) {
+        return 0;
+    }
+    if (cfg.input_trans0213 || cfg.output_trans0213 || desc->gather_rank > 0 || cfg.slice_stop > cfg.slice_start) {
+        return 0;
+    }
+    if (vec_size != 8 && vec_size != 16) {
+        return 0;
+    }
+    const size_t rot = cfg.rotary_ndims;
+    if (rot != cfg.head_size || rot == 0 || (rot & (rot - 1)) != 0 || rot % (2 * vec_size) != 0) {
+        return 0;
+    }
+    const auto& in_l = params.input_layouts[0];
+    const auto& cos_l = params.input_layouts[1];
+    const auto& sin_l = params.input_layouts[2];
+    const auto& out_l = params.output_layouts[0];
+    for (const auto* l : {&in_l, &cos_l, &sin_l, &out_l}) {
+        if (l->format != format::bfyx || l->count() != l->get_linear_size() || l->data_padding.is_dynamic()) {
+            return 0;
+        }
+    }
+    if (in_l.data_type != cos_l.data_type || in_l.data_type != sin_l.data_type ||
+        (in_l.data_type != out_l.data_type && out_l.data_type != ov::element::i8)) {
+        return 0;
+    }
+    // input0 is (b, tokens, heads, rot); cos/sin are (b, tokens, 1, rot), so a cos element is at
+    // flat_token * rot + (elem % rot).
+    if (extract_channel(ChannelName::X, in_l) != rot || extract_channel(ChannelName::Y, in_l) != cfg.head_cnt) {
+        return 0;
+    }
+    for (const auto* l : {&cos_l, &sin_l}) {
+        if (extract_channel(ChannelName::X, *l) != rot || extract_channel(ChannelName::Y, *l) != 1 ||
+            extract_channel(ChannelName::BATCH, *l) != extract_channel(ChannelName::BATCH, in_l) ||
+            extract_channel(ChannelName::FEATURE, *l) != extract_channel(ChannelName::FEATURE, in_l)) {
+            return 0;
+        }
+    }
+    if (out_l.count() != in_l.count() || in_l.count() % vec_size != 0) {
+        return 0;
+    }
+    return in_l.count() / vec_size;
 }
 
 class RopeGenerator : public KernelGenerator {
@@ -99,14 +191,28 @@ protected:
         } else if (desc->config.is_ltx_video) {
             jit.make("LTX_VIDEO", true);
         } else if (desc->config.is_interleaved) {
-            jit.make("RotateInterleaved", true);
+            if (!params.is_dynamic() && interleaved_contig_gws(params, get_vec_size(params)) != 0) {
+                jit.make("ROPE_CONTIG", true);
+                const char* mode = std::getenv("OV_ROPE_CONTIG");
+                if (mode != nullptr && std::string(mode) == "copy") {
+                    jit.make("ROPE_CONTIG_COPY", true);
+                }
+            } else {
+                jit.make("RotateInterleaved", true);
+                if (interleaved_reversed_gws(params)) {
+                    jit.make("REVERSED_GWS", true);
+                }
+            }
         } else {
             jit.make("RotateHalf", true);
-            if (get_vec_size(params) == 1) {
+            if (get_vec_size(params) == 1 || half_reversed_gws(params, get_vec_size(params))) {
                 jit.make("REVERSED_GWS", true);
             }
         }
         jit.make("VEC_SIZE", get_vec_size(params));
+        if (params.get_output_layout(0).data_type == ov::element::i8) {
+            jit.make("OUTPUT_I8", true);
+        }
         if (params.get_input_layout(0).data_type != params.get_input_layout(1).data_type) {
             jit.add(make_type_jit_constants("ACCUMULATOR", params.get_input_layout(1).data_type));
         } else {
@@ -150,6 +256,36 @@ protected:
                 const auto& in_l = params.input_layouts[0];
                 const auto& out_l = params.output_layouts[0];
 
+                auto largest_divisor_leq = [](size_t n, size_t cap) {
+                    for (size_t d = std::min(n, cap); d > 1; d--) {
+                        if (n % d == 0) {
+                            return d;
+                        }
+                    }
+                    return size_t{1};
+                };
+
+                if (size_t flat = interleaved_contig_gws(params, vec_size); flat != 0) {
+                    wgs.global = {flat, 1, 1};
+                    const size_t cap = std::min<size_t>(256, static_cast<size_t>(params.get_device_info().max_work_group_size));
+                    // Prefer a whole number of 16-wide subgroups; fall back to any divisor.
+                    size_t l0 = 1;
+                    for (size_t d = (cap / 16) * 16; d >= 16; d -= 16) {
+                        if (flat % d == 0) {
+                            l0 = d;
+                            break;
+                        }
+                    }
+                    wgs.local = {l0 > 1 ? l0 : largest_divisor_leq(flat, cap), 1, 1};
+                    if (const char* s = std::getenv("OV_ROPE_LWS0")) {
+                        size_t v = static_cast<size_t>(std::atoi(s));
+                        if (v > 0 && flat % v == 0) {
+                            wgs.local = {v, 1, 1};
+                        }
+                    }
+                    return;
+                }
+
                 if (cfg.is_qwen) {
                     auto b = extract_channel(ChannelName::BATCH, in_l);
                     auto f = extract_channel(ChannelName::FEATURE, in_l);
@@ -183,6 +319,44 @@ protected:
                         wgs.global[0] = wgs.global[2];
                         wgs.global[2] = tmp;
                     }
+                }
+
+                auto largest_divisor = [](size_t n, size_t cap) {
+                    for (size_t d = std::min(n, cap); d > 1; d--) {
+                        if (n % d == 0) {
+                            return d;
+                        }
+                    }
+                    return size_t{1};
+                };
+
+                if (half_reversed_gws(params, vec_size)) {
+                    std::swap(wgs.global[0], wgs.global[2]);
+                    // gws0 is a multiple of the rotary half-width here, so a whole number of
+                    // 16-wide subgroups fits and every lane stays inside one row.
+                    const size_t l0 = wgs.global[0] % 32 == 0 ? 32 : (wgs.global[0] % 16 == 0 ? 16 : 1);
+                    wgs.local = {l0, largest_divisor(wgs.global[1], std::max(size_t{1}, 256 / l0)), 1};
+                    return;
+                }
+
+                if (interleaved_reversed_gws(params)) {
+                    std::swap(wgs.global[0], wgs.global[2]);
+                    // Keep dim 0 whole where possible so a subgroup stays inside one row, then
+                    // spend what is left of the workgroup budget on the sequence dimension.
+                    const size_t l0 = largest_divisor(wgs.global[0], 32);
+                    wgs.local = {l0, largest_divisor(wgs.global[1], std::max(size_t{1}, 256 / l0)), 1};
+                    // Debug hook: OV_ROPE_LWS="a b c" forces the local size, so the workgroup
+                    // shape can be swept without a rebuild. gws0 is 18 here, which is not a
+                    // multiple of the 16-wide subgroup, so the default straddles rows.
+                    if (const char* s = std::getenv("OV_ROPE_LWS")) {
+                        std::istringstream is(s);
+                        size_t a = 0, b2 = 0, c = 0;
+                        if (is >> a >> b2 >> c && a && b2 && c && wgs.global[0] % a == 0 && wgs.global[1] % b2 == 0 &&
+                            wgs.global[2] % c == 0) {
+                            wgs.local = {a, b2, c};
+                        }
+                    }
+                    return;
                 }
 
                 // We need to set the 1st local workgroup size as large as possible for better performance.

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/rope_opt.hpp
@@ -34,7 +34,15 @@ struct RopeOpt : public ImplementationManager {
             return false;
         }
 
-        return one_of(in0_layout.data_type, supported_types) && one_of(out_layout.data_type, supported_types);
+        // veesion: an i8 output is allowed so the f16 -> s8 narrowing of SDPA's K can ride along
+        // in the rotation's store instead of costing a separate full-tensor pass.
+        static constexpr std::array supported_out_types = {
+            ov::element::f32,
+            ov::element::f16,
+            ov::element::i8,
+        };
+
+        return one_of(in0_layout.data_type, supported_types) && one_of(out_layout.data_type, supported_out_types);
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_gen_micro.cpp
@@ -14,6 +14,7 @@
 #include "intel_gpu/primitives/scaled_dot_product_attention.hpp"
 #include "ocl_v2/utils/jitter.hpp"
 #include "scaled_dot_product_attention_inst.h"
+#include "quantize_inst.h"
 #include "paged_attention_inst.h"
 #include "paged_attention_opt.hpp"
 #include "sdpa_base.hpp"
@@ -41,6 +42,11 @@ inline size_t get_d_max(size_t head_size) {
         }
     }
     return head_size;
+}
+
+const char* veesion_env(const char* name) {
+    const char* v = std::getenv(name);
+    return (v && *v) ? v : nullptr;
 }
 
 micro::Type convert_type(ov::element::Type t) {
@@ -261,6 +267,18 @@ inline size_t micro_get_value_cache_id(const kernel_impl_params& params) {
     }
     auto desc = params.typed_desc<scaled_dot_product_attention>();
     return get_value_cache_id(*desc);
+}
+
+// veesion: true when V has been physically materialised as (batch, heads, head_size, tokens),
+// which the graph signals with input_v_transpose_order == {0, 1, 3, 2}. The V*S microkernel
+// contracts V over tokens, so that layout makes its reduction axis the contiguous one and
+// gemmstone can load A straight to registers instead of staging it through SLM.
+inline bool micro_transpose_v(const kernel_impl_params& params) {
+    if (params.is_type<paged_attention>())
+        return false;
+    if (params.input_layouts[2].get_partial_shape().is_dynamic())
+        return false;
+    return params.typed_desc<scaled_dot_product_attention>()->input_v_transpose_order == std::vector<int64_t>{0, 1, 3, 2};
 }
 
 struct sdpa_config_t {
@@ -955,8 +973,17 @@ KernelData SDPAMicroGenerator::get_kernel_data(const kernel_impl_params& params)
     kd.code->jit += generateShim(gemms[vs_id], micro::HostLanguage::OpenCL_C, shim_options);
 
     bool need_256_grf = false;
+    // OV_SDPA_GRF=256 forces the large register file even when the chosen microkernels do not
+    // demand it. Occupancy here is capped by SLM (~52 KB of a 64 KB budget = one workgroup per
+    // Xe-core), not by thread slots, so halving the slots per EU costs nothing while doubling
+    // the register budget available to the tile.
+    if (const char* grf = std::getenv("OV_SDPA_GRF")) {
+        need_256_grf = std::string(grf) == "256";
+    }
     if (gemms[kq_id].grfMin > 128 || gemms[vs_id].grfMin > 128) {
         need_256_grf = true;
+    }
+    if (need_256_grf) {
         kd.code->options += " -cl-intel-256-GRF-per-thread";
     }
 
@@ -1069,7 +1096,11 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
 
     auto ldq = k_head_size * ov::element::Type(Q.data_type).size();
     auto ldk = k_head_size * ov::element::Type(K.data_type).size();
-    auto ldv = v_head_size * ov::element::Type(V.data_type).size();
+    const bool transpose_v = micro_transpose_v(params);
+    const auto v_seq_len = micro_get_seq_length(params, 2).get_max_length();
+    // With a transposed V the leading dimension is the token count, not the head size.
+    auto ldv = static_cast<size_t>(transpose_v && v_seq_len > 0 ? v_seq_len : static_cast<int64_t>(v_head_size)) *
+               ov::element::Type(V.data_type).size();
     auto lda = v_head_size * ov::element::Type(out.data_type).size();
 
     jit.make("D_MAX", d_max);
@@ -1107,6 +1138,12 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
         jit.make("WITH_SCALE", data_inputs_num > scale_input_idx);
     }
 
+    if (!config.is_paged_attention && params.typed_desc<scaled_dot_product_attention>()->has_rope_q) {
+        // cos/sin are (batch, tokens, HEAD_SIZE) halves, shared by every head, so the table's
+        // row stride is HEAD_SIZE and its batch stride is q * HEAD_SIZE.
+        jit.make("WITH_ROPE_Q", 1);
+    }
+
     jit.make("Q_ALIGN", micro::alignment_for_ld(static_cast<int>(ldq)));
     jit.make("K_ALIGN", micro::alignment_for_ld(static_cast<int>(ldk)));
     jit.make("V_ALIGN", micro::alignment_for_ld(static_cast<int>(ldv)));
@@ -1115,6 +1152,7 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
     jit.make("IS_PREFILL", m_is_prefill);
     jit.make("IS_GQA_SINGLE_TOKEN", m_is_gqa_single_token);
     jit.make("TRANSPOSE_K", false);
+    jit.make("TRANSPOSE_V", transpose_v);
     jit.make("IS_PAGED_ATTENTION", config.is_paged_attention ? 1 : 0);
     jit.make("KV_HEADS_NUM", config.kv_heads_num);
     jit.make("HEADS_NUM", m_is_gqa_single_token ? config.kv_heads_num : config.heads_num);
@@ -1122,6 +1160,98 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
     jit.make("QRY_DATA_T", to_ocl_type(Q.data_type));
     jit.make("KEY_DATA_T", to_ocl_type(K.data_type));
     jit.make("VAL_DATA_T", to_ocl_type(V.data_type));
+
+    // Integer K^T*Q, selected by an s8 key. Q must then already hold integer codes (the graph
+    // folds both quantization steps into the op's scale input, which the kernel applies to S
+    // anyway), so the in-kernel quantization that packs Q into SLM is exact at step 1.
+    jit.make("I8_KQ", (K.data_type == ov::element::i8 || veesion_env("OV_SDPA_I8KQ")) ? 1 : 0);
+
+    // Integer V*S, selected by an s8 value. The softmax operand is already exp(s - rowmax),
+    // i.e. in [0, 1] with at least one 1 per query column, and micro-SDPA defers the 1/rowsum
+    // past the accumulation -- so a FIXED [0, 1] grid is fully used on every row and every key
+    // block. That is the one condition under which quantising softmax probabilities is not
+    // resolution-bound (iteration 34 on the CPU track).
+    // Occupancy probe. The per-workgroup SLM budget decides how many workgroups an Xe-core can
+    // host: 64 KB total, so 32 KB is the cliff. SLM_SHAVE shrinks the declaration WITHOUT
+    // shrinking the pointers, so the arithmetic is unchanged and the answers are garbage --
+    // it prices the cliff before anyone pays to reach it honestly.
+    if (const char* shave = std::getenv("OV_SDPA_SLM_SHAVE"))
+        jit.make("SLM_SHAVE", std::atoi(shave));
+    jit.make("SLM_DUMP", veesion_env("OV_SDPA_SLM_DUMP") ? 1 : 0);
+
+    const bool i8_vs = (V.data_type == ov::element::i8 || veesion_env("OV_SDPA_I8VS"));
+    jit.make("I8_VS", i8_vs ? 1 : 0);
+    if (i8_vs) {
+        // s8 x s8 is the only pair gemmstone selects here, so the probability grid is
+        // [0, 127]. The graph carries the rest of the dequantisation: it divides V by
+        // absmax/127 per head before narrowing, and folds the matching per-head factor into
+        // attn.proj's weight columns, leaving one global constant for the kernel.
+        jit.make("I8_VS_LEVELS", 127);
+        const char* deq = veesion_env("OV_SDPA_VS_DEQ");
+        jit.make("I8_VS_DEQ", deq ? deq : "1.0f");
+        if (veesion_env("OV_SDPA_I8VS_FOLD")) {
+            // exp(x - (m - ln(LEVELS))) = LEVELS * exp(x - m): the quantize multiply
+            // disappears, the running-max differences that drive the rescale cancel the
+            // shift, and the final dequant drops its /LEVELS. ln(127).
+            jit.make("I8_VS_EXP_FOLDED", 1);
+            jit.make("I8_VS_MAX_SHIFT", "4.8441871f");
+        }
+        if (veesion_env("OV_SDPA_I8VS_MAGIC"))
+            // RTE via the 2^23 exponent bias; see tile_quantize_to_char4.
+            jit.make("I8_VS_QUANT_MAGIC", 1);
+    }
+
+    // veesion: when the trailing per-tensor quantizer is fused into micro-SDPA
+    // (OV_SDPA_OUT_I8, see prepare_primitive_fusing), the output layout turns i8 and the
+    // store epilogue must emit the quantizer itself. Mirror scale_shift_opt's per-tensor
+    // branch exactly: tmp = in*pre_scale [+pre_shift] [round] [*post_scale] [+post_shift]
+    // [clamp] convert_char_sat_rte. When no post scale/shift intervenes the round folds
+    // into the saturated conversion, which is what the generic epilogue relies on too.
+    bool out_i8 = out.data_type == ov::element::i8;
+    if (veesion_env("OV_SDPA_OUT_I8_DEBUG"))
+        std::cerr << "[veesion] micro jit: out_dt=" << out.data_type << " out_i8=" << out_i8
+                  << " fused_desc=" << params.fused_desc.size() << std::endl;
+    if (out_i8) {
+        bool found_quantize = false;
+        for (const auto& fd : params.fused_desc) {
+            if (!fd.is_type<quantize>())
+                continue;
+            const auto p = fd.get_typed_fuse_params<QuantizeFuseParams>();
+            if (veesion_env("OV_SDPA_OUT_I8_DEBUG")) {
+                std::cerr << "[veesion] SDPA_OUT_I8 fused: in_scale=" << p->_in_scale
+                          << " in_shift=" << p->_in_shift << " need_pre_shift=" << p->_need_pre_shift
+                          << " out_scale=" << p->_out_scale << " out_shift=" << p->_out_shift
+                          << " need_post_scale=" << p->_need_post_scale
+                          << " need_post_shift=" << p->_need_post_shift
+                          << " out_lo=" << p->_out_lo << " out_hi=" << p->_out_hi
+                          << " need_clamp=" << p->_need_clamp
+                          << " need_min_clamp=" << p->_need_min_clamp
+                          << " need_max_clamp=" << p->_need_max_clamp
+                          << " per_tensor_in_range=" << p->_per_tensor_input_range
+                          << " per_tensor_in_scale=" << p->_per_tensor_input_scale
+                          << std::endl;
+            }
+            jit.make("SDPA_Q_PRE_SCALE", p->_in_scale);
+            jit.make("SDPA_Q_PRE_SHIFT", p->_in_shift);
+            jit.make("SDPA_Q_NEED_PRE_SHIFT", p->_need_pre_shift ? 1 : 0);
+            jit.make("SDPA_Q_POST_SCALE", p->_out_scale);
+            jit.make("SDPA_Q_POST_SHIFT", p->_out_shift);
+            jit.make("SDPA_Q_NEED_POST_SCALE", p->_need_post_scale ? 1 : 0);
+            jit.make("SDPA_Q_NEED_POST_SHIFT", p->_need_post_shift ? 1 : 0);
+            jit.make("SDPA_Q_OUT_LO", p->_out_lo);
+            jit.make("SDPA_Q_OUT_HI", p->_out_hi);
+            jit.make("SDPA_Q_NEED_CLAMP", p->_need_clamp ? 1 : 0);
+            jit.make("SDPA_Q_NEED_MIN_CLAMP", p->_need_min_clamp ? 1 : 0);
+            jit.make("SDPA_Q_NEED_MAX_CLAMP", p->_need_max_clamp ? 1 : 0);
+            found_quantize = true;
+            break;
+        }
+        // An i8 output layout can only come from the fused quantize epilogue; if the
+        // constants are missing the buffer is i8 while the store would be half, so fail hard.
+        OPENVINO_ASSERT(found_quantize,
+                        "[GPU] SDPA micro kernel has i8 output but no fused quantize epilogue");
+    }
+    jit.make("SDPA_OUT_I8", out_i8 ? 1 : 0);
 
     auto elems_per_byte = [](ov::element::Type dt) {
         switch (dt) {
@@ -1221,6 +1351,7 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
     // const ov::Dimension n_values = micro_get_seq_length(params, 2);
     const ov::Dimension n_values = ov::Dimension(v_head_size);
 
+
     bool d_full = (head_size == static_cast<size_t>(d_max));
     bool v_full = (head_size == static_cast<size_t>(tile_v));
     bool k_full = !n_keys.is_dynamic() && (n_keys.get_length() % tile_k) == 0;
@@ -1252,14 +1383,25 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
         // tile_ops.cl defines DEF_BLOCK2D_LOAD_STORE for half up to vl=16 (BR=32, BC=8).
         // tile element vector = sg_tile_m * max_BC / sg_size; must be <= 16 (max defined vl).
         const bool block2d_compatible = (sg_tile_m * 8 / sg_size) <= 16;  // sg_tile_m <= 32
-        const bool use_block2d = lda % 16 == 0 && vbytes % 4 == 0 && block2d_compatible;
+        // veesion: the block2d store is defined on the half tile only; keep it off when the
+        // fused quantizer turns the output into i8 (char tile store).
+        const bool use_block2d = lda % 16 == 0 && vbytes % 4 == 0 && block2d_compatible && !out_i8;
         GPU_DEBUG_TRACE_DETAIL << "BLOCK_2D_A check: sg_tile_m=" << sg_tile_m << " sg_size=" << sg_size << " lda=" << lda << " vbytes=" << vbytes
                                << " block2d_compatible=" << block2d_compatible << " => " << (use_block2d ? "enabled" : "disabled") << std::endl;
         if (use_block2d)
             jit.make("BLOCK_2D_A", 1);
     }
 
-    if (device_info.arch >= gpu_arch::xe_hpc) {
+    // veesion: upstream gates the cooperative K/V prefetch behind xe_hpc, but it is written
+    // against __builtin_IB_lsc_prefetch_global_*, which Xe-HPG/Xe-LPG implement too. Without
+    // it every key-block iteration stalls on the global loads of K and V. Opt in with
+    // OV_SDPA_PREFETCH=1; read here rather than from the plugin config because the config is
+    // frozen at OpenVINO import while kernels are built later, so both spellings can be
+    // compared inside one process.
+    bool prefetch_arch = device_info.arch >= gpu_arch::xe_hpc;
+    if (const char* pf = std::getenv("OV_SDPA_PREFETCH"))
+        prefetch_arch = std::string(pf) != "0";
+    if (prefetch_arch) {
         jit.make("PREFETCH_MASK", 1);
         jit.make("PREFETCH_K0", (config.is_paged_attention && !m_is_prefill) ? 0 : 1);
         jit.make("PREFETCH_K", (config.is_paged_attention && !m_is_prefill) ? 0 : 1);
@@ -1335,13 +1477,72 @@ JitConstants SDPAMicroGenerator::get_jit_constants(const kernel_impl_params& par
     if (data_inputs_num > 3 && !config.is_paged_attention && sdpa_has_runtime_attn_mask_input(params)) {
         jit.add(convert_strides("MSK", "INPUT3", {0, 1, 2, 3}));
         jit.add(unit_parameters("MSK"));
+
+        // veesion: a [b, h, 1, k] mask carries one value per KEY and none per query, yet the
+        // general path in sdpa_micro.cl materialises it as a full S-shaped tile through a
+        // transposed load -- sg_tile_n times the traffic and registers for the same
+        // information, plus a half->float tile copy and a full-tile add. MASK_PER_KEY loads a
+        // coalesced sg_tile_m vector instead and broadcasts it along the query direction with
+        // the machinery REMAINDER_K's k_mask already uses. Off with OV_SDPA_MASK_K=0.
+        const auto& msk_shape = params.input_layouts[3].get_partial_shape();
+        bool per_key = msk_shape.size() == 4 && msk_shape[2].is_static() && msk_shape[2].get_length() == 1 &&
+                       msk_shape[3].is_static() && msk_shape[3].get_length() > 1;
+        if (const char* e = std::getenv("OV_SDPA_MASK_K"))
+            per_key = per_key && std::string(e) != "0";
+        jit.make("MASK_PER_KEY", per_key ? 1 : 0);
     }
 
-    // std::cout << "JIT for micro kernel:" << std::endl;
-    // for (auto it : jit) {
-    //     std::cout << "jit[" << it.name << "] = " << it.value << std::endl;
-    // }
-    // std::cout << std::endl;
+    // veesion: OV_SDPA_SOFTMAX is read at kernel-build time rather than from the plugin
+    // config, which is frozen when OpenVINO is imported -- so two spellings can be compared
+    // in one process and drift cannot favour either.
+    //
+    // "nomax" computes softmax as exp(s)/sum(exp(s)) instead of the max-shifted form. It is
+    // the same function; the running maximum exists only to keep exp() from overflowing
+    // f32, and dropping it removes an SLM atomic-max reduction, one split workgroup barrier
+    // per key block, and the per-key-block rescale of the output accumulator. Safe exactly
+    // when the pre-softmax scores stay below ~88; measured error on this model is unchanged
+    // (slightly better, since the accumulator is no longer repeatedly rescaled).
+    //
+    // "noexp" replaces the exponential with a multiply. Diagnostic only -- it establishes
+    // that the transcendental itself is not the cost.
+    if (const char* mode = std::getenv("OV_SDPA_SOFTMAX")) {
+        const std::string m(mode);
+        if (m.find("nomax") != std::string::npos) {
+            jit.make("DIAG_NO_MAX", 1);
+        }
+        if (m.find("noexp") != std::string::npos) {
+            jit.make("DIAG_NO_EXP", 1);
+        }
+        // "altmax" exponentiates against the subgroup-local maximum immediately, then
+        // corrects with the workgroup maximum afterwards, so the SLM barrier wait leaves the
+        // critical path. Same function, extra multiply. The kernel already carries the arm;
+        // nothing upstream ever defines it.
+        if (m.find("altmax") != std::string::npos) {
+            jit.make("ALT_MAX", 1);
+        }
+        // Attribution arms. Each deletes one stage and produces wrong answers; they exist
+        // only to split the measured SDPA time between the two micro-GEMMs and the softmax
+        // that sits between them.
+        if (m.find("skipkq") != std::string::npos) {
+            jit.make("DIAG_SKIP_KQ", 1);
+        }
+        if (m.find("skipvs") != std::string::npos) {
+            jit.make("DIAG_SKIP_VS", 1);
+        }
+        if (m.find("skipsm") != std::string::npos) {
+            jit.make("DIAG_SKIP_SM", 1);
+        }
+        // "skipstore" keeps the quantize (or the f16 pack) but deletes the S staging
+        // store; "skipqnt" deletes the whole staging. Only meaningful under skipvs,
+        // where nothing consumes S: they split the measured i8-vs-f16 staging penalty
+        // between the quantize ALU and the store itself.
+        if (m.find("skipstore") != std::string::npos) {
+            jit.make("DIAG_SKIP_STORE", 1);
+        }
+        if (m.find("skipqnt") != std::string::npos) {
+            jit.make("DIAG_SKIP_QNT", 1);
+        }
+    }
 
     return jit;
 }
@@ -1409,6 +1610,12 @@ Arguments SDPAMicroGenerator::get_arguments_desc(const kernel_impl_params& param
         const uint32_t sink_idx = ScaledDotProductAttentionInputIdx::SINK;
         if (config.input_num > sink_idx)
             args.push_back({ArgumentDescriptor::Types::INPUT, sink_idx});  // Sink
+
+        if (params.typed_desc<scaled_dot_product_attention>()->has_rope_q) {
+            const auto total = static_cast<uint32_t>(params.input_layouts.size());
+            args.push_back({ArgumentDescriptor::Types::INPUT, total - 2});  // RoPE cos
+            args.push_back({ArgumentDescriptor::Types::INPUT, total - 1});  // RoPE sin
+        }
 
         args.push_back({ArgumentDescriptor::Types::SCALAR, 0});  // D
         args.push_back({ArgumentDescriptor::Types::SCALAR, 1});  // K
@@ -1501,6 +1708,32 @@ size_t SDPAMicroGenerator::get_tile_qsize(const KernelData& kernel_data) {
     return wg_tile_q;
 }
 
+namespace {
+void veesion_dump_strategy(const char* tag, micro::GEMMStrategy& s) {
+    if (!veesion_env("OV_SDPA_DUMP"))
+        return;
+    std::cerr << "[sdpa-strategy] " << tag << " unroll=" << s.unroll[0] << "x" << s.unroll[1] << "x" << s.unroll[2]
+              << " wg=" << s.wg[0] << "x" << s.wg[1] << "x" << s.wg[2] << " systolic=" << s.systolic << " dpasw=" << s.dpasw
+              << " fused=" << s.fused << " fixedSystolic=" << s.fixedSystolic << " slmA=" << s.slmA << " slmB=" << s.slmB
+              << " slmATrans=" << s.slmATrans << " slmBTrans=" << s.slmBTrans << " slmBuffers=" << s.slmBuffers
+              << " unrollKSLM=" << s.unrollKSLM << " ka_load=" << s.ka_load << " kb_load=" << s.kb_load
+              << " ka_prefetch=" << s.ka_prefetch << " kb_prefetch=" << s.kb_prefetch << " prefetchA=" << s.prefetchA
+              << " prefetchB=" << s.prefetchB << " barrierFreq=" << s.barrierFreq << " coopA=" << static_cast<int>(s.coopA)
+              << " registerScheme=" << static_cast<int>(s.registerScheme) << " GRFs=" << s.GRFs << std::endl;
+}
+void veesion_dump_kq(micro::GEMMStrategy& s) {
+    if (const char* v = veesion_env("OV_SDPA_KQ_KSLM"))
+        s.unrollKSLM = std::atoi(v);
+    // Iteration 46: forcing s.slmA=1 here (to stage K through SLM and kill the ~4x redundant
+    // global K reads that wg=8x4 with coopA=0 implies) segfaults the nGEN generator during
+    // microkernel emission, for every combination of coopA and unrollKSLM tried. It is not an
+    // SLM-budget rejection -- preflight runs after this hook and would have skipped the
+    // strategy cleanly. The knob is removed rather than left in as a diagnostic: it crashes
+    // the process instead of reporting, so it can only mislead.
+    veesion_dump_strategy("kq", s);
+}
+}  // namespace
+
 std::mutex SDPAMicroGenerator::m;
 void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
                                            const sdpa_configuration& configuration,
@@ -1529,6 +1762,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
     const ov::Dimension n_keys = micro_get_seq_length(params, 1);
     const ov::Dimension n_queries = micro_get_seq_length(params, 0);
     const ov::Dimension n_values = ov::Dimension(v_head_size);
+    const bool transpose_v = micro_transpose_v(params);
     const auto head_num = micro_get_num_heads(params, 0);
     const auto batch = out_ps[0] * static_cast<ov::Dimension>(head_num);
 
@@ -1538,6 +1772,7 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
 
     /* Retrieve pre-tuned kernel configuration */
     sdpa_config_t* config = nullptr;
+    sdpa_config_t config_override{};
     bool thin_q = (!n_queries.is_dynamic() && n_queries.get_length() <= 16) || !is_prefill;
     if (is_paged_attention && !is_prefill)
         thin_q = is_gqa_single_token;
@@ -1567,9 +1802,37 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
     }
     }
 
-    if (!is_prefill) {
-        const auto& wg_cfg = GPU_DEBUG_VALUE_OR(params.get_program().get_config().get_micro_sdpa_workgroup_config(), std::vector<int>{});
-        if (wg_cfg.size() >= 4) {
+    {  // veesion: debug override must apply in prefill too, so the tile config is tunable for ViT-shaped SDPA.
+       // 4 ints override the workgroup shape only; 8 ints also override the subgroup tile sizes
+       // (unroll_*), which are what actually set the microkernel's register tile and are otherwise
+       // unreachable from outside the chooser.
+        auto wg_cfg = GPU_DEBUG_VALUE_OR(params.get_program().get_config().get_micro_sdpa_workgroup_config(), std::vector<int>{});
+        // OV_SDPA_TILE is re-read on every kernel build, unlike the plugin config, which is
+        // frozen when OpenVINO is imported. Without it two tile shapes cannot be compared in
+        // one process, and comparing them across processes cannot cancel this iGPU's drift.
+        if (const char* tile_env = std::getenv("OV_SDPA_TILE")) {
+            wg_cfg.clear();
+            std::istringstream is(tile_env);
+            for (int v = 0; is >> v;) {
+                wg_cfg.push_back(v);
+            }
+        }
+        // The chooser hands back a pointer into a table of file-scope configs, so writing the
+        // override through it would corrupt that table for every later compile in the process.
+        if (!wg_cfg.empty()) {
+            config_override = *config;
+            config = &config_override;
+        }
+        if (wg_cfg.size() >= 8) {
+            config->unroll_m_kq = wg_cfg[0];
+            config->unroll_n_kq = wg_cfg[1];
+            config->unroll_m_vs = wg_cfg[2];
+            config->unroll_n_vs = wg_cfg[3];
+            config->wg_m_kq = wg_cfg[4];
+            config->wg_n_kq = wg_cfg[5];
+            config->wg_m_vs = wg_cfg[6];
+            config->wg_n_vs = wg_cfg[7];
+        } else if (wg_cfg.size() >= 4) {
             config->wg_m_kq = wg_cfg[0];
             config->wg_n_kq = wg_cfg[1];
             config->wg_m_vs = wg_cfg[2];
@@ -1612,6 +1875,12 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
     micro::GEMMOptions opts_kq;
     opts_kq.localB = true;
     opts_kq.slmPtr = true;
+    // Probe: can gemmstone build a K^T*Q microkernel that reads K from SLM? That is the
+    // prerequisite for rotating K in the caller's staging loop and deleting the standalone
+    // k-side RoPE node. Selection happens here, long before the OCL build, so a failure is
+    // reported cheaply.
+    if (veesion_env("OV_SDPA_KQ_LOCALA"))
+        opts_kq.localA = true;
 
     const bool use_asymmetric_quantization = configuration.use_asymmetric_quantization;
 
@@ -1721,9 +1990,22 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
     reqs_kq.push_back(micro::StrategyRequirement::WGM == config->wg_m_kq);
     reqs_kq.push_back(micro::StrategyRequirement::WGN == config->wg_n_kq);
 
+    if (K.data_type == ov::element::i8 || veesion_env("OV_SDPA_I8KQ")) {
+        // s8 x s8 -> s32. The paged-attention "quantized" path only ever sets Ta = s8 as a
+        // DECOMPRESSION hint (Tb stays f16 and A is dequantised on load), so it cannot be
+        // reused here: this needs integer dpas on both operands.
+        problem_kq.Ta = problem_kq.Tb = micro::Type::s8;
+        problem_kq.Ta_ext = problem_kq.Tb_ext = micro::Type::s8;
+        problem_kq.Tc = problem_kq.Tc_ext = micro::Type::s32;
+        problem_kq.Ts = micro::Type::s32;
+        problem_kq.B.crosspack = 4;
+        problem_kq.A.setAlignment(micro::alignment_for_ld(static_cast<int>(k_head_size * problem_kq.Ta)));
+    }
+
     /* Ask microkernel provider for microkernel */
     try {
-        gemm_kq = micro::select_gemm_microkernel(opts_kq, hw_info, sizes, problem_kq, reqs_kq);
+        const bool kq_hook = veesion_env("OV_SDPA_DUMP") || veesion_env("OV_SDPA_KQ_KSLM");
+        gemm_kq = micro::select_gemm_microkernel(opts_kq, hw_info, sizes, problem_kq, reqs_kq, kq_hook ? veesion_dump_kq : nullptr);
     } catch (const std::runtime_error& ex) {
         GPU_DEBUG_TRACE_DETAIL << "Can't create KQ sdpa_micro kernel: " << ex.what() << "\n";
         throw;
@@ -1833,6 +2115,11 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
     if (is_int4_kv_cache && is_paged_attention && !is_prefill) {
         // INT4 V: ldv = packed_head_bytes + scales = v_head_size * u4 + 4 = 68
         problem_vs.A.setAlignment(static_cast<int>(v_head_size * problem_vs.Ta_ext) + 4);
+    } else if (transpose_v) {
+        // V is physically (batch, heads, head_size, tokens): A is k-contiguous, leading
+        // dimension is the token count. Lets gemmstone load A to registers instead of SLM.
+        problem_vs.A.layout = micro::MatrixLayout::T;
+        problem_vs.A.setAlignment(micro::alignment_for_ld(static_cast<int>(n_keys.get_length() * problem.Ta)));
     } else {
         problem_vs.A.setAlignment(micro::alignment_for_ld(static_cast<int>(v_head_size * problem.Ta)));
     }
@@ -1855,7 +2142,35 @@ void SDPAMicroGenerator::init_microkernels(const kernel_impl_params& params,
     auto adjust_vs = [](micro::GEMMStrategy& strategy) {
         /* Enable dpasw */
         strategy.dpasw |= strategy.fused;
+        if (const char* v = veesion_env("OV_SDPA_VS_SLMA")) {
+            if (std::atoi(v) == 0) {
+                strategy.slmA = false;
+                if (!strategy.slmB)
+                    strategy.slmBuffers = 0;
+            }
+        }
+        if (const char* v = veesion_env("OV_SDPA_VS_KSLM"))
+            strategy.unrollKSLM = std::atoi(v);
+        if (const char* v = veesion_env("OV_SDPA_VS_SLMATRANS"))
+            strategy.slmATrans = std::atoi(v) != 0;
+        if (const char* v = veesion_env("OV_SDPA_VS_KALOAD"))
+            strategy.ka_load = std::atoi(v);
+        veesion_dump_strategy("vs", strategy);
     };
+    if (V.data_type == ov::element::i8 || veesion_env("OV_SDPA_I8VS")) {
+        problem_vs.Ta = problem_vs.Tb = micro::Type::s8;
+        problem_vs.Ta_ext = problem_vs.Tb_ext = micro::Type::s8;
+        problem_vs.Tc = problem_vs.Tc_ext = micro::Type::s32;
+        problem_vs.Ts = micro::Type::s32;
+        // 32 bytes of k per crosspack group, matching tile_store_t_sys_src2's
+        // cp = 32 / sizeof(element). At f16 that spelling is 16 elements; at s8 it is 32.
+        problem_vs.B.crosspack = 32;
+        if (transpose_v)
+            problem_vs.A.setAlignment(micro::alignment_for_ld(static_cast<int>(n_keys.get_length() * problem_vs.Ta)));
+        else
+            problem_vs.A.setAlignment(micro::alignment_for_ld(static_cast<int>(v_head_size * problem_vs.Ta)));
+    }
+
     /* Ask microkernel provider for microkernel */
     try {
         gemm_vs = micro::select_gemm_microkernel(opts_vs, hw_info, sizes, problem_vs, reqs_vs, adjust_vs);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.cpp
@@ -49,6 +49,10 @@ public:
     SDPAOptImpl() : SDPAImplBase(SDPAOpt::get_type_info_static()) {}
     explicit SDPAOptImpl(const RuntimeParams& impl_param) : SDPAOptImpl() {
         auto params = SDPABase::requires_shape_canonicalization(impl_param) ? SDPABase::static_canonicalize_shapes(impl_param) : impl_param;
+        if (std::getenv("OV_SDPA_OUT_I8_DEBUG"))
+            std::cerr << "[veesion] SDPAOptImpl ctor: node out_dt=" << static_cast<int>(impl_param.output_layouts[0].data_type)
+                      << " canon out_dt=" << static_cast<int>(params.output_layouts[0].data_type)
+                      << " fused=" << impl_param.fused_desc.size() << " canon_fused=" << params.fused_desc.size() << std::endl;
         GPU_DEBUG_TRACE_DETAIL << "create stages for dynamic = " << params.is_dynamic() << "\n";
         if (params.is_dynamic()) {
             GPU_DEBUG_TRACE_DETAIL << "add stages for dynamic ...\n";
@@ -76,11 +80,15 @@ public:
 #ifdef ENABLE_ONEDNN_FOR_GPU
                 } else if (SDPAOpt::supports_micro_sdpa(params)) {
                     GPU_DEBUG_TRACE_DETAIL << "add stage for micro_sdpa non-dynamic with prefill_stage \n";
+                    if (std::getenv("OV_SDPA_TRACE"))
+                        std::cerr << "[veesion] micro_sdpa prefill stage added\n";
                     add_stage(regular_micro_multi_tokens, params);
                     // Sometimes micro kernel will fail due to "Insufficient registers in requested bundle",
                     // In this case, fallback to opt kernel.
                     if (!has_stage(regular_micro_multi_tokens)) {
                         GPU_DEBUG_TRACE_DETAIL << "fail to create micro kernel, fallback to regular_multi_tokens for prefill \n";
+                        if (std::getenv("OV_SDPA_TRACE"))
+                            std::cerr << "[veesion] micro_sdpa FAILED, fallback to opt\n";
                         add_stage(regular_multi_tokens, params);
                     }
 #endif
@@ -217,7 +225,12 @@ bool SDPAOpt::supports_micro_sdpa(const RuntimeParams& params) {
     ov::Dimension K_num_heads_dim = get_num_heads(k_layout, extended_input_k_transpose_order);
     ov::Dimension V_num_heads_dim = get_num_heads(v_layout, extended_input_v_transpose_order);
 
-    if (extended_input_q_transpose_order[3] != 3 || extended_input_k_transpose_order[3] != 3 || extended_input_v_transpose_order[3] != 3) {
+    // veesion: {0, 1, 3, 2} on V means the value tensor is physically (batch, heads, head_size,
+    // tokens), which is the layout the V*S microkernel wants -- see TRANSPOSE_V in
+    // sdpa_gen_micro.cpp. Every other order still has to keep head_size last.
+    const bool value_transposed = extended_input_v_transpose_order == std::vector<int64_t>{0, 1, 3, 2};
+    if (extended_input_q_transpose_order[3] != 3 || extended_input_k_transpose_order[3] != 3 ||
+        (extended_input_v_transpose_order[3] != 3 && !value_transposed)) {
         return false;
     }
 
@@ -256,6 +269,8 @@ std::unique_ptr<primitive_impl> SDPAOpt::create_impl(const program_node& node, c
     try {
         return std::make_unique<SDPAOptImpl>(params);
     } catch (const std::exception& e) {
+        if (std::getenv("OV_SDPA_OUT_I8_DEBUG"))
+            std::cerr << "[veesion] SDPAOptImpl creation FAILED: " << e.what() << std::endl;
         OPENVINO_THROW("Failed to create SDPAOptImpl: ", e.what());
     }
 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_opt.hpp
@@ -51,7 +51,14 @@ struct SDPAOpt : public ImplementationManager {
             return false;
         }
 
-        if (!one_of(q_layout.data_type, supported_q_types) || !one_of(out_layout.data_type, supported_q_types)) {
+        // veesion: an i8 output is only produced when the trailing quantizer was fused into
+        // this SDPA (OV_SDPA_OUT_I8, see prepare_primitive_fusing.cpp), so accept it only in
+        // that shape; everything else keeps the stock f32/f16 output contract.
+        const bool fused_i8_output = std::getenv("OV_SDPA_OUT_I8") != nullptr &&
+                                     out_layout.data_type == ov::element::i8 &&
+                                     node.has_fused_primitives();
+        if (!one_of(q_layout.data_type, supported_q_types) ||
+            (!one_of(out_layout.data_type, supported_q_types) && !fused_i8_output)) {
             return false;
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_utils.hpp
@@ -14,6 +14,9 @@ namespace ov::intel_gpu::ocl {
 // Data inputs are QKV, mask and scale. Beam table and quantization params are not considered.
 inline size_t get_data_inputs_num(const cldnn::scaled_dot_product_attention& desc) {
     size_t data_inputs_num = desc.input_size();
+    if (desc.has_rope_q) {
+        data_inputs_num -= 2;
+    }
     if (desc.indirect_axis != -1) {
         data_inputs_num--;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_micro.cl
@@ -31,17 +31,45 @@
 #define q_tile_sg_n DIV_UP(ugemm_kq_wg_tile_n, sg_per_wg)
 
 /* Instantiate tile types and operations */
+#if I8_KQ
+/* K^T*Q runs on the integer pipe, so ugemm_kq accumulates in s32. Everything downstream of
+   the gemm -- mask, softmax, VS -- stays float, so the s32 tile is converted and dequantized
+   the moment it comes back. */
+#define Q_SLM_ROWS (D_MAX / 4)
+typedef ugemm_kq_c_type s_tile_type_int;
+DECLARE_2D_TILE(s_tile_type, float, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
+        ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
+        ugemm_kq_c_type_nblock1)
+#else
+#define Q_SLM_ROWS (D_MAX / 2)
 typedef ugemm_kq_c_type s_tile_type;
+#endif
+#if I8_VS
+/* V*S on the integer pipe. The softmax operand is exp(s - rowmax), i.e. in [0, 1] with at
+   least one 1 per query, and micro-SDPA defers the 1/rowsum past the accumulation -- so the
+   fixed [0, I8_VS_LEVELS] grid is fully used on every row and every key block. The s32 block
+   result is converted immediately because the flash-attention rescale between blocks is a
+   float multiply. */
+typedef ugemm_vs_c_type a_tile_type_int;
+DECLARE_2D_TILE(a_tile_type, float, SUBGROUP_SIZE, ugemm_vs_c_type_block0,
+        ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
+        ugemm_vs_c_type_nblock1)
+#define S_SLM_ELEM_SIZE 1
+#else
 typedef ugemm_vs_c_type a_tile_type;
+#define S_SLM_ELEM_SIZE sizeof(half)
+#endif
 
-DECLARE_2D_TILE(q_tile_type, uint, SUBGROUP_SIZE, D_MAX / 2, 1, 1, q_tile_sg_n)
+DECLARE_2D_TILE(q_tile_type, uint, SUBGROUP_SIZE, Q_SLM_ROWS, 1, 1, q_tile_sg_n)
 
+#if !I8_KQ
 #ifdef BLOCK_Q
 DECLARE_2D_TILE_BLOCK_OPS(
         q_tile_type, uint, SUBGROUP_SIZE, D_MAX / 2, 1, 1, q_tile_sg_n)
 #elif Q_ALIGN < 4
 DECLARE_2D_TILE_LOAD_PACKED_HALF(
         q_tile_type, SUBGROUP_SIZE, D_MAX / 2, 1, 1, q_tile_sg_n)
+#endif
 #endif
 
 #ifdef BLOCK_A
@@ -55,6 +83,80 @@ DECLARE_2D_TILE(a_tile_type_half, half, SUBGROUP_SIZE, ugemm_vs_sg_tile_m, 8, 1,
 DECLARE_2D_TILE(s_tile_type_half2, uint, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
         ugemm_kq_c_type_block1 / 2, ugemm_kq_c_type_nblock0,
         ugemm_kq_c_type_nblock1)
+
+#if I8_VS
+/* Same uint carrier as the VNNI half2 tile, so tile_store_t_sys_src2 lays out the identical
+   32-byte crosspack groups; only the k-per-group count changes, 16 halves -> 32 chars. */
+DECLARE_2D_TILE(s_tile_type_char4, uint, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
+        ugemm_kq_c_type_block1 / 4, ugemm_kq_c_type_nblock0,
+        ugemm_kq_c_type_nblock1)
+
+#ifdef I8_VS_QUANT_MAGIC
+/* RTE via the 2^23 exponent bias: (v*sc) + 2^23 pins the float's exponent so the
+   mantissa low bits hold the ties-to-even-rounded integer, and the low byte of each
+   lane is the char code. Bit-identical to convert_char4_sat_rte for products in
+   [0, 127] (saturation is dead there), at one FMA + shifts/ors per lane instead of the
+   cvt/clamp/pack sequence. The _ns variants drop the scale multiply outright for
+   I8_VS_EXP_FOLDED, whose exponentials already sit on the [0, LEVELS] grid. */
+#define tile_quantize_to_char4(t, t_new, sc) \
+    do { \
+        _Pragma("unroll") for (int i = 0; i < sizeof(t.x) / sizeof(t.x[0]); \
+                               i++) { \
+            _Pragma("unroll") for (int s = 0; \
+                                   s < sizeof(t.x[0]) / sizeof(t.x[0][0]) / 4; \
+                                   s++) { \
+                float4 v = {t.x[i][4 * s], t.x[i][4 * s + 1], \
+                        t.x[i][4 * s + 2], t.x[i][4 * s + 3]}; \
+                float4 m_ = v * (sc) + 8388608.0f; \
+                uint4 u_ = as_uint4(m_); \
+                t_new.x[i][s] = u_.x | (u_.y << 8) | (u_.z << 16) | (u_.w << 24); \
+            } \
+        } \
+    } while (0)
+#define tile_quantize_to_char4_ns(t, t_new) \
+    do { \
+        _Pragma("unroll") for (int i = 0; i < sizeof(t.x) / sizeof(t.x[0]); \
+                               i++) { \
+            _Pragma("unroll") for (int s = 0; \
+                                   s < sizeof(t.x[0]) / sizeof(t.x[0][0]) / 4; \
+                                   s++) { \
+                float4 v = {t.x[i][4 * s], t.x[i][4 * s + 1], \
+                        t.x[i][4 * s + 2], t.x[i][4 * s + 3]}; \
+                float4 m_ = v + 8388608.0f; \
+                uint4 u_ = as_uint4(m_); \
+                t_new.x[i][s] = u_.x | (u_.y << 8) | (u_.z << 16) | (u_.w << 24); \
+            } \
+        } \
+    } while (0)
+#else
+#define tile_quantize_to_char4(t, t_new, sc) \
+    do { \
+        _Pragma("unroll") for (int i = 0; i < sizeof(t.x) / sizeof(t.x[0]); \
+                               i++) { \
+            _Pragma("unroll") for (int s = 0; \
+                                   s < sizeof(t.x[0]) / sizeof(t.x[0][0]) / 4; \
+                                   s++) { \
+                float4 v = {t.x[i][4 * s], t.x[i][4 * s + 1], \
+                        t.x[i][4 * s + 2], t.x[i][4 * s + 3]}; \
+                t_new.x[i][s] = as_uint(convert_char4_sat_rte(v * (sc))); \
+            } \
+        } \
+    } while (0)
+#define tile_quantize_to_char4_ns(t, t_new) \
+    do { \
+        _Pragma("unroll") for (int i = 0; i < sizeof(t.x) / sizeof(t.x[0]); \
+                               i++) { \
+            _Pragma("unroll") for (int s = 0; \
+                                   s < sizeof(t.x[0]) / sizeof(t.x[0][0]) / 4; \
+                                   s++) { \
+                float4 v = {t.x[i][4 * s], t.x[i][4 * s + 1], \
+                        t.x[i][4 * s + 2], t.x[i][4 * s + 3]}; \
+                t_new.x[i][s] = as_uint(convert_char4_sat_rte(v)); \
+            } \
+        } \
+    } while (0)
+#endif
+#endif
 
 DECLARE_2D_TILE(
         s_sum_tile_type, float, SUBGROUP_SIZE, ugemm_kq_sg_tile_n, 1, 1, 1)
@@ -85,6 +187,60 @@ DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE, ugemm_vs_c_type_block0,
         ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
         ugemm_vs_c_type_nblock1, a_tile_type_half, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8)
+#endif
+
+#if SDPA_OUT_I8
+/* veesion: the trailing per-tensor scale_shift_opt quantizer is fused into this kernel, so
+   the store lands on the i8 grid directly. sdpa_out_quant_step mirrors the generic fused
+   quantize epilogue (fused_ops_jitter) step for step; with no post scale/shift the round
+   folds into the saturated rte conversion, and pre_scale == 1.0 makes the whole chain a
+   plain round-and-saturate (the v-folded proj arm). */
+char sdpa_out_quant_step(float x) {
+    float tmp = x * SDPA_Q_PRE_SCALE;
+#if SDPA_Q_NEED_PRE_SHIFT
+    tmp += SDPA_Q_PRE_SHIFT;
+#endif
+#if SDPA_Q_NEED_POST_SCALE || SDPA_Q_NEED_POST_SHIFT
+    tmp = round(tmp);
+#endif
+#if SDPA_Q_NEED_POST_SCALE
+    tmp *= SDPA_Q_POST_SCALE;
+#endif
+#if SDPA_Q_NEED_POST_SHIFT
+    tmp += SDPA_Q_POST_SHIFT;
+#endif
+#if SDPA_Q_NEED_CLAMP
+#if SDPA_Q_NEED_MIN_CLAMP && SDPA_Q_NEED_MAX_CLAMP
+    tmp = clamp(tmp, SDPA_Q_OUT_LO, SDPA_Q_OUT_HI);
+#elif SDPA_Q_NEED_MIN_CLAMP
+    tmp = max(tmp, SDPA_Q_OUT_LO);
+#elif SDPA_Q_NEED_MAX_CLAMP
+    tmp = min(tmp, SDPA_Q_OUT_HI);
+#endif
+#endif
+    return convert_char_sat_rte(tmp);
+}
+
+DECLARE_2D_TILE(a_tile_type_char, char, SUBGROUP_SIZE, ugemm_vs_sg_tile_m, 8, 1,
+        ugemm_vs_sg_tile_n / 8)
+
+#define DECLARE_2D_TILE_QUANT_REBLOCK_CHAR(tile_type0, sg0, br0, bc0, nbr0, nbc0, \
+        tile_type1, sg1, br1, bc1, nbr1, nbc1) \
+    __attribute__((overloadable)) void tile_quant_reblock_char( \
+            tile_type0 t0, tile_type1 *t1) { \
+        _Pragma("unroll") for (int j = 0; j < bc0 * nbc0; j++) { \
+            _Pragma("unroll") for (int i0 = 0; i0 < br0 * nbr0; i0 += sg0) { \
+                tile_access(*t1, i0, j, sg1, br1, bc1, nbr1) \
+                        = sdpa_out_quant_step( \
+                        tile_access(t0, i0, j, sg0, br0, bc0, nbr0)); \
+            } \
+        } \
+    }
+
+DECLARE_2D_TILE_QUANT_REBLOCK_CHAR(a_tile_type, SUBGROUP_SIZE,
+        ugemm_vs_c_type_block0, ugemm_vs_c_type_block1,
+        ugemm_vs_c_type_nblock0, ugemm_vs_c_type_nblock1, a_tile_type_char,
+        SUBGROUP_SIZE, ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8)
 #endif
 
 DECLARE_2D_TILE_VREDUCE(s_tile_type, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
@@ -125,6 +281,15 @@ DECLARE_2D_TILE_RSELECT(a_scale_tile_type, SUBGROUP_SIZE, ugemm_vs_sg_tile_n, 1,
 #define cooperative_prefetch_2d_k cooperative_prefetch_2d_maybe_rem
 #endif
 
+#if TRANSPOSE_V
+#define cooperative_prefetch_2d_v( \
+        ptr, r, c, rmax, cmax, ld, sg_id, n_sg, sg_size, caching) \
+    cooperative_prefetch_2d_maybe_rem( \
+            ptr, c, r, cmax, rmax, ld, sg_id, n_sg, sg_size, caching)
+#else
+#define cooperative_prefetch_2d_v cooperative_prefetch_2d_maybe_rem
+#endif
+
 #if REMAINDER_Q
 #define tile_load_block_rem_q tile_load_block
 #define tile_store_block_rem_q tile_store_block
@@ -146,7 +311,11 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         const global QRY_DATA_T *Kc,
         const global QRY_DATA_T *Vc,
 #endif
+#if SDPA_OUT_I8
+        global char *A,
+#else
         global half *A,
+#endif
 #if IS_PAGED_ATTENTION
         const __global INPUT3_TYPE* subsequence_begins,
     #if !IS_PREFILL
@@ -170,6 +339,10 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 #if HAS_TOKEN_TYPE_IDS
         const __global int* token_type_ids,
+#endif
+#if WITH_ROPE_Q
+        const global half *rope_cos,
+        const global half *rope_sin,
 #endif
 #if IS_PAGED_ATTENTION
         const __global int* blocked_indexes_start_and_gws_mapping
@@ -330,6 +503,12 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     uint lda = DST_S2;
 #endif
 
+/* Leading dimension the V*S microkernel indexes A by. Under TRANSPOSE_V the value tensor is
+   physically (head_dim, tokens), so A is k-contiguous and its stride is the head_dim one --
+   as K*Q already gets under TRANSPOSE_K. `ldv` stays the token stride in both layouts, which
+   is what every V pointer advance below is expressed in. */
+    const uint ldv_g = TRANSPOSE_V ? VAL_S3 : VAL_S2;
+
 #if KEY_SCALES || KEY_ZERO_POINTS
     uint ldkq = DIV_UP(d, KEY_GROUP_SIZE);
     uint num_key_groups = d / KEY_GROUP_SIZE;
@@ -347,15 +526,29 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     uint sg_j_vs = sg_ij / ugemm_vs_sg_per_wg_m;
 
     /* SLM allocations -- place in one array to work around compiler bug */
-#define Q_slm_size (D_MAX * ugemm_kq_wg_tile_n * sizeof(half))
-#define S_slm_size (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * sizeof(half))
+#define Q_slm_size (Q_SLM_ROWS * 4 * ugemm_kq_wg_tile_n)
+#define S_slm_size (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * S_SLM_ELEM_SIZE)
 #define S_sum_slm_size \
     (ugemm_kq_wg_tile_n * ugemm_kq_sg_per_wg_m * sizeof(float))
 #define S_max_slm_size (ugemm_kq_wg_tile_n * sizeof(float))
 #define ugemm_slm_size MAX(ugemm_kq_slm_size, ugemm_vs_slm_size)
 
+#ifndef SLM_SHAVE
+#define SLM_SHAVE 0
+#endif
     local char slm[Q_slm_size + S_slm_size + S_sum_slm_size + S_max_slm_size
-            + ugemm_slm_size];
+            + ugemm_slm_size - SLM_SHAVE];
+
+#if SLM_DUMP
+    if (get_global_id(0) == 0 && get_global_id(1) == 0 && get_global_id(2) == 0)
+        printf("[slm] Q=%d S=%d Ssum=%d Smax=%d ugemm=%d(kq %d vs %d) total=%d shave=%d\n",
+                (int)Q_slm_size, (int)S_slm_size, (int)S_sum_slm_size,
+                (int)S_max_slm_size, (int)ugemm_slm_size, (int)ugemm_kq_slm_size,
+                (int)ugemm_vs_slm_size,
+                (int)(Q_slm_size + S_slm_size + S_sum_slm_size + S_max_slm_size
+                        + ugemm_slm_size - SLM_SHAVE),
+                (int)SLM_SHAVE);
+#endif
 
     local half *Q_slm = (local half *)&slm[0];
     local half *S_slm = (local half *)&slm[Q_slm_size];
@@ -452,7 +645,58 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     /* Load Q tile, destined for SLM */
     q_tile_type Q_tile;
     uint q0_copy = q_tile_sg_n * sg_ij;
-#ifdef BLOCK_Q
+#if I8_KQ
+    /* Quantize Q on the way in: four consecutive head-dim values per lane become one
+       VNNI-packed dword of s8, which is the crosspack-4 layout ugemm_kq wants for B. */
+    {
+        const uint lid = get_sub_group_local_id();
+#if WITH_ROPE_Q
+        /* The cos/sin table is (batch, tokens, d) and shared by every head and layer. Four
+           consecutive head-dim values are two interleaved rotation pairs, so the rotation
+           happens here, on the float values, before they are rounded onto the s8 grid. */
+        const global half *rope_c = rope_cos + (size_t)b1 * q * d;
+        const global half *rope_s = rope_sin + (size_t)b1 * q * d;
+#endif
+#pragma unroll
+        for (int j = 0; j < q_tile_sg_n; j++) {
+            int q_col = wg_j0 + q0_copy + j;
+            bool in_range = (q_col < q);
+            const global QRY_DATA_T *qp = Q + (size_t)q_col * ldq;
+#if WITH_ROPE_Q
+            const global half *cp = rope_c + (size_t)q_col * d;
+            const global half *sp = rope_s + (size_t)q_col * d;
+#endif
+#pragma unroll
+            for (int i0 = 0; i0 < Q_SLM_ROWS; i0 += SUBGROUP_SIZE) {
+                int r = i0 + lid;
+                float4 v = (float4)(0.0f);
+                if (in_range && 4 * r < d) {
+                    v.s0 = convert_float(qp[4 * r + 0]);
+                    v.s1 = convert_float(qp[4 * r + 1]);
+                    v.s2 = convert_float(qp[4 * r + 2]);
+                    v.s3 = convert_float(qp[4 * r + 3]);
+#if WITH_ROPE_Q
+                    float4 rc = (float4)(convert_float(cp[4 * r + 0]),
+                            convert_float(cp[4 * r + 1]),
+                            convert_float(cp[4 * r + 2]),
+                            convert_float(cp[4 * r + 3]));
+                    float4 rs = (float4)(convert_float(sp[4 * r + 0]),
+                            convert_float(sp[4 * r + 1]),
+                            convert_float(sp[4 * r + 2]),
+                            convert_float(sp[4 * r + 3]));
+                    v = (float4)(rc.s0 * v.s0 - rs.s0 * v.s1,
+                            rc.s1 * v.s1 + rs.s1 * v.s0,
+                            rc.s2 * v.s2 - rs.s2 * v.s3,
+                            rc.s3 * v.s3 + rs.s3 * v.s2);
+#endif
+                }
+                char4 c = convert_char4_sat_rte(v);
+                tile_access(Q_tile, i0, j, SUBGROUP_SIZE, Q_SLM_ROWS, 1, 1)
+                        = as_uint(c);
+            }
+        }
+    }
+#elif defined(BLOCK_Q)
     tile_load_block_rem_q(
             &Q_tile, (global uint *)Q, q, ldq >> 1, 0, wg_j0 + q0_copy);
 #elif Q_ALIGN >= 4
@@ -460,6 +704,37 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
             wg_j0 + q0_copy);
 #else
     tile_load_packed_half(&Q_tile, Q, d, q, ldq, 0, wg_j0 + q0_copy);
+#endif
+
+#if WITH_ROPE_Q && !I8_KQ
+    /* Interleaved RoPE, fused into the Q staging above. Q_tile elements are uints holding two
+       consecutive head-dim halves, which is exactly one rotation pair (2i, 2i+1), so the whole
+       rotation is register-local. The cos/sin table is (batch, tokens, d) and shared by every
+       head, so it tile-loads with the same shape as Q at row stride d/2 uints. */
+    {
+        const uint ld_rope = (uint)(d >> 1);
+        const global uint *cos_u = (const global uint *)rope_cos + (size_t)b1 * q * ld_rope;
+        const global uint *sin_u = (const global uint *)rope_sin + (size_t)b1 * q * ld_rope;
+        q_tile_type C_tile, S_rope_tile;
+#if defined(BLOCK_Q)
+        tile_load_block_rem_q(&C_tile, cos_u, q, ld_rope, 0, wg_j0 + q0_copy);
+        tile_load_block_rem_q(&S_rope_tile, sin_u, q, ld_rope, 0, wg_j0 + q0_copy);
+#else
+        tile_load(&C_tile, cos_u, (d + 1) >> 1, q, ld_rope, 0, wg_j0 + q0_copy);
+        tile_load(&S_rope_tile, sin_u, (d + 1) >> 1, q, ld_rope, 0, wg_j0 + q0_copy);
+#endif
+#pragma unroll
+        for (int i = 0; i < sizeof(Q_tile.x) / sizeof(Q_tile.x[0]); i++) {
+#pragma unroll
+            for (int s = 0; s < sizeof(Q_tile.x[0]) / sizeof(Q_tile.x[0][0]); s++) {
+                half2 v = as_half2(Q_tile.x[i][s]);
+                half2 c = as_half2(C_tile.x[i][s]);
+                half2 sn = as_half2(S_rope_tile.x[i][s]);
+                Q_tile.x[i][s] = as_uint((half2)(c.s0 * v.s0 - sn.s0 * v.s1,
+                                                 c.s1 * v.s1 + sn.s1 * v.s0));
+            }
+        }
+    }
 #endif
 
 #if WITH_SCALE
@@ -572,7 +847,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 
     /* Store Q tile to SLM */
     tile_store_t_sys_src1(
-            Q_tile, (local uint *)&Q_slm[0], D_MAX / 2, q0_copy, 0);
+            Q_tile, (local uint *)&Q_slm[0], Q_SLM_ROWS, q0_copy, 0);
 
     /* Clear S column sums/maxes */
     s_sum_tile_type S_sum_tile;
@@ -597,6 +872,19 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         uint sg_j0_kq = sg_j_kq * ugemm_kq_sg_tile_n;
 
 #if WITH_ATTN_MASK
+#if MASK_PER_KEY
+        /* Query-invariant mask ([b, h, 1, k]): one value per KEY, so load a sg_tile_m
+         * vector coalesced and broadcast it across the query direction at apply time.
+         * The general path below materialises a full S-shaped tile through a transposed
+         * load instead, which costs sg_tile_n times the traffic and registers for the
+         * same information. */
+        mask_tile_type_float mask_k;
+#pragma unroll
+        for (int ii = 0; ii < ugemm_kq_sg_tile_m / SUBGROUP_SIZE; ii++) {
+            const int key_idx = k0 + sg_i0_kq + ii * SUBGROUP_SIZE + get_sub_group_local_id();
+            mask_k.x[0][ii] = key_idx < k ? convert_float(msk[key_idx]) : 0.0f;
+        }
+#else
         /* Load mask. No remainder handling needed assuming k block size is a power of 2. */
         mask_tile_type mask_tile;
         if (MSK_D2 == 1 && MSK_D3 > 1) {
@@ -607,6 +895,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         } else {
             tile_load_t(&mask_tile, msk, q, k, sg_j0_kq + wg_j0, k0 + sg_i0_kq);
         }
+#endif
 #endif
 
 #if REMAINDER_K
@@ -842,6 +1131,21 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     #endif
     #endif
 #endif /* PA_INTEGRITY_CHECK */
+#elif defined(DIAG_SKIP_KQ)
+        s_tile_type S_tile;
+        tile_fill(S_tile, (float)(k0 & 1) * 1e-3f
+                        + convert_float(((const global half *)K)[k0]) * 0.0f);
+#elif I8_KQ
+        s_tile_type S_tile;
+        {
+            s_tile_type_int S_tile_i = ugemm_kq((const global char *)K, ldk,
+                    (const local char *)Q_slm, D_MAX, causal_k,
+                    ugemm_kq_wg_tile_n, d, k0, 0, 0, sg_i_kq, sg_j_kq,
+                    (local char *)ugemm_slm);
+            /* No dequantization here: the graph folds both quantization steps into the
+               scale input, which is applied to S a few lines below. */
+            tile_copy(S_tile_i, S_tile);
+        }
 #else
         s_tile_type S_tile
                 = ugemm_kq(K, ldk, Q_slm, D_MAX, causal_k, ugemm_kq_wg_tile_n, d, k0,
@@ -944,6 +1248,15 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #ifdef STATIC_SCALAR_ATTN_MASK_VALUE
 #define mask_scale_op(x) ((x) + masked_scale)
         tile_elementwise(S_tile, mask_scale_op);
+#elif WITH_ATTN_MASK && MASK_PER_KEY
+#ifdef LOG_2_E_MUL_SCALE
+#define unscale(x) ((x)*iscale)
+        tile_elementwise(mask_k, unscale);
+#else
+#define scale(x) ((x)* scale)
+        tile_elementwise(S_tile, scale);
+#endif
+        tile_hbroadcast_add(&S_tile, mask_k);
 #elif WITH_ATTN_MASK
         mask_tile_type_float mask_tile_float;
         tile_copy(mask_tile, mask_tile_float);
@@ -1080,10 +1393,14 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         /* Before softmax, we will need to scale columns by maximum values to avoid overflow. */
 
         /* Compute our maxima and reduce across SLM */
+#ifdef DIAG_NO_MAX
+        tile_fill(S_max_tile, 0.0f);
+#else
         tile_vreduce_max(S_tile, &S_max_tile);
         tile_atomic_max_full(
                 S_max_tile, S_max_slm, ugemm_kq_wg_tile_n, sg_j0_kq, 0);
         intel_work_group_barrier_arrive(CLK_LOCAL_MEM_FENCE);
+#endif
 
         #ifdef HAS_SINK_INPUT
         const int cur_k = causal_k - k0 - 1;
@@ -1108,13 +1425,13 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #else
     const int window_v_pf_begin = 0;
 #endif
-        cooperative_prefetch_2d_maybe_rem(
+        cooperative_prefetch_2d_v(
                 /* ptr */ V + (size_t)ldv * window_v_pf_begin / VAL_ELEMENTS_PER_BYTE,
                 /* r */ d,
                 /* c */ causal_k - k0 - window_v_pf_begin,
                 /* rmax */ PREFETCH_D_MAX,
                 /* cmax */ ugemm_kq_wg_tile_m - window_v_pf_begin,
-                /* ld */ ldv,
+                /* ld */ ldv_g,
                 /* sg_id */ sg_ij,
                 /* n_sg */ sg_per_wg,
                 /* sg_size */ SUBGROUP_SIZE,
@@ -1150,20 +1467,36 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 #endif
 
-#ifndef ALT_MAX
+#if !defined(ALT_MAX) && !defined(DIAG_NO_MAX)
         /* Read back WG-wide maxima */
         intel_work_group_barrier_wait(CLK_LOCAL_MEM_FENCE);
         tile_load_full(&S_max_tile, S_max_slm, ugemm_kq_wg_tile_n, sg_j0_kq, 0);
 #endif
 
+#if I8_VS_EXP_FOLDED && !defined(ALT_MAX) && !defined(DIAG_NO_MAX)
+        /* Fold the quantize grid into the exponent: exp(x - (m - ln(LEVELS))) is
+           LEVELS * exp(x - m), so the per-element quantize multiply disappears and the
+           final dequant drops its /LEVELS. The rescale and sink paths consume only
+           differences of maxima or the same shifted exponentials, so they stay
+           consistent with the unshifted function. */
+#define i8_vs_shift_max(x) ((x) - (I8_VS_MAX_SHIFT))
+        tile_elementwise(S_max_tile, i8_vs_shift_max);
+#endif
+
+#ifndef DIAG_NO_MAX
         tile_vbroadcast_sub(&S_tile, S_max_tile);
+#endif
 /* Scale + exponentiate */
-#ifdef LOG_2_E_MUL_SCALE
+#if defined(DIAG_NO_EXP)
+#define scaled_exp(x) ((x)*scale)
+#elif defined(LOG_2_E_MUL_SCALE)
 #define scaled_exp(x) native_vexp2(x * scale)
 #else
 #define scaled_exp(x) native_vexp2(x * log2_e)
 #endif
+#ifndef DIAG_SKIP_SM
         tile_elementwise(S_tile, scaled_exp);
+#endif
 
 #ifdef ALT_MAX
         /* Read back WG-wide maxima and adjust S to match */
@@ -1179,8 +1512,12 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 
         /* Accumulate sums. S tile is transposed for easy summation. */
         s_sum_tile_type S_sum_tile1;
+#ifdef DIAG_SKIP_SM
+        tile_fill(S_sum_tile1, 0.125f);
+#else
         tile_fill(S_sum_tile1, 0.0f);
         tile_vreduce_add(S_tile, &S_sum_tile1);
+#endif
 #ifdef HAS_SINK_INPUT
         if (is_last_m_sg){
             s_sum_tile_type sink_minus_max_exp;
@@ -1219,15 +1556,36 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
             }
         }
 #endif
+#if I8_VS
+#ifndef DIAG_SKIP_QNT
+        s_tile_type_char4 S_tile_char4;
+#if I8_VS_EXP_FOLDED
+        /* exponentials already sit on the [0, LEVELS] grid; no scale multiply remains */
+        tile_quantize_to_char4_ns(S_tile, S_tile_char4);
+#else
+        tile_quantize_to_char4(S_tile, S_tile_char4, (float)I8_VS_LEVELS);
+#endif
+#ifndef DIAG_SKIP_STORE
+        tile_store_t_sys_src2(S_tile_char4, (local uint *)S_slm,
+                ugemm_vs_sg_tile_n, ugemm_kq_wg_tile_m / 4, sg_i0_kq / 4,
+                sg_j0_kq);
+#endif
+#endif
+#else
+#ifndef DIAG_SKIP_QNT
         tile_copy_to_half2(S_tile, S_tile_half2);
-
+#endif
+#ifndef DIAG_SKIP_STORE
         /* Store to SLM, in packed format */
         tile_store_t_sys_src2(S_tile_half2, (local uint *)S_slm,
                 ugemm_vs_sg_tile_n, ugemm_kq_wg_tile_m / 2, sg_i0_kq / 2,
                 sg_j0_kq);
+#endif
+#endif
         intel_work_group_barrier_arrive(CLK_LOCAL_MEM_FENCE);
 
         /* Rescale existing accumulator and sums to match new maxima */
+#ifndef DIAG_NO_MAX
         if (!first) {
 #ifdef LOG_2_E_MUL_SCALE
 #define binary_exp_sub(x, y) native_vexp2(scale *((x) - (y)))
@@ -1252,6 +1610,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #endif
             tile_hbroadcast_mul(&A_tile, A_scale_tile);
         }
+#endif
 
         /* Accumulate sums */
         tile_binary(S_sum_tile, S_sum_tile1, binary_add);
@@ -1450,9 +1809,23 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
             tile_binary(A_tile, A_tile1, binary_add);
         }
     #endif
+#elif defined(DIAG_SKIP_VS)
+        a_tile_type A_tile1;
+        tile_fill(A_tile1, convert_float(((const global half *)V)[k0]));
+        V += ldv * ugemm_kq_wg_tile_m / VAL_ELEMENTS_PER_BYTE;
+#elif I8_VS
+        a_tile_type A_tile1;
+        {
+            a_tile_type_int A_tile1_i = ugemm_vs((const global char *)V, ldv_g,
+                    (const local char *)S_slm, ugemm_kq_wg_tile_m, d,
+                    ugemm_kq_wg_tile_n, k_chunk, 0, 0, 0, sg_i_vs, sg_j_vs,
+                    (local char *)ugemm_slm);
+            tile_copy(A_tile1_i, A_tile1);
+        }
+        V += ldv * ugemm_kq_wg_tile_m / VAL_ELEMENTS_PER_BYTE;
 #else
         a_tile_type A_tile1 = ugemm_vs(
-                V, ldv, S_slm, ugemm_kq_wg_tile_m, d, ugemm_kq_wg_tile_n,
+                V, ldv_g, S_slm, ugemm_kq_wg_tile_m, d, ugemm_kq_wg_tile_n,
                 k_chunk, 0, 0, 0, sg_i_vs, sg_j_vs, (local char *)ugemm_slm
 #if VAL_SCALES == QUANTIZE_2D
                 ,
@@ -1506,20 +1879,40 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 
     /* Rescale by 1 / (column sums) */
     tile_elementwise(A_scale_tile, native_vrecip);
+#if I8_VS
+    /* Fold both integer grids out here: the probability step 1/I8_VS_LEVELS and the one
+       global part of V's step. The per-head residual is folded into attn.proj's weights. */
+#if I8_VS_EXP_FOLDED
+    /* the exponentials carry the LEVELS factor already, so only V's grid remains */
+#define i8_vs_deq(x) ((x) * (I8_VS_DEQ))
+#else
+#define i8_vs_deq(x) ((x) * ((I8_VS_DEQ) / (float)(I8_VS_LEVELS)))
+#endif
+    tile_elementwise(A_scale_tile, i8_vs_deq);
+#endif
     tile_hbroadcast_mul(&A_tile, A_scale_tile);
-
-    /* Convert to half precision and store */
-    a_tile_type_half A_tile_half;
-    tile_copy_reblock(A_tile, &A_tile_half);
 
     uint sg_i0_vs = sg_i_vs * ugemm_vs_sg_tile_m;
     uint sg_j0_vs = sg_j_vs * ugemm_vs_sg_tile_n + wg_j0;
 
-#ifdef BLOCK_2D_A
-    tile_store_block2d(A_tile_half, A, d, q, lda, sg_i0_vs, sg_j0_vs);
-#elif defined(BLOCK_A)
-    tile_store_block_rem_q(A_tile_half, A, q, lda, sg_i0_vs, sg_j0_vs);
+#if SDPA_OUT_I8
+    /* Fused trailing quantizer: reblock the float accumulator onto the i8 grid and store
+       char directly -- the standalone quantize pass over the f16 output disappears, along
+       with its extra round trip through half. */
+    a_tile_type_char A_tile_char;
+    tile_quant_reblock_char(A_tile, &A_tile_char);
+    tile_store(A_tile_char, A, d, q, lda, sg_i0_vs, sg_j0_vs);
 #else
+    /* Convert to half precision and store */
+    a_tile_type_half A_tile_half;
+    tile_copy_reblock(A_tile, &A_tile_half);
+
+# ifdef BLOCK_2D_A
+    tile_store_block2d(A_tile_half, A, d, q, lda, sg_i0_vs, sg_j0_vs);
+# elif defined(BLOCK_A)
+    tile_store_block_rem_q(A_tile_half, A, q, lda, sg_i0_vs, sg_j0_vs);
+# else
     tile_store(A_tile_half, A, d, q, lda, sg_i0_vs, sg_j0_vs);
+# endif
 #endif
 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/kernel_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/kernel_generator.cpp
@@ -4,6 +4,7 @@
 
 #include "kernel_generator.hpp"
 
+#include <cstdlib>
 #include <cctype>
 
 #include "common_utils/kernel_generator_base.hpp"
@@ -123,6 +124,15 @@ std::string KernelGenerator::get_build_options(const RuntimeParams& params) cons
     const auto& device_info = prog.get_engine().get_device_info();
     if (device_info.vendor_id == cldnn::INTEL_VENDOR_ID) {
         options = " -cl-mad-enable";
+        if (const char* ftz = std::getenv("OV_GPU_FTZ"))
+            if (ftz[0] == '1')
+                options += " -cl-denorms-are-zero";
+        // OV_GPU_FASTMATH=1 lets IGC use the fast reciprocal/rsqrt/transcendental paths and
+        // relax floating point contraction ordering. MVN's rsqrt and the eltwise chains are
+        // the only places it can bite; the gate reports what it costs.
+        if (const char* fm = std::getenv("OV_GPU_FASTMATH"))
+            if (fm[0] == '1')
+                options += " -cl-fast-relaxed-math";
 
         if (prog.get_config().get_enable_large_allocations())
             options += " -cl-intel-greater-than-4GB-buffer-required";

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -13,6 +13,7 @@
 #include "resample_inst.h"
 #include "reshape_inst.h"
 #include "rms_inst.h"
+#include "rope_inst.h"
 #include "arg_max_min_inst.h"
 #include "shape_of_inst.h"
 #include "select_inst.h"
@@ -439,7 +440,10 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, reorder_node
         !node.get_program().is_body_program() && !prev.is_in_shape_of_subgraph() && prev.get_preferred_impl_type() != cldnn::impl_types::cpu) {
         // case for truncate mode
         if ((prev.is_type<mvn>() || prev.is_type<concatenation>() || prev.is_type<gather>() || prev.is_type<broadcast>() ||
-            prev.is_type<select>() || prev.is_type<eltwise>() || prev.is_type<rms>()) &&
+            prev.is_type<select>() || prev.is_type<eltwise>() || prev.is_type<rms>() ||
+            // veesion: see remove_redundant_reorders -- rope stores through TO_OUTPUT_TYPE, so it
+            // can narrow to the s8 K that micro-SDPA's KQ microkernel wants without a second pass.
+            prev.is_type<rope>()) &&
             node.is_type_conversion_only()) {
             return true;
         }

--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -7,6 +7,7 @@
 #include "data_inst.h"
 #include "pooling_inst.h"
 #include <algorithm>
+#include <cstdlib>
 #include <utility>
 #include <vector>
 #include <sstream>
@@ -107,9 +108,15 @@ static bool is_direct_ancestor(const program_node& child, const program_node& ta
     if (target.get_users().size() != 2)
         return false;
 
-    // Limit the iteration depth to 5 for performance reason
+    // Limit the iteration depth for compile-time reasons. A transformer block's attention
+    // branch is 5 hops deep (proj -> sdpa -> rope -> q gemm -> layernorm -> block input), so
+    // a limit of 5 silently demotes every attention residual to a binary_add post-op.
+    static const int max_depth = []() {
+        const char* e = std::getenv("OV_ADD_ANCESTOR_DEPTH");
+        return e ? std::atoi(e) : 16;
+    }();
     const auto* iter = &child;
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < max_depth; i++) {
         if (iter == &target)
             return true;
         if (iter->get_dependencies().empty())

--- a/src/plugins/intel_gpu/src/graph/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/scaled_dot_product_attention.cpp
@@ -39,6 +39,10 @@ layout scaled_dot_product_attention_inst::calc_output_layout(scaled_dot_product_
 
     auto default_out_dt = data_type_traits::is_floating_point(input0_layout.data_type) ? input0_layout.data_type : data_types::f32;
     auto output_type = desc->output_data_types[0].value_or(default_out_dt);
+    // veesion: honor the fused epilogue output type (mirrors softmax_inst::calc_output_layout), so the
+    // recalc_output_layout at the end of program::fuse_nodes doesn't revert the i8 layout of a fused quantize.
+    if (impl_param.has_fused_primitives())
+        output_type = impl_param.get_output_element_type();
     auto output_format = input0_layout.format;
     auto q_shape = transpose_shape(input0_layout.get_partial_shape(),
                                 desc->input_q_transpose_order);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gather_elements_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gather_elements_ref.cl
@@ -38,7 +38,11 @@ KERNEL(gather_elements_ref)(OPTIONAL_SHAPE_INFO_ARG
     const uint f = dim2 % OUTPUT_FEATURE_NUM;
     const uint b = dim2 / OUTPUT_FEATURE_NUM;
 
-    const uint out_idx = GET_OUTPUT_INDEX(INPUT1, ORDER);
+    // The indices and the output share a shape but not necessarily their pitches: an indices
+    // tensor that is a padded view of a larger buffer (a crop) needs its own index, or every
+    // store lands at the wrong offset and past the end of the output.
+    const uint idx_idx = GET_OUTPUT_INDEX(INPUT1, ORDER);
+    const uint out_idx = GET_OUTPUT_INDEX(OUTPUT, ORDER);
     LOAD_AND_HANDLE_NEGATIVE_INDICES;
     const uint input_idx = GET_OUTPUT_INDEX(INPUT0, DATA_INDEX_ORDER);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_bfyx_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/mvn_gpu_bfyx_opt.cl
@@ -32,18 +32,40 @@ KERNEL (mvn_gpu_bfyx_opt)(
     float my_sum = 0;
     float tmp;
 
+#ifdef MVN_CACHE_ITERS
+    // The data set is small enough that every element this work item touches lives in
+    // registers, so the mean, variance and normalize loops read global memory once between
+    // them instead of three times. The arithmetic is unchanged, element for element.
+    float cached[MVN_CACHE_ITERS];
+#   define MVN_LOAD(i) cached[i]
+#   pragma unroll
+    for (uint i = 0; i < MVN_CACHE_ITERS; ++i)
+        if (i < iters_num)
+            cached[i] = (float)input[my_data_offset + i * workers_per_data_set];
+#   pragma unroll
+    for (uint i = 0; i < MVN_CACHE_ITERS; ++i)
+        if (i < iters_num)
+            my_sum += cached[i];
+#else
+#   define MVN_LOAD(i) (input[my_data_offset + i * workers_per_data_set])
     //each WI reads items_num consecutive items from batch*feature
     for (uint i=0; i<iters_num; ++i)
     {
         my_sum += (float)input[my_data_offset + i * workers_per_data_set];
     }
+#endif
 
     my_sum = work_group_reduce_add(my_sum) / data_set_size;
 
 #if NORMALIZE_VARIANCE == 0
+#ifdef MVN_CACHE_ITERS
+#   pragma unroll
+    for (uint i = 0; i < MVN_CACHE_ITERS; ++i) { if (i >= iters_num) continue;
+#else
     for (uint i=0; i<iters_num; ++i) {
+#endif
         uint iteration_in_data_set_offset = i * workers_per_data_set;
-        ACTIVATION_TYPE result = TO_ACTIVATION_TYPE(input[my_data_offset + iteration_in_data_set_offset]) - TO_ACTIVATION_TYPE(my_sum);
+        ACTIVATION_TYPE result = TO_ACTIVATION_TYPE(MVN_LOAD(i)) - TO_ACTIVATION_TYPE(my_sum);
 #   if HAS_FUSED_OPS
         FUSED_OPS;
         output[my_data_offset + iteration_in_data_set_offset] = FUSED_OPS_RESULT;
@@ -54,6 +76,15 @@ KERNEL (mvn_gpu_bfyx_opt)(
 #else
 
     float my_variance = 0.f;
+#ifdef MVN_CACHE_ITERS
+#   pragma unroll
+    for (uint i = 0; i < MVN_CACHE_ITERS; ++i) {
+        if (i >= iters_num)
+            continue;
+        tmp = cached[i] - my_sum;
+        my_variance = fma(tmp, tmp, my_variance);
+    }
+#else
     //each WI reads items_num consecutive items from batch*feature
     for (uint i=0; i<iters_num; ++i)
     {
@@ -61,6 +92,7 @@ KERNEL (mvn_gpu_bfyx_opt)(
         tmp -= my_sum;
         my_variance = fma(tmp, tmp, my_variance);
     }
+#endif
 
     my_variance = work_group_reduce_add(my_variance);
 
@@ -77,9 +109,14 @@ KERNEL (mvn_gpu_bfyx_opt)(
 
     my_variance = work_group_broadcast(my_variance, 0);
 
+#ifdef MVN_CACHE_ITERS
+#   pragma unroll
+    for (uint i = 0; i < MVN_CACHE_ITERS; ++i) { if (i >= iters_num) continue;
+#else
     for (uint i=0; i<iters_num; ++i) {
+#endif
         uint iteration_in_data_set_offset = i * workers_per_data_set;
-        ACTIVATION_TYPE result = (TO_ACTIVATION_TYPE(input[my_data_offset + iteration_in_data_set_offset]) - TO_ACTIVATION_TYPE(my_sum)) * TO_ACTIVATION_TYPE(my_variance);
+        ACTIVATION_TYPE result = (TO_ACTIVATION_TYPE(MVN_LOAD(i)) - TO_ACTIVATION_TYPE(my_sum)) * TO_ACTIVATION_TYPE(my_variance);
 #   if HAS_FUSED_OPS
         FUSED_OPS;
         output[my_data_offset + iteration_in_data_set_offset] = FUSED_OPS_RESULT;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_f_y_axes.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/permute_f_y_axes.cl
@@ -50,6 +50,47 @@ KERNEL (permute_f_y_axes)(
     }
 }
 
+#elif defined (PERMUTE_FY_TILED)
+
+// Square SLM tile, sized so that both the load and the store move a full cache line per
+// subgroup. The default path for this shape picks TILE_SIZE 8 and lws {1,1,8}: eight work
+// items each reading 16 contiguous bytes 1152 bytes apart, so most of every 64-byte line
+// fetched is discarded on the read and again on the write.
+__attribute__((reqd_work_group_size(FY_TILE, FY_TH, 1)))
+KERNEL (permute_f_y_axes)(
+    const __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output
+    )
+{
+    __local OUTPUT_TYPE tile[FY_TILE][FY_TILE + 1];
+
+    const int tx = get_local_id(0);
+    const int ty = get_local_id(1);
+    const int y0 = get_group_id(0) * FY_TILE;
+    const int f0 = get_group_id(1) * FY_TILE;
+    const int b_idx = get_global_id(2);
+    const int y_idx = y0 + tx;
+
+    __attribute__((opencl_unroll_hint))
+    for (int i = 0; i < FY_TILE; i += FY_TH) {
+        const int f_idx = f0 + ty + i;
+        if (f_idx < INPUT0_FEATURE_NUM) {
+            INPUT0_TYPE res = input[INPUT0_GET_INDEX(b_idx, f_idx, y_idx, 0)];
+            tile[tx][ty + i] = TO_OUTPUT_TYPE(ACTIVATION(DECODE_INPUT0_COMPUTE_TYPE(res), ACTIVATION_PARAMS));
+        }
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int f_out = f0 + tx;
+    if (f_out < INPUT0_FEATURE_NUM) {
+        __attribute__((opencl_unroll_hint))
+        for (int i = 0; i < FY_TILE; i += FY_TH) {
+            output[OUTPUT_GET_INDEX(b_idx, y0 + ty + i, f_out, 0)] = tile[ty + i][tx];
+        }
+    }
+}
+
 #elif defined (THREE_DIM_TRANSPOSE)
 
 #ifdef SUB_GROUP_SIZE

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/scatter_elements_update_ref.cl
@@ -320,11 +320,12 @@ KERNEL(scatter_elements_update_ref)(OPTIONAL_SHAPE_INFO_ARG
                     #endif
                 }
             #endif
-            if (reduction_thread[output_idx] > 1) {
-                FUNC_CALL(atomic_reduce_local)(&reduction_v[output_idx], val_fixed);
-            } else {
-                reduction_v[output_idx] = val_fixed;
-            }
+            // reduction_v was set to the reduction's neutral element before the barrier, so
+            // an unconditional atomic reduce is correct for every mode. Selecting a plain
+            // store when the counter reads 1 is a race: the counter is still being
+            // incremented by the other work items sharing this output_idx, so a work item
+            // can read 1, take the store, and clobber contributions already accumulated.
+            FUNC_CALL(atomic_reduce_local)(&reduction_v[output_idx], val_fixed);
 
             barrier(CLK_LOCAL_MEM_FENCE);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
@@ -4,6 +4,7 @@
 
 #include "intel_gpu/runtime/device.hpp"
 #include "kernel_base_opencl.h"
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -173,6 +174,14 @@ std::shared_ptr<KernelString> KernelBaseOpenCL::GetKernelString(const std::strin
         kernel_string->undefs = jit.second;
         if (engine_info.vendor_id == cldnn::INTEL_VENDOR_ID) {
             kernel_string->options = exe_mode + " -cl-mad-enable";
+            // OV_GPU_FTZ=1 asks IGC to flush denormals to zero. Peaky softmax puts most
+            // probabilities below the f16/f32 denormal threshold; on the CPU track that cost 1.94x.
+            if (const char* ftz = std::getenv("OV_GPU_FTZ"))
+                if (ftz[0] == '1')
+                    kernel_string->options += " -cl-denorms-are-zero";
+            if (const char* fm = std::getenv("OV_GPU_FASTMATH"))
+                if (fm[0] == '1')
+                    kernel_string->options += " -cl-fast-relaxed-math";
             if (engine_info.bOptHintsSupport)
                 kernel_string->options += " -DOPT_HINTS_SUPPORTED=1";
             if (engine_info.enable_large_allocations)

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_elements_kernel_ref.cpp
@@ -54,7 +54,7 @@ static std::string GetAxisDimSizeStr(const gather_elements_params& params) {
 
 static std::string GetLoadAndHandleNegativeIndicesStr(const gather_elements_params& params) {
     std::string str = "const int axis_dim = " + GetAxisDimSizeStr(params) + ";";
-    str += "const int indices_val_read = (int)indices[out_idx];";
+    str += "const int indices_val_read = (int)indices[idx_idx];";
     str += "const int indices_val = indices_val_read < 0 ? indices_val_read + axis_dim : indices_val_read;";
     return str;
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bfyx_opt.cpp
@@ -102,6 +102,11 @@ JitConstants MVNKernelBfyxOpt::GetJitConstants(const mvn_params& params, MVNKern
             MakeJitConstant("DATA_SETS_COUNT", dispatchData.dataSetsCount),
             MakeJitConstant("DATA_SET_SIZE", dispatchData.dataSetSize),
         });
+        // Hold each work item's slice of the data set in registers so the mean, variance and
+        // normalize loops share one pass over global memory instead of taking three.
+        const size_t iters = CeilDiv(dispatchData.dataSetSize, dispatchData.lws[0]);
+        if (iters <= 8)
+            jit.AddConstant(MakeJitConstant("MVN_CACHE_ITERS", iters));
     }
     auto activation_dt = GetActivationType(params);
     jit.Merge(MakeTypeJitConstants(activation_dt, "ACTIVATION"));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_f_y_axes.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_f_y_axes.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <string>
 
 #include "common_tools.h"
@@ -33,6 +34,36 @@ bool IsSimpleMemCopyOperation(const permute_params& params) {
 
 bool Is3DTranspose(const permute_params& params) {
     return params.inputs[0].X().v > 1 && params.inputs[0].GetLayout() != DataLayout::bfyx;
+}
+
+// veesion: OV_PERMUTE_TILE is the side of a square SLM tile; 0 keeps the stock path.
+// 64 halves this node (34.7 -> 66.9 GB/s) but is a wash end to end: at two requests in flight
+// the transpose is hidden behind compute, so freeing bandwidth buys nothing (iteration 42).
+size_t TiledSide() {
+    static const size_t side = [] {
+        const char* v = std::getenv("OV_PERMUTE_TILE");
+        return v ? static_cast<size_t>(std::atoi(v)) : 64UL;
+    }();
+    return side;
+}
+
+// Rows of the tile loaded per work-item pass; the work group is FY_TILE x FY_TH.
+size_t TiledHeight() {
+    static const size_t h = [] {
+        const char* v = std::getenv("OV_PERMUTE_TH");
+        return v ? static_cast<size_t>(std::atoi(v)) : 8UL;
+    }();
+    return h;
+}
+
+bool UseTiled(const permute_params& params) {
+    const size_t side = TiledSide();
+    const size_t th = TiledHeight();
+    if (side < 8 || (side & (side - 1)) != 0 || th == 0 || side % th != 0)
+        return false;
+    const auto& in = params.inputs[0];
+    return in.X().v == 1 && SimpleLayout(in.GetLayout()) && SimpleLayout(params.outputs[0].GetLayout()) &&
+           params.fused_ops.empty() && in.Y().v % side == 0;
 }
 
 size_t GetFeatureBlockSize(const permute_params& params) {
@@ -125,6 +156,14 @@ JitConstants PermuteKernel_f_y_axes::GetJitConstants(const permute_params& param
                                                      const CommonDispatchData& dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
 
+    if (UseTiled(params)) {
+        jit.AddConstant(MakeJitConstant("PERMUTE_FY_TILED", ""));
+        jit.AddConstant(MakeJitConstant("FY_TILE", TiledSide()));
+        jit.AddConstant(MakeJitConstant("FY_TH", TiledHeight()));
+        jit.Merge(MakeTypeJitConstants(params.inputs[0].GetDType(), "ACCUMULATOR"));
+        return jit;
+    }
+
     if (params.inputs[0].X().v != 1) {
         if (IsSimpleMemCopyOperation(params)) {
             jit.AddConstant(MakeJitConstant("PERMUTE_SIMPLE_MEM_COPY", ""));
@@ -183,6 +222,14 @@ static inline std::vector<size_t> GetGWS(const permute_params& params) {
 
 CommonDispatchData PermuteKernel_f_y_axes::SetDefault(const permute_params& params) const {
     CommonDispatchData dispatchData;
+    if (UseTiled(params)) {
+        const auto& in = params.inputs[0];
+        const size_t side = TiledSide();
+        const size_t th = TiledHeight();
+        dispatchData.gws = {in.Y().v, CeilDiv(in.Feature().v, side) * th, in.Batch().v};
+        dispatchData.lws = {side, th, 1};
+        return dispatchData;
+    }
     dispatchData.gws = GetGWS(params);
     if (IsSimpleMemCopyOperation(params)) {
         auto in_layout = params.inputs[0].GetLayout();

--- a/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
@@ -116,7 +116,9 @@ static void CreateScaledDotProductAttentionOp(ProgramBuilder& p, const std::shar
 }
 
 static void CreateSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op::internal::SDPA>& op) {
-    validate_inputs_count(op, {cnt_inputs_with_qkv, cnt_inputs_with_mask, cnt_inputs_with_scale, cnt_inputs_with_sink});
+    const size_t rope_inputs = op->get_rope_q() ? 2 : 0;
+    validate_inputs_count(op, {cnt_inputs_with_qkv + rope_inputs, cnt_inputs_with_mask + rope_inputs,
+                               cnt_inputs_with_scale + rope_inputs, cnt_inputs_with_sink + rope_inputs});
     auto inputs = p.GetInputInfo(op);
     auto layerName = layer_type_name_ID(op);
 
@@ -138,7 +140,10 @@ static void CreateSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op::intern
                                                          transpose_orders[0],
                                                          transpose_orders[1],
                                                          transpose_orders[2],
-                                                         transpose_orders[3]);
+                                                         transpose_orders[3],
+                                                         {},
+                                                         false,
+                                                         op->get_rope_q());
     if (scalar_scale) {
         sdpa_prim.scale_val = scalar_scale->cast_vector<float>()[0];
     }

--- a/src/plugins/intel_gpu/src/plugin/transformations/op/sdpa.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/op/sdpa.cpp
@@ -37,6 +37,27 @@ SDPA::SDPA(const OutputVector& inputs,
            const std::vector<int64_t>& order_k,
            const std::vector<int64_t>& order_v,
            const std::vector<int64_t>& order_out,
+           const ov::element::Type output_type,
+           bool rope_q)
+    : m_is_causal(is_causal)
+    , m_order_q(order_q)
+    , m_order_k(order_k)
+    , m_order_v(order_v)
+    , m_order_out(order_out)
+    , m_output_type(output_type)
+    , m_compressed(false)
+    , m_rope_q(rope_q) {
+    set_arguments(inputs);
+    set_causal(is_causal);
+    validate_and_infer_types();
+}
+
+SDPA::SDPA(const OutputVector& inputs,
+           const bool is_causal,
+           const std::vector<int64_t>& order_q,
+           const std::vector<int64_t>& order_k,
+           const std::vector<int64_t>& order_v,
+           const std::vector<int64_t>& order_out,
            const QuantizationAttribute& quantization_attrs,
            const ov::element::Type output_type)
     : m_is_causal(is_causal)
@@ -61,13 +82,14 @@ std::shared_ptr<ov::Node> SDPA::clone_with_new_inputs(const ov::OutputVector& ne
                                   m_order_k,
                                   m_order_v,
                                   m_order_out,
-                                  m_output_type);
+                                  m_output_type,
+                                  m_rope_q);
 }
 
 void SDPA::validate_and_infer_types() {
     const auto input_size = get_input_size();
 
-    const auto compression_inputs = get_compression_inputs_num();
+    const auto compression_inputs = get_compression_inputs_num() + (m_rope_q ? 2 : 0);
     NODE_VALIDATION_CHECK(this,
         input_size >= 3 + compression_inputs && input_size <= 5 + compression_inputs,
         "Number of inputs is incorrect. Current value is: ",

--- a/src/plugins/intel_gpu/src/plugin/transformations/rope_sdpa_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/rope_sdpa_fusion.cpp
@@ -1,0 +1,111 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "rope_sdpa_fusion.hpp"
+
+#include <cstdlib>
+#include <string>
+
+#include "intel_gpu/op/indirect_sdpa.hpp"
+#include "intel_gpu/op/sdpa.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "ov_ops/rotary_positional_embeddings.hpp"
+
+namespace ov::intel_gpu {
+
+// The kernel indexes the table as (batch, token, head_size) halves, so the leading dims have to
+// collapse to batch*tokens with head_size innermost and nothing else in between.
+static bool is_flat_cos_sin(const ov::Output<ov::Node>& out, int64_t batch, int64_t tokens, int64_t head_size) {
+    const auto& pshape = out.get_partial_shape();
+    if (pshape.is_dynamic() || pshape.size() < 2)
+        return false;
+    if (pshape[pshape.size() - 1].get_length() != head_size)
+        return false;
+    int64_t lead = 1;
+    for (size_t i = 0; i + 1 < pshape.size(); i++)
+        lead *= pshape[i].get_length();
+    return lead == batch * tokens;
+}
+
+RoPESDPAFusion::RoPESDPAFusion() {
+    using namespace ov::pass::pattern;
+
+    auto rope_m = wrap_type<ov::op::internal::RoPE>(consumers_count(1));
+
+    const char* disable = std::getenv("OV_ROPE_SDPA");
+    const bool enabled = !disable || std::string(disable) != "0";
+
+    ov::matcher_pass_callback callback = [=](Matcher& m) {
+        if (!enabled)
+            return false;
+        auto rope = ov::as_type_ptr<ov::op::internal::RoPE>(m.get_match_root());
+        if (!rope || rope->get_input_size() != 3)
+            return false;
+        const auto& cfg = rope->get_config();
+        if (!cfg.is_interleaved || cfg.input_trans0213 || cfg.output_trans0213 || cfg.is_chatglm ||
+            cfg.is_qwen || cfg.support_2d_rope || cfg.support_3d_rope || cfg.is_ltx_video ||
+            cfg.use_rope_cache || cfg.gather_position_arg_id != 0 || cfg.slice_start != cfg.slice_stop)
+            return false;
+
+        const auto& x_shape = rope->get_input_partial_shape(0);
+        if (x_shape.is_dynamic() || x_shape.size() != 4)
+            return false;
+        const int64_t batch = x_shape[0].get_length();
+        const int64_t tokens = x_shape[1].get_length();
+        const int64_t head_size = x_shape[3].get_length();
+        if (cfg.rotary_ndims != static_cast<size_t>(head_size) || head_size % 2 != 0)
+            return false;
+
+        if (rope->get_output_element_type(0) != ov::element::f16)
+            return false;
+        for (size_t i = 1; i < 3; i++) {
+            if (rope->get_input_element_type(i) != ov::element::f16)
+                return false;
+            if (!is_flat_cos_sin(rope->input_value(i), batch, tokens, head_size))
+                return false;
+        }
+
+        const auto& targets = rope->output(0).get_target_inputs();
+        if (targets.size() != 1)
+            return false;
+        const auto& target = *targets.begin();
+        if (target.get_index() != 0)
+            return false;
+
+        auto sdpa = ov::as_type_ptr<ov::intel_gpu::op::SDPA>(target.get_node()->shared_from_this());
+        // IndirectSDPA derives from SDPA but reaches the primitive through a different creator.
+        if (!sdpa || ov::as_type_ptr<ov::intel_gpu::op::IndirectSDPA>(sdpa))
+            return false;
+        const auto sdpa_inputs = sdpa->get_input_size();
+        if (sdpa->get_kv_compressed() || sdpa->get_rope_q() || sdpa_inputs < 3 || sdpa_inputs > 5)
+            return false;
+        if (transformation_callback(sdpa))
+            return false;
+
+        // cos/sin go last so the existing mask/scale slots keep their indices.
+        ov::OutputVector inputs = sdpa->input_values();
+        inputs[0] = rope->input_value(0);
+        inputs.push_back(rope->input_value(1));
+        inputs.push_back(rope->input_value(2));
+
+        auto new_sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs,
+                                                                 sdpa->get_causal(),
+                                                                 sdpa->get_input0_transpose_order(),
+                                                                 sdpa->get_input1_transpose_order(),
+                                                                 sdpa->get_input2_transpose_order(),
+                                                                 sdpa->get_output_transpose_order(),
+                                                                 sdpa->get_output_type(),
+                                                                 true);
+        new_sdpa->set_friendly_name(sdpa->get_friendly_name());
+        ov::copy_runtime_info(ov::NodeVector{rope, sdpa}, new_sdpa);
+        ov::replace_node(sdpa, new_sdpa);
+        return true;
+    };
+
+    this->register_matcher(std::make_shared<Matcher>(rope_m, "RoPESDPAFusion"), callback);
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/rope_sdpa_fusion.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/rope_sdpa_fusion.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+
+namespace ov::intel_gpu {
+
+/// Deletes the interleaved RoPE that feeds SDPA's Q by handing the cos/sin table to SDPA as two
+/// extra trailing inputs; micro-SDPA then rotates Q inside the tile load it already performs.
+class RoPESDPAFusion : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("RoPESDPAFusion");
+    RoPESDPAFusion();
+};
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
@@ -196,10 +196,16 @@ TransposeVLSDPAMatcher::TransposeVLSDPAMatcher() {
 }
 
 TransposeSDPAMatcher::TransposeSDPAMatcher() {
+    // veesion: i8 and u8 are accepted alongside the float types because micro-SDPA can contract
+    // an integer K on the systolic pipe. This matcher folds q, k and v ALL-OR-NOTHING, so a
+    // single narrowed operand rejecting here does not merely leave one transpose materialised
+    // -- it materialises all three and, downstream, un-fuses the q-side RoPE as well.
     auto is_fp_type = [](const ov::Output<ov::Node>& output) -> bool {
         switch (output.get_element_type()) {
             case ov::element::f16:
-            case ov::element::f32: return true;
+            case ov::element::f32:
+            case ov::element::i8:
+            case ov::element::u8: return true;
             default: return false;
         }
     };
@@ -248,15 +254,23 @@ TransposeSDPAMatcher::TransposeSDPAMatcher() {
         size_t input_k_output_idx = sdpa->get_input_source_output(1).get_index();
         size_t input_v_output_idx = sdpa->get_input_source_output(2).get_index();
 
-        auto process_transpose = [](const std::shared_ptr<Node>& transpose_node,
-                                    const std::shared_ptr<Node>& transpose_order_const_node,
-                                    std::vector<int64_t>& order,
-                                    size_t& output_idx) {
+        // veesion: {0, 1, 3, 2} on V is the marker for a value tensor that has been physically
+        // materialised as (batch, heads, head_size, tokens). micro-SDPA's V*S microkernel
+        // contracts V over tokens, so with the deployed layout its reduction axis is the strided
+        // one and gemmstone answers with an SLM staging pass; k-contiguous V lets it load
+        // straight to registers as K*Q already does. Folding the transpose here is what keeps it
+        // a stride relabelling rather than a second physical permute.
+        const std::vector<int64_t> value_transposed_order = {0, 1, 3, 2};
+        auto process_transpose = [&](const std::shared_ptr<Node>& transpose_node,
+                                     const std::shared_ptr<Node>& transpose_order_const_node,
+                                     std::vector<int64_t>& order,
+                                     size_t& output_idx,
+                                     bool is_value = false) {
             auto transpose_order_const = ov::as_type_ptr<ov::op::v0::Constant>(transpose_order_const_node);
 
             order = transpose_order_const->cast_vector<int64_t>();
             // Allow any transposes without head_size dim position change
-            if (order.back() != static_cast<int64_t>(order.size() - 1))
+            if (order.back() != static_cast<int64_t>(order.size() - 1) && !(is_value && order == value_transposed_order))
                 return false;
 
             auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(transpose_node);
@@ -279,7 +293,7 @@ TransposeSDPAMatcher::TransposeSDPAMatcher() {
         if (pattern_map.count(transpose_v_m) > 0)
             can_fuse_transposes &= process_transpose(pattern_map.at(transpose_v_m).get_node_shared_ptr(),
                                                      pattern_map.at(transpose_v_order_m).get_node_shared_ptr(),
-                                                     order_v, input_v_output_idx);
+                                                     order_v, input_v_output_idx, true);
 
         if (!can_fuse_transposes)
             return false;

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -77,6 +77,7 @@
 #include "openvino/pass/backward_graph_rewrite.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
+#include "openvino/pass/serialize.hpp"
 #include "openvino/pass/sdpa_to_vlsdpa.hpp"
 #include "ov_ops/gather_matmul_compressed.hpp"
 #include "plugin/transformations/bcast_and_pad_zp_buffers.hpp"
@@ -117,6 +118,7 @@
 #include "plugin/transformations/sink_reshape.hpp"
 #include "plugin/transformations/transpose_fusion.hpp"
 #include "plugin/transformations/sdpa_transpose_fusion.hpp"
+#include "plugin/transformations/rope_sdpa_fusion.hpp"
 #include "plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.hpp"
 #include "plugin/transformations/expand_broadcast_reshape_sdpa_fusion.hpp"
 #include "plugin/transformations/disable_fp16_comp_rms.hpp"
@@ -1524,6 +1526,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         };
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMovScalar>(allowed_data_movement_ops);
 
+        if (const char* d = std::getenv("OV_GPU_DUMP_PRE_ROPE"))
+            manager.register_pass<ov::pass::Serialize>(std::string(d) + ".xml", std::string(d) + ".bin");
         manager.register_pass<ov::pass::RoPEFusion>(true);
         pass_config->disable<ov::pass::RoPEFusionGPTJ>();
         pass_config->disable<ov::pass::RoPEFusionIOSlicing>();
@@ -1659,6 +1663,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();
         }
         manager.register_pass<ov::intel_gpu::ExpandBroadcastReshapeSDPAFusion>();
+        // Hand SDPA the RoPE cos/sin table so Q is rotated inside the tile load it already does.
+        manager.register_pass<ov::intel_gpu::RoPESDPAFusion>();
 
         manager.register_pass<ov::pass::GLUFusion>();
         manager.register_pass<ov::intel_gpu::IndirectKVCache>();


### PR DESCRIPTION
### What this is

An int8 attention path for a narrow ViT-B encoder (576 wide, 9 heads, depth 12, head_dim 64,
K=1000 tokens after patch dropping) on Intel integrated GPU and CPU. Opened as a **draft /
RFC**: the work is measured and numerically validated, but it is not mergeable as it stands and
I would rather agree the shape with maintainers than guess. See *Not ready to merge* below.

Seven commits, each self-contained:

| commit | what |
|---|---|
| `core: sdpa` | admit non-real operand types on `ScaledDotProductAttention` |
| `intel_gpu: sdpa` | i8 K for K·Q and s8 V·S inside micro-kernel SDPA, dequant folded into the SDPA scale |
| `intel_gpu: rope` | fused rotate-half RoPE, q-side folded into SDPA |
| `intel_gpu: kernels` | MVN, permute (tiled, i8-capable), gather/scatter at bandwidth |
| `intel_gpu: plumbing` | layout/fusing/reorder/kernel-generator support for the above |
| `intel_cpu` | int8 softmax·V with deferred row-sum, low-degree fast exp, per-output-channel int8 brgemm bias fix |
| `snippets` | softmax decomposition + buffer memory for a quantized attention chain |

### Why the core change is first

`validate_and_infer_types()` requires every SDPA operand to be a real type, so an int8 K or V is
a type-check failure before any plugin can say whether its attention kernel could consume it
directly. Without relaxing that, the GPU path below cannot be expressed at all — it fails with
`Mixed input types are not supported`. The output type stays driven by the query operand and
shape inference is untouched, but I appreciate this is a core-level change made for a plugin's
benefit, and it is the part I most expect pushback on.

### Measured effect

End to end on the encoder above, against the same graph with these commits reverted, on an
Arc-class integrated GPU (Xe-LPG) and its host CPU:

* **iGPU: 2.15×**
* **CPU: 3.43×**

Where the GPU time goes afterwards: int8 FC 35.6%, SDPA 33.1%, f16 FC 10.3%, MVN 8.3%,
V-transpose 5.2%, RoPE-k 4.1% — 86% of it in components individually measured at a hardware
ceiling (int8 GEMM at ~28.5 TOPS, MVN at ~117 GB/s). The device is ~97% busy and not
bandwidth-bound.

### Numerics

Validated against 32 fp32 golden outputs from real video, produced by the unmodified
formulation. Relative L2 **0.0267**, centered **0.0763**, against a gate of 0.035 / 0.090.
A deliberately broken control (attention removed) scores 0.544 / 1.121, so the gate discriminates.
`argmax` is unchanged on all 32.

### Not ready to merge — what I would like guidance on

1. **Environment variables.** The branch introduces ~48 `OV_*` env vars gating these paths, plus
   a local `veesion_env()` helper in `sdpa_gen_micro.cpp`. That is how it was explored, not how
   it should ship. They need to become plugin config properties, compile-time selection driven by
   the graph, or `ENABLE_DEBUG_CAPS`-guarded — I would like to know which you prefer before
   rewriting them.
2. **The submodule bump.** The `intel_gpu` SDPA commit bumps `onednn_gpu` to pick up a GEMM
   dispatch change (`xe_hp_systolic` currently pre-empts the gemmstone-generated kernel by
   implementation-list order, so the cost model never compares the two on these int8 shapes).
   It currently points at a personal fork and must not merge that way; the oneDNN change needs
   to land first. Happy to split that dependency out.
3. **Hardware coverage.** Everything here was measured on **Xe-LPG (Arc-class) only**. The
   micro-kernel SDPA path is what carries the int8 K/V work, and I have not verified what
   happens on Xe-LP (Gen12 Iris Xe) or older, where I would expect the generator not to be
   selected and the new knobs to be inert. Guidance on the intended fallback would help.
4. **Tests.** None yet. I did not want to write them against an interface that is going to
   change once (1) is settled.

Numerical validation used a fixed checkpoint and a frozen golden set rather than the public
test suite; happy to reproduce against whatever you consider authoritative.
