### PR TITLE
snippets: optionally defer softmax normalization past an integer matmul

### DIFF
--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -136,6 +136,15 @@ public:
     bool has_domain_sensitive_ops() const {
         return config.m_has_domain_sensitive_ops;
     }
+    // See SubgraphConfig::m_defer_softmax_normalization. Survives clone() and
+    // clone_with_new_inputs(), so it may be set on the tokenized Subgraph op; it is read when
+    // data_flow_transformations() runs, i.e. during generate().
+    void set_defer_softmax_normalization(bool defer) {
+        config.m_defer_softmax_normalization = defer;
+    }
+    bool defer_softmax_normalization() const {
+        return config.m_defer_softmax_normalization;
+    }
 
     // plugin sets generator for a snippet to some specific generator.
     // it's going to be replaced with Jitters table later
@@ -237,6 +246,10 @@ private:
         // True if Subgraph contains ops that are not applicable to auto broadcast rule.
         // (e.g. GroupNormalization, reshape)
         bool m_has_broadcast_sensitive_ops = false;
+        // True if SoftmaxDecomposition may apply the softmax row sums to the output of an integer
+        // matmul that consumes the softmax, rather than to the softmax itself. Off by default: it
+        // re-quantizes that operand, so it is a plugin's decision to make on its own models.
+        bool m_defer_softmax_normalization = false;
 #ifdef SNIPPETS_DEBUG_CAPS
         std::shared_ptr<DebugCapsConfig> m_debug_config = std::make_shared<DebugCapsConfig>();
 #endif

--- a/src/common/snippets/include/snippets/pass/softmax_decomposition.hpp
+++ b/src/common/snippets/include/snippets/pass/softmax_decomposition.hpp
@@ -10,13 +10,30 @@ namespace ov::snippets::pass {
 
 /**
  * @interface SoftmaxDecomposition
- * @brief Decomposes Softmax to a range of low-level operations
+ * @brief Decomposes Softmax to a range of low-level operations.
+ *
+ *        With defer_normalization, and where the Softmax feeds an integer matmul across a
+ *        quantizer, the reciprocal of the row sums is applied to the matmul's dequantized output
+ *        instead of to the Softmax, so that the quantizer sees exp(s - rowmax) rather than the
+ *        normalized probabilities. The two forms agree in exact arithmetic. In quantized arithmetic
+ *        they do not: the row sums are at least 1, so the deferred operand occupies at least as
+ *        much of the quantization grid, and the rescale divides the resulting error back down by
+ *        the same factor. The error bound is therefore smaller, but the result is not the one the
+ *        source graph specifies, and on a grid the normalized probabilities barely use the two can
+ *        differ by more than they agree. That is why this is off by default and has to be asked
+ *        for by a consumer that has measured the trade-off on its own models.
+ *
+ *        When it is asked for, the rewrite is still emitted only where the pass has established on
+ *        the graph that each step between the Softmax and the matmul either commutes with a
+ *        positive per-row scale or is the quantization step itself, applied to an operand a scale
+ *        has already spread over the grid; and that neither the quantizer's range nor the matmul's
+ *        i32 accumulator is narrower than the deferred operand needs.
  * @ingroup snippets
  */
 class SoftmaxDecomposition : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("snippets::pass::SoftmaxDecomposition");
-    SoftmaxDecomposition();
+    explicit SoftmaxDecomposition(bool defer_normalization = false);
 };
 
 }  // namespace ov::snippets::pass

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -234,7 +234,11 @@ Subgraph::Subgraph(const OutputVector& args, const std::shared_ptr<ov::Model>& b
 
 std::shared_ptr<Node> Subgraph::clone_with_new_inputs(const OutputVector& inputs) const {
     INTERNAL_OP_SCOPE(Subgraph);
-    return std::make_shared<Subgraph>(inputs, body().clone());
+    auto result = std::make_shared<Subgraph>(inputs, body().clone());
+    // The rest of the config is recomputed from the body by init_config(); this one cannot be,
+    // because it is a caller's decision rather than a property of the graph.
+    result->config.m_defer_softmax_normalization = config.m_defer_softmax_normalization;
+    return result;
 }
 
 void Subgraph::validate_and_infer_types() {
@@ -437,6 +441,10 @@ std::shared_ptr<Subgraph> Subgraph::clone() const {
     // so we have to cast away constness to copy runtime info
     ov::copy_runtime_info(std::const_pointer_cast<Node>(shared_from_this()), result);
     result->set_friendly_name(get_friendly_name());
+    // Every other config field is recomputed from the body by init_config(); this one cannot be,
+    // because it is a caller's decision rather than a property of the graph, and the CPU plugin
+    // clones the tokenized Subgraph before any transformation runs on it.
+    result->config.m_defer_softmax_normalization = config.m_defer_softmax_normalization;
     if (m_linear_ir) {
         result->m_linear_ir = lowered::LinearIRBuilder().clone(m_linear_ir);
     }
@@ -477,7 +485,7 @@ void Subgraph::data_flow_transformations(
         manager.register_pass<snippets::pass::MatMulToBrgemm>();
         manager.register_pass<snippets::pass::FuseTransposeBrgemm>();
         manager.register_pass<snippets::pass::TransposeDecomposition>();
-        manager.register_pass<snippets::pass::SoftmaxDecomposition>();
+        manager.register_pass<snippets::pass::SoftmaxDecomposition>(config.m_defer_softmax_normalization);
         manager.register_pass<snippets::pass::GNDecomposition>();
     }
     manager.register_pass<snippets::pass::BroadcastToMoveBroadcast>();

--- a/src/common/snippets/src/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/pass/softmax_decomposition.cpp
@@ -4,31 +4,361 @@
 
 #include "snippets/pass/softmax_decomposition.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <memory>
+#include <set>
 #include <utility>
 #include <vector>
 
 #include "openvino/core/except.hpp"
 #include "openvino/core/graph_util.hpp"
+#include "openvino/core/partial_shape.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
 #include "openvino/op/exp.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
 #include "openvino/op/multiply.hpp"
+#include "openvino/op/round.hpp"
 #include "openvino/op/softmax.hpp"
 #include "openvino/op/subtract.hpp"
+#include "openvino/op/util/attr_types.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/util/log.hpp"
 #include "snippets/itt.hpp"
 #include "snippets/lowered/port_descriptor.hpp"
+#include "snippets/op/brgemm.hpp"
+#include "snippets/op/convert_saturation.hpp"
+#include "snippets/op/convert_truncation.hpp"
 #include "snippets/op/powerstatic.hpp"
 #include "snippets/op/reduce.hpp"
 #include "snippets/utils/utils.hpp"
 
 namespace ov::snippets::pass {
 
-SoftmaxDecomposition::SoftmaxDecomposition() {
+namespace {
+
+// A decomposed FakeQuantize is at most a clamp, a scale, a shift, a rounding and a narrowing.
+// Sixteen is clear of that and bounds the walk on graphs that are not this pattern.
+constexpr size_t max_walk_depth = 16;
+
+// What the walk knows about the deferred operand where it has got to. `peak` bounds its magnitude
+// and is exactly 1.0 at the Softmax, since exp(s - rowmax) attains 1 on every row and never
+// exceeds it. A step that scales the operand moves `peak` with it, so `peak > 1.0` is also the
+// test for "a quantization scale has been crossed": nothing else can raise it. `type` is what the
+// operand is held in at that point, so that a scale can be refused when its own result would no
+// longer fit -- the deferred operand is the larger of the two forms and is the one that overflows
+// first.
+struct DeferredOperand {
+    double peak = 1.0;
+    ov::element::Type type;
+};
+
+// A quantizer's scale, zero point or clamp bound is a scalar or one value per channel. Reading a
+// constant costs a full conversion to float, so an operand far larger than that is not one of
+// these and is refused before it is decoded rather than after.
+constexpr size_t max_constant_elements = 4096;
+
+// Lowest and highest element of `node`'s constant input `idx`. False when that input is not a
+// constant whose values this can read.
+bool constant_extremes(const ov::Node* node, size_t idx, float& lowest, float& highest) {
+    const auto* constant = ov::as_type<const ov::op::v0::Constant>(node->get_input_node_ptr(idx));
+    if (constant == nullptr || constant->get_element_type().bitwidth() < 8 ||
+        ov::shape_size(constant->get_shape()) > max_constant_elements) {
+        return false;
+    }
+    const auto values = constant->cast_vector<float>();
+    if (values.empty() || std::any_of(values.begin(), values.end(), [](float value) {
+            return std::isnan(value);
+        })) {
+        return false;
+    }
+    const auto bounds = std::minmax_element(values.begin(), values.end());
+    lowest = *bounds.first;
+    highest = *bounds.second;
+    return true;
+}
+
+// `type` is known to represent a value of magnitude `peak`. This is a whitelist rather than a
+// fallthrough on is_integral(), which is merely !is_real() and would admit string and the sub-byte
+// float types; anything whose range is not derived here is declined. boolean is deliberately absent
+// even though its range is trivially known: a cast to it is the predicate x != 0, which is not a
+// narrowing of a magnitude and does not commute with a scale.
+bool type_can_represent(const ov::element::Type& type, double peak) {
+    if (!std::isfinite(peak)) {
+        return false;
+    }
+    // A finite double cannot exceed f64's range, and f32 arithmetic could not have carried a value
+    // past f32's range to reach this point. bf16 shares f32's exponent range.
+    if (type == ov::element::f64) {
+        return true;
+    }
+    if (type == ov::element::f32 || type == ov::element::bf16) {
+        return peak <= static_cast<double>(std::numeric_limits<float>::max());
+    }
+    if (type == ov::element::f16) {
+        return peak <= 65504.0;
+    }
+    static constexpr std::array<ov::element::Type_t, 10> integral_types{ov::element::Type_t::i4,
+                                                                        ov::element::Type_t::i8,
+                                                                        ov::element::Type_t::i16,
+                                                                        ov::element::Type_t::i32,
+                                                                        ov::element::Type_t::i64,
+                                                                        ov::element::Type_t::u4,
+                                                                        ov::element::Type_t::u8,
+                                                                        ov::element::Type_t::u16,
+                                                                        ov::element::Type_t::u32,
+                                                                        ov::element::Type_t::u64};
+    if (std::find(integral_types.begin(), integral_types.end(), type) == integral_types.end()) {
+        return false;
+    }
+    const auto bits = static_cast<int>(type.bitwidth());
+    return peak <= std::ldexp(1.0, type.is_signed() ? bits - 1 : bits) - 1.0;
+}
+
+// The rescale multiplies the dequantized product, which the deferral leaves a factor of the row sum
+// larger than it would otherwise be, and the row sum is at least 1 and at most the reduced
+// dimension. Only the types with at least f32's exponent range are taken to hold that; f16 would
+// reach infinity on a long enough row and is declined rather than reasoned about. This says nothing
+// about the i32 accumulator, which `accumulator_absorbs_deferred_operand` covers.
+bool absorbs_deferred_magnitude(const ov::element::Type& type) {
+    return type == ov::element::f32 || type == ov::element::f64 || type == ov::element::bf16;
+}
+
+bool is_shape_preserving_single_output(const ov::Node* node, size_t data_idx) {
+    return node->get_output_size() == 1 && node->get_output_partial_shape(0) == node->get_input_partial_shape(data_idx);
+}
+
+bool has_constant_operand(const ov::Node* node, size_t data_idx, float& lowest, float& highest) {
+    return node->get_input_size() == 2 && constant_extremes(node, 1 - data_idx, lowest, highest);
+}
+
+// A step that a positive per-row scale commutes with: a scale by a positive constant, or a shift by
+// zero.
+bool cross_scaling_step(const ov::Node* node, size_t data_idx, DeferredOperand& operand) {
+    float lowest = 0.F;
+    float highest = 0.F;
+    if (!has_constant_operand(node, data_idx, lowest, highest)) {
+        return false;
+    }
+    if (ov::is_type<ov::op::v1::Multiply>(node)) {
+        if (lowest <= 0.F || !std::isfinite(highest)) {
+            return false;
+        }
+        operand.peak *= highest;
+        return type_can_represent(operand.type, operand.peak);
+    }
+    // Only with the data on the numerator: c / x is a reciprocal, not a scale, and its magnitude
+    // grows without bound as the operand shrinks.
+    if (ov::is_type<ov::op::v1::Divide>(node) && data_idx == 0) {
+        if (lowest <= 0.F || !std::isfinite(highest)) {
+            return false;
+        }
+        operand.peak /= lowest;
+        return type_can_represent(operand.type, operand.peak);
+    }
+    // Commuting a scale past x + c would scale c with it. Subtract is accepted on the numerator
+    // side only, since 0 - x negates and the operand is relied on downstream to be non-negative.
+    if (ov::is_type<ov::op::v1::Add>(node) || (ov::is_type<ov::op::v1::Subtract>(node) && data_idx == 0)) {
+        return lowest == 0.F && highest == 0.F;
+    }
+    return false;
+}
+
+// Rounding and narrowing to an integer type are the two steps that do not commute with a scale at
+// all: they are meaning-preserving here only as the quantization step itself, applied to an operand
+// a scale has already spread over the target grid. Applied to values in (0, 1] they collapse them
+// -- a bare Round would send every probability to 0 but the deferred row maximum to 1, which is a
+// different function, not a differently quantized one.
+//
+// `peak` is exactly 1.0 until a scale moves it, so this tests "a scale came first", which is
+// necessary rather than sufficient: a gain barely above 1 passes it and still rounds the two forms
+// differently. Nothing tighter is available here, because the grid the rounding lands on is only
+// known at the narrowing that follows; a real FakeQuantize cannot produce such a gain, since
+// levels >= 2 over a range the operand fills gives at least the operand's own magnitude back.
+bool is_quantization_step(const DeferredOperand& operand) {
+    return operand.peak > 1.0;
+}
+
+// One step of the quantizer between the softmax and the matmul.
+//
+// A clamp may be crossed only when it does not bite `peak`: a range calibrated on the normalized
+// probabilities generally stops below it, and clipping there cannot be undone by the rescale applied
+// after the matmul.
+bool cross_quantizer_step(const ov::Node* node, size_t data_idx, DeferredOperand& operand) {
+    if (!is_shape_preserving_single_output(node, data_idx)) {
+        return false;
+    }
+    if (ov::is_type<ov::op::v5::Round>(node)) {
+        if (!is_quantization_step(operand)) {
+            return false;
+        }
+        // A code can round up, so what leaves is bounded by the ceiling rather than by `peak`. The
+        // accumulator bound is derived from this, and a fraction of a code matters there.
+        operand.peak = std::ceil(operand.peak);
+        return true;
+    }
+    if (ov::is_type_any_of<ov::op::v0::Convert,
+                           ov::snippets::op::ConvertSaturation,
+                           ov::snippets::op::ConvertTruncation>(node)) {
+        const auto& to = node->get_output_element_type(0);
+        if ((!to.is_real() && !is_quantization_step(operand)) || !type_can_represent(to, operand.peak)) {
+            return false;
+        }
+        operand.type = to;
+        return true;
+    }
+    float lowest = 0.F;
+    float highest = 0.F;
+    if (ov::is_type<ov::op::v1::Maximum>(node)) {
+        return has_constant_operand(node, data_idx, lowest, highest) && highest <= 0.F;
+    }
+    if (ov::is_type<ov::op::v1::Minimum>(node)) {
+        return has_constant_operand(node, data_idx, lowest, highest) && lowest >= operand.peak;
+    }
+    return cross_scaling_step(node, data_idx, operand);
+}
+
+// FuseTransposeBrgemm runs before this pass and folds a transpose into whichever port it sat on,
+// recording it as a non-planar layout there. Under either fold the product's axes no longer
+// correspond to the row sums' and a row would be divided by another row's sum, which a shape
+// comparison cannot see. Operand 1 is not checked: it does not carry the probabilities.
+bool has_planar_probability_layouts(const std::shared_ptr<ov::snippets::op::Brgemm>& brgemm) {
+    const auto& in_desc = lowered::PortDescriptorUtils::get_port_descriptor_ptr(brgemm->input(0));
+    const auto& out_desc = lowered::PortDescriptorUtils::get_port_descriptor_ptr(brgemm->output(0));
+    return utils::is_planar_layout(in_desc->get_layout()) && utils::is_planar_layout(out_desc->get_layout());
+}
+
+// The normalized operand's row sums to the quantization grid maximum however long the row is, so the
+// i32 accumulator never had to be reasoned about. The deferred operand's does not: every element is
+// up to `peak` in its own right, so the accumulation grows with the reduced dimension and this is
+// the one bound the deferral can actually break. Brgemm::get_output_type only yields i32 for an i8
+// weight operand, which is what bounds the other factor.
+bool accumulator_absorbs_deferred_operand(const std::shared_ptr<ov::snippets::op::Brgemm>& brgemm, double peak) {
+    const auto& shape = brgemm->get_input_partial_shape(0);
+    if (shape.rank().is_dynamic() || shape.size() < 2 || shape[shape.size() - 1].is_dynamic()) {
+        return false;
+    }
+    constexpr double weight_peak = 128.0;
+    const auto reduced_dimension = static_cast<double>(shape[shape.size() - 1].get_length());
+    return peak * reduced_dimension * weight_peak <= static_cast<double>(std::numeric_limits<int32_t>::max());
+}
+
+// The matmul that consumes this softmax, when the graph is a quantized attention chain
+//     Softmax -> <quantizer> -> Brgemm accumulating in i32
+// and a null pointer for every other graph, with `operand` left describing however far it got. Only
+// operand 0 carries the probabilities.
+std::shared_ptr<ov::snippets::op::Brgemm> find_int8_consumer(const ov::Output<ov::Node>& softmax,
+                                                             DeferredOperand& operand) {
+    operand.type = softmax.get_element_type();
+    ov::Output<ov::Node> cursor = softmax;
+    for (size_t hop = 0; hop < max_walk_depth; ++hop) {
+        const auto targets = cursor.get_target_inputs();
+        if (targets.size() != 1) {
+            return nullptr;
+        }
+        const auto target = *targets.begin();
+        auto* next = target.get_node();
+        if (ov::is_type<ov::snippets::op::Brgemm>(next)) {
+            const auto brgemm = ov::as_type_ptr<ov::snippets::op::Brgemm>(next->shared_from_this());
+            const bool accumulates_in_i32 = brgemm->get_output_element_type(0) == ov::element::i32;
+            if (target.get_index() != 0 || !accumulates_in_i32) {
+                return nullptr;
+            }
+            return brgemm;
+        }
+        if (!cross_quantizer_step(next, target.get_index(), operand)) {
+            return nullptr;
+        }
+        cursor = next->output(0);
+    }
+    return nullptr;
+}
+
+// An integer matmul accumulates in i32 and the return to real arithmetic is a separate node, so the
+// rescale is anchored on that node's output. There is no walk to do: a narrowing to a smaller
+// integer type would clip an accumulator the deferral has made larger, and an elementwise step whose
+// operands are still integers cannot produce a real result, so the conversion has to be the matmul's
+// immediate and only consumer.
+ov::Output<ov::Node> find_dequantized_output(const std::shared_ptr<ov::snippets::op::Brgemm>& brgemm) {
+    const auto targets = brgemm->output(0).get_target_inputs();
+    if (targets.size() != 1) {
+        return {};
+    }
+    const auto target = *targets.begin();
+    auto* next = target.get_node();
+    const bool is_conversion = ov::is_type_any_of<ov::op::v0::Convert,
+                                                  ov::snippets::op::ConvertSaturation,
+                                                  ov::snippets::op::ConvertTruncation>(next);
+    if (!is_conversion || !is_shape_preserving_single_output(next, target.get_index()) ||
+        !next->get_output_element_type(0).is_real()) {
+        return {};
+    }
+    return next->output(0);
+}
+
+// Multiplying `anchor` by the row sums leaves `anchor`'s shape intact. A dynamic dimension
+// broadcast-merges with anything, so it is declined rather than merged away vacuously.
+bool rescale_preserves_shape(const ov::Output<ov::Node>& anchor, const ov::Output<ov::Node>& row_sum_reciprocal) {
+    const auto& anchor_shape = anchor.get_partial_shape();
+    const auto& sums_shape = row_sum_reciprocal.get_partial_shape();
+    if (anchor_shape.is_dynamic() || sums_shape.is_dynamic()) {
+        return false;
+    }
+    auto merged = anchor_shape;
+    if (!ov::PartialShape::broadcast_merge_into(merged, sums_shape, ov::op::AutoBroadcastType::NUMPY)) {
+        return false;
+    }
+    return merged == anchor_shape;
+}
+
+// Where the reciprocal row sums should be applied instead of to the Softmax, and the matmul they
+// have to stay ordered against. An empty `anchor` when any precondition of the reassociation does
+// not hold on the graph, in which case the caller emits the decomposition exactly as it always was.
+struct Deferral {
+    ov::Output<ov::Node> anchor;
+    std::shared_ptr<ov::snippets::op::Brgemm> brgemm;
+};
+
+Deferral find_deferral(const ov::Output<ov::Node>& softmax, const ov::Output<ov::Node>& row_sum_reciprocal) {
+    DeferredOperand operand;
+    const auto brgemm = find_int8_consumer(softmax, operand);
+    if (!brgemm || !has_planar_probability_layouts(brgemm) ||
+        !accumulator_absorbs_deferred_operand(brgemm, operand.peak)) {
+        return {};
+    }
+    const auto anchor = find_dequantized_output(brgemm);
+    if (anchor.get_node() == nullptr) {
+        return {};
+    }
+    // The row sums carry the softmax input's type and the anchor whatever the dequantization
+    // converted to. This pass runs before PropagatePrecision, so those need not agree yet, and
+    // multiplying operands of different types would throw out of the callback rather than decline.
+    if (anchor.get_element_type() != row_sum_reciprocal.get_element_type() ||
+        !absorbs_deferred_magnitude(anchor.get_element_type()) ||
+        !rescale_preserves_shape(anchor, row_sum_reciprocal)) {
+        return {};
+    }
+    return {anchor, brgemm};
+}
+
+}  // namespace
+
+SoftmaxDecomposition::SoftmaxDecomposition(bool defer_normalization) {
     MATCHER_SCOPE(SoftmaxDecomposition);
     auto softmax_v1_m = ov::pass::pattern::wrap_type<ov::op::v1::Softmax>();
     auto softmax_v8_m = ov::pass::pattern::wrap_type<ov::op::v8::Softmax>();
@@ -57,17 +387,63 @@ SoftmaxDecomposition::SoftmaxDecomposition() {
         const auto reduce_sum = std::make_shared<ov::snippets::op::ReduceSum>(exp, normalized_axis);
         ov::snippets::op::ReduceBase::compute_and_set_reduce_subtensors(reduce_sum);
         const auto power = std::make_shared<ov::snippets::op::PowerStatic>(reduce_sum, -1.F);
-        const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, power);
 
         OPENVINO_ASSERT(normalized_axis < rank, "Softmax has incorrect axis");
         std::vector<size_t> subtensor(rank, 1);
         for (size_t i = normalized_axis; i < rank; ++i) {
             subtensor[i] = utils::get_full_dim_value();
         }
-
         lowered::PortDescriptorUtils::set_port_descriptor(power->input(0), subtensor);
         lowered::PortDescriptorUtils::set_port_descriptor(power->output(0), std::move(subtensor));
 
+        // On a quantized attention chain the reciprocal row sums are applied to the output of the
+        // matmul that consumes the softmax rather than to the softmax itself, so that what reaches
+        // the quantizer is exp(s - rowmax) instead of the normalized probabilities. Every
+        // precondition is checked on the graph; any of them failing leaves the decomposition
+        // exactly as it was.
+        // The reassociation holds only when the axis the row sums reduce is the axis the matmul
+        // contracts. Both tokenizers pin the softmax to the last axis well before this pass, but
+        // nothing here would otherwise notice a body where that is not so.
+        const bool reduces_contracted_axis = normalized_axis + 1 == rank;
+        auto deferral = defer_normalization && reduces_contracted_axis
+                            ? find_deferral(softmax->output(0), power->output(0))
+                            : Deferral{};
+        if (deferral.anchor.get_node() != nullptr) {
+            const auto sinks = deferral.anchor.get_target_inputs();
+            // With the rescale moved past it, the matmul no longer consumes the row sums, so a
+            // topological sort is free to schedule the reduction after the matmul -- which reads
+            // the exp tile a second time and inverts the buffer lifetimes the memory solver then
+            // has to place. The control dependency is what orders the two. It is not removed
+            // afterwards: it is the only record of an ordering the data flow no longer implies, and
+            // ov::replace_node carries it across any later replacement of either end.
+            deferral.brgemm->add_control_dependency(power);
+            const auto rescale = std::make_shared<ov::op::v1::Multiply>(deferral.anchor, power);
+            for (const auto& sink : sinks) {
+                sink.replace_source_output(rescale->output(0));
+            }
+            copy_runtime_info(softmax, {reduce_max, subtract, exp, reduce_sum, power, rescale});
+            const auto softmax_name = softmax->get_friendly_name();
+            rescale->set_friendly_name(softmax_name + "/rescale");
+            // Tensor names move with the value their consumers read. The rescale now supplies what
+            // the anchor used to, so a body whose output is the anchor would otherwise lose its
+            // output tensor names -- an interface change, not a labelling one. The Softmax's own
+            // names stay where replace_node_update_name puts them, on the Exp: the value
+            // softmax(s) is no longer materialized anywhere, and the Exp is the point in the graph
+            // it used to occupy. Its single consumer is the quantizer, so nothing reads it by name.
+            const auto anchor_names = deferral.anchor.get_names();
+            deferral.anchor.set_names({});
+            rescale->output(0).set_names(anchor_names);
+            OPENVINO_DEBUG("SoftmaxDecomposition deferred the normalization of ",
+                           softmax_name,
+                           " past ",
+                           deferral.brgemm->get_friendly_name());
+            // The Softmax's friendly name goes to the Exp, as it does to the Multiply on the path
+            // below: replace_node_update_name puts it there, and a matcher pass leaving the matched
+            // node's name on no node at all would lose it from dumps and profiling.
+            return ov::replace_node_update_name(softmax, exp);
+        }
+
+        const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, power);
         copy_runtime_info(softmax, {reduce_max, subtract, exp, reduce_sum, power, multiply});
         return ov::replace_node_update_name(softmax, multiply);
     };

--- a/src/common/snippets/tests/src/pass/softmax_decomposition_deferred.cpp
+++ b/src/common/snippets/tests/src/pass/softmax_decomposition_deferred.cpp
@@ -1,0 +1,802 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/exp.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/minimum.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/round.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/op/subtract.hpp"
+#include "snippets/lowered/port_descriptor.hpp"
+#include "snippets/op/brgemm.hpp"
+#include "snippets/op/convert_saturation.hpp"
+#include "snippets/op/powerstatic.hpp"
+#include "snippets/op/reduce.hpp"
+#include "snippets/op/subgraph.hpp"
+#include "snippets/pass/softmax_decomposition.hpp"
+#include "snippets/utils/utils.hpp"
+
+using namespace ov;
+
+/* SoftmaxDecomposition applies the row sums to the output of the matmul that consumes the softmax
+ * when, and only when, that matmul is an integer one reached across a quantizer that still
+ * represents the deferred operand. There is one declining test per precondition, so that removing
+ * any single guard turns a test red.
+ */
+
+namespace {
+
+// The chain between the softmax and the quantizer. It may add parameters of its own, and is invoked
+// once per model so that the two never share a node.
+using ChainBuilder = std::function<Output<Node>(const Output<Node>&, ParameterVector&)>;
+
+std::vector<size_t> row_subtensor(size_t rank, size_t axis) {
+    std::vector<size_t> subtensor(rank, 1);
+    for (size_t i = axis; i < rank; ++i) {
+        subtensor[i] = ov::snippets::utils::get_full_dim_value();
+    }
+    return subtensor;
+}
+
+std::shared_ptr<Node> make_shifted_exp(const Output<Node>& scores, size_t axis) {
+    const auto reduce_max = std::make_shared<ov::snippets::op::ReduceMax>(scores, axis);
+    ov::snippets::op::ReduceBase::compute_and_set_reduce_subtensors(reduce_max);
+    const auto subtract = std::make_shared<ov::op::v1::Subtract>(scores, reduce_max);
+    return std::make_shared<ov::op::v0::Exp>(subtract);
+}
+
+std::shared_ptr<Node> make_row_sum_reciprocal(const Output<Node>& exp, size_t axis) {
+    const auto reduce_sum = std::make_shared<ov::snippets::op::ReduceSum>(exp, axis);
+    ov::snippets::op::ReduceBase::compute_and_set_reduce_subtensors(reduce_sum);
+    const auto power = std::make_shared<ov::snippets::op::PowerStatic>(reduce_sum, -1.F);
+    // The pass sets these, so a reference that omits them is not quite what it emits.
+    const auto subtensor = row_subtensor(exp.get_partial_shape().size(), axis);
+    ov::snippets::lowered::PortDescriptorUtils::set_port_descriptor(power->input(0), subtensor);
+    ov::snippets::lowered::PortDescriptorUtils::set_port_descriptor(power->output(0), subtensor);
+    return power;
+}
+
+// exp(x - rowmax) / rowsum, i.e. what the pass emits when it declines to defer.
+std::shared_ptr<Node> make_normalized_softmax(const Output<Node>& scores, size_t axis) {
+    const auto exp = make_shifted_exp(scores, axis);
+    return std::make_shared<ov::op::v1::Multiply>(exp, make_row_sum_reciprocal(exp, axis));
+}
+
+// What CommonFakeQuantizeDecomposition leaves between the softmax and the matmul: a clamp to the
+// calibrated range, then a scale, a rounding and a narrowing. The clamp is emitted unconditionally,
+// so `input_high` decides whether the deferred operand -- exactly 1.0 on every row -- survives it,
+// and `scale` against `narrow_to` decides whether it still fits the narrowing.
+std::shared_ptr<Node> make_quantizer(const Output<Node>& probabilities,
+                                     float input_high,
+                                     float scale,
+                                     const element::Type& narrow_to,
+                                     bool saturating = false) {
+    const auto& type = probabilities.get_element_type();
+    const auto low = ov::op::v0::Constant::create(type, Shape{}, {0.F});
+    const auto high = ov::op::v0::Constant::create(type, Shape{}, {input_high});
+    const auto clamped_low = std::make_shared<ov::op::v1::Maximum>(probabilities, low);
+    const auto clamped = std::make_shared<ov::op::v1::Minimum>(clamped_low, high);
+    const auto step = ov::op::v0::Constant::create(type, Shape{}, {scale});
+    const auto scaled = std::make_shared<ov::op::v1::Multiply>(clamped, step);
+    const auto rounded = std::make_shared<ov::op::v5::Round>(scaled, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
+    if (saturating) {
+        return std::make_shared<ov::snippets::op::ConvertSaturation>(rounded, narrow_to);
+    }
+    return std::make_shared<ov::op::v0::Convert>(rounded, narrow_to);
+}
+
+// A matmul whose layouts are recorded where the pass reads them. Passing them to the ctor would not
+// do: `layout_c` there only permutes the inferred shape, and validate_and_infer_types reverts it
+// from the port descriptor, which is also where FuseTransposeBrgemm writes a fold.
+std::shared_ptr<ov::snippets::op::Brgemm> make_brgemm(const Output<Node>& a,
+                                                      const Output<Node>& b,
+                                                      const std::vector<size_t>& input_layout = {},
+                                                      const std::vector<size_t>& output_layout = {}) {
+    const auto brgemm = std::make_shared<ov::snippets::op::Brgemm>(a, b);
+    const std::vector<size_t> subtensor(2, ov::snippets::utils::get_full_dim_value());
+    ov::snippets::lowered::PortDescriptorUtils::set_port_descriptor(brgemm->input(0), subtensor, input_layout);
+    ov::snippets::lowered::PortDescriptorUtils::set_port_descriptor(brgemm->output(0), subtensor, output_layout);
+    brgemm->validate_and_infer_types();
+    return brgemm;
+}
+
+const Shape default_scores{1, 2, 8, 8};
+const Shape default_values{1, 2, 8, 4};
+
+// Shapes whose head and row extents are equal, so permuting them leaves the product's shape
+// untouched. The shape check then cannot decline, and the layout is the only thing left that can
+// tell a folded transpose from a planar one. Used by the three layout tests below.
+const Shape equal_extent_scores{1, 8, 8, 8};
+const Shape equal_extent_values{1, 8, 8, 4};
+
+// One graph shape, varied by whichever precondition a test pins.
+struct Chain {
+    ChainBuilder between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) {
+        return x;
+    };
+    float input_high = 1.F;
+    float quantizer_scale = 255.F;
+    element::Type narrow_to = element::u8;
+    element::Type scores_type = element::f32;
+    element::Type dequantize_to = element::f32;
+    bool saturating_narrowing = false;
+    int axis = -1;
+    PartialShape scores = default_scores;
+    PartialShape values = default_values;
+    std::vector<size_t> input_layout{};
+    std::vector<size_t> output_layout{};
+    bool scale_the_accumulator = false;
+    bool narrow_the_accumulator = false;
+    bool fork_the_softmax = false;
+    bool fork_the_accumulator = false;
+};
+
+}  // namespace
+
+class SoftmaxDecompositionDeferredTests : public TransformationTestsF {
+public:
+    SoftmaxDecompositionDeferredTests() {
+        comparator.enable(FunctionsComparator::CONST_VALUES);
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        manager.register_pass<ov::snippets::pass::SoftmaxDecomposition>(true);
+    }
+
+    // Which of the three forms of the same chain to build: what the pass is given, what it emits
+    // when it declines, and what it emits when it defers.
+    enum class Form : uint8_t { Original, Normalized, Deferred };
+
+    // `Softmax -> chain -> quantizer -> i8 Brgemm -> ... -> Convert(real)`.
+    static std::shared_ptr<Model> build(const Chain& chain, Form form) {
+        const auto rank = static_cast<int>(chain.scores.rank().get_length());
+        const auto axis = static_cast<size_t>(chain.axis < 0 ? chain.axis + rank : chain.axis);
+        auto scores = std::make_shared<ov::op::v0::Parameter>(chain.scores_type, chain.scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, chain.values);
+        ParameterVector parameters{scores, values};
+        Output<Node> probabilities;
+        std::shared_ptr<Node> row_sum_reciprocal;
+        if (form == Form::Original) {
+            probabilities = std::make_shared<ov::op::v8::Softmax>(scores, chain.axis);
+        } else if (form == Form::Normalized) {
+            probabilities = make_normalized_softmax(scores, axis);
+        } else {
+            const auto exp = make_shifted_exp(scores, axis);
+            row_sum_reciprocal = make_row_sum_reciprocal(exp, axis);
+            probabilities = exp;
+        }
+        const auto quantized = make_quantizer(chain.between_softmax_and_quantizer(probabilities, parameters),
+                                              chain.input_high,
+                                              chain.quantizer_scale,
+                                              chain.narrow_to,
+                                              chain.saturating_narrowing);
+        const auto brgemm = make_brgemm(quantized, values, chain.input_layout, chain.output_layout);
+        if (row_sum_reciprocal) {
+            brgemm->add_control_dependency(row_sum_reciprocal);
+        }
+        Output<Node> accumulator = brgemm->output(0);
+        if (chain.scale_the_accumulator) {
+            const auto gain = ov::op::v0::Constant::create(element::i32, Shape{}, {2});
+            accumulator = std::make_shared<ov::op::v1::Multiply>(accumulator, gain);
+        }
+        if (chain.narrow_the_accumulator) {
+            accumulator = std::make_shared<ov::op::v0::Convert>(accumulator, element::i8);
+        }
+        OutputVector outputs;
+        if (chain.fork_the_accumulator) {
+            outputs.push_back(std::make_shared<ov::op::v0::Convert>(accumulator, chain.dequantize_to));
+        }
+        Output<Node> dequantized = std::make_shared<ov::op::v0::Convert>(accumulator, chain.dequantize_to);
+        if (row_sum_reciprocal) {
+            dequantized = std::make_shared<ov::op::v1::Multiply>(dequantized, row_sum_reciprocal);
+        }
+        outputs.push_back(dequantized);
+        if (chain.fork_the_softmax) {
+            outputs.push_back(std::make_shared<ov::op::v0::Exp>(probabilities));
+        }
+        return std::make_shared<Model>(outputs, parameters);
+    }
+
+    // The pass leaves the chain alone: the reference normalizes the softmax in place.
+    void expect_decline(const Chain& chain) {
+        model = build(chain, Form::Original);
+        model_ref = build(chain, Form::Normalized);
+    }
+
+    // The pass rewrites the chain: the reference applies the row sums after the dequantization.
+    // Here the rescale is the body's last node, so the Result's friendly name derives from a node
+    // the pass created and named after the Softmax -- it cannot match a reference whose equivalent
+    // node was auto-named. The tensor names on that output, which are the part a caller can
+    // observe, are still compared.
+    void expect_defer(const Chain& chain) {
+        disable_result_friendly_names_check();
+        model = build(chain, Form::Original);
+        model_ref = build(chain, Form::Deferred);
+    }
+};
+
+TEST_F(SoftmaxDecompositionDeferredTests, DeferredPastInt8Brgemm) {
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, default_values);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(scores, -1);
+        auto brgemm = make_brgemm(make_quantizer(softmax, 1.F, 255.F, element::u8), values);
+        auto dequantized = std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+        auto scale = ov::op::v0::Constant::create(element::f32, Shape{}, {1.F / 255.F});
+        auto rescaled = std::make_shared<ov::op::v1::Multiply>(dequantized, scale);
+        model = std::make_shared<Model>(OutputVector{rescaled}, ParameterVector{scores, values});
+    }
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, default_values);
+        auto exp = make_shifted_exp(scores, 3);
+        auto row_sum_reciprocal = make_row_sum_reciprocal(exp, 3);
+        auto brgemm = make_brgemm(make_quantizer(exp, 1.F, 255.F, element::u8), values);
+        brgemm->add_control_dependency(row_sum_reciprocal);
+        auto dequantized = std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+        // The row sums land on the first real-typed value after the matmul, ahead of the
+        // dequantization multiply rather than after it.
+        auto normalized = std::make_shared<ov::op::v1::Multiply>(dequantized, row_sum_reciprocal);
+        auto scale = ov::op::v0::Constant::create(element::f32, Shape{}, {1.F / 255.F});
+        auto rescaled = std::make_shared<ov::op::v1::Multiply>(normalized, scale);
+        model_ref = std::make_shared<Model>(OutputVector{rescaled}, ParameterVector{scores, values});
+    }
+}
+
+// With the anchor at the body output the rescale becomes the Result's producer, so it has to take
+// over the tensor names identifying that value. The graph comparator's tensor-name check, seeded by
+// CopyTensorNamesToRefModel, is what fails if it does not.
+TEST_F(SoftmaxDecompositionDeferredTests, DeferredWhenAnchorIsBodyOutput) {
+    disable_result_friendly_names_check();
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, default_values);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(scores, -1);
+        auto brgemm = make_brgemm(make_quantizer(softmax, 1.F, 255.F, element::u8), values);
+        auto dequantized = std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+        model = std::make_shared<Model>(OutputVector{dequantized}, ParameterVector{scores, values});
+    }
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, default_values);
+        auto exp = make_shifted_exp(scores, 3);
+        auto row_sum_reciprocal = make_row_sum_reciprocal(exp, 3);
+        auto brgemm = make_brgemm(make_quantizer(exp, 1.F, 255.F, element::u8), values);
+        brgemm->add_control_dependency(row_sum_reciprocal);
+        auto dequantized = std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+        auto normalized = std::make_shared<ov::op::v1::Multiply>(dequantized, row_sum_reciprocal);
+        model_ref = std::make_shared<Model>(OutputVector{normalized}, ParameterVector{scores, values});
+    }
+}
+
+TEST_F(SoftmaxDecompositionDeferredTests, DeferredWithEqualExtentsAndPlanarLayout) {
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, equal_extent_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, equal_extent_values);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(scores, -1);
+        auto brgemm = make_brgemm(make_quantizer(softmax, 1.F, 255.F, element::u8), values);
+        auto dequantized = std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+        auto scale = ov::op::v0::Constant::create(element::f32, Shape{}, {1.F / 255.F});
+        auto rescaled = std::make_shared<ov::op::v1::Multiply>(dequantized, scale);
+        model = std::make_shared<Model>(OutputVector{rescaled}, ParameterVector{scores, values});
+    }
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, equal_extent_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, equal_extent_values);
+        auto exp = make_shifted_exp(scores, 3);
+        auto row_sum_reciprocal = make_row_sum_reciprocal(exp, 3);
+        auto brgemm = make_brgemm(make_quantizer(exp, 1.F, 255.F, element::u8), values);
+        brgemm->add_control_dependency(row_sum_reciprocal);
+        auto dequantized = std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+        auto normalized = std::make_shared<ov::op::v1::Multiply>(dequantized, row_sum_reciprocal);
+        auto scale = ov::op::v0::Constant::create(element::f32, Shape{}, {1.F / 255.F});
+        auto rescaled = std::make_shared<ov::op::v1::Multiply>(normalized, scale);
+        model_ref = std::make_shared<Model>(OutputVector{rescaled}, ParameterVector{scores, values});
+    }
+}
+
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredPastFoldedOutputTranspose) {
+    Chain chain;
+    chain.scores = equal_extent_scores;
+    chain.values = equal_extent_values;
+    chain.output_layout = {0, 2, 1, 3};
+    expect_decline(chain);
+}
+
+// FuseTransposeBrgemm folds a transpose into whichever port it sat on, so the operand port has to
+// be checked too.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredPastFoldedOperandTranspose) {
+    Chain chain;
+    chain.scores = equal_extent_scores;
+    chain.values = equal_extent_values;
+    chain.input_layout = {0, 2, 1, 3};
+    expect_decline(chain);
+}
+
+// A range calibrated on the normalized probabilities stops below 1.0, and the deferred operand
+// reaches exactly 1.0 on every row. Deferring into that clamp would flatten every row's largest
+// weight onto one code point, which the later rescale could not undo. Both bounds here are ones
+// OpenVINO's own int8 MHA reference models put on this exact tensor: MHAINT8MatMulFunction's
+// 0.820726 and MHAINT8MatMulTypeRelaxedFunction's 0.245, in ov_snippets_models/src/subgraph_mha.cpp.
+// Neither reaches 1.0, so on both of those graphs the pass declines -- calibrated attention
+// probabilities do not get close to 1, and widening that range is not this pass's business.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredIntoNarrowerQuantizerRange) {
+    Chain chain;
+    chain.input_high = 0.820726F;
+    expect_decline(chain);
+}
+
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredIntoTypeRelaxedQuantizerRange) {
+    Chain chain;
+    chain.input_high = 0.245F;
+    expect_decline(chain);
+}
+
+// A clamp from below above zero is not the identity on the deferred operand either.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredIntoRaisedQuantizerFloor) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto floor = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {0.5F});
+        return std::make_shared<ov::op::v1::Maximum>(x, floor);
+    };
+    expect_decline(chain);
+}
+
+// The narrowing has to represent the operand at the scale reached by then: 311 does not fit u8.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenScaleOutgrowsTheNarrowing) {
+    Chain chain;
+    chain.quantizer_scale = 311.F;
+    expect_decline(chain);
+}
+
+// ... and a signed narrowing stops at 127, not 255, so the bound has to respect signedness.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenScaleOutgrowsASignedNarrowing) {
+    Chain chain;
+    chain.quantizer_scale = 200.F;
+    chain.narrow_to = element::i8;
+    expect_decline(chain);
+}
+
+// A scale crossed before a clamp raises the operand's bound, so the clamp is compared against that
+// bound rather than against 1.0.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenScaleOutgrowsClampBound) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto gain = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {4.F});
+        const auto amplified = std::make_shared<ov::op::v1::Multiply>(x, gain);
+        const auto bound = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {1.5F});
+        return std::make_shared<ov::op::v1::Minimum>(amplified, bound);
+    };
+    expect_decline(chain);
+}
+
+// A negative factor is not a positive scale: it would invert the clamp reasoning below it.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossNegativeScale) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto gain = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {-1.F});
+        return std::make_shared<ov::op::v1::Multiply>(x, gain);
+    };
+    expect_decline(chain);
+}
+
+// c / x is a reciprocal, not a scale: its magnitude grows without bound as the operand shrinks.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossReciprocal) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto numerator = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {2.F});
+        return std::make_shared<ov::op::v1::Divide>(numerator, x);
+    };
+    expect_decline(chain);
+}
+
+// 0 - x negates an operand the clamp rules rely on being non-negative.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossNegation) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto zero = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {0.F});
+        return std::make_shared<ov::op::v1::Subtract>(zero, x);
+    };
+    expect_decline(chain);
+}
+
+// Commuting a scale past x + c would scale c with it.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossNonZeroShift) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto shift = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {1.F});
+        return std::make_shared<ov::op::v1::Add>(x, shift);
+    };
+    expect_decline(chain);
+}
+
+// A join with a second activation is not a quantizer at all.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossActivationJoin) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector& parameters) -> Output<Node> {
+        auto bias = std::make_shared<ov::op::v0::Parameter>(x.get_element_type(), x.get_partial_shape());
+        parameters.push_back(bias);
+        return std::make_shared<ov::op::v1::Add>(x, bias);
+    };
+    expect_decline(chain);
+}
+
+// An op the whitelist does not name is not crossed, whatever its operands look like.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossAnUnrecognizedOp) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto shape = ov::op::v0::Constant::create(element::i32, Shape{3}, {1, 16, 8});
+        return std::make_shared<ov::op::v1::Reshape>(x, shape, false);
+    };
+    expect_decline(chain);
+}
+
+// A crossable op still has to preserve the shape of its data input, or an element no longer belongs
+// to the row whose sum would rescale it. A per-head scale broadcasts, and is otherwise admissible.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossABroadcastingScale) {
+    Chain chain;
+    chain.scores = Shape{1, 1, 8, 8};
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        // The factors are 1.0 so that the bound they carry cannot make the clamp below decline
+        // first; the only thing wrong with this step is that it changes the shape.
+        const auto gain = ov::op::v0::Constant::create(x.get_element_type(), Shape{1, 2, 1, 1}, {1.F, 1.F});
+        return std::make_shared<ov::op::v1::Multiply>(x, gain);
+    };
+    expect_decline(chain);
+}
+
+// The row sums reduce the softmax axis, so it has to be the axis the matmul contracts. The product
+// is square here so that the shape check cannot decline first and mask this one.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenSoftmaxAxisIsNotContracted) {
+    Chain chain;
+    chain.axis = -2;
+    chain.values = default_scores;
+    expect_decline(chain);
+}
+
+// replace_node_update_name rewrites every consumer of the softmax, so a second one would silently
+// receive the unnormalized exponential.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenSoftmaxHasASecondConsumer) {
+    Chain chain;
+    chain.fork_the_softmax = true;
+    expect_decline(chain);
+}
+
+// A second consumer of an intermediate accumulator would keep the un-rescaled value.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenAccumulatorHasASecondConsumer) {
+    Chain chain;
+    chain.fork_the_accumulator = true;
+    expect_decline(chain);
+}
+
+// The deferral makes the accumulator up to a factor of K larger, so a narrowing on that leg would
+// clip where it did not before.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredPastNarrowedAccumulator) {
+    Chain chain;
+    chain.narrow_the_accumulator = true;
+    expect_decline(chain);
+}
+
+// ... and a scale on that leg can overflow it, so it is not crossed while the value is an integer.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredPastScaledAccumulator) {
+    Chain chain;
+    chain.scale_the_accumulator = true;
+    expect_decline(chain);
+}
+
+// This pass runs before PropagatePrecision, so the row sums and the dequantized product need not
+// agree in type yet. Multiplying them together would throw out of the callback rather than decline.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenRescaleOperandTypesDisagree) {
+    Chain chain;
+    chain.dequantize_to = element::bf16;
+    expect_decline(chain);
+}
+
+// f16 has neither f32's exponent range nor a bound derived here, so it is declined rather than
+// assumed to hold an accumulator the deferral has enlarged.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenAnchorCannotAbsorbTheGrowth) {
+    Chain chain;
+    chain.scores_type = element::f16;
+    chain.dequantize_to = element::f16;
+    expect_decline(chain);
+}
+
+// Each narrowing is checked against its own type's range, not one shared bound. This puts the
+// operand past f16's range while leaving the rest of the chain admissible.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenScaleOutgrowsAnF16Conversion) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto gain = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {1e5F});
+        const auto amplified = std::make_shared<ov::op::v1::Multiply>(x, gain);
+        const auto narrowed = std::make_shared<ov::op::v0::Convert>(amplified, element::f16);
+        return std::make_shared<ov::op::v0::Convert>(narrowed, x.get_element_type());
+    };
+    chain.input_high = 1e5F;
+    chain.quantizer_scale = 1e-3F;
+    expect_decline(chain);
+}
+
+// A cast to boolean is the predicate x != 0, not a narrowing of a magnitude: it maps the deferred
+// operand and the normalized one to the same thing, so what follows no longer distinguishes them and
+// the rescale would divide a result the operand never scaled. Its range trivially admits the operand
+// at this scale, which is exactly why the range check alone must not be what decides it.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossABooleanConversion) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto gain = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {2.F});
+        const auto amplified = std::make_shared<ov::op::v1::Multiply>(x, gain);
+        const auto narrowed = std::make_shared<ov::op::v0::Convert>(amplified, element::boolean);
+        return std::make_shared<ov::op::v0::Convert>(narrowed, x.get_element_type());
+    };
+    chain.input_high = 2.F;
+    chain.quantizer_scale = 100.F;
+    expect_decline(chain);
+}
+
+// A conversion to a type whose range this does not reason about is declined even when a bound could
+// be derived for it: u1 would admit the operand at this scale, and is still not crossed.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossAnUnreasonedType) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto narrowed = std::make_shared<ov::op::v0::Convert>(x, element::u1);
+        return std::make_shared<ov::op::v0::Convert>(narrowed, x.get_element_type());
+    };
+    expect_decline(chain);
+}
+
+// A dynamic dimension broadcast-merges with anything, so the shape check would hold vacuously.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredOnDynamicShapes) {
+    Chain chain;
+    chain.scores = PartialShape::dynamic(4);
+    chain.values = PartialShape::dynamic(4);
+    expect_decline(chain);
+}
+
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredPastF32Brgemm) {
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::f32, default_values);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(scores, -1);
+        model = std::make_shared<Model>(OutputVector{make_brgemm(softmax, values)}, ParameterVector{scores, values});
+    }
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::f32, default_values);
+        model_ref = std::make_shared<Model>(OutputVector{make_brgemm(make_normalized_softmax(scores, 3), values)},
+                                            ParameterVector{scores, values});
+    }
+}
+
+// Only operand 0 carries the probabilities, so the row sums do not correspond to a product whose
+// operand 1 they came from.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenProbabilitiesAreOnOperandOne) {
+    const auto build = [](const Output<Node>& probabilities, const Output<Node>& other) {
+        const auto quantized = make_quantizer(probabilities, 1.F, 127.F, element::i8);
+        const auto brgemm = make_brgemm(other, quantized);
+        return std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+    };
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 8, 8});
+        auto other = std::make_shared<ov::op::v0::Parameter>(element::u8, Shape{1, 2, 8, 8});
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(scores, -1);
+        model = std::make_shared<Model>(OutputVector{build(softmax, other)}, ParameterVector{scores, other});
+    }
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 8, 8});
+        auto other = std::make_shared<ov::op::v0::Parameter>(element::u8, Shape{1, 2, 8, 8});
+        model_ref = std::make_shared<Model>(OutputVector{build(make_normalized_softmax(scores, 3), other)},
+                                            ParameterVector{scores, other});
+    }
+}
+
+// Rounding and narrowing to an integer are the two steps that do not commute with a scale at all.
+// They are admissible here only as the quantization step itself, applied to an operand a scale has
+// already spread over the target grid. Applied straight to values in (0, 1] they are a different
+// function, not a differently quantized one: a bare rounding sends every normalized probability on
+// a row of eight to 0 but the deferred row maximum to 1, and a bare narrowing to u8 truncates the
+// same way. The range check cannot see either -- 1.0 fits u8 comfortably.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossAnUnscaledRounding) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        return std::make_shared<ov::op::v5::Round>(x, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
+    };
+    expect_decline(chain);
+}
+
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossAnUnscaledNarrowing) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto narrowed = std::make_shared<ov::op::v0::Convert>(x, element::u8);
+        return std::make_shared<ov::op::v0::Convert>(narrowed, x.get_element_type());
+    };
+    expect_decline(chain);
+}
+
+// A scale that shrinks the operand does not make a rounding admissible either: the grid it lands on
+// is coarser than the operand's own range, not finer.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossARoundingBehindAShrinkingScale) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto gain = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {0.5F});
+        const auto shrunk = std::make_shared<ov::op::v1::Multiply>(x, gain);
+        return std::make_shared<ov::op::v5::Round>(shrunk, ov::op::v5::Round::RoundMode::HALF_TO_EVEN);
+    };
+    expect_decline(chain);
+}
+
+// The normalized operand's row sums to the grid maximum however long the row is; the deferred one's
+// grows with it. 8 rows of u8 codes against i8 weights cannot overflow i32, but 2^25 of them can, so
+// the reduced dimension has to be part of the decision.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredWhenTheAccumulatorCannotHoldTheDeferredRow) {
+    Chain chain;
+    chain.scores = PartialShape{1, 1, 8, 1 << 25};
+    chain.values = PartialShape{1, 1, 1 << 25, 4};
+    expect_decline(chain);
+}
+
+TEST_F(SoftmaxDecompositionDeferredTests, DeferredWhenTheAccumulatorIsWideEnoughForTheRow) {
+    Chain chain;
+    chain.scores = PartialShape{1, 1, 8, 1 << 15};
+    chain.values = PartialShape{1, 1, 1 << 15, 4};
+    expect_defer(chain);
+}
+
+// FakeQuantizeDecomposition emits snippets' own saturating conversion, not ov::op::v0::Convert, so
+// that is the narrowing the pass actually meets in production.
+TEST_F(SoftmaxDecompositionDeferredTests, DeferredAcrossASaturatingNarrowing) {
+    Chain chain;
+    chain.saturating_narrowing = true;
+    expect_defer(chain);
+}
+
+// bf16 shares f32's exponent range, so it can hold a product the deferral has enlarged.
+TEST_F(SoftmaxDecompositionDeferredTests, DeferredWhenBothRescaleOperandsAreBf16) {
+    Chain chain;
+    chain.scores_type = element::bf16;
+    chain.dequantize_to = element::bf16;
+    expect_defer(chain);
+}
+
+// A scale on the numerator of a divide, and shifts by zero, all commute with the row sums.
+TEST_F(SoftmaxDecompositionDeferredTests, DeferredAcrossADivideAndZeroShifts) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto divisor = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {4.F});
+        const auto divided = std::make_shared<ov::op::v1::Divide>(x, divisor);
+        const auto zero = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {0.F});
+        const auto shifted = std::make_shared<ov::op::v1::Add>(divided, zero);
+        return std::make_shared<ov::op::v1::Subtract>(shifted, zero);
+    };
+    chain.input_high = 0.25F;
+    chain.quantizer_scale = 1020.F;
+    expect_defer(chain);
+}
+
+// The walk is bounded, so a chain of admissible steps longer than the bound is declined rather than
+// followed. Seventeen zero shifts is one more than the bound allows.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossAChainLongerThanTheWalk) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        Output<Node> cursor = x;
+        const auto zero = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {0.F});
+        for (int i = 0; i < 17; ++i) {
+            cursor = std::make_shared<ov::op::v1::Add>(cursor, zero);
+        }
+        return cursor;
+    };
+    expect_decline(chain);
+}
+
+// A scale this pass cannot read the extremes of is not a scale it can commute with: a sub-byte
+// constant it will not decode, or a constant carrying NaN or an infinity. The narrowing to u4 ahead
+// of the sub-byte scale is admissible on its own -- the operand has been spread over that grid and
+// fits it -- so it is the constant's own width that declines.
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossASubByteScale) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto spread = ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {8.F});
+        const auto amplified = std::make_shared<ov::op::v1::Multiply>(x, spread);
+        const auto narrowed = std::make_shared<ov::op::v0::Convert>(amplified, element::u4);
+        const auto gain = ov::op::v0::Constant::create(element::u4, Shape{}, {2});
+        const auto scaled = std::make_shared<ov::op::v1::Multiply>(narrowed, gain);
+        return std::make_shared<ov::op::v0::Convert>(scaled, x.get_element_type());
+    };
+    expect_decline(chain);
+}
+
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossANaNScale) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto gain =
+            ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {std::numeric_limits<float>::quiet_NaN()});
+        return std::make_shared<ov::op::v1::Multiply>(x, gain);
+    };
+    expect_decline(chain);
+}
+
+TEST_F(SoftmaxDecompositionDeferredTests, NotDeferredAcrossAnInfiniteScale) {
+    Chain chain;
+    chain.between_softmax_and_quantizer = [](const Output<Node>& x, ParameterVector&) -> Output<Node> {
+        const auto gain =
+            ov::op::v0::Constant::create(x.get_element_type(), Shape{}, {std::numeric_limits<float>::infinity()});
+        return std::make_shared<ov::op::v1::Multiply>(x, gain);
+    };
+    expect_decline(chain);
+}
+
+// The deferral is off unless a consumer asks for it, so the same chain that DeferredPastInt8Brgemm
+// rewrites has to come out normalized in place under a default-constructed pass.
+class SoftmaxDecompositionDefaultTests : public TransformationTestsF {
+public:
+    SoftmaxDecompositionDefaultTests() {
+        comparator.enable(FunctionsComparator::CONST_VALUES);
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        manager.register_pass<ov::snippets::pass::SoftmaxDecomposition>();
+    }
+};
+
+TEST_F(SoftmaxDecompositionDefaultTests, NormalizesInPlaceOnADeferrableChain) {
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, default_values);
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(scores, -1);
+        auto brgemm = make_brgemm(make_quantizer(softmax, 1.F, 255.F, element::u8), values);
+        auto dequantized = std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+        model = std::make_shared<Model>(OutputVector{dequantized}, ParameterVector{scores, values});
+    }
+    {
+        auto scores = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+        auto values = std::make_shared<ov::op::v0::Parameter>(element::i8, default_values);
+        auto brgemm = make_brgemm(make_quantizer(make_normalized_softmax(scores, 3), 1.F, 255.F, element::u8), values);
+        auto dequantized = std::make_shared<ov::op::v0::Convert>(brgemm, element::f32);
+        model_ref = std::make_shared<Model>(OutputVector{dequantized}, ParameterVector{scores, values});
+    }
+}
+
+// The opt-in is a caller's decision, not a property of the body, so init_config() cannot recover it
+// the way it recovers the rest of SubgraphConfig. The CPU plugin clones the tokenized Subgraph
+// before anything transforms it, so a flag that does not survive cloning is a flag no plugin can
+// use -- and nothing else in the suite would notice, because the pass tests construct the pass
+// directly.
+TEST(SoftmaxDecompositionSubgraphConfig, DeferralSurvivesCloning) {
+    auto inner = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+    auto softmax = std::make_shared<ov::op::v8::Softmax>(inner, -1);
+    auto body = std::make_shared<Model>(OutputVector{softmax}, ParameterVector{inner});
+    auto outer = std::make_shared<ov::op::v0::Parameter>(element::f32, default_scores);
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(OutputVector{outer}, body);
+
+    EXPECT_FALSE(subgraph->defer_softmax_normalization());
+    subgraph->set_defer_softmax_normalization(true);
+
+    const auto cloned = subgraph->clone();
+    const auto with_new_inputs =
+        ov::as_type_ptr<ov::snippets::op::Subgraph>(subgraph->clone_with_new_inputs(OutputVector{outer}));
+    ASSERT_TRUE(with_new_inputs);
+    EXPECT_TRUE(cloned->defer_softmax_normalization());
+    EXPECT_TRUE(with_new_inputs->defer_softmax_normalization());
+}

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -495,6 +495,13 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             } catch (ov::Exception&) {
                 OPENVINO_THROW("Wrong value for property key ", ov::intel_cpu::enable_sage_attn.name());
             }
+        } else if (key == ov::intel_cpu::snippets_defer_softmax_normalization.name()) {
+            try {
+                snippetsDeferSoftmaxNormalization = val.as<bool>();
+            } catch (ov::Exception&) {
+                OPENVINO_THROW("Wrong value for property key ",
+                               ov::intel_cpu::snippets_defer_softmax_normalization.name());
+            }
         } else if (key == ov::enable_weightless.name()) {
             try {
                 enableWeightless = val.as<bool>();

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -93,6 +93,7 @@ struct Config {
     ov::internal::CacheQuantAlgorithm keyCacheQuantAlg = ov::internal::CacheQuantAlgorithm::SCALAR;
     ov::internal::CacheQuantAlgorithm valueCacheQuantAlg = ov::internal::CacheQuantAlgorithm::SCALAR;
     bool enableSageAttn = false;
+    bool snippetsDeferSoftmaxNormalization = false;
     ov::threading::IStreamsExecutor::Config streamExecutorConfig;
     int streams = 1;
     bool streamsChanged = false;

--- a/src/plugins/intel_cpu/src/internal_properties.hpp
+++ b/src/plugins/intel_cpu/src/internal_properties.hpp
@@ -80,4 +80,17 @@ static constexpr Property<bool, PropertyMutability::RW> enable_tensor_parallel{"
  */
 static constexpr Property<bool, PropertyMutability::RW> enable_sage_attn{"ENABLE_SAGE_ATTN"};
 
+/**
+ * @brief Where Snippets fuses a Softmax whose result reaches an integer MatMul across a quantizer,
+ * apply the softmax row sums to that MatMul's dequantized output instead of to the Softmax, so the
+ * quantizer sees exp(s - rowmax) rather than the normalized probabilities. The two agree in exact
+ * arithmetic but not in quantized arithmetic, and which one a model wants depends on how its
+ * Softmax was calibrated, so this is a decision about a model rather than an optimization and it is
+ * off unless it is asked for.
+ * @param true - defer the normalization past the MatMul
+ * @param false - normalize in place (default)
+ */
+static constexpr Property<bool, PropertyMutability::RW> snippets_defer_softmax_normalization{
+    "SNIPPETS_DEFER_SOFTMAX_NORMALIZATION"};
+
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -239,6 +239,9 @@ Subgraph::Subgraph(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
     const auto& tmp_snippet = ov::as_type_ptr<snippets::op::Subgraph>(op);
     CPU_NODE_ASSERT(tmp_snippet, "Attempt to create Subgraph node from an invalid op type");
     subgraph_attrs->snippet = tmp_snippet->clone();
+    // Set on the clone rather than on the tokenized op: the clone is what this node transforms and
+    // generates from, and the flag is read when its data-flow pipeline runs.
+    subgraph_attrs->snippet->set_defer_softmax_normalization(context->getConfig().snippetsDeferSoftmaxNormalization);
     subgraph_attrs->bodyHash = getBodyHash(tmp_snippet);
 
 #if defined(OPENVINO_ARCH_ARM64)

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/snippets_defer_softmax_normalization.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/snippets_defer_softmax_normalization.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common_test_utils/ov_plugin_cache.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "internal_properties.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/compiled_model.hpp"
+#include "openvino/runtime/exec_model_info.hpp"
+#include "openvino/runtime/properties.hpp"
+#include "openvino/runtime/tensor.hpp"
+#include "subgraph_mha.hpp"
+
+namespace ov::test::snippets {
+
+namespace {
+
+// The int8 MHA body with the Softmax quantized on a softmax's theoretical [0, 1] range rather than
+// on a calibrated one -- the only in-tree graph the deferred normalization fires on.
+const std::vector<ov::PartialShape> mha_int8_unit_range_shapes{{1, 128, 16, 64},
+                                                               {1, 128, 16, 64},
+                                                               {1, 16, 1, 1},
+                                                               {1, 128, 16, 64}};
+
+size_t count_subgraphs(const ov::CompiledModel& compiled_model) {
+    size_t subgraphs = 0;
+    for (const auto& op : compiled_model.get_runtime_model()->get_ops()) {
+        const auto& rt_info = op->get_rt_info();
+        const auto layer_type = rt_info.find(ov::exec_model_info::LAYER_TYPE);
+        if (layer_type == rt_info.end()) {
+            ADD_FAILURE() << "no layerType on " << op->get_friendly_name();
+            continue;
+        }
+        subgraphs += layer_type->second.as<std::string>() == "Subgraph";
+    }
+    return subgraphs;
+}
+
+std::vector<float> infer(const ov::AnyMap& properties, size_t& subgraphs) {
+    const auto model = MHAINT8MatMulFunction(mha_int8_unit_range_shapes, 1.F).getOriginal();
+
+    ov::AnyMap config{{"SNIPPETS_MODE", "IGNORE_CALLBACK"}, ov::hint::inference_precision(ov::element::f32)};
+    config.insert(properties.begin(), properties.end());
+    auto compiled_model =
+        ov::test::utils::PluginCache::get().core()->compile_model(model, ov::test::utils::DEVICE_CPU, config);
+    subgraphs = count_subgraphs(compiled_model);
+
+    auto request = compiled_model.create_infer_request();
+    for (size_t i = 0; i < compiled_model.inputs().size(); ++i) {
+        const auto& input = compiled_model.inputs()[i];
+        // Seeded per input, so the three rounds see identical data and the four inputs do not.
+        request.set_tensor(input,
+                           ov::test::utils::create_and_fill_tensor(
+                               input.get_element_type(),
+                               input.get_shape(),
+                               ov::test::utils::InputGenerateData(-1, 2, 256, static_cast<int32_t>(i) + 1)));
+    }
+    request.infer();
+
+    const auto output = request.get_output_tensor(0);
+    EXPECT_EQ(output.get_element_type(), ov::element::f32);
+    const auto* data = output.data<float>();
+    return {data, data + output.get_size()};
+}
+
+size_t count_differing(const std::vector<float>& lhs, const std::vector<float>& rhs) {
+    EXPECT_EQ(lhs.size(), rhs.size());
+    size_t differing = 0;
+    for (size_t i = 0; i < lhs.size() && i < rhs.size(); ++i) {
+        differing += lhs[i] != rhs[i];
+    }
+    return differing;
+}
+
+}  // namespace
+
+// Nothing else in the suite crosses the boundary between a plugin property and this option: the
+// pass tests construct SoftmaxDecomposition directly, and every MHA functional test runs with the
+// default. The hop has to be checked by running the model rather than by reading the flag back,
+// because a dropped opt-in still compiles and still computes a softmax -- reading it back would
+// pass just as happily against a pipeline that never consulted it.
+TEST(smoke_Snippets_DeferSoftmaxNormalization, PropertyReachesTheSnippetsPass) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    size_t default_subgraphs = 0;
+    size_t off_subgraphs = 0;
+    size_t on_subgraphs = 0;
+    const auto by_default = infer({}, default_subgraphs);
+    const auto normalized = infer({{ov::intel_cpu::snippets_defer_softmax_normalization.name(), false}}, off_subgraphs);
+    const auto deferred = infer({{ov::intel_cpu::snippets_defer_softmax_normalization.name(), true}}, on_subgraphs);
+
+    // Without a tokenized body there is no pass to reach, and the comparisons below would hold or
+    // fail for an unrelated reason. How many bodies this graph tokenizes into is not this test's
+    // business -- smoke_Snippets_MHAINT8MatMulUnitRange already pins that -- only that it does.
+    ASSERT_GT(default_subgraphs, 0U);
+    ASSERT_GT(off_subgraphs, 0U);
+    ASSERT_GT(on_subgraphs, 0U);
+
+    // Not setting the property and setting it to false must be the same thing, which is what pins
+    // the default now that a plugin can move it.
+    EXPECT_EQ(count_differing(by_default, normalized), 0U);
+
+    // Deferring re-quantizes MatMul1's left operand, so on this body the answer moves over most of
+    // the output: 112896 of 131072 elements as measured on avx2+avx_vnni. A floor rather than a
+    // bare inequality, so that a change leaving only a handful of elements moving fails here
+    // instead of squeaking through. The bar is set well under the measured share because the exact
+    // count is a quantization coincidence rate and may shift with the brgemm accumulation order on
+    // another ISA; removing the opt-in entirely takes it to 0, which is what it has to catch.
+    EXPECT_GT(count_differing(normalized, deferred), deferred.size() / 8);
+}
+
+}  // namespace ov::test::snippets

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha_quantized.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha_quantized.cpp
@@ -53,6 +53,23 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(CPUTestUtils::empty_plugin_config)),
     MHA::getTestCaseName);
 
+// The same graph, but with the Softmax quantized on a softmax's theoretical [0, 1] range instead of
+// a calibrated one -- the only in-tree form on which SoftmaxDecomposition's deferred normalization
+// can fire, so a change of its default would show up here first. Only the first shape set is used:
+// the last two are dynamic, and the rewrite declines on a dynamic anchor, so they would pin nothing.
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAINT8MatMulUnitRange,
+    MHAINT8MatMulUnitRange,
+    ::testing::Combine(::testing::Values(inputShapesQuantized.front()),
+                       ::testing::Values(std::vector<element::Type>{}),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(false),  // The graph doesn't contain Multiply
+                       ::testing::Values(7),      // FQx3, Transpose1 on inputs + MHA + Transpose on output + Deq Mul
+                       ::testing::Values(5),      // FQx3 on inputs + MHA + Deq Mul
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
 INSTANTIATE_TEST_SUITE_P(
     smoke_Snippets_MHAQuantMatMul0,
     MHAQuantMatMul0,

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -132,6 +132,15 @@ protected:
     void init_thresholds() override;
 };
 
+// The same graph with the Softmax quantized on a softmax's theoretical [0, 1] range rather than on
+// a calibrated one. That is the form on which SoftmaxDecomposition would defer the normalization
+// past MatMul1 if a plugin asked it to, so this is the model that pins the default: the CPU plugin
+// does not ask, so the result must stay within the int8 MHA tolerance of the reference.
+class MHAINT8MatMulUnitRange : public MHAINT8MatMul {
+protected:
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
+};
+
 class MHAQuantMatMul0 : public MHA {
 protected:
     std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -329,6 +329,10 @@ void MHAINT8MatMul::init_thresholds() {
     abs_threshold = 4e-6;
 }
 
+std::shared_ptr<SnippetsFunctionBase> MHAINT8MatMulUnitRange::get_subgraph() const {
+    return std::make_shared<ov::test::snippets::MHAINT8MatMulFunction>(inputDynamicShapes, 1.f);
+}
+
 std::shared_ptr<SnippetsFunctionBase> MHAQuantMatMul0::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAQuantMatMul0Function>(inputDynamicShapes);
 }
@@ -418,6 +422,12 @@ TEST_P(MHATransposedB, CompareWithRefImpl) {
 
 TEST_P(MHAINT8MatMul, CompareWithRefImpl) {
     run();
+}
+
+TEST_P(MHAINT8MatMulUnitRange, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    run();
+    validateNumSubgraphs();
 }
 
 TEST_P(MHAQuantMatMul0, CompareWithRefImpl) {

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
@@ -354,12 +354,20 @@ protected:
  */
 class MHAINT8MatMulFunction : public SnippetsFunctionBase {
 public:
-    explicit MHAINT8MatMulFunction(const std::vector<PartialShape>& inputShapes)
-            : SnippetsFunctionBase(inputShapes) {
+    // `softmaxOutputHigh` is the upper bound of the FakeQuantize on the Softmax output. The default
+    // is a calibrated one, i.e. the largest probability actually observed, which is below 1.
+    // Passing 1.f instead gives the theoretical range of a softmax, which is what an export that
+    // does not calibrate that tensor produces -- and the only form on which SoftmaxDecomposition
+    // defers the normalization past MatMul1.
+    explicit MHAINT8MatMulFunction(const std::vector<PartialShape>& inputShapes, float softmaxOutputHigh = 0.820726f)
+        : SnippetsFunctionBase(inputShapes),
+          softmax_output_high(softmaxOutputHigh) {
         OPENVINO_ASSERT(input_shapes.size() == 4, "Got invalid number of input shapes");
     }
+
 protected:
     std::shared_ptr<ov::Model> initOriginal() const override;
+    const float softmax_output_high;
 };
 
 /* Graph:

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
@@ -815,8 +815,14 @@ std::shared_ptr<ov::Model> MHAINT8MatMulFunction::initOriginal() const {
                                                    {-35.0172004}, {34.7436294}, {-35.0172004}, {34.7436294});
     const auto add = std::make_shared<ov::op::v1::Add>(fq3, addParam);
     const auto softMax = std::make_shared<ov::op::v8::Softmax>(add, -1);
-    auto fq4 = ov::test::utils::make_fake_quantize(softMax, ov::element::f32, 256, {1},
-                                                   {0}, {0.820726}, {0}, {0.820726});
+    auto fq4 = ov::test::utils::make_fake_quantize(softMax,
+                                                   ov::element::f32,
+                                                   256,
+                                                   {1},
+                                                   {0},
+                                                   {softmax_output_high},
+                                                   {0},
+                                                   {softmax_output_high});
     const auto transpose2 = std::make_shared<ov::op::v1::Transpose>(fq2, transpose2Const);
     const auto matMul1 = std::make_shared<ov::op::v0::MatMul>(fq4, transpose2, transA, transB);
     auto fq5 = ov::test::utils::make_fake_quantize(matMul1, ov::element::f32, 256, {1},


### PR DESCRIPTION
`SoftmaxDecomposition` normalizes in place: it emits `exp(s - rowmax)` and divides by the row sums
before anything downstream sees the result. When the consumer is an integer matmul reached across a
quantizer, that is the wrong place to divide.

`softmax(s) @ V` and `(exp(s - rowmax) @ V) / rowsum` are the same function in exact arithmetic, but
they are not the same thing to quantize. The normalized probabilities have a per-tensor range set by
the peakiest row, so a fixed grid is largely unused on the flatter ones. `exp(s - rowmax)` peaks at
exactly 1.0 on every row by construction, so the same grid is fully used whatever a row's peakedness.
Both loops are blocked over the same rows, so the row sums are still live when the product needs them
and nothing has to be spilled to keep them.

**In quantized arithmetic the two forms disagree, and the deferred one is not automatically the
one you want.** Its error *bound* is smaller: the row sum is at least 1 -- the argmax term of
`exp(s - rowmax)` is exactly 1 and the rest are positive -- so the deferred operand is elementwise
at least as large as the normalized one, both go through the same clamp, scale and rounding, and
the rescale after the matmul divides the resulting error back down by the row sum. But a smaller
error bound against exact arithmetic is not the same as agreeing with the graph as written, and
the gap is not always small. Measured on the model added here (`MHAINT8MatMulUnitRange`, a
`[0, 1]`-quantized softmax on a near-uniform attention row of 128): enabling the deferral moves the
compiled output by up to **200%** relative to the same model executed by the reference
implementation. The reason is that on a flat row the normalized probabilities land on two or three
code points of a 256-level `[0, 1]` grid, so the graph as written is throwing away almost
everything, and computing it accurately instead is a large change rather than a small one.

**That is why the deferral is off by default.** OpenVINO's contract is that the compiled model
computes what the source model specifies, not something more accurate; so this ships as a mechanism
a consumer opts into once it has measured the trade-off on its own models, not as a new default.

### What it does

The row sums are applied to the first real-typed value after the matmul instead of to the softmax.
It is a deliberate re-quantization of that operand rather than a bit-exact rewrite, so it is applied
only where every precondition can be *checked on the graph* rather than assumed:

- the softmax's consumer chain must reach a `Brgemm` on operand 0 whose accumulator is `i32` — the
  point is to hand a quantizer a better-conditioned operand, and there is nothing to gain when none
  is there;
- the softmax's axis must be the one the matmul contracts. Both tokenizers pin that two passes
  earlier, but nothing here would otherwise notice a body where it does not hold;
- every step in between must be one across which a positive per-row scale either commutes or is
  itself the quantization: a scale by a positive constant, a rounding, a narrowing, or a clamp. A
  shift may be crossed only when it is zero, since commuting a scale past `x + c` scales `c` too. A
  division is crossed only with the data on the numerator — `c / x` is a reciprocal, whose magnitude
  grows without bound as the operand shrinks — and a subtraction likewise, since `0 - x` negates an
  operand the clamp rules rely on being non-negative;
- **a rounding or a narrowing to an integer type is crossed only once a scale has spread the operand
  over the target grid.** These two steps do not commute with a scale at all; they are admissible
  here only as the quantization itself. Applied straight to values in `(0, 1]` they compute a
  different function rather than a differently quantized one — a bare `Round` sends every normalized
  probability on a reasonably long row to 0 but the deferred row maximum to 1. The running bound
  starts at exactly 1.0 and only a scale can raise it, so "the bound has grown" is exactly the
  condition that a scale came first. A conversion to `boolean` is declined outright: it is the
  predicate `x != 0`, not a narrowing of a magnitude;
- **a clamp must not bite the deferred operand, and a narrowing must still represent it.** Both are
  checked against that same running bound, so a clamp is compared against the operand's magnitude at
  that point in the chain rather than against 1.0. This is the condition that matters most: a range
  calibrated on the normalized probabilities generally stops below 1.0, and deferring into such a
  clamp would flatten every row's largest weight onto one code point where the later rescale could
  not undo it. `CommonFakeQuantizeDecomposition` emits that clamp unconditionally and its bounds are
  constants on the node, so they are read rather than assumed;
- **the `i32` accumulator must hold the deferred row.** This is the one bound the deferral can
  actually break. The normalized operand's row sums to the grid maximum however long the row is; the
  deferred one's grows with the reduced dimension, by up to the row sum. `Brgemm` accumulates in
  `i32` only for an `i8` weight operand, so the product of the operand bound, the reduced dimension
  and 128 is compared against `INT32_MAX` before deferring. At realistic sequence lengths there is
  several orders of magnitude of headroom; the check is there because nothing else would notice, and
  `vpdpbusd` wraps silently;
- between the accumulator and the first real-typed value, only a shape-preserving conversion to a
  real type may be crossed, so a narrowing that would clip the enlarged accumulator, or a zero-point
  correction, may not;
- the matmul's operand-0 and output layouts must both still be planar. `FuseTransposeBrgemm` runs
  before this pass and folds a transpose into whichever port it sat on; under either fold the
  product's axes no longer correspond to the row sums' and a row would be divided by another row's
  sum. A shape comparison cannot see this, and sees nothing at all under dynamic dimensions, so both
  layouts are read from the port descriptors. Operand 1 is not checked — it does not carry the
  probabilities;
- multiplying the row sums into the anchor must leave its shape unchanged, and the two must already
  agree in element type — this pass runs before `PropagatePrecision`, and multiplying mismatched
  operands would throw out of the callback rather than decline. Dynamic dimensions are declined
  rather than broadcast-merged, since a dynamic dimension merges with anything and the comparison
  would hold vacuously, so the deferral does not currently fire on a dynamic-shape body.

Any graph failing any of these decomposes exactly as it did before, and nothing throws. An f32
matmul is unaffected.

**Turning it on.** `SoftmaxDecomposition`'s constructor takes `defer_normalization`, defaulting to
`false`, and `Subgraph` carries it as `SubgraphConfig::m_defer_softmax_normalization` with a
`set_defer_softmax_normalization()` setter, so a plugin can set it on the tokenized `Subgraph` op.
It is copied by both `clone()` and `clone_with_new_inputs()`, which the rest of `SubgraphConfig`
does not need — `init_config()` recomputes those from the body, and this one cannot be recomputed
because it is a caller's decision rather than a property of the graph. That matters concretely:
`intel_cpu` clones the tokenized `Subgraph` before any transformation runs on it, so without the
copy the setter would be silently inert on the only in-tree plugin. `DeferralSurvivesCloning`
pins it. No in-tree caller sets the flag, so nothing changes for anyone today. If you would rather
it were reached through a plugin property or a `PassConfig` callback instead, say which and I will
move it.

### What this does *not* apply to

Worth being explicit, because it decides whether the change is useful to you. A quantizer range
calibrated by observing the normalized probabilities stops below 1.0, so the clamp rule declines on
such a model — including on **both int8 MHA bodies in this repository's own test helpers**, whose
bounds are `0.820726` (`MHAINT8MatMulFunction`) and `0.245`
(`MHAINT8MatMulTypeRelaxedFunction`), both in `ov_snippets_models/src/subgraph_mha.cpp`. Widening
that range is not this pass's business, so it declines rather than reaching for it. The deferral
applies where that operand is quantized on a fixed `[0, 1]` grid, which is what an export targeting
this reassociation produces.

`MHAINT8MatMulFunction` now takes that bound as a constructor argument, and
`smoke_Snippets_MHAINT8MatMulUnitRange` instantiates it at `1.0` — the one in-tree graph on which
the deferral *can* fire. With the default it does not fire, and that test is what pins the default:
it is bit-identical to master. It is also what produced the 200% figure above, by being run with
the flag forced on.

Being honest about what that leaves untested: with the deferral off everywhere in tree, its
*lowered* behaviour — the buffer lifetimes, the control dependency — is exercised by no functional
test. The unit tests pin the graph the pass emits, not the loops it becomes. If you would like the
CPU plugin to set the flag behind a property so that path gets CI coverage, tell me and I will add
it here rather than in the change that consumes it.

The rescale takes over the tensor names the anchor was carrying, since it is now what the anchor's
consumers read; without that, a body whose output is the anchor loses its output tensor names.

Once the matmul no longer consumes the reduction, a topological sort is free to schedule the
reduction after it, which reads the exp tile a second time and inverts the buffer lifetimes. A
control dependency pins the order. It is deliberately left on the graph rather than removed after
the sort: it is the only record of an ordering the data flow no longer implies, `ov::replace_node`
carries it across any later replacement of either end, and `LinearIRBuilder` clones it through
`topological_sort`, which honours it.

### Tests

`softmax_decomposition_deferred.cpp` has 45 cases. One constructs the pass with its default and
asserts that a fully deferrable chain is still normalized in place. One sets the flag on a
`Subgraph` and asserts it survives both cloning paths. The other 43 construct the pass with
`defer_normalization = true`: seven where the deferral fires — one with the
anchor at the body output, which pins the tensor-name transfer, one across the saturating conversion
`FakeQuantizeDecomposition` actually emits, one at a reduced dimension near the accumulator bound —
and the rest declining, one per precondition, so that removing any single check turns a test red.

Six guards were re-verified discriminating by mutation for this revision: each was removed or
inverted in turn, the suite rebuilt, and a named test confirmed to fail — the two scale-before-
rounding rules, the accumulator bound, the clamp bound, and the two planar-layout checks. One
deliberate guard is *not* discriminating and should not be presented as if it were: declining
`boolean` in the type whitelist is redundant, because a `boolean` conversion needs the bound to be
above 1 to pass the scale rule and at or below 1 to pass the range rule. It is kept because a cast
to `boolean` is a predicate rather than a narrowing and the whitelist is the honest place to say so,
not because any test can distinguish it.

The existing `SoftmaxDecomposition` lowering tests cover the unchanged default path.

### Measurement

An enabling change with no speed claim of its own: it removes a constraint that otherwise forces the
softmax's neighbours out of int8 on a quantized attention chain. Whatever gain follows appears in the
change that takes advantage of it and should be measured there.

Accuracy has to be measured per model, since the deferral re-quantizes that operand by design. The
argument above says it cannot be worse where it fires, but that is an argument, not a measurement.
Happy to produce runs on whichever public quantized attention models you consider representative.

---

AI assistance used: yes
If yes: drafting the graph-selection conditions, the comments, the unit tests and this description;
eleven adversarial review passes over the diff.
Human validation performed: built from a clean configure of this component and its test target;
`clang-format -style=file` clean; **the 43 new unit tests pass and the full `ov_snippets_func_tests`
suite passes at 236/236**, and on CPU
`smoke_Snippets_MHAINT8MatMul*` / `MHAQuantMatMul0` / `MHAFQ*` pass 14/14 excluding three
`MHAINT8MatMul` shapes that fail identically with this pass reverted to master (verified by
reverting it and re-running, so they are pre-existing and not from this change); six preconditions verified discriminating by removing each in turn and
confirming a named test fails, with the one non-discriminating guard called out above rather than
counted. Reviewed the pass against the ops `CommonFakeQuantizeDecomposition` actually emits, against
the layouts `MatMulToBrgemm` and `FuseTransposeBrgemm` leave on the ports it reads, and against
`Brgemm::get_output_type` for the accumulator bound. **Not yet done, and I would rather say so than
imply otherwise:** performance measurement, which belongs to the change that consumes this one; and
any functional coverage of the deferred path's lowering, which is impossible while no in-tree
caller enables it.
