### PR TITLE
intel_gpu: raise the onednn sum post-op ancestor-walk depth

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -107,9 +107,37 @@ static bool is_direct_ancestor(const program_node& child, const program_node& ta
     if (target.get_users().size() != 2)
         return false;
 
-    // Limit the iteration depth to 5 for performance reason
+    // The walk follows dependency(0) only, so this bounds the length of the single-input chain
+    // between the two nodes; the equality test precedes the hop, so a bound of N reaches a target
+    // at most N - 1 hops away.
+    //
+    // An attention residual sits 6 hops up. Walking dependency(0) from the projection that carries
+    // the post-op, on a graph dump of a multi-head attention block:
+    //
+    //     0  the output projection            <- carries the fused eltwise sum
+    //     1  reshape                          <- heads folded back into the feature axis
+    //     2  the attention op
+    //     3  reshape                          <- feature axis split into heads
+    //     4  the QKV matmul
+    //     5  the norm
+    //     6  the block input                  <- the residual root, two users
+    //
+    // 7 is therefore the smallest bound that reaches it, and the bound is kept at that minimum
+    // deliberately. Note the two reshapes: it is easy to count this chain as 4 hops from the
+    // operator list alone and conclude a bound of 5 or 6 is enough, and both leave every
+    // attention residual demoted.
+    //
+    // Raising it beyond the minimum is not a compile-time cost -- the walk is a bounded pointer
+    // chase. It is a trade. What the result decides is add_fusing_type::sum versus binary_add, and
+    // both are post-ops on the same onednn primitive: sum lets onednn accumulate into the added
+    // tensor's buffer, at the price of disabling implicit concat on that predecessor
+    // (prepare_buffer_fusing), inhibiting reorder elimination in two passes (layout_optimizer and
+    // remove_redundant_reorders) and blocking buffer sharing (basic_memory_dependencies). So a
+    // longer chain should only be admitted against a workload that is measured to want it.
+    static constexpr int max_ancestor_walk_depth = 7;
+
     const auto* iter = &child;
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < max_ancestor_walk_depth; i++) {
         if (iter == &target)
             return true;
         if (iter->get_dependencies().empty())

--- a/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
@@ -180,3 +180,66 @@ TEST(add_onednn_optimization_attributes, fc_sum_u8_residual_input_uses_binary) {
     auto fusing_type = onednn_add_fusing_helpers::get_add_fusing_type(fc_node, fused[0]);
     ASSERT_EQ(fusing_type, add_fusing_type::binary_per_tensor);
 }
+
+// Builds input -> conv1 -> ... -> conv{depth} plus eltwise(conv1, conv{depth}), which puts conv1
+// exactly depth-1 dependency(0) hops above the node the eltwise fuses into.
+static add_fusing_type residual_chain_fusing_type(cldnn::engine& engine, size_t depth) {
+    auto in_layout = layout{ov::PartialShape({1, 16, 32, 32}), data_types::f16, format::bfyx};
+    auto weight = engine.allocate_memory(layout{ov::PartialShape({16, 16, 1, 1}), data_types::f16, format::bfyx});
+
+    topology topology;
+    topology.add(input_layout("input", in_layout));
+    topology.add(data("weight", weight));
+    for (size_t i = 1; i <= depth; i++) {
+        auto prev = (i == 1) ? input_info("input") : input_info("conv" + std::to_string(i - 1));
+        topology.add(convolution("conv" + std::to_string(i), prev, "weight", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    }
+    auto last = "conv" + std::to_string(depth);
+    topology.add(eltwise("eltwise", input_info("conv1"), input_info(last), eltwise_mode::sum));
+    topology.add(reorder("reorder", input_info("eltwise"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    auto prog = program::build_program(engine, topology, config, false, false);
+
+    prog->get_layout_optimizer().add_all_onednn_impls_optimization_attribute();
+    program_wrapper::apply_opt_pass<prepare_primitive_fusing>(*prog);
+    program_wrapper::apply_opt_pass<add_onednn_optimization_attributes>(*prog);
+
+    auto& last_node = prog->get_node(last);
+    auto& cldnn_post_ops = last_node.get_fused_primitives();
+    EXPECT_EQ(cldnn_post_ops.size(), 1u) << "the residual eltwise did not fuse into " << last;
+    if (cldnn_post_ops.size() != 1)
+        return add_fusing_type::not_supported;
+    // conv1 feeds both conv2 and the fused eltwise, which is what puts get_add_fusing_type on the
+    // is_direct_ancestor path rather than the single-user shortcut.
+    EXPECT_EQ(prog->get_node("conv1").get_users().size(), 2u);
+    return onednn_add_fusing_helpers::get_add_fusing_type(last_node, cldnn_post_ops[0]);
+}
+
+// An attention residual reaches six hops back -- projection, reshape, attention, reshape, QKV
+// matmul, norm, block input -- and the walk must still find it. See the hop-by-hop listing on
+// max_ancestor_walk_depth in program_helpers.cpp.
+TEST(add_onednn_optimization_attributes, sum_post_op_for_six_hop_residual) {
+    auto& engine = get_test_engine();
+
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    ASSERT_EQ(residual_chain_fusing_type(engine, 7), add_fusing_type::sum);
+}
+
+// Pins the bound from both sides, so that neither raising nor lowering it passes unnoticed.
+// The two depths straddle max_ancestor_walk_depth in program_helpers.cpp: a chain of n
+// convolutions puts the target n-1 hops up, and a bound of N reaches N-1 hops. The lower side is
+// the same depth the test above uses, since the bound is held at the minimum that case needs.
+TEST(add_onednn_optimization_attributes, ancestor_walk_depth_boundary) {
+    auto& engine = get_test_engine();
+
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    ASSERT_EQ(residual_chain_fusing_type(engine, 7), add_fusing_type::sum);
+    ASSERT_EQ(residual_chain_fusing_type(engine, 8), add_fusing_type::binary_per_tensor);
+}


### PR DESCRIPTION
`onednn_add_fusing_helpers::get_add_fusing_type` decides whether an eltwise sum fused onto a node
becomes an onednn `sum` post-op or a `binary_add` post-op. Both are post-ops on the same primitive
— the difference is that `sum` accumulates in place, so the primitive's destination is the added
tensor's buffer rather than a fresh allocation. It is only legal when the added tensor is either
single-use or a *direct ancestor* of the node that consumes it, and `is_direct_ancestor` establishes
the latter by walking `dependency(0)` upward under a fixed bound.

The bound was 5, and because the equality test runs before the hop it reached a target at most four
hops away. An attention residual sits **six** hops up. Walking `dependency(0)` from the projection
that carries the post-op, read off a graph dump of a multi-head attention block:

```
0  the output projection      <- carries the fused eltwise sum
1  reshape                    <- heads folded back into the feature axis
2  the attention op
3  reshape                    <- feature axis split into heads
4  the QKV matmul
5  the norm
6  the block input            <- the residual root, two users
```

The ancestor test therefore failed, and the residual fell back to `binary_add`. The new bound is
`7`, the smallest value that reaches hop 6.

The two reshapes are the part worth flagging, because they are easy to miss: counting the chain from
the operator list alone gives four hops and suggests a bound of 5 or 6 would do, and both of those
leave every attention residual demoted.

This is not specific to any one model. It applies wherever an attention residual reaches the onednn
path with the surrounding conditions `get_add_fusing_type` already requires — both nodes statically
shaped, and matching format, tensor, padding and element size. The static-shape requirement makes
that a considerably narrower set than "any attention model", and I would rather scope the claim than
have you find the gate yourself.

### What the bound actually trades

Not compile time — the walk is a bounded pointer chase per fused-sum candidate, and the original
`// Limit the iteration depth to 5 for performance reason` was never the binding constraint.

The cost is on the other side. Returning `sum` instead of `binary_add` also:

- disables implicit concat for that predecessor (`prepare_buffer_fusing.cpp`),
- blocks reorder elimination in two passes (`layout_optimizer.cpp`, `remove_redundant_reorders.cpp`),
- marks the node and the in-place root non-shareable (`basic_memory_dependencies.cpp`).

So the additional graphs a higher bound admits are a trade, not a free win, and I would rather say so
than have a reviewer discover it. That is why the bound is `7` and not more: the smallest value that
reaches the chain above, and nothing beyond it.

### On the bound, since you asked for the minimum

You were right to push on this, and the number in the earlier revision of this description was wrong
in both directions. `16` was over-provisioned — it was only the value the change had been developed
at. But `6`, which that text offered as "the smallest bound that covers the pattern", does not cover
it either: the chain is six hops, not five, so 6 reaches hop 5 and stops one short.

Rather than argue this from a benchmark, I read it off the graph. Dumping the compiled graph at a
range of bounds and counting onednn post-ops on an internal transformer workload:

| bound | `sum` post-ops | `binary_add` |
|---|---|---|
| 6 | about half | the rest — one per attention block |
| 7 | all of them | none |
| 8 … 16 | all of them | none |

Every attention projection in that model is demoted at 6 and fused at 7, and the decision is then
identical from 7 upward — so 7 is both sufficient and minimal there. That is a compile-time property
of the graph, which makes it exact rather than a measurement, and independent of my hardware and of
run-to-run noise.

### What the lower bound costs, in memory

The decision above has a consequence that is also exact. `sum` accumulates in place, so the
primitive's destination *is* the residual buffer; `binary_add` needs a destination of its own. With
`OV_GPU_DUMP_MEMORY_POOL=1`, device-side footprint for the same graph and the same work:

| bound | device memory in use |
|---|---|
| 7 | **1.00x** (baseline) |
| 6 | **2.35x** |

That is one full activation tensor per attention block no longer being reused, plus the knock-on
from the buffer sharing that `sum` also unblocks. It reproduced bit-identically over three runs per
bound, which it should — it is a compile-time allocation plan, not a measurement.

### What I cannot give you: a runtime figure

I would rather show you the failure than assert a number. Candidate-only, order-alternated, adjacent
paired A/B of bound 6 against bound 7, six pairs of eight timed passes each:

```
mean within-pair difference   +1.35%   (bound 6 slower)
standard error                +-3.64%
```

Not resolvable. Worse, the sign of the difference tracks *position within the pair* rather than the
bound — the second run of a pair is consistently the faster one by around 4%, a warm-cache artifact
larger than the effect being measured — and per-run spread on this machine reached 20%. So any
millisecond figure I quoted for this change would be an artifact, and I am not going to quote one.

The honest summary is that on my workload this change is a memory win of the size above and a
runtime difference too small for my hardware to see. If you want the runtime side established
properly, name a public attention model you consider representative and a device you trust, and I
will run it there.

### Safety of the chain length

Six passes consult `get_add_fusing_type` and have to agree with each other. For the in-place `sum`
to be safe, the second user of the target must consume it before the node carrying the post-op
clobbers it. The walk proves a `dependency(0)` chain `C -> n1 -> ... -> A`; with `A` having exactly
two users and a chain of length >= 2, the chain node whose `dependency(0)` is `A` *is* that second
user, and it is a transitive `dependency(0)` ancestor of `C`, so it runs first. That argument is
independent of chain length, which is why moving the bound introduces no new aliasing hazard — but
I would like it checked by someone who owns this pass.

### Tests

Two tests in `add_onednn_optimization_attributes_test.cpp`, both building a chain of *n*
convolutions with a residual sum so the target sits *n-1* `dependency(0)` hops up:

- `sum_post_op_for_six_hop_residual` — the motivating case, the chain listed above.
- `ancestor_walk_depth_boundary` — 6 and 7 hops, straddling the bound, so that raising it is caught
  as well as lowering it. Since the bound is held at the minimum the motivating case needs, its
  lower side is that same six-hop chain; the seven-hop assertion is the one that fails if the
  constant is ever raised without a workload to justify it.

Both are **verified discriminating** by mutating the constant and rebuilding, rather than merely
passing: at 5 (the old bound) and at 6 both fail, returning `binary_per_tensor` where `sum` is
expected, and at 8 the boundary test fails on its seven-hop assertion while the six-hop test still
passes.

Both return early on devices without `immad`, as their four neighbours in this file do — note that
means they assert nothing rather than reporting as skipped on such a runner, so CI has to schedule
them on an oneDNN-capable device for them to mean anything.

### Follow-up worth doing separately

Deriving the depth from the graph instead of using a fixed bound is the more robust form.

### AI assistance

```text
AI assistance used: yes
If yes: drafting the change and the tests, and four adversarial review passes over the diff. The
        second cut the submission from six files to one, removing graph-pass hunks that could not
        take effect on their own and two OpenCL fast-math build flags that were being applied to
        every kernel in the plugin rather than to the intended one. The third caught
        that my own justification was wrong about the mechanism: I had described binary_add as a
        separate kernel launch, when both it and sum are post-ops on the same onednn primitive.
        The fourth caught that my first pair of tests bracketed the bound instead of pinning it.
        A fifth pass established the bound empirically instead of by argument, after a reviewer
        asked for either the minimal bound or a workload requiring a larger one. Dumping the
        compiled graph at a range of bounds showed the chain is six hops rather than the five the
        description had claimed, so both 16 and the 6 I had offered were wrong; 7 is the minimum,
        and 7 through 16 give an identical set of post-ops.
Human validation performed: built the GPU plugin and ov_gpu_unit_tests (Release, oneDNN enabled)
        and ran them on Intel Arc integrated graphics, which reports the DPAS feature flag that
        gates supports_immad. All 6 tests in add_onednn_optimization_attributes pass at a bound of
        7. Both new tests verified discriminating by mutating the constant and rebuilding: at 5 and
        at 6 both fail, returning binary_per_tensor where sum is expected; at 8 the boundary test
        fails on its seven-hop assertion while the six-hop test still passes. Those failures are
        also what establishes that the immad-guarded assertions really execute on this runner
        rather than being skipped over. Ran the suites covering all six consumers of
        get_add_fusing_type -- 4181 passed, 0 failed (4237 ran, 56 skipped as
        their device guards decline them). The chain length was read off a dumped
        compiled graph by walking dependency(0) from each attention projection to its residual
        root, which is what showed the two reshapes the earlier description had omitted.
```
