### PR TITLE
intel_cpu: an opt-in low-degree exp for softmax numerators

### DIFF
--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -495,6 +495,12 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             } catch (ov::Exception&) {
                 OPENVINO_THROW("Wrong value for property key ", ov::intel_cpu::enable_sage_attn.name());
             }
+        } else if (key == ov::intel_cpu::snippets_approximate_softmax_exp.name()) {
+            try {
+                snippetsApproximateSoftmaxExp = val.as<bool>();
+            } catch (ov::Exception&) {
+                OPENVINO_THROW("Wrong value for property key ", ov::intel_cpu::snippets_approximate_softmax_exp.name());
+            }
         } else if (key == ov::enable_weightless.name()) {
             try {
                 enableWeightless = val.as<bool>();

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -93,6 +93,7 @@ struct Config {
     ov::internal::CacheQuantAlgorithm keyCacheQuantAlg = ov::internal::CacheQuantAlgorithm::SCALAR;
     ov::internal::CacheQuantAlgorithm valueCacheQuantAlg = ov::internal::CacheQuantAlgorithm::SCALAR;
     bool enableSageAttn = false;
+    bool snippetsApproximateSoftmaxExp = false;
     ov::threading::IStreamsExecutor::Config streamExecutorConfig;
     int streams = 1;
     bool streamsChanged = false;

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
@@ -28,6 +28,7 @@
 #include "openvino/op/clamp.hpp"
 #include "snippets/op/powerstatic.hpp"
 #include "utils/general_utils.h"
+#include "utils/rt_info/approximate_exp_attribute.hpp"
 
 using namespace dnnl::impl::utils;
 using namespace dnnl::impl::cpu;
@@ -2086,6 +2087,10 @@ void jit_negative_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
 }
 
 /// EXP ///
+// The fast path below is selected per Exp node by MarkApproximateSoftmaxExp and enabled per
+// compiled model with ov::intel_cpu::snippets_approximate_softmax_exp, whose documentation states
+// the error and the saturation points a caller is accepting.
+
 jit_exp_emitter::jit_exp_emitter(x64::jit_generator_t* host, x64::cpu_isa_t host_isa, ov::element::Type exec_prc)
     : jit_emitter(host, host_isa, exec_prc) {
     prepare_table();
@@ -2093,9 +2098,10 @@ jit_exp_emitter::jit_exp_emitter(x64::jit_generator_t* host, x64::cpu_isa_t host
 
 jit_exp_emitter::jit_exp_emitter(x64::jit_generator_t* host,
                                  x64::cpu_isa_t host_isa,
-                                 [[maybe_unused]] const std::shared_ptr<ov::Node>& node,
+                                 const std::shared_ptr<ov::Node>& node,
                                  ov::element::Type exec_prc)
-    : jit_emitter(host, host_isa, exec_prc) {
+    : jit_emitter(host, host_isa, exec_prc),
+      m_use_fast_exp(node != nullptr && is_approximate_exp(node)) {
     prepare_table();
 }
 
@@ -2125,6 +2131,33 @@ void jit_exp_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
     auto vmm_src = Vmm(in_vec_idxs[0]);
     auto vmm_dst = Vmm(out_vec_idxs[0]);
+
+    if (m_use_fast_exp) {
+        // 2^(x*log2e), with a degree-1 minimax polynomial on the fraction and the underflow handled
+        // by clamping in the log2 domain instead of a mask and a blend: one vfmadd213ps where the
+        // accurate path below has a degree-5 polynomial, and no vcmpps/vblendvps pair. Saturates at
+        // both ends rather than reaching zero or an infinity.
+        auto vmm_f = Vmm(aux_vec_idxs[0]);
+        auto vmm_scale = Vmm(aux_vec_idxs[1]);
+        // The clamps must stay ahead of the exponent-field build below, which computes
+        // (n + 127) << 23. They pin n to [-100, 127]; register_table_entries says why the bottom is
+        // not the -126 that field could still represent.
+        h->uni_vmulps(vmm_f, vmm_src, table_val("log2ef"));
+        h->uni_vminps(vmm_f, vmm_f, table_val("fast_hi"));
+        h->uni_vmaxps(vmm_f, vmm_f, table_val("fast_lo"));
+        // Round to nearest, so the fraction lands in [-0.5, 0.5] -- the interval the polynomial
+        // below is fitted on.
+        const auto _op_near = 0U;
+        h->uni_vroundps(vmm_scale, vmm_f, _op_near);
+        h->uni_vsubps(vmm_f, vmm_f, vmm_scale);
+        h->uni_vcvtps2dq(vmm_scale, vmm_scale);
+        h->uni_vpaddd(vmm_scale, vmm_scale, table_val("exponent_bias"));
+        h->uni_vpslld(vmm_scale, vmm_scale, 23);
+        h->uni_vmovups(vmm_dst, table_val("fast_exp_c1"));
+        h->uni_vfmadd213ps(vmm_dst, vmm_f, table_val("fast_exp_c0"));
+        h->uni_vmulps(vmm_dst, vmm_dst, vmm_scale);
+        return;
+    }
 
     Vmm vmm_mask = need_vmm_mask() ? Vmm(aux_vec_idxs[0]) : Vmm();
     auto vmm_aux0 = Vmm(aux_vec_idxs[0 + static_cast<size_t>(need_vmm_mask())]);
@@ -2192,6 +2225,36 @@ void jit_exp_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std
 }
 
 void jit_exp_emitter::register_table_entries() {
+    // Both paths build the exponent field from these two.
+    push_arg_entry_of("log2ef", 0x3fb8aa3b, true);
+    push_arg_entry_of("exponent_bias", 0x0000007f, true);
+
+    if (m_use_fast_exp) {
+        // Minimax fit of 2^f on f in [-0.5, 0.5]: max relative error 2.98e-2. Its constant
+        // term is not exactly 1, so unlike a Taylor form this cannot reuse "one" as the final
+        // addend.
+        push_arg_entry_of("fast_exp_c0", 0x3f83b6bc, true);  // 1.029014111f
+        push_arg_entry_of("fast_exp_c1", 0x3f2f9e4c, true);  // 0.686009169f
+        // The clamp bounds, in the log2 domain. Clamping at an integer pins the rounded exponent
+        // to it and the fraction to one side of zero, so the polynomial is c0 exactly at the
+        // bottom and at most c0 at the top. +127 is the largest that keeps the result finite:
+        // c0 * 2^127 = 1.75e38, below FLT_MAX.
+        //
+        // The bottom is not the mirror of that. Every value this emitter produces on a marked node
+        // is about to be divided by a sum of its own row, so the number that has to stay normal is
+        // the quotient, not the floor. With the input already reduced by the row maximum each term
+        // is at most c0, so a row of N terms sums to at most N * c0 and the smallest quotient is
+        // 2^lo / N. Stopping at -126 -- the smallest exponent that is itself normal -- therefore
+        // hands a subnormal to the matmul that consumes the probabilities as soon as the row sum
+        // exceeds c0, which is every row with two comparable entries, and subnormal arithmetic
+        // costs one to two orders of magnitude on x86. -100 keeps the quotient normal for rows of
+        // up to 2^25 elements, and costs nothing that matters: it moves the floor from 1.21e-38 to
+        // 8.12e-31, still 28 orders of magnitude below the 2.98e-2 error the fast path already has.
+        push_arg_entry_of("fast_hi", 0x42fe0000, true);  // +127
+        push_arg_entry_of("fast_lo", 0xc2c80000, true);  // -100
+        return;
+    }
+
     push_arg_entry_of("pol1", 0x3f7ffffb, true);  // p1 = 0.999999701f
     push_arg_entry_of("pol2", 0x3efffee3, true);  // p2 = 0.499991506f
     push_arg_entry_of("pol3", 0x3e2aad40, true);  // p3 = 0.166676521f
@@ -2201,13 +2264,14 @@ void jit_exp_emitter::register_table_entries() {
     push_arg_entry_of("one", CONST_1_F, true);
     push_arg_entry_of("half", 0x3f000000, true);
     push_arg_entry_of("ln2f", 0x3f317218, true);
-    push_arg_entry_of("log2ef", 0x3fb8aa3b, true);
     push_arg_entry_of("ln_flt_max_f", 0x42b17218, true);
     push_arg_entry_of("ln_flt_min_f", 0xc2aeac50, true);
-    push_arg_entry_of("exponent_bias", 0x0000007f, true);
 }
 
 size_t jit_exp_emitter::aux_vecs_count() const {
+    if (m_use_fast_exp) {
+        return 2;
+    }
     return need_vmm_mask() ? 3 : 2;
 }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.hpp
@@ -654,6 +654,10 @@ private:
 
     void register_table_entries() override;
     size_t aux_vecs_count() const override;
+
+    // Set from the node's run-time info, which MarkApproximateSoftmaxExp puts there. Never true
+    // for the Exp that jit_erf_emitter owns, which is built through the constructor taking no node.
+    bool m_use_fast_exp{false};
 };
 
 class jit_erf_emitter : public jit_emitter {

--- a/src/plugins/intel_cpu/src/internal_properties.hpp
+++ b/src/plugins/intel_cpu/src/internal_properties.hpp
@@ -80,4 +80,26 @@ static constexpr Property<bool, PropertyMutability::RW> enable_tensor_parallel{"
  */
 static constexpr Property<bool, PropertyMutability::RW> enable_sage_attn{"ENABLE_SAGE_ATTN"};
 
+/**
+ * @brief Evaluate the exponential of a softmax numerator with a degree-1 polynomial instead of the
+ * accurate one, wherever Snippets fuses the softmax. Buys one fused multiply-add in place of a
+ * degree-5 polynomial and a compare/blend pair. Off unless asked for, and x86-64 only.
+ *
+ * What enabling it costs:
+ *  - Max relative error 2.98e-2 on the exponential, against the accurate path's 3.9e-7. Normalising
+ *    does not cancel it; the worst case on the normalised probabilities is 6.15e-2.
+ *  - exp(0) returns 1.0290141, not 1.
+ *  - Saturation in place of underflow and overflow, at neither of the accurate path's knees and to
+ *    neither of its values: at or below x = -69.3147 it returns 8.1175e-31 rather than zero, and at
+ *    or above x = 88.0297 it returns 1.7508e38 rather than +inf. So a masked-out row entry comes
+ *    out at 8.1175e-31 where the accurate path gives it exactly zero. The floor is held that far
+ *    above FLT_MIN on purpose, so that dividing it by the row sum still yields a normal for rows of
+ *    up to 2^25 elements; no input yields an infinity, a denormal or a NaN, and neither does
+ *    normalising one.
+ * @param true - approximate
+ * @param false - accurate
+ */
+static constexpr Property<bool, PropertyMutability::RW> snippets_approximate_softmax_exp{
+    "SNIPPETS_APPROXIMATE_SOFTMAX_EXP"};
+
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -95,6 +95,7 @@
 #    include "snippets/lowered/pass/insert_buffers.hpp"
 #    include "snippets/lowered/pass/insert_loops.hpp"
 #    include "snippets/pass/fuse_transpose_brgemm.hpp"
+#    include "snippets/pass/softmax_decomposition.hpp"
 #    include "transformations/snippets/common/pass/enforce_precision.hpp"
 #    include "transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.hpp"
 #    include "transformations/snippets/x64/pass/eliminate_brgemm_copy_b.hpp"
@@ -103,6 +104,7 @@
 #    include "transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.hpp"
 #    include "transformations/snippets/x64/pass/lowered/insert_brgemm_copy_buffers.hpp"
 #    include "transformations/snippets/x64/pass/lowered/parallelize_gated_mlp_n_loops.hpp"
+#    include "transformations/snippets/x64/pass/mark_approximate_softmax_exp.hpp"
 #    include "transformations/snippets/x64/pass/remove_converts.hpp"
 #    include "transformations/snippets/x64/pass/repack_matmul_weights.hpp"
 #endif
@@ -630,6 +632,14 @@ Subgraph::DataFlowPasses Subgraph::getDataFlowPasses() {
         SNIPPETS_REGISTER_PASS_RELATIVE_X86_64(Place::After,
                                                pass::EnforcePrecision,
                                                ov::snippets::pass::FuseTransposeBrgemm);
+    }
+
+    if (context->getConfig().snippetsApproximateSoftmaxExp && has_domain_sensitive_ops()) {
+        // Relative to SoftmaxDecomposition, which is registered only for domain-sensitive bodies --
+        // a PassPosition whose anchor is absent throws. See the pass for why it has to run there.
+        SNIPPETS_REGISTER_PASS_RELATIVE_X86_64(Place::After,
+                                               ov::snippets::pass::SoftmaxDecomposition,
+                                               ov::intel_cpu::pass::MarkApproximateSoftmaxExp);
     }
 
     SNIPPETS_REGISTER_PASS_RELATIVE_X86_64(Place::Before,

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/mark_approximate_softmax_exp.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/mark_approximate_softmax_exp.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "mark_approximate_softmax_exp.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "openvino/cc/pass/itt.hpp"
+#include "openvino/core/node.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/itt.hpp"
+#include "openvino/op/exp.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "snippets/itt.hpp"
+#include "snippets/op/powerstatic.hpp"
+#include "snippets/op/reduce.hpp"
+#include "utils/rt_info/approximate_exp_attribute.hpp"
+
+ov::intel_cpu::pass::MarkApproximateSoftmaxExp::MarkApproximateSoftmaxExp() {
+    MATCHER_SCOPE(MarkApproximateSoftmaxExp);
+    auto multiply_m = ov::pass::pattern::wrap_type<ov::op::v1::Multiply>();
+
+    auto callback = [](ov::pass::pattern::Matcher& m) {
+        OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "ov::intel_cpu::pass::MarkApproximateSoftmaxExp")
+        const auto multiply = m.get_match_root();
+
+        std::shared_ptr<ov::Node> exp;
+        std::shared_ptr<ov::snippets::op::PowerStatic> reciprocal;
+        for (size_t i = 0; i < multiply->get_input_size(); ++i) {
+            const auto operand = multiply->get_input_node_shared_ptr(i);
+            if (ov::is_type<ov::op::v0::Exp>(operand)) {
+                exp = operand;
+            } else if (const auto power = ov::as_type_ptr<ov::snippets::op::PowerStatic>(operand)) {
+                reciprocal = power;
+            }
+        }
+        if (exp == nullptr || reciprocal == nullptr || reciprocal->get_power() != -1.F) {
+            return false;
+        }
+
+        // The reciprocal has to be of a sum of this very exp, otherwise the numerator and the
+        // denominator do not share the approximation and the error does not stay on a ratio.
+        const auto reduce_sum = ov::as_type_ptr<ov::snippets::op::ReduceSum>(reciprocal->get_input_node_shared_ptr(0));
+        if (reduce_sum == nullptr || reduce_sum->get_input_node_shared_ptr(0) != exp) {
+            return false;
+        }
+
+        // Any consumer beyond the row sum and the normalising multiply would see the approximation
+        // on a raw exponential instead.
+        if (exp->get_output_target_inputs(0).size() != 2) {
+            return false;
+        }
+
+        mark_as_approximate_exp(exp);
+        // The graph is unchanged: only run-time information was added.
+        return false;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(multiply_m, matcher_name);
+    register_matcher(m, callback);
+}

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/mark_approximate_softmax_exp.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/mark_approximate_softmax_exp.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+
+namespace ov::intel_cpu::pass {
+
+/**
+ * @interface MarkApproximateSoftmaxExp
+ * @brief Marks the Exp that SoftmaxDecomposition emits, so that jit_exp_emitter takes its fast
+ *        path. Registered only when the caller asked for the approximation via
+ *        ov::intel_cpu::snippets_approximate_softmax_exp.
+ *
+ *        Only that Exp is marked. The approximation was only ever characterised on a value that is
+ *        divided by a sum of itself along the reduction axis, so any other Exp -- including the one
+ *        jit_erf_emitter owns -- keeps the accurate path.
+ *
+ *        The pass must run directly after SoftmaxDecomposition, while the pattern is still exactly
+ *        as it was emitted. Later passes obscure it: PropagatePrecision puts ConvertSaturation on
+ *        either leg, and MulAddToFMA folds the normalising Multiply into a FusedMulAdd whenever its
+ *        consumer is an Add. Matching after either of those would fail silently and simply leave
+ *        the approximation switched off.
+ * @ingroup snippets
+ */
+class MarkApproximateSoftmaxExp : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("MarkApproximateSoftmaxExp");
+    MarkApproximateSoftmaxExp();
+};
+
+}  // namespace ov::intel_cpu::pass

--- a/src/plugins/intel_cpu/src/utils/rt_info/approximate_exp_attribute.cpp
+++ b/src/plugins/intel_cpu/src/utils/rt_info/approximate_exp_attribute.cpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "approximate_exp_attribute.hpp"
+
+#include <memory>
+
+#include "openvino/core/node.hpp"
+
+namespace ov::intel_cpu {
+
+ApproximateExp::~ApproximateExp() = default;
+
+void mark_as_approximate_exp(const std::shared_ptr<ov::Node>& node) {
+    node->get_rt_info()[ApproximateExp::get_type_info_static()] = ApproximateExp{};
+}
+
+bool is_approximate_exp(const std::shared_ptr<const ov::Node>& node) {
+    const auto& rt_info = node->get_rt_info();
+    return rt_info.find(ApproximateExp::get_type_info_static()) != rt_info.end();
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/rt_info/approximate_exp_attribute.hpp
+++ b/src/plugins/intel_cpu/src/utils/rt_info/approximate_exp_attribute.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+
+#include "openvino/core/node.hpp"
+#include "openvino/core/rtti.hpp"
+#include "openvino/core/runtime_attribute.hpp"
+
+namespace ov::intel_cpu {
+
+/**
+ * @brief Marks an Exp whose value is divided by a sum of itself along the reduction axis, i.e. the
+ * numerator of a softmax. Set by ov::intel_cpu::pass::MarkApproximateSoftmaxExp and read by
+ * jit_exp_emitter, which then takes its fast path. The decision is taken in a transformation rather
+ * than in the emitter so that it is made on the graph shape SoftmaxDecomposition produces, before
+ * later passes can obscure it.
+ */
+class ApproximateExp : public ov::RuntimeAttribute {
+public:
+    OPENVINO_RTTI("approximate_exp");
+    ApproximateExp() = default;
+    ~ApproximateExp() override;
+
+    // The mark states something about this node's own consumers, so it must never be carried onto
+    // another node by a pass that copies run-time info.
+    [[nodiscard]] bool is_copyable() const override {
+        return false;
+    }
+};
+
+void mark_as_approximate_exp(const std::shared_ptr<ov::Node>& node);
+bool is_approximate_exp(const std::shared_ptr<const ov::Node>& node);
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 if(NOT X86_64)
     list(APPEND EXCLUDED_SOURCE_PATHS_FOR_UNIT_TEST
       ${CMAKE_CURRENT_SOURCE_DIR}/jit_kernel_test.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/jit_exp_emitter_test.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/registers_pool.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/transformations/x64
       ${CMAKE_CURRENT_SOURCE_DIR}/snippets_transformations/x64

--- a/src/plugins/intel_cpu/tests/unit/jit_exp_emitter_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/jit_exp_emitter_test.cpp
@@ -1,0 +1,314 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/jit_generator.hpp"
+#include "emitters/plugin/x64/jit_eltwise_emitters.hpp"
+#include "openvino/core/except.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/exp.hpp"
+#include "openvino/op/parameter.hpp"
+#include "utils/rt_info/approximate_exp_attribute.hpp"
+
+using namespace dnnl::impl::cpu::x64;
+
+namespace ov::intel_cpu {
+namespace {
+
+size_t simd_width(cpu_isa_t isa) {
+    return isa == avx512_core ? 16U : (isa == avx2 ? 8U : 4U);
+}
+
+// Runs one jit_exp_emitter over a buffer, one vector at a time. The destination register can be
+// pointed at the source register, which is the case the fast path has to survive: it reads vmm_src
+// after it has begun writing its auxiliaries.
+class jit_exp_test_kernel : public jit_generator_t {
+public:
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_exp_test_kernel)
+
+    jit_exp_test_kernel(bool approximate, cpu_isa_t isa, bool alias_dst_onto_src, bool with_node = true)
+        : jit_generator_t(jit_name(), isa),
+          m_approximate(approximate),
+          m_with_node(with_node),
+          m_isa(isa),
+          m_dst_idx(alias_dst_onto_src ? 1U : 2U) {}
+
+    void create() {
+        ASSERT_EQ(create_kernel(), dnnl::impl::status::success);
+        m_fn = reinterpret_cast<fn_t>(const_cast<uint8_t*>(jit_ker()));
+    }
+
+    std::vector<float> operator()(const std::vector<float>& src) const {
+        std::vector<float> dst(src.size(), 0.F);
+        for (size_t i = 0; i < src.size(); i += simd_width(m_isa)) {
+            m_fn(src.data() + i, dst.data() + i);
+        }
+        return dst;
+    }
+
+private:
+    using fn_t = void (*)(const float*, float*);
+
+    void generate() override {
+        if (m_with_node) {
+            const auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1});
+            const auto exp = std::make_shared<ov::op::v0::Exp>(param);
+            if (m_approximate) {
+                mark_as_approximate_exp(exp);
+            }
+            m_emitter = std::make_unique<jit_exp_emitter>(this, m_isa, exp, ov::element::f32);
+        } else {
+            m_emitter = std::make_unique<jit_exp_emitter>(this, m_isa, ov::element::f32);
+        }
+
+        preamble();
+        load(1, ptr[abi_param1]);
+        m_emitter->emit_code({1}, {m_dst_idx}, {3, 4, 5});
+        store(ptr[abi_param2], m_dst_idx);
+        postamble();
+        m_emitter->emit_data();
+    }
+
+    void load(size_t idx, const Xbyak::Address& src) {
+        if (m_isa == avx512_core) {
+            uni_vmovups(Xbyak::Zmm(static_cast<int>(idx)), src);
+        } else if (m_isa == avx2) {
+            uni_vmovups(Xbyak::Ymm(static_cast<int>(idx)), src);
+        } else {
+            uni_vmovups(Xbyak::Xmm(static_cast<int>(idx)), src);
+        }
+    }
+
+    void store(const Xbyak::Address& dst, size_t idx) {
+        if (m_isa == avx512_core) {
+            uni_vmovups(dst, Xbyak::Zmm(static_cast<int>(idx)));
+        } else if (m_isa == avx2) {
+            uni_vmovups(dst, Xbyak::Ymm(static_cast<int>(idx)));
+        } else {
+            uni_vmovups(dst, Xbyak::Xmm(static_cast<int>(idx)));
+        }
+    }
+
+    bool m_approximate;
+    bool m_with_node;
+    cpu_isa_t m_isa;
+    size_t m_dst_idx;
+    std::unique_ptr<jit_exp_emitter> m_emitter;
+    fn_t m_fn{nullptr};
+};
+
+cpu_isa_t widest_supported_isa() {
+    if (mayiuse(avx512_core)) {
+        return avx512_core;
+    }
+    if (mayiuse(avx2)) {
+        return avx2;
+    }
+    // sse41 is the narrowest the emitter supports, and vroundps needs it.
+    OPENVINO_ASSERT(mayiuse(sse41), "jit_exp_emitter requires at least sse41");
+    return sse41;
+}
+
+// The interval a softmax numerator lives on after its row maximum has been subtracted, stopping
+// just above the fast path's saturation knee at -100 * ln2 = -69.3147. Below that the two paths
+// deliberately part company -- the accurate one keeps evaluating its polynomial and then flushes to
+// zero, this one saturates -- and each behaviour is pinned by its own test rather than folded into
+// an error bound. The length is a multiple of the widest vector so the same buffer drives every ISA.
+std::vector<float> sweep() {
+    std::vector<float> xs;
+    xs.reserve(1 << 16);
+    for (int i = 0; i < (1 << 16); ++i) {
+        xs.push_back(-69.F + (69.F * static_cast<float>(i)) / static_cast<float>((1 << 16) - 1));
+    }
+    return xs;
+}
+
+struct Summary {
+    double max_rel_err;
+    size_t n_not_finite;  // inf or nan
+    size_t n_denormal;    // subnormal or zero, i.e. anything the fast path claims never to emit
+                          // (the accurate path does emit zeros, but not on this sweep)
+    float min_out;
+    float max_out;
+};
+
+Summary summarise(const std::vector<float>& xs, const std::vector<float>& ys) {
+    Summary s{0.0, 0U, 0U, ys.front(), ys.front()};
+    for (size_t i = 0; i < xs.size(); ++i) {
+        const float y = ys[i];
+        if (!std::isfinite(y)) {
+            ++s.n_not_finite;
+            continue;
+        }
+        if (std::fabs(y) < std::numeric_limits<float>::min()) {
+            ++s.n_denormal;
+        }
+        s.min_out = std::min(s.min_out, y);
+        s.max_out = std::max(s.max_out, y);
+        const double exact = std::exp(static_cast<double>(xs[i]));
+        s.max_rel_err = std::max(s.max_rel_err, std::fabs(static_cast<double>(y) - exact) / exact);
+    }
+    return s;
+}
+
+std::pair<double, double> signed_rel_err_range(const std::vector<float>& xs, const std::vector<float>& ys) {
+    double lo = 0.0;
+    double hi = 0.0;
+    for (size_t i = 0; i < xs.size(); ++i) {
+        const double exact = std::exp(static_cast<double>(xs[i]));
+        const double e = (static_cast<double>(ys[i]) - exact) / exact;
+        lo = std::min(lo, e);
+        hi = std::max(hi, e);
+    }
+    return {lo, hi};
+}
+
+std::vector<float> run(bool approximate, cpu_isa_t isa, const std::vector<float>& xs, bool alias = false) {
+    jit_exp_test_kernel kernel(approximate, isa, alias);
+    kernel.create();
+    return kernel(xs);
+}
+
+constexpr float FAST_EXP_C0 = 1.02901411F;       // the polynomial's constant term
+constexpr float FAST_EXP_FLOOR = 8.117490e-31F;  // c0 * 2^-100
+constexpr float FAST_EXP_CEIL = 1.7507768e38F;   // c0 * 2^127
+
+}  // namespace
+
+// Pins the whole trade the property advertises: the error it costs, and the fact that it buys that
+// error without ever producing an infinity, a NaN or a denormal. A single wrong hex digit in any of
+// the four fast-path constants moves one of these.
+TEST(JitExpEmitter, approximate_path_matches_its_advertised_error_and_range) {
+    const auto isa = widest_supported_isa();
+    const auto xs = sweep();
+    const auto ys = run(true, isa, xs);
+    const auto s = summarise(xs, ys);
+
+    EXPECT_LT(s.max_rel_err, 3.0e-2);
+    EXPECT_GT(s.max_rel_err, 2.0e-2);  // it really is the degree-1 fit, not the accurate path
+    EXPECT_EQ(s.n_not_finite, 0U);
+    EXPECT_EQ(s.n_denormal, 0U);
+    EXPECT_GE(s.min_out, FAST_EXP_FLOOR);
+    EXPECT_FLOAT_EQ(s.max_out, FAST_EXP_C0);  // the sweep ends at x = 0
+}
+
+// The property advertises two error figures and the sweep above pins the one on the exponential.
+// This pins the other, which is the one a caller sees: normalising divides one fast-path value by a
+// sum of them, and because a minimax fit equioscillates about zero there is no common bias to
+// cancel, so a probability carries more error than the exponential did rather than less. The worst
+// case is (1 + hi) / (1 + lo) - 1, approached when one entry of a row carries the largest positive
+// error and the row sum is dominated by entries carrying the largest negative one.
+TEST(JitExpEmitter, approximate_path_error_on_a_normalised_probability_stays_within_its_bound) {
+    const auto isa = widest_supported_isa();
+    const auto xs = sweep();
+    const auto [lo, hi] = signed_rel_err_range(xs, run(true, isa, xs));
+    const double worst_ratio = (1.0 + hi) / (1.0 + lo) - 1.0;
+
+    EXPECT_LT(worst_ratio, 6.2e-2);
+    EXPECT_GT(worst_ratio, 5.9e-2);  // and it really is worse than the 2.98e-2 on the exponential
+}
+
+// The fast path reads its source register after it has begun writing its auxiliaries, so a caller
+// that points the destination at the source is the interesting register case: reordering those two
+// writes passes every other test here and fails this one.
+TEST(JitExpEmitter, approximate_path_is_correct_when_the_destination_aliases_the_source) {
+    const auto isa = widest_supported_isa();
+    const auto xs = sweep();
+    const auto separate = run(true, isa, xs, false);
+    const auto aliased = run(true, isa, xs, true);
+
+    EXPECT_EQ(aliased, separate);
+    EXPECT_FLOAT_EQ(aliased.back(), FAST_EXP_C0);  // the sweep ends at x = 0, so this is the fast path
+}
+
+// The accurate path is what every other Exp in the plugin gets, so the same kernel has to keep
+// producing it for an unmarked node.
+TEST(JitExpEmitter, accurate_path_is_untouched_for_an_unmarked_exp) {
+    const auto isa = widest_supported_isa();
+    const auto xs = sweep();
+    const auto s = summarise(xs, run(false, isa, xs));
+
+    EXPECT_LT(s.max_rel_err, 1.0e-6);
+    EXPECT_EQ(s.n_not_finite, 0U);
+}
+
+// The constructor that takes a node has to stay indistinguishable from the pre-existing one that
+// takes none whenever the node is unmarked -- same amount of code, same bits out. A table mistake
+// would be invisible here, since table_val resolves by name and both sides share one table; what
+// this catches is the accurate path acquiring anything that depends on the node being present.
+TEST(JitExpEmitter, unmarked_exp_is_bit_identical_to_the_constructor_that_takes_no_node) {
+    const auto isa = widest_supported_isa();
+    const auto xs = sweep();
+    jit_exp_test_kernel with_node(false, isa, false, true);
+    jit_exp_test_kernel without_node(false, isa, false, false);
+    with_node.create();
+    without_node.create();
+
+    EXPECT_EQ(with_node.getSize(), without_node.getSize());
+    EXPECT_EQ(with_node(xs), without_node(xs));
+}
+
+TEST(JitExpEmitter, approximate_path_saturates_instead_of_overflowing_or_underflowing) {
+    const auto isa = widest_supported_isa();
+    const size_t w = simd_width(isa);
+    std::vector<float> xs(w, 0.F);
+    xs[0] = 0.F;
+    xs[1] = -1000.F;
+    xs[2] = 1000.F;
+    xs[3] = std::numeric_limits<float>::quiet_NaN();
+
+    const auto ys = run(true, isa, xs);
+
+    EXPECT_FLOAT_EQ(ys[0], FAST_EXP_C0);  // exp(0) is c0, not 1
+    EXPECT_FLOAT_EQ(ys[1], FAST_EXP_FLOOR);
+    EXPECT_FLOAT_EQ(ys[2], FAST_EXP_CEIL);
+    EXPECT_FLOAT_EQ(ys[3], FAST_EXP_CEIL);  // vminps returns src2 on NaN, so a NaN saturates high
+}
+
+// The guard on where the floor sits, which register_table_entries explains: the quotient is what
+// has to stay normal, not the floor, so this drives a masked-out entry through the emitter and
+// normalises it by the largest row the table comment claims to cover. At 2^-126 every one of these
+// would be a subnormal, and a masked attention row is made of nothing else.
+TEST(JitExpEmitter, normalising_a_saturated_entry_still_yields_a_normal) {
+    const auto isa = widest_supported_isa();
+    const size_t w = simd_width(isa);
+    std::vector<float> xs(w, 0.F);
+    xs[0] = -1.0e4F;  // a masked-out attention entry
+
+    const auto ys = run(true, isa, xs);
+
+    ASSERT_FLOAT_EQ(ys[0], FAST_EXP_FLOOR);
+    for (const size_t n : {w, size_t{1} << 10, size_t{1} << 25}) {
+        const float smallest = ys[0] / (static_cast<float>(n) * FAST_EXP_C0);
+        EXPECT_GE(smallest, std::numeric_limits<float>::min()) << "row of " << n;
+    }
+}
+
+// sse41 has no FMA and no 256-bit integer shifts, so it is the ISA on which a wrongly chosen
+// uni_ helper would show up first.
+TEST(JitExpEmitter, approximate_path_is_the_same_function_on_sse41) {
+    if (!mayiuse(sse41)) {
+        GTEST_SKIP() << "sse41 not available";
+    }
+    const auto xs = sweep();
+    const auto s = summarise(xs, run(true, sse41, xs));
+
+    EXPECT_LT(s.max_rel_err, 3.0e-2);
+    EXPECT_GT(s.max_rel_err, 2.0e-2);  // and it is the degree-1 fit, not the accurate path
+    EXPECT_EQ(s.n_not_finite, 0U);
+    EXPECT_EQ(s.n_denormal, 0U);
+}
+
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/mark_approximate_softmax_exp_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/mark_approximate_softmax_exp_test.cpp
@@ -1,0 +1,237 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "transformations/snippets/x64/pass/mark_approximate_softmax_exp.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+
+#include "cache/multi_cache.h"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "emitters/snippets/x64/cpu_generator.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/core/type.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/exp.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/pass/manager.hpp"
+#include "snippets/op/powerstatic.hpp"
+#include "snippets/op/reduce.hpp"
+#include "snippets/op/result.hpp"
+#include "snippets/op/subgraph.hpp"
+#include "snippets/pass/manager.hpp"
+#include "snippets/pass/positioned_pass.hpp"
+#include "snippets/pass/softmax_decomposition.hpp"
+#include "transformations/snippets/common/op/fused_mul_add.hpp"
+#include "transformations/snippets/common/pass/mul_add_to_fma.hpp"
+#include "utils/rt_info/approximate_exp_attribute.hpp"
+
+namespace ov::test::snippets {
+
+namespace {
+
+constexpr size_t softmax_axis = 3;
+const ov::PartialShape shape{1, 4, 16, 16};
+
+std::shared_ptr<ov::Model> decomposed_softmax() {
+    const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    const auto softmax = std::make_shared<ov::op::v8::Softmax>(data, static_cast<int64_t>(softmax_axis));
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{data});
+    ov::pass::Manager manager;
+    manager.register_pass<ov::snippets::pass::SoftmaxDecomposition>();
+    manager.run_passes(model);
+    return model;
+}
+
+std::shared_ptr<ov::Node> find_exp(const std::shared_ptr<ov::Model>& model) {
+    for (const auto& op : model->get_ordered_ops()) {
+        if (ov::is_type<ov::op::v0::Exp>(op)) {
+            return op;
+        }
+    }
+    return nullptr;
+}
+
+void run_marking(const std::shared_ptr<ov::Model>& model) {
+    ov::pass::Manager manager;
+    manager.register_pass<ov::intel_cpu::pass::MarkApproximateSoftmaxExp>();
+    manager.run_passes(model);
+}
+
+// Exp -> ReduceSum -> PowerStatic(power) -> Multiply(Exp, .), with the reciprocal optionally taken
+// over a different exponential. The numerator is returned alongside the model: asserting on
+// "the first Exp in the graph" instead would not distinguish the two exponentials of the
+// sum_of_the_same_exp == false case, and the test would pass with the check it exists to pin
+// removed.
+struct HandBuilt {
+    std::shared_ptr<ov::Model> model;
+    std::shared_ptr<ov::Node> numerator;
+};
+
+HandBuilt hand_built_softmax(float power, bool extra_consumer) {
+    const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    const auto exp = std::make_shared<ov::op::v0::Exp>(data);
+    const auto reduce_sum = std::make_shared<ov::snippets::op::ReduceSum>(exp, softmax_axis);
+    const auto reciprocal = std::make_shared<ov::snippets::op::PowerStatic>(reduce_sum, power);
+    const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, reciprocal);
+    ov::OutputVector results{multiply};
+    if (extra_consumer) {
+        results.push_back(exp);
+    }
+    return {std::make_shared<ov::Model>(results, ov::ParameterVector{data}), exp};
+}
+
+// The numerator still feeds its own row sum -- so the consumer count is the same two as a match --
+// but the reciprocal that scales it is taken over the sum of a different exponential. Only the
+// check that the two sums are the same one can reject this, which is what makes it discriminating.
+HandBuilt reciprocal_of_a_foreign_sum() {
+    const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    const auto exp = std::make_shared<ov::op::v0::Exp>(data);
+    const auto own_sum = std::make_shared<ov::snippets::op::ReduceSum>(exp, softmax_axis);
+    const auto other_exp = std::make_shared<ov::op::v0::Exp>(data);
+    const auto foreign_sum = std::make_shared<ov::snippets::op::ReduceSum>(other_exp, softmax_axis);
+    const auto reciprocal = std::make_shared<ov::snippets::op::PowerStatic>(foreign_sum, -1.F);
+    const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, reciprocal);
+    return {std::make_shared<ov::Model>(ov::OutputVector{multiply, own_sum}, ov::ParameterVector{data}), exp};
+}
+
+// A snippets Subgraph whose body is a Softmax whose result is then added to something -- the shape
+// the CPU plugin hands to the snippets data-flow pipeline. Built rather than tokenized so the test
+// does not depend on the tokenizer's heuristics. The trailing Add is what makes the position of the
+// marking pass observable: MulAddToFMA folds the softmax's normalising Multiply into a FusedMulAdd,
+// so a pass that runs after it no longer sees the pattern.
+std::shared_ptr<ov::snippets::op::Subgraph> softmax_subgraph(const ov::intel_cpu::MultiCachePtr& cache) {
+    const auto outer = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    const auto outer_bias = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    const auto body_param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    const auto bias = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    const auto softmax = std::make_shared<ov::op::v8::Softmax>(body_param, static_cast<int64_t>(softmax_axis));
+    const auto add = std::make_shared<ov::op::v1::Add>(softmax, bias);
+    // PropagatePrecision looks the body's output op up in the target machine's jitter table, which
+    // only knows the snippets Result, not ov::op::v0::Result.
+    const auto result = std::make_shared<ov::snippets::op::Result>(add);
+    const auto body = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{body_param, bias});
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(ov::OutputVector{outer, outer_bias}, body);
+    // PropagatePrecision, which the pipeline registers unconditionally, asks the generator for the
+    // target machine, so the Subgraph needs one before any data-flow pass can run. The generator
+    // only holds a weak reference to the kernel cache, so the caller has to keep it alive.
+    subgraph->set_generator(std::make_shared<ov::intel_cpu::CPUGenerator>(dnnl::impl::cpu::x64::avx2, cache));
+    return subgraph;
+}
+
+// The two backend passes of Subgraph::getDataFlowPasses that interact, at the positions it gives
+// them. MulAddToFMA is listed first on purpose: a marking pass mutated to PipelineEnd then lands
+// after the fold, which is what makes the position observable.
+std::vector<ov::snippets::pass::Manager::PositionedPassBase> backend_passes() {
+    return {{ov::snippets::pass::PassPosition(ov::snippets::pass::PassPosition::Place::PipelineEnd),
+             std::make_shared<ov::intel_cpu::pass::MulAddToFMA>()},
+            {ov::snippets::pass::PassPosition(ov::snippets::pass::PassPosition::Place::After,
+                                              ov::snippets::pass::SoftmaxDecomposition::get_type_info_static()),
+             std::make_shared<ov::intel_cpu::pass::MarkApproximateSoftmaxExp>()}};
+}
+
+std::vector<ov::snippets::pass::Manager::PositionedPassBase> without_marking() {
+    return {{ov::snippets::pass::PassPosition(ov::snippets::pass::PassPosition::Place::PipelineEnd),
+             std::make_shared<ov::intel_cpu::pass::MulAddToFMA>()}};
+}
+
+}  // namespace
+
+TEST(MarkApproximateSoftmaxExp, marks_the_exp_of_a_decomposed_softmax) {
+    const auto model = decomposed_softmax();
+    const auto exp = find_exp(model);
+    ASSERT_NE(exp, nullptr);
+    ASSERT_FALSE(ov::intel_cpu::is_approximate_exp(exp));
+
+    run_marking(model);
+
+    EXPECT_TRUE(ov::intel_cpu::is_approximate_exp(exp));
+}
+
+TEST(MarkApproximateSoftmaxExp, leaves_an_exp_that_is_not_a_softmax_numerator) {
+    const auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape);
+    const auto exp = std::make_shared<ov::op::v0::Exp>(data);
+    const auto model = std::make_shared<ov::Model>(ov::OutputVector{exp}, ov::ParameterVector{data});
+
+    run_marking(model);
+
+    EXPECT_FALSE(ov::intel_cpu::is_approximate_exp(exp));
+}
+
+TEST(MarkApproximateSoftmaxExp, leaves_an_exp_divided_by_a_sum_of_another_exp) {
+    const auto [model, exp] = reciprocal_of_a_foreign_sum();
+
+    run_marking(model);
+
+    EXPECT_FALSE(ov::intel_cpu::is_approximate_exp(exp));
+}
+
+TEST(MarkApproximateSoftmaxExp, leaves_an_exp_scaled_by_a_power_that_is_not_the_reciprocal) {
+    const auto [model, exp] = hand_built_softmax(-2.F, false);
+
+    run_marking(model);
+
+    EXPECT_FALSE(ov::intel_cpu::is_approximate_exp(exp));
+}
+
+TEST(MarkApproximateSoftmaxExp, leaves_an_exp_that_is_also_read_unnormalised) {
+    const auto [model, exp] = hand_built_softmax(-1.F, true);
+
+    run_marking(model);
+
+    EXPECT_FALSE(ov::intel_cpu::is_approximate_exp(exp));
+}
+
+TEST(MarkApproximateSoftmaxExp, hand_built_positive_matches_the_decomposed_one) {
+    // Pins that the four negatives above differ from a match in exactly the property each names,
+    // rather than in the way the graph was built.
+    const auto [model, exp] = hand_built_softmax(-1.F, false);
+
+    run_marking(model);
+
+    EXPECT_TRUE(ov::intel_cpu::is_approximate_exp(exp));
+}
+
+// The guard the previous version of this feature lacked. Every other test here drives the matcher
+// standalone, which is exactly the shape of test that stayed green while the selection rule could
+// never fire. This one runs the real snippets data-flow pipeline with the pass at the position the
+// plugin gives it, so it fails if the anchor pass is renamed or removed, and -- given the order the
+// two backend passes are listed in above -- if the marking is moved to the end of the pipeline,
+// where MulAddToFMA has already folded the pattern away.
+TEST(MarkApproximateSoftmaxExp, fires_at_its_registered_position_in_the_snippets_pipeline) {
+    const auto cache = std::make_shared<ov::intel_cpu::MultiCache>(1);
+    const auto subgraph = softmax_subgraph(cache);
+
+    subgraph->data_flow_transformations({}, {}, {}, backend_passes());
+
+    // The fold is what makes the position observable, so a test that stopped provoking it would
+    // stop guarding anything.
+    const auto ops = subgraph->body_ptr()->get_ordered_ops();
+    ASSERT_TRUE(std::any_of(ops.begin(), ops.end(), [](const std::shared_ptr<ov::Node>& op) {
+        return ov::is_type<ov::intel_cpu::FusedMulAdd>(op);
+    }));
+    const auto exp = find_exp(subgraph->body_ptr());
+    ASSERT_NE(exp, nullptr);
+    EXPECT_TRUE(ov::intel_cpu::is_approximate_exp(exp));
+}
+
+// The same pipeline with the pass not registered -- what every caller that did not ask for the
+// approximation gets. Pins that the mark comes from the pass and not from the pipeline itself.
+TEST(MarkApproximateSoftmaxExp, leaves_the_pipeline_alone_when_it_is_not_registered) {
+    const auto cache = std::make_shared<ov::intel_cpu::MultiCache>(1);
+    const auto subgraph = softmax_subgraph(cache);
+
+    subgraph->data_flow_transformations({}, {}, {}, without_marking());
+
+    const auto exp = find_exp(subgraph->body_ptr());
+    ASSERT_NE(exp, nullptr);
+    EXPECT_FALSE(ov::intel_cpu::is_approximate_exp(exp));
+}
+
+}  // namespace ov::test::snippets


### PR DESCRIPTION
Adds an opt-in cheaper `exp` for the numerator of a Snippets-fused softmax, behind the internal
plugin property `ov::intel_cpu::snippets_approximate_softmax_exp`. Off by default, and with it off
the emitted code is unchanged.

### Details:

 - `2^(x*log2e)` is evaluated with a degree-1 minimax polynomial on the fraction, and the underflow
   is handled by clamping in the log2 domain instead of a mask and a blend: one `vfmadd213ps` where
   the accurate path has a degree-5 polynomial, and no `vcmpps`/`vblendvps` pair.
 - Eligibility is decided by a data-flow pass, `MarkApproximateSoftmaxExp`, registered directly
   after `SoftmaxDecomposition`, and recorded in the node's runtime info, which survives lowering.
   It marks only an `Exp` that feeds both a `ReduceSum` and a `Multiply` by the reciprocal of that
   same sum, and nothing else; `jit_erf_emitter`'s own `Exp` is built through the constructor that
   takes no node and always keeps the accurate path.
 - The emitter lays down only the constants the selected path reads. x86-64 only -- the
   registration macro is empty on every other architecture.

### What enabling it costs:

 - Max relative error `2.98e-2` on the exponential, against the accurate path's `3.9e-7`.
   Normalising does not cancel it: the error is a function of `frac(x*log2e)`, and a minimax fit
   equioscillates about zero, so there is no common bias to divide out. The worst case on the
   normalised probabilities is `2e/(1-e) = 6.15e-2`, worse than on the raw exponential.
 - `exp(0)` returns `c0 = 1.0290141`, not 1.
 - Saturation instead of underflow or overflow, at neither of the accurate path's knees and to
   neither of its values. At or below `x = -69.3147` it returns `c0*2^-100 = 8.1175e-31`, where the
   accurate path still evaluates its polynomial and flushes to zero only strictly below
   `ln_flt_min_f`. At or above `x = 88.0297` it returns `c0*2^127 = 1.7508e38`, where the accurate
   path reaches `+inf` from `x = 88.3763` upwards. No input yields an infinity, a denormal or a NaN.

### Why the clamp floor is `2^-100` rather than the smallest normal exponent:

Every value this emitter produces on a marked node is about to be divided by a sum of its own row,
so what has to stay normal is the quotient, not the floor. The input has already had the row maximum
subtracted, so each term is at most `c0`, a row of `N` terms sums to at most `N*c0`, and the smallest
quotient is `2^lo / N`. Stopping at `-126` -- the smallest exponent that is itself normal --
therefore hands a subnormal to the matmul that consumes the probabilities as soon as the row sum
exceeds `c0`, which is every row with two comparable entries and every masked attention row.
Measured on the layer described under Verification, with a causal `-1e4` mask:

| clamp floor | property off | property on | paired | pairs favouring on |
|---|---|---|---|---|
| `2^-126` | 0.671 ms | 32.447 ms | **-97.9%** | 0/10 |
| `2^-100` | 0.669 ms | 0.646 ms | +3.87% | 10/10 |

`-100` keeps the quotient normal for rows of up to `2^25` elements, and costs nothing measurable in
exchange: it moves the floor from `1.21e-38` to `8.12e-31`, still 28 orders of magnitude below the
`2.98e-2` error the fast path already carries, on values that are then divided by a row sum and
consumed by an `f32` matmul.

`CPU_DENORMALS_OPTIMIZATION` is not a substitute for this. The plugin applies it by setting MXCSR on
the compiling thread, so any unrelated model compiled earlier in the same process leaves the shared
TBB worker pool without it and the 32 ms comes back -- measured, on the same graph.

### Verification:

 - The emitted instruction sequence was simulated exactly -- round-to-nearest-even, x86
   `minps`/`maxps` NaN semantics, the exponent-field construction and f32 rounding at every step --
   over all 2^32 float inputs. No input yields an infinity, a NaN, a denormal or a non-positive
   result, and the observed range is exactly `[8.117490e-31, 1.750777e38]`. Every accuracy and
   saturation figure above comes from that run.
 - 16 unit tests. The marking pass on a real decomposed softmax and on four near-misses that must
   not be marked; that it fires in the Snippets data-flow pipeline when registered where the plugin
   registers it, and does nothing when it is not; and the emitted code itself, JIT-compiled and
   executed on the widest available ISA and on `sse41`, for the error bound on the exponential and
   on a normalised probability, both saturation points, `exp(0)`, the absence of any infinity, NaN
   or denormal, a destination register aliased onto the source, that normalising a saturated entry
   still yields a normal for rows up to `2^25`, and that an unmarked `Exp` is bit-identical to the
   pre-existing constructor that takes no node.
 - `ov_cpu_unit_tests`: 2683 passed, 1 failure unrelated to this change and present on the base
   commit (`ModelPreferThreadsIntegrationTest.x86_hybrid_fp32_main_cores_only`).
 - The accurate path is bit-identical to the base commit: an FNV-1a hash of its output over a
   65536-point sweep is unchanged on both `avx2` and `sse41` when `jit_eltwise_emitters.{cpp,hpp}`
   are reverted to the base revision. The two table entries this PR moves to the front of
   `register_table_entries` are keyed by name, not by push order.
 - Speed, on one attention layer built from opset ops -- `[1, 8, 256, 64]`, 8 heads, 256 tokens,
   `f32`, with a `256x256` additive mask -- one stream on four pinned cores. Ten order-alternated
   pairs in a single process, 300 iterations per arm, differenced within each pair so drift cancels:
   **+3.89%** with no mask (10/10 pairs favour the property) and **+4.00%** with a causal mask
   (10/10). The property pays in proportion to the softmax's share of the layer, so it is worth
   least where the matmuls are widest and more as they get cheaper.
 - End to end against a CPU plugin built from this branch: compiling one model with the property off
   and on changes the output by `1.65e-2` max absolute over 8192 values (max `|ref|` = 0.926), which
   is inside the `6.15e-2` bound on normalised probabilities quoted above, and no-property is
   bit-identical to explicitly-off.
 - `clang-format` clean under the CI-pinned clang-format 18.

<details>
<summary><code>paired.cpp</code> -- the benchmark behind the two tables</summary>

```cpp
// Order-alternated paired benchmark of SNIPPETS_APPROXIMATE_SOFTMAX_EXP on one attention layer.
// Both arms live in one process and are differenced within each pair, so drift cancels.
// Build against a CPU plugin built from this branch; run as `./paired` or `./paired masked`.
#include <openvino/openvino.hpp>
#include <openvino/opsets/opset8.hpp>
#include <algorithm>
#include <chrono>
#include <cstdio>
#include <random>
#include <string>
#include <vector>
using namespace ov;

int main(int argc, char** argv) {
    const bool masked = argc > 1 && std::string(argv[1]) == "masked";
    const int pairs = 10, iters = 300;
    Shape s{1, 8, 256, 64}, ms{1, 1, 256, 256};
    auto q = std::make_shared<opset8::Parameter>(element::f32, s);
    auto k = std::make_shared<opset8::Parameter>(element::f32, s);
    auto v = std::make_shared<opset8::Parameter>(element::f32, s);
    auto mask = std::make_shared<opset8::Parameter>(element::f32, ms);
    auto sm = std::make_shared<opset8::Softmax>(
        std::make_shared<opset8::Add>(std::make_shared<opset8::MatMul>(q, k, false, true), mask), 3);
    auto model = std::make_shared<Model>(
        OutputVector{std::make_shared<opset8::MatMul>(sm, v, false, false)}, ParameterVector{q, k, v, mask});

    std::mt19937 rng(1);
    std::uniform_real_distribution<float> d(-1.f, 1.f);
    std::vector<float> dq(shape_size(s)), dk(shape_size(s)), dv(shape_size(s)), dm(shape_size(ms));
    for (auto* b : {&dq, &dk, &dv}) for (auto& x : *b) x = d(rng);
    for (size_t i = 0; i < 256; ++i)
        for (size_t j = 0; j < 256; ++j) dm[i * 256 + j] = (masked && j > i) ? -1e4f : 0.f;

    Core core;
    std::vector<double> deltas, off_t, on_t;
    auto arm = [&](bool approx) {
        auto cm = core.compile_model(model, "CPU",
            {{"SNIPPETS_APPROXIMATE_SOFTMAX_EXP", approx}, {"NUM_STREAMS", 1}, {"INFERENCE_NUM_THREADS", 4}});
        auto req = cm.create_infer_request();
        req.set_input_tensor(0, Tensor(element::f32, s, dq.data()));
        req.set_input_tensor(1, Tensor(element::f32, s, dk.data()));
        req.set_input_tensor(2, Tensor(element::f32, s, dv.data()));
        req.set_input_tensor(3, Tensor(element::f32, ms, dm.data()));
        for (int i = 0; i < 30; ++i) req.infer();
        std::vector<double> t;
        for (int i = 0; i < iters; ++i) {
            auto a = std::chrono::steady_clock::now();
            req.infer();
            t.push_back(std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - a).count());
        }
        std::sort(t.begin(), t.end());
        return t[t.size() / 2];
    };
    for (int i = 0; i < pairs; ++i) {
        double off, on;
        if (i % 2 == 0) { off = arm(false); on = arm(true); } else { on = arm(true); off = arm(false); }
        off_t.push_back(off); on_t.push_back(on);
        deltas.push_back((off / on - 1.0) * 100.0);
    }
    std::sort(off_t.begin(), off_t.end()); std::sort(on_t.begin(), on_t.end());
    auto dsort = deltas; std::sort(dsort.begin(), dsort.end());
    int wins = 0; for (double x : deltas) wins += (x > 0);
    printf("%-8s off %.3f ms  on %.3f ms  paired %+.2f%% [%+.2f..%+.2f]  %d/%d pairs favour on\n",
           masked ? "masked" : "plain", off_t[pairs / 2], on_t[pairs / 2],
           dsort[pairs / 2], dsort.front(), dsort.back(), wins, pairs);
}
```

</details>

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - Used for drafting the emitter sequence, the marking pass, the tests and this description, and for
   adversarial review passes over the diff. Human validation: what `SoftmaxDecomposition` emits, and
   the pass ordering around it, read back in the source rather than assumed; the accuracy and
   saturation figures from the exhaustive simulation above; the unit tests built and run, with each
   guard mutation-tested -- reverting the clamp floor to `2^-126`, single wrong hex digits in the
   polynomial coefficient and in the clamp bound, and moving the marking pass past the point where
   the pattern has been folded away each turn the corresponding test red; the accurate path's
   bit-identity to the base commit established by rebuilding with the emitter reverted rather than
   argued; and the speed and accuracy figures measured against a CPU plugin built from this branch.
   Not done: this host is AVX2-max, so the AVX-512 encoding of the fast path is covered by the
   ISA-generic `uni_` helpers and by simulation rather than by execution.
