### PR TITLE
[GPU] Fix SelectiveSSM сoverity issues (backport to 2026.4 release)

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_selective_ssm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_selective_ssm.cpp
@@ -181,6 +181,7 @@ protected:
                                                                             params.get_device_info(),
                                                                             Kind,
                                                                             selective_ssm_jit::paged_private_value_budget);
+        OPENVINO_ASSERT(subgroup_size != 0, "PagedSelectiveSSM JIT kernel requires a non-zero subgroup size");
 
         if (!params.is_dynamic())
             jit.make("SSM_TOKEN_COUNT", x_shape[0].get_length());
@@ -227,6 +228,7 @@ protected:
                                                                                 params.get_device_info(),
                                                                                 Kind,
                                                                                 selective_ssm_jit::paged_private_value_budget);
+            OPENVINO_ASSERT(head_dim_block != 0, "PagedSelectiveSSM JIT kernel requires a non-zero head dimension block");
 
             kd.params.workGroups.local = {subgroup_size, 1, 1};
             kd.params.local_memory_args.clear();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/selective_ssm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/selective_ssm.cpp
@@ -86,6 +86,7 @@ protected:
         const size_t discrete_target = get_discrete_head_dim_target(params);
         const size_t head_dim_block =
             selective_ssm_jit::get_head_dim_block(head_dim, state_size, subgroup_size, params.get_device_info(), Kind, private_values_budget, discrete_target);
+        OPENVINO_ASSERT(subgroup_size != 0, "SelectiveSSM JIT kernel requires a non-zero subgroup size");
 
         jit.make("SSM_SEQUENCE_SIZE", x_shape[1].get_length());
         jit.make("SSM_NUM_HEADS", x_shape[2].get_length());
@@ -136,6 +137,7 @@ protected:
                                                                                 Kind,
                                                                                 private_values_budget,
                                                                                 discrete_target);
+            OPENVINO_ASSERT(head_dim_block != 0, "SelectiveSSM JIT kernel requires a non-zero head dimension block");
 
             kd.params.workGroups.global = {cldnn::ceil_div(head_dim, head_dim_block) * subgroup_size, num_heads, batch};
             kd.params.workGroups.local = {subgroup_size, 1, 1};


### PR DESCRIPTION
### Details:

**Backport of https://github.com/openvinotoolkit/openvino/pull/37821 to 2026.4 release**

- Validate the selected subgroup size before deriving JIT state iteration counts.
- Validate the head-dimension block before forming SelectiveSSM dispatch grids.
- Apply the same fail-fast guards to standalone and paged SelectiveSSM JIT generators.

### AI Assistance:

- AI assistance used: yes

### Tickets:

- CVS-193444
