### PR TITLE
[CPU] Fix SelectiveSSM coverity issues (backport to 2026.4 release)

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/paged_selective_ssm_executor.cpp
@@ -180,6 +180,7 @@ void PagedSelectiveSSMExecutor::execute(const MemoryArgs& memory) {
         m_cached_projection_elements != projection_elements) {
         OPENVINO_ASSERT(update_scratchpad(memory));
     }
+    OPENVINO_ASSERT(m_scratch != nullptr, "PagedSelectiveSSM scratch memory is not initialized.");
 
     const node::kernel::PagedSelectiveSSMShape shape{x_dims[0],
                                                      x_dims[1],

--- a/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/selective_ssm_executor.cpp
@@ -137,6 +137,7 @@ void SelectiveSSMExecutor::execute(const MemoryArgs& memory) {
         m_cached_projection_elements != projection_elements) {
         OPENVINO_ASSERT(update_scratchpad(memory));
     }
+    OPENVINO_ASSERT(m_scratch != nullptr, "SelectiveSSM scratch memory is not initialized.");
 
     node::kernel::SelectiveSSMShape shape{x_dims[0], x_dims[1], x_dims[2], x_dims[3], B_dims[2], B_dims[3]};
     auto* state_scratch = m_scratch->getDataAs<float>();

--- a/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/selective_ssm.cpp
@@ -83,11 +83,16 @@ void selective_ssm_typed(const DataT* A,
                          float* state_scratch,
                          size_t scratch_head_dim,
                          const CpuParallelPtr& cpu_parallel) {
+    OPENVINO_ASSERT(shape.num_groups > 0, "SelectiveSSM requires a positive number of groups.");
+    const auto heads_per_group = shape.num_heads / shape.num_groups;
+    OPENVINO_ASSERT(heads_per_group > 0 && heads_per_group * shape.num_groups == shape.num_heads,
+                    "SelectiveSSM requires the number of groups to evenly divide the number of heads.");
+    OPENVINO_ASSERT(scratch_head_dim > 0, "SelectiveSSM scratch head dimension must be positive.");
+
     const auto batch_state_stride =
         checked_size_product({shape.num_heads, shape.head_dim, shape.state_size}, "recurrent state batch");
     const auto head_state_stride = checked_size_product({shape.head_dim, shape.state_size}, "recurrent state head");
     const auto scratch_stride = checked_size_product({scratch_head_dim, shape.state_size}, "state scratch");
-    const auto heads_per_group = shape.num_heads / shape.num_groups;
     const auto p_block_count = ov::util::ceil_div(shape.head_dim, scratch_head_dim);
 
     cpu_parallel
@@ -353,6 +358,12 @@ void paged_selective_ssm_typed(const DataT* A,
                                float* state_scratch,
                                size_t scratch_head_dim,
                                const CpuParallelPtr& cpu_parallel) {
+    OPENVINO_ASSERT(shape.num_groups > 0, "PagedSelectiveSSM requires a positive number of groups.");
+    const auto heads_per_group = shape.num_heads / shape.num_groups;
+    OPENVINO_ASSERT(heads_per_group > 0 && heads_per_group * shape.num_groups == shape.num_heads,
+                    "PagedSelectiveSSM requires the number of groups to evenly divide the number of heads.");
+    OPENVINO_ASSERT(scratch_head_dim > 0, "PagedSelectiveSSM scratch head dimension must be positive.");
+
     const auto& subsequence_begins = metadata.subsequence_begins;
     const auto& block_indices = metadata.block_indices;
     const auto& block_indices_begins = metadata.block_indices_begins;
@@ -362,7 +373,6 @@ void paged_selective_ssm_typed(const DataT* A,
     const auto block_stride = checked_size_product({shape.num_heads, shape.head_dim, shape.state_size}, "state block");
     const auto head_stride = checked_size_product({shape.head_dim, shape.state_size}, "state head");
     const auto scratch_stride = checked_size_product({scratch_head_dim, shape.state_size}, "state scratch");
-    const auto heads_per_group = shape.num_heads / shape.num_groups;
     const auto p_block_count = ov::util::ceil_div(shape.head_dim, scratch_head_dim);
 
     cpu_parallel->parallel_for3d(
@@ -568,11 +578,12 @@ size_t checked_size_product(std::initializer_list<size_t> dimensions, const char
 
     size_t result = 1;
     for (const auto dimension : dimensions) {
-        OPENVINO_ASSERT(result <= std::numeric_limits<size_t>::max() / dimension,
+        size_t product = 0;
+        OPENVINO_ASSERT(!ov::util::mul_overflow(result, dimension, product),
                         "SelectiveSSM size overflow while calculating ",
                         tensor_name,
                         ".");
-        result *= dimension;
+        result = product;
     }
     return result;
 }


### PR DESCRIPTION
### Details:

**Backport of https://github.com/openvinotoolkit/openvino/pull/37818 to the 2026.4 release**

- Add explicit scratch initialization assertions before dereferencing executor scratch memory.
- Guard group and scratch divisors in SelectiveSSM and PagedSelectiveSSM kernels.
- Use `ov::util::mul_overflow` for checked tensor-size products.

### Tickets:

- CVS-193442
- CVS-193445
- CVS-193446

### AI Assistance:

- AI assistance used: yes