### PR TITLE
[GPU] Link gpu plugin with -z nodelete when built with SYCL

### DIFF
--- a/src/plugins/intel_gpu/CMakeLists.txt
+++ b/src/plugins/intel_gpu/CMakeLists.txt
@@ -148,6 +148,16 @@ target_compile_options(${TARGET_NAME} PRIVATE
 
 target_link_libraries(${TARGET_NAME} PRIVATE openvino_intel_gpu_graph openvino::pugixml)
 
+# Unloading a .so with SYCL code is unsafe in two ways:
+#  1. libsycl.so drops the kernel name index on unregister, so kernels provided
+#     by another loaded module go missing.
+#  2. libsycl.so's static destructor touches vtables (e.g., SYCLMemObjAllocatorHolder)
+#     emitted in the unloaded module at process exit (observed on an NVIDIA backend).
+# Mark the plugin NODELETE so it is never unloaded.
+if(OV_GPU_WITH_SYCL AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_options(${TARGET_NAME} PRIVATE "LINKER:-z,nodelete")
+endif()
+
 target_include_directories(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 


### PR DESCRIPTION
### Details:
- In #37046 , unloading the GPU plugin caused SYCL kernel images registered by another loaded module to become unavailable.
  - Plugin unloading also caused a separate shutdown-time issue in our local NVIDIA GPU development environment.
- On Linux builds using SYCL, link the GPU plugin with `-z nodelete` so that the dynamic loader does not unload the plugin.
- Verified that this resolves errors in subsequent SYCL tests, such as `sycl_engine.memory_creation`, that occurred after
  `permute_fused_eltwise_rank_mismatch.new_shape_infer_5d_peer_and_5d_host` unloaded the GPU plugin in `ov_gpu_unit_tests`.

### AI Assistance:
- AI assistance used: yes
- AI was used for writing and reviewing code.
- Human validation performed: build, tests, and manual checks
