### PR TITLE
[GPU] reverting out-of-bounds fixes to fsv16 convolution kernels (perf drop addressing)

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16.cl
@@ -21,6 +21,7 @@
 
 #define AS_FILTER_TYPE8   CAT(as_, FILTER_TYPE8)
 
+
 #if OUTPUT_FORMAT_BFYX
 #   define OUTPUTVTYPE(n)       CAT(OUTPUT_TYPE, n)
 #   define TO_OUTPUTVTYPE       CAT(convert_, OUTPUTVTYPE(OUTPUT_X_BLOCK_SIZE))
@@ -59,7 +60,6 @@ KERNEL(convolution_bfyx_f16)(
     const int xy = get_global_id(0);
     const int x = (xy % X_BLOCKS) * OUTPUT_X_BLOCK_SIZE;
     const int y = (xy / X_BLOCKS);
-    const int input_spatial_size_x = INPUT0_SIZE_X;
 
     const int lid1 = (int)get_local_id(1);
     const int feature_per_wg = (int)get_local_size(1) / SLM_DIV_FACTOR;
@@ -82,9 +82,6 @@ KERNEL(convolution_bfyx_f16)(
 
     const int input_x = x * STRIDE_SIZE_X - PADDING_SIZE_X;
     const int input_y = y * STRIDE_SIZE_Y - PADDING_SIZE_Y;
-    const int right_unreachable_count_x = min(max(0, input_x + INPUT_LINE_SIZE - input_spatial_size_x), 
-                                                INPUT_LINE_SIZE);
-    const int left_unreachable_count_x = min(max(0, -input_x), INPUT_LINE_SIZE);
 
     // Input offset calculations:
     const uint input_x_pitch = FEATURE_SLICE_SIZE;
@@ -191,8 +188,7 @@ KERNEL(convolution_bfyx_f16)(
                 {
                     for (int xb = 0; xb < INPUT_LINE_SIZE; xb++)
                     {
-                        const int in_x = input_x + xb;
-                        if (icb * FEATURE_SLICE_SIZE + sglid >= FILTER_IFM_NUM || in_x < 0 || in_x >= input_spatial_size_x)
+                        if (icb * FEATURE_SLICE_SIZE + sglid >= FILTER_IFM_NUM)
                             line_cache[xb] = 0;
                         else
                             line_cache[xb] = input[grouped_input_offset +
@@ -206,12 +202,7 @@ KERNEL(convolution_bfyx_f16)(
 #endif  // INPUT_LEFTOVERS
                 {
                     int xb = 0;
-                    for (int i = 0; i < left_unreachable_count_x; i++){
-                        line_cache[xb + i] = 0;
-                    }
-                    xb += left_unreachable_count_x;
-                    const int reachable_size = INPUT_LINE_SIZE - right_unreachable_count_x;
-                    for (; xb + 8 <= reachable_size; xb += 8) {
+                    for (; xb + 8 <= INPUT_LINE_SIZE; xb += 8) {
                         INPUT_TYPE8 vv = DT_INPUT_BLOCK_READ8(input, grouped_input_offset +
                                                                   icb * input_fs_pitch +
                                                                   kh * DILATION_SIZE_Y * input_y_pitch +
@@ -226,7 +217,7 @@ KERNEL(convolution_bfyx_f16)(
                         line_cache[xb + 6] = vv[6];
                         line_cache[xb + 7] = vv[7];
                     }
-                    for (; xb + 4 <= reachable_size; xb += 4) {
+                    for (; xb + 4 <= INPUT_LINE_SIZE; xb += 4) {
                         INPUT_TYPE4 vv = DT_INPUT_BLOCK_READ4(input, grouped_input_offset +
                                                                   icb * input_fs_pitch +
                                                                   kh * DILATION_SIZE_Y * input_y_pitch +
@@ -237,14 +228,11 @@ KERNEL(convolution_bfyx_f16)(
                         line_cache[xb + 2] = vv[2];
                         line_cache[xb + 3] = vv[3];
                     }
-                    for (; xb < reachable_size; xb++) {
+                    for (; xb < INPUT_LINE_SIZE; xb++) {
                         line_cache[xb] = DT_INPUT_BLOCK_READ(input, grouped_input_offset +
                                                                  icb * input_fs_pitch +
                                                                  kh * DILATION_SIZE_Y * input_y_pitch +
                                                                  xb * input_x_pitch);
-                    }
-                    for (int i = 0; i < right_unreachable_count_x; i++){
-                        line_cache[xb + i] = 0;
                     }
                 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16_1x1.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/convolution_gpu_bfyx_f16_1x1.cl
@@ -162,21 +162,7 @@ KERNEL(convolution_b_fs_yx_fsv16_1x1)(
 #else // PADDED_INPUT
 
 #if X_BLOCK_SIZE > 1
-            if (xy * X_BLOCK_SIZE + X_BLOCK_SIZE <= INPUT0_SIZE_X * INPUT0_SIZE_Y) {
-                src = UNIT_BLOCK_READ_VEC(input, input_offset + k * input_fs_pitch + input_y * input_y_pitch + input_x * input_x_pitch);
-            } else {
-                __attribute__((opencl_unroll_hint(X_BLOCK_SIZE)))
-                for (int i = 0; i < X_BLOCK_SIZE; i++) {
-                    if (xy * X_BLOCK_SIZE + i >= INPUT0_SIZE_X * INPUT0_SIZE_Y)
-                        break;
-
-                    const uint xb = (input_x + i) % INPUT0_SIZE_X;
-                    const uint yb = input_y + (input_x + i) / INPUT0_SIZE_X;
-                    const uint input_idx = input_offset + k * input_fs_pitch + yb * input_y_pitch + xb * input_x_pitch;
-
-                    src[i] = UNIT_BLOCK_READ(input, input_idx);
-                }
-            }
+            src = UNIT_BLOCK_READ_VEC(input, input_offset + k * input_fs_pitch + input_y * input_y_pitch + input_x * input_x_pitch);
 #else
             src = UNIT_BLOCK_READ(input, input_offset + k * input_fs_pitch);
 #endif // X_BLOCK_SIZE > 1


### PR DESCRIPTION
### Details:
 - Reverting out-of-bounds fixes that caused perf issues

### Tickets:
 - CVS-193478
 - CVS-193396
 - CVS-193955

### AI Assistance:
 - AI assistance used: no