### PR TITLE
[NPUW] Align chunked prefill KV cache and inputs to the left

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.cpp
@@ -285,7 +285,10 @@ void ov::npuw::util::copy_per_layer_inputs_chunk_to_left(const ov::SoPtr<ov::ITe
     const size_t chunk_bytes = static_cast<size_t>(chunk_tokens) * src_per_token_bytes;
     const size_t offset_bytes = static_cast<size_t>(src_offset_tokens) * src_per_token_bytes;
 
-    fill_tensor_bytes(dst, 0u);
+    if (chunk_tokens < dst_seq_len) {
+        auto* dst_data = reinterpret_cast<uint8_t*>(dst->data());
+        std::memset(dst_data + chunk_bytes, 0, dst_seq_len_bytes - chunk_bytes);
+    }
     std::copy_n(reinterpret_cast<const uint8_t*>(src->data()) + offset_bytes,
                 chunk_bytes,
                 reinterpret_cast<uint8_t*>(dst->data()));

--- a/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.cpp
@@ -214,10 +214,10 @@ void ov::npuw::util::pad_position_ids(const ov::SoPtr<ov::ITensor>& padded_posit
     }
 }
 
-void ov::npuw::util::copy_per_layer_inputs_chunk_to_right(const ov::SoPtr<ov::ITensor>& src,
-                                                          const ov::SoPtr<ov::ITensor>& dst,
-                                                          uint32_t src_offset_tokens,
-                                                          uint32_t chunk_tokens) {
+void ov::npuw::util::copy_per_layer_inputs_chunk_to_left(const ov::SoPtr<ov::ITensor>& src,
+                                                         const ov::SoPtr<ov::ITensor>& dst,
+                                                         uint32_t src_offset_tokens,
+                                                         uint32_t chunk_tokens) {
     // Gemma4 26B A4B has dangling per_layer_inputs with zero-sized tensors.
     if (src->get_byte_size() == 0u || dst->get_byte_size() == 0u) {
         OPENVINO_ASSERT(src->get_byte_size() == 0u && dst->get_byte_size() == 0u,
@@ -285,7 +285,8 @@ void ov::npuw::util::copy_per_layer_inputs_chunk_to_right(const ov::SoPtr<ov::IT
     const size_t chunk_bytes = static_cast<size_t>(chunk_tokens) * src_per_token_bytes;
     const size_t offset_bytes = static_cast<size_t>(src_offset_tokens) * src_per_token_bytes;
 
+    fill_tensor_bytes(dst, 0u);
     std::copy_n(reinterpret_cast<const uint8_t*>(src->data()) + offset_bytes,
                 chunk_bytes,
-                reinterpret_cast<uint8_t*>(dst->data()) + dst->get_byte_size() - chunk_bytes);
+                reinterpret_cast<uint8_t*>(dst->data()));
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.hpp
@@ -43,12 +43,12 @@ std::optional<ov::Output<const ov::Node>> find_port_by_names(const std::vector<o
 
 void pad_position_ids(const ov::SoPtr<ov::ITensor>& padded_position_ids, const ov::SoPtr<ov::ITensor>& position_ids);
 
-// Copy chunk_tokens from src starting at src_offset_tokens into dst, right-aligned on seq_len dim.
-// Leading bytes in dst are left unchanged.
-void copy_per_layer_inputs_chunk_to_right(const ov::SoPtr<ov::ITensor>& src,
-                                          const ov::SoPtr<ov::ITensor>& dst,
-                                          uint32_t src_offset_tokens,
-                                          uint32_t chunk_tokens);
+// Copy chunk_tokens from src starting at src_offset_tokens into dst, left-aligned on seq_len dim.
+// Trailing bytes in dst are zeroed.
+void copy_per_layer_inputs_chunk_to_left(const ov::SoPtr<ov::ITensor>& src,
+                                         const ov::SoPtr<ov::ITensor>& dst,
+                                         uint32_t src_offset_tokens,
+                                         uint32_t chunk_tokens);
 
 }  // namespace util
 }  // namespace npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_block_kvcache_strategy.cpp
@@ -878,7 +878,10 @@ void LLMBlockKVCacheStrategy::copy_outputs_to_blocks(const std::shared_ptr<ov::I
 
         auto src_to_copy = src_tensor;
         if (src_seq_len > num_tokens) {
-            src_to_copy = uu::make_tensor_slice(src_tensor, kv_dim, src_seq_len - num_tokens, src_seq_len);
+            const bool is_chunked_prefill =
+                m_req.m_npuw_llm_compiled_model->m_use_chunk_prefill && request == m_req.m_prefill_request;
+            const uint32_t src_start = is_chunked_prefill ? 0u : src_seq_len - num_tokens;
+            src_to_copy = uu::make_tensor_slice(src_tensor, kv_dim, src_start, src_start + num_tokens);
         }
 
         const uint32_t start_pos = current_kv_position;

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -904,8 +904,10 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     } else {
         LOG_DEBUG("Adding position_ids input in case it doesn't exist in model: LFM-2 case.");
         ov::npuw::AddPositionIdsParam().run_on_model(kvcache_model);
-        LOG_DEBUG("Right-align attention_mask slice for Conv operations: LFM-2 case.");
-        ov::npuw::RightAlignMaskSliceForConv().run_on_model(kvcache_model);
+        if (!m_use_chunk_prefill) {
+            LOG_DEBUG("Right-align attention_mask slice for Conv operations: LFM-2 case.");
+            ov::npuw::RightAlignMaskSliceForConv().run_on_model(kvcache_model);
+        }
         LOG_DEBUG("Transform kvcache model from stateful to stateless.");
         ov::pass::StatefulToStateless().run_on_model(kvcache_model);
     }
@@ -942,6 +944,11 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     LOG_DEBUG("Creating prefill model as clone of transformed kvcache one.");
     auto prefill_model = kvcache_model->clone();
     prefill_model->set_friendly_name(kvcache_model->get_friendly_name() + "_prefill");
+
+    if (m_use_chunk_prefill && !m_is_embedding) {
+        LOG_DEBUG("Right-align attention_mask slice for Conv operations in generate model: LFM-2 case.");
+        ov::npuw::RightAlignMaskSliceForConv().run_on_model(kvcache_model);
+    }
 
     m_kvcache_desc =
         KVCacheDesc{max_prompt_len, max_prompt_len + min_response_len, 0u, seq_len_dim, max_generation_token_len};

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -1112,12 +1112,12 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
                 m_prefill_base_request->update_history_size(kvcache_desc.num_stored_tokens);
             }
 
-            // Gemma4 E2B/E4B: copy the current chunk of per_layer_inputs right-aligned on seq_len dim.
+            // Gemma4 E2B/E4B: copy the current chunk of per_layer_inputs left-aligned on seq_len dim.
             // Source shape: [1, input_prompt_len, num_layers, proj_dim]
             // Dest shape:   [1, chunk_prompt_len, num_layers, proj_dim] (static)
             if (per_layer_inputs) {
                 auto dst = m_prefill_request->get_tensor(m_prefill_in_ports.at(layer_names::per_layer_inputs));
-                ov::npuw::util::copy_per_layer_inputs_chunk_to_right(
+                ov::npuw::util::copy_per_layer_inputs_chunk_to_left(
                     per_layer_inputs,
                     dst,
                     kvcache_desc.num_stored_tokens - m_continued_prefill_base,

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -722,7 +722,6 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
         const auto& pre_kv_dim = kv_dim(kvcache_desc.v_tensors_transposed_pre);
         const auto& gen_kv_dim = kv_dim(kvcache_desc.v_tensors_transposed_gen);
 
-        const auto prefill_chunk_size = m_npuw_llm_compiled_model->m_prefill_chunk_size;
         const bool use_chunk_prefill = m_npuw_llm_compiled_model->m_use_chunk_prefill;
         if (use_chunk_prefill) {
             // The chunk prefilled KV results are divided into two parts:

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -770,8 +770,8 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
             auto prefill_present_kv_chunk =
                 uu::make_tensor_slice(prefill_out_tensor,
                                       pre_kv_dim,
-                                      static_cast<uint32_t>(prefill_chunk_size - m_tokens_in_present_chunk),
-                                      static_cast<uint32_t>(prefill_chunk_size));
+                                      0u,
+                                      static_cast<uint32_t>(m_tokens_in_present_chunk));
 
             auto kvcache_last_kv_chunk = uu::make_tensor_slice(kvcache_in_tensor,
                                                                gen_kv_dim,
@@ -829,7 +829,10 @@ void ov::npuw::LLMInferRequest::update_kvcache_for(
         uint32_t src_seq_len = static_cast<uint32_t>(src_tensor->get_shape()[kv_dim]);
         OPENVINO_ASSERT(num_tokens <= src_seq_len);
         if (src_seq_len > num_tokens) {
-            auto src_slice = uu::make_tensor_slice(src_tensor, kv_dim, src_seq_len - num_tokens, src_seq_len);
+            const bool is_chunked_prefill = m_npuw_llm_compiled_model->m_use_chunk_prefill &&
+                                             request == m_prefill_request;
+            const uint32_t src_start = is_chunked_prefill ? 0u : src_seq_len - num_tokens;
+            auto src_slice = uu::make_tensor_slice(src_tensor, kv_dim, src_start, src_start + num_tokens);
             uu::copy_tensor_by_dim(src_slice, dst_slice, kv_dim, kv_dim);
         } else {
             uu::copy_tensor_by_dim(src_tensor, dst_slice, kv_dim, kv_dim);
@@ -1036,17 +1039,11 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
 
             // Populate the attention mask for the present chunk
             // For the already processed tokens, they will be added into the attention mask after inference call
-            size_t last_chunk_offset = attn_mask_in_tensor->get_size() - chunk_prompt_len;
-            if (current_prompts_len < chunk_prompt_len) {
-                // We will populate current_prompts_len on the right side of attention mask for the processing tokens
-                // If the current prompt length is smaller than the chunk prompt length,
-                // clear the last chunk of the attention mask to ensure non-relevant tokens are masked
-                ov::npuw::util::fill_tensor<int64_t>(attn_mask_in_tensor, 0, last_chunk_offset);
-            }
+            ov::npuw::util::fill_tensor<int64_t>(attn_mask_in_tensor, 0, kvcache_desc.num_stored_tokens);
 
             std::copy_n(attention_mask->data<int64_t>() + kvcache_desc.num_stored_tokens,
                         current_prompts_len,
-                        attn_mask_in_tensor->data<int64_t>() + attn_mask_in_tensor->get_size() - current_prompts_len);
+                        attn_mask_in_tensor->data<int64_t>() + kvcache_desc.num_stored_tokens);
 
             // Caller tensors hold only the delta during a continued prefill, so they are
             // indexed relative to the absolute base the continuation started at. The
@@ -1061,8 +1058,7 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             ov::npuw::util::fill_tensor_bytes(input_ids_in_tensor, 0u);
             std::copy_n(reinterpret_cast<uint8_t*>(input_ids->data()) + prefilled_bytes,
                         current_prefill_bytes,
-                        reinterpret_cast<uint8_t*>(input_ids_in_tensor->data()) + input_ids_in_tensor->get_byte_size() -
-                            current_prefill_bytes);
+                        reinterpret_cast<uint8_t*>(input_ids_in_tensor->data()));
 
             // NB: Regular LLM uses 2D position_ids [BATCH, SEQ_LEN], Qwen2.5 VL/Omni, Qwen3.5 VL use 3D position_ids
             // [3, BATCH, SEQ_LEN]
@@ -1076,11 +1072,12 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
                                                   pos_src_offset,
                                                   pos_src_offset + static_cast<uint32_t>(current_prompts_len));
 
+            ov::npuw::util::fill_tensor_bytes(pos_ids_in_tensor, 0u);
             auto pos_ids_slice =
                 ov::npuw::util::make_tensor_slice(pos_ids_in_tensor,
                                                   static_cast<uint32_t>(last_dim),
-                                                  static_cast<uint32_t>(chunk_prompt_len - current_prompts_len),
-                                                  static_cast<uint32_t>(chunk_prompt_len));
+                                                  0u,
+                                                  static_cast<uint32_t>(current_prompts_len));
 
             // Copy with proper stride handling
             NPUW_ASSERT(pos_ids_slice._ptr &&
@@ -1131,18 +1128,12 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             }
 
             // Gemma4-26B-A4B MoE: token_type_ids is [BATCH, SEQ_LEN].
-            // clear the tail window only for last chunk, then right-align current tokens.
             if (has_token_type_ids) {
                 const size_t total_len = token_type_ids_in_tensor->get_size();
-                if (current_prompts_len < chunk_prompt_len) {
-                    // Skip clear for full chunks since copy_n overwrites the whole window.
-                    std::fill_n(token_type_ids_in_tensor->data<int64_t>() + total_len - chunk_prompt_len,
-                                chunk_prompt_len,
-                                int64_t{0});
-                }
+                std::fill_n(token_type_ids_in_tensor->data<int64_t>(), total_len, int64_t{0});
                 std::copy_n(token_type_ids->data<int64_t>() + kvcache_desc.num_stored_tokens,
                             current_prompts_len,
-                            token_type_ids_in_tensor->data<int64_t>() + total_len - current_prompts_len);
+                            token_type_ids_in_tensor->data<int64_t>());
             }
 
             // Prepare KV blocks or bind memory for this chunk via strategy.
@@ -1180,11 +1171,6 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             if (!is_last_chunk) {
                 // Attention mask and lincache update for intermediate chunks.
                 copy_lincache(m_prefill_request, m_prefill_request, m_prefill_out_ports, m_prefill_in_ports);
-
-                std::copy_n(
-                    attn_mask_in_tensor->data<int64_t>() + attn_mask_in_tensor->get_size() - current_prompts_len,
-                    current_prompts_len,
-                    attn_mask_in_tensor->data<int64_t>() + kvcache_desc.num_stored_tokens - current_prompts_len);
             }
         });
 

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -767,11 +767,10 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
             }
 
             // Copy part 2 KV results
-            auto prefill_present_kv_chunk =
-                uu::make_tensor_slice(prefill_out_tensor,
-                                      pre_kv_dim,
-                                      0u,
-                                      static_cast<uint32_t>(m_tokens_in_present_chunk));
+            auto prefill_present_kv_chunk = uu::make_tensor_slice(prefill_out_tensor,
+                                                                  pre_kv_dim,
+                                                                  0u,
+                                                                  static_cast<uint32_t>(m_tokens_in_present_chunk));
 
             auto kvcache_last_kv_chunk = uu::make_tensor_slice(kvcache_in_tensor,
                                                                gen_kv_dim,
@@ -829,8 +828,8 @@ void ov::npuw::LLMInferRequest::update_kvcache_for(
         uint32_t src_seq_len = static_cast<uint32_t>(src_tensor->get_shape()[kv_dim]);
         OPENVINO_ASSERT(num_tokens <= src_seq_len);
         if (src_seq_len > num_tokens) {
-            const bool is_chunked_prefill = m_npuw_llm_compiled_model->m_use_chunk_prefill &&
-                                             request == m_prefill_request;
+            const bool is_chunked_prefill =
+                m_npuw_llm_compiled_model->m_use_chunk_prefill && request == m_prefill_request;
             const uint32_t src_start = is_chunked_prefill ? 0u : src_seq_len - num_tokens;
             auto src_slice = uu::make_tensor_slice(src_tensor, kv_dim, src_start, src_start + num_tokens);
             uu::copy_tensor_by_dim(src_slice, dst_slice, kv_dim, kv_dim);
@@ -1073,11 +1072,10 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
                                                   pos_src_offset + static_cast<uint32_t>(current_prompts_len));
 
             ov::npuw::util::fill_tensor_bytes(pos_ids_in_tensor, 0u);
-            auto pos_ids_slice =
-                ov::npuw::util::make_tensor_slice(pos_ids_in_tensor,
-                                                  static_cast<uint32_t>(last_dim),
-                                                  0u,
-                                                  static_cast<uint32_t>(current_prompts_len));
+            auto pos_ids_slice = ov::npuw::util::make_tensor_slice(pos_ids_in_tensor,
+                                                                   static_cast<uint32_t>(last_dim),
+                                                                   0u,
+                                                                   static_cast<uint32_t>(current_prompts_len));
 
             // Copy with proper stride handling
             NPUW_ASSERT(pos_ids_slice._ptr &&

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -1128,7 +1128,8 @@ void ov::npuw::LLMInferRequest::infer_chunked_prefill(ov::SoPtr<ov::ITensor> inp
             if (has_token_type_ids) {
                 const size_t total_len = token_type_ids_in_tensor->get_size();
                 std::fill_n(token_type_ids_in_tensor->data<int64_t>(), total_len, int64_t{0});
-                std::copy_n(token_type_ids->data<int64_t>() + kvcache_desc.num_stored_tokens,
+                const uint32_t token_type_src_offset = kvcache_desc.num_stored_tokens - m_continued_prefill_base;
+                std::copy_n(token_type_ids->data<int64_t>() + token_type_src_offset,
                             current_prompts_len,
                             token_type_ids_in_tensor->data<int64_t>());
             }

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -168,6 +168,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_infer_request_port_names_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_trim_kvcache_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/lincache_utils_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/per_layer_inputs_copy_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/model_builder_lora_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning_options_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_options_smoke_test.cpp
@@ -190,6 +191,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pipeline_passes/remove_token_type_ids_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pipeline_passes/stateful_to_stateless_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pyramid_attention_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pyramid_attention_left_alignment_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/sdpa_pattern_matcher_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/host_flash_attention_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/moe_k_tag_test.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_continued_prefill_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_continued_prefill_test.cpp
@@ -65,9 +65,9 @@ struct LLMContinuedPrefillTestAccess {
 
     static ov::SoPtr<ov::ITensor> prefill_present(Request& req, const std::string& past_name) {
         auto present_name = past_name;
-        present_name.replace(present_name.find(Request::layer_names::past_key_values),
-                             std::string(Request::layer_names::past_key_values).size(),
-                             "present");
+        const auto pos = present_name.find(Request::layer_names::past_key_values);
+        OPENVINO_ASSERT(pos != std::string::npos, "Unexpected KV cache name: ", past_name);
+        present_name.replace(pos, std::string(Request::layer_names::past_key_values).size(), "present");
         return req.m_prefill_request->get_tensor(req.m_prefill_out_ports.at(present_name));
     }
 

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_continued_prefill_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_continued_prefill_test.cpp
@@ -103,6 +103,20 @@ struct LLMContinuedPrefillTestAccess {
     static uint32_t block_size(const ov::npuw::LLMBlockKVCacheStrategy& strategy) {
         return strategy.m_block_size;
     }
+
+    static ov::SoPtr<ov::ITensor> prefill_output(Request& req, const std::string& output_name) {
+        return req.m_prefill_request->get_tensor(req.m_prefill_out_ports.at(output_name));
+    }
+
+    static void copy_prefill_outputs_to_blocks(Request& req, uint32_t num_tokens, uint32_t current_kv_position) {
+        auto* strategy = block_strategy(req);
+        OPENVINO_ASSERT(strategy != nullptr, "Block-KV strategy is not initialized");
+        strategy->copy_outputs_to_blocks(req.m_prefill_request,
+                                         req.m_prefill_out_ports,
+                                         num_tokens,
+                                         req.m_npuw_llm_compiled_model->m_kvcache_desc.v_tensors_transposed_pre,
+                                         current_kv_position);
+    }
 };
 
 }  // namespace ov::test::npuw
@@ -500,7 +514,8 @@ TEST_F(LLMContinuedPrefillTest, ShortTailChunkKeepsInputsAndKvSourceLeftAligned)
     auto input_ids = LLMContinuedPrefillTestAccess::prefill_input_ids(req);
     ASSERT_EQ(input_ids->get_size(), 32u);
     EXPECT_EQ(input_ids->data<int64_t>()[0], 1);
-    EXPECT_TRUE(std::all_of(input_ids->data<int64_t>() + 1, input_ids->data<int64_t>() + input_ids->get_size(),
+    EXPECT_TRUE(std::all_of(input_ids->data<int64_t>() + 1,
+                            input_ids->data<int64_t>() + input_ids->get_size(),
                             [](int64_t value) {
                                 return value == 0;
                             }));
@@ -516,10 +531,10 @@ TEST_F(LLMContinuedPrefillTest, ShortTailChunkKeepsInputsAndKvSourceLeftAligned)
 
     auto attention_mask = LLMContinuedPrefillTestAccess::prefill_attention_mask(req);
     ASSERT_GE(attention_mask->get_size(), prompt_len);
-    EXPECT_TRUE(std::all_of(attention_mask->data<int64_t>(), attention_mask->data<int64_t>() + prompt_len,
-                            [](int64_t value) {
-                                return value == 1;
-                            }));
+    EXPECT_TRUE(
+        std::all_of(attention_mask->data<int64_t>(), attention_mask->data<int64_t>() + prompt_len, [](int64_t value) {
+            return value == 1;
+        }));
     EXPECT_TRUE(std::all_of(attention_mask->data<int64_t>() + prompt_len,
                             attention_mask->data<int64_t>() + attention_mask->get_size(),
                             [](int64_t value) {
@@ -547,8 +562,8 @@ TEST_F(LLMContinuedPrefillTest, ShortTailChunkKeepsInputsAndKvSourceLeftAligned)
 
     for (const auto& name : LLMContinuedPrefillTestAccess::past_names(req)) {
         auto generate = LLMContinuedPrefillTestAccess::generate_past(req, name);
-        auto last_token = ov::npuw::util::make_tensor_slice(
-            generate, generate_seq_dim(name), last_token_position, prompt_len);
+        auto last_token =
+            ov::npuw::util::make_tensor_slice(generate, generate_seq_dim(name), last_token_position, prompt_len);
         EXPECT_EQ(materialize_bytes(last_token), expected_kv_bytes.at(name)) << name;
     }
 }
@@ -699,6 +714,67 @@ TEST_F(LLMBlockContinuedPrefillTest, GrantedContinuationTruncatesBlockPoolAndRun
     // The continuation hands over to an ordinary generate step on the block pool.
     run_generate_step(104);
     EXPECT_EQ(stored_tokens(), 105);
+}
+
+TEST_F(LLMBlockContinuedPrefillTest, ShortPrefillCopyReadsLeftAlignedKvOutput) {
+    auto& req = request();
+    auto* strategy = LLMContinuedPrefillTestAccess::block_strategy(req);
+    ASSERT_NE(strategy, nullptr);
+
+    constexpr uint32_t block_size = 32u;
+    run_full_prefill(block_size);
+
+    std::unordered_map<std::string, std::vector<uint8_t>> expected_tokens;
+    uint8_t seed = 17u;
+    for (const auto& [layer_idx, layer_managers] : LLMContinuedPrefillTestAccess::block_managers(*strategy)) {
+        auto prepare_output = [&](const char* kv_kind,
+                                  bool is_value,
+                                  const std::unique_ptr<ov::npuw::KVCacheBlockManager>& manager) {
+            if (!manager) {
+                return;
+            }
+            const std::string output_name = "present." + std::to_string(layer_idx) + "." + kv_kind;
+            auto output = LLMContinuedPrefillTestAccess::prefill_output(req, output_name);
+            const auto& desc = LLMContinuedPrefillTestAccess::desc(req);
+            const uint32_t kv_dim = is_value && desc.v_tensors_transposed_pre ? 3u : desc.dim;
+            const uint32_t output_seq_len = static_cast<uint32_t>(output->get_shape()[kv_dim]);
+            ASSERT_EQ(output_seq_len, block_size);
+
+            auto left_token = ov::npuw::util::make_tensor_slice(output, kv_dim, 0u, 1u);
+            fill_tensor_pattern(left_token, seed);
+            expected_tokens.emplace(output_name, materialize_bytes(left_token));
+
+            auto right_token = ov::npuw::util::make_tensor_slice(output, kv_dim, output_seq_len - 1u, output_seq_len);
+            fill_tensor_pattern(right_token, static_cast<uint8_t>(seed + 1u));
+            seed = static_cast<uint8_t>(seed + 31u);
+        };
+
+        prepare_output("key", false, layer_managers.key_manager);
+        prepare_output("value", true, layer_managers.value_manager);
+    }
+
+    LLMContinuedPrefillTestAccess::copy_prefill_outputs_to_blocks(req, 1u, block_size);
+
+    for (const auto& [layer_idx, layer_managers] : LLMContinuedPrefillTestAccess::block_managers(*strategy)) {
+        auto expect_copied_token = [&](const char* kv_kind,
+                                       bool is_value,
+                                       const std::unique_ptr<ov::npuw::KVCacheBlockManager>& manager) {
+            if (!manager) {
+                return;
+            }
+            const std::string output_name = "present." + std::to_string(layer_idx) + "." + kv_kind;
+            const auto allocated_blocks = manager->get_allocated_blocks();
+            ASSERT_EQ(allocated_blocks.size(), 2u);
+            const auto& desc = LLMContinuedPrefillTestAccess::desc(req);
+            const uint32_t kv_dim = is_value && desc.v_tensors_transposed_pre ? 3u : desc.dim;
+            auto copied_token =
+                ov::npuw::util::make_tensor_slice(manager->get_block_tensor(allocated_blocks.back()), kv_dim, 0u, 1u);
+            EXPECT_EQ(materialize_bytes(copied_token), expected_tokens.at(output_name)) << output_name;
+        };
+
+        expect_copied_token("key", false, layer_managers.key_manager);
+        expect_copied_token("value", true, layer_managers.value_manager);
+    }
 }
 
 }  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/llm_continued_prefill_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/llm_continued_prefill_test.cpp
@@ -55,6 +55,26 @@ struct LLMContinuedPrefillTestAccess {
         return req.m_prefill_request->get_tensor(req.m_prefill_in_ports.at(Request::layer_names::attention_mask));
     }
 
+    static ov::SoPtr<ov::ITensor> prefill_input_ids(Request& req) {
+        return req.m_prefill_request->get_tensor(req.m_prefill_in_ports.at(Request::layer_names::input_ids));
+    }
+
+    static ov::SoPtr<ov::ITensor> prefill_position_ids(Request& req) {
+        return req.m_prefill_request->get_tensor(req.m_prefill_in_ports.at(Request::layer_names::position_ids));
+    }
+
+    static ov::SoPtr<ov::ITensor> prefill_present(Request& req, const std::string& past_name) {
+        auto present_name = past_name;
+        present_name.replace(present_name.find(Request::layer_names::past_key_values),
+                             std::string(Request::layer_names::past_key_values).size(),
+                             "present");
+        return req.m_prefill_request->get_tensor(req.m_prefill_out_ports.at(present_name));
+    }
+
+    static void copy_kvcache(Request& req) {
+        req.copy_kvcache();
+    }
+
     static bool generate_initialized(Request& req) {
         return req.m_generate_initialized;
     }
@@ -467,6 +487,70 @@ TEST_F(LLMContinuedPrefillTest, SingleTokenDeltaRoutesToContinuedPrefill) {
     EXPECT_EQ(stored_tokens(), 65);
     // The delta ran as a prefill, so the generate phase re-initializes next.
     EXPECT_FALSE(LLMContinuedPrefillTestAccess::generate_initialized(req));
+}
+
+TEST_F(LLMContinuedPrefillTest, ShortTailChunkKeepsInputsAndKvSourceLeftAligned) {
+    auto& req = request();
+    constexpr uint32_t prompt_len = 65u;
+    constexpr uint32_t last_token_position = prompt_len - 1u;
+
+    run_full_prefill(prompt_len);
+    EXPECT_EQ(stored_tokens(), prompt_len);
+
+    auto input_ids = LLMContinuedPrefillTestAccess::prefill_input_ids(req);
+    ASSERT_EQ(input_ids->get_size(), 32u);
+    EXPECT_EQ(input_ids->data<int64_t>()[0], 1);
+    EXPECT_TRUE(std::all_of(input_ids->data<int64_t>() + 1, input_ids->data<int64_t>() + input_ids->get_size(),
+                            [](int64_t value) {
+                                return value == 0;
+                            }));
+
+    auto position_ids = LLMContinuedPrefillTestAccess::prefill_position_ids(req);
+    ASSERT_EQ(position_ids->get_size(), 32u);
+    EXPECT_EQ(position_ids->data<int64_t>()[0], last_token_position);
+    EXPECT_TRUE(std::all_of(position_ids->data<int64_t>() + 1,
+                            position_ids->data<int64_t>() + position_ids->get_size(),
+                            [](int64_t value) {
+                                return value == 0;
+                            }));
+
+    auto attention_mask = LLMContinuedPrefillTestAccess::prefill_attention_mask(req);
+    ASSERT_GE(attention_mask->get_size(), prompt_len);
+    EXPECT_TRUE(std::all_of(attention_mask->data<int64_t>(), attention_mask->data<int64_t>() + prompt_len,
+                            [](int64_t value) {
+                                return value == 1;
+                            }));
+    EXPECT_TRUE(std::all_of(attention_mask->data<int64_t>() + prompt_len,
+                            attention_mask->data<int64_t>() + attention_mask->get_size(),
+                            [](int64_t value) {
+                                return value == 0;
+                            }));
+
+    uint8_t seed = 17u;
+    std::unordered_map<std::string, std::vector<uint8_t>> expected_kv_bytes;
+    for (const auto& name : LLMContinuedPrefillTestAccess::past_names(req)) {
+        auto present = LLMContinuedPrefillTestAccess::prefill_present(req, name);
+        const auto seq_dim = prefill_seq_dim(name);
+        const auto seq_len = static_cast<uint32_t>(present->get_shape()[seq_dim]);
+        ASSERT_EQ(seq_len, 32u);
+
+        auto left_token = ov::npuw::util::make_tensor_slice(present, seq_dim, 0u, 1u);
+        fill_tensor_pattern(left_token, seed);
+        expected_kv_bytes.emplace(name, materialize_bytes(left_token));
+
+        auto right_token = ov::npuw::util::make_tensor_slice(present, seq_dim, seq_len - 1u, seq_len);
+        fill_tensor_pattern(right_token, static_cast<uint8_t>(seed + 1u));
+        seed = static_cast<uint8_t>(seed + 31u);
+    }
+
+    LLMContinuedPrefillTestAccess::copy_kvcache(req);
+
+    for (const auto& name : LLMContinuedPrefillTestAccess::past_names(req)) {
+        auto generate = LLMContinuedPrefillTestAccess::generate_past(req, name);
+        auto last_token = ov::npuw::util::make_tensor_slice(
+            generate, generate_seq_dim(name), last_token_position, prompt_len);
+        EXPECT_EQ(materialize_bytes(last_token), expected_kv_bytes.at(name)) << name;
+    }
 }
 
 // A preflight rejection mutates nothing and leaves the command pending, so a

--- a/src/plugins/intel_npu/tests/unit/npuw/per_layer_inputs_copy_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/per_layer_inputs_copy_test.cpp
@@ -31,22 +31,22 @@ std::vector<float> to_vec(const ov::SoPtr<ov::ITensor>& t) {
     return std::vector<float>(data, data + t->get_size());
 }
 
-// --- copy_per_layer_inputs_chunk_to_right tests ---------------------------------
+// --- copy_per_layer_inputs_chunk_to_left tests ----------------------------------
 
 // Test 1: copy the first chunk of src to dst.
 // src shape [1,4,2,2], dst shape [1,2,2,2].
 // Copy chunk_tokens=2 starting at src_offset=0 -> dst should equal src[0:2].
-TEST(PerLayerInputsCopyTest, ChunkAtOffsetZeroCopiesToRight) {
+TEST(PerLayerInputsCopyTest, ChunkAtOffsetZeroCopiesToLeft) {
     // src: [1, 4, 2, 2], values 0..15
     auto src = make_per_layer_tensor(/*seq_len=*/4, /*num_layers=*/2, /*proj_dim=*/2, /*start_val=*/0.f);
     // dst: [1, 2, 2, 2]
     auto dst = make_per_layer_tensor(/*seq_len=*/2, /*num_layers=*/2, /*proj_dim=*/2, /*start_val=*/99.f);
 
-    ASSERT_NO_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_right(src, dst, /*offset=*/0, /*chunk=*/2));
+    ASSERT_NO_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_left(src, dst, /*offset=*/0, /*chunk=*/2));
 
     // src tokens 0,1 -> values [0..7]
     const auto result = to_vec(dst);
-    // dst is right-aligned; since chunk==dst_seq_len the entire dst is overwritten
+    // dst is left-aligned; since chunk==dst_seq_len the entire dst is overwritten
     std::vector<float> expected = {0.f,
                                    1.f,
                                    2.f,
@@ -59,45 +59,45 @@ TEST(PerLayerInputsCopyTest, ChunkAtOffsetZeroCopiesToRight) {
 }
 
 // Test 2: copy a middle chunk (offset=2, chunk=2) from a src with 6 tokens.
-// dst has 4 token slots; chunk fills the right 2 slots, left 2 slots are left unchanged.
-TEST(PerLayerInputsCopyTest, ChunkAtOffsetCopiesRightAlignedLeavesLeadingBytesUnchanged) {
+// dst has 4 token slots; chunk fills the left 2 slots and clears the trailing slots.
+TEST(PerLayerInputsCopyTest, ChunkAtOffsetCopiesLeftAlignedAndClearsTrailingBytes) {
     // src: [1, 6, 2, 2], values 0..23
     auto src = make_per_layer_tensor(6, 2, 2, 0.f);
     // dst: [1, 4, 2, 2], sequential values starting from 99 (99, 100, 101, ...)
     auto dst = make_per_layer_tensor(4, 2, 2, 99.f);
 
-    ASSERT_NO_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_right(src, dst, /*offset=*/2, /*chunk=*/2));
+    ASSERT_NO_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_left(src, dst, /*offset=*/2, /*chunk=*/2));
 
     // src tokens at offset 2,3 -> src flat indices [8..15]
     const auto result = to_vec(dst);
-    // Right-aligned: dst tokens 0,1 are unchanged (sequential from start_val=99); dst tokens 2,3 hold src[2],src[3]
-    std::vector<float> expected = {99.f,
-                                   100.f,
-                                   101.f,
-                                   102.f,  // unchanged (token 0)
-                                   103.f,
-                                   104.f,
-                                   105.f,
-                                   106.f,  // unchanged (token 1)
-                                   8.f,
+    // Left-aligned: dst tokens 0,1 hold src[2],src[3]; dst tokens 2,3 are cleared.
+    std::vector<float> expected = {8.f,
                                    9.f,
                                    10.f,
-                                   11.f,  // token 2
+                                   11.f,  // token 0
                                    12.f,
                                    13.f,
                                    14.f,
-                                   15.f};  // token 3
+                                   15.f,  // token 1
+                                   0.f,
+                                   0.f,
+                                   0.f,
+                                   0.f,  // cleared token 2
+                                   0.f,
+                                   0.f,
+                                   0.f,
+                                   0.f};  // cleared token 3
     EXPECT_EQ(result, expected);
 }
 
 // Test 3: chunk_tokens == 1 (generate step).
-TEST(PerLayerInputsCopyTest, SingleTokenChunkCopiesToLastSlot) {
+TEST(PerLayerInputsCopyTest, SingleTokenChunkCopiesToFirstSlot) {
     // src: [1, 3, 2, 2], values 0..11
     auto src = make_per_layer_tensor(3, 2, 2, 0.f);
     // dst: [1, 1, 2, 2]
     auto dst = make_per_layer_tensor(1, 2, 2, 99.f);
 
-    ASSERT_NO_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_right(src, dst, /*offset=*/0, /*chunk=*/1));
+    ASSERT_NO_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_left(src, dst, /*offset=*/0, /*chunk=*/1));
 
     const auto result = to_vec(dst);
     // src token 0 -> values [0,1,2,3]
@@ -109,35 +109,35 @@ TEST(PerLayerInputsCopyTest, SingleTokenChunkCopiesToLastSlot) {
 TEST(PerLayerInputsCopyTest, ZeroChunkTokensThrows) {
     auto src = make_per_layer_tensor(4, 2, 2);
     auto dst = make_per_layer_tensor(4, 2, 2);
-    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_right(src, dst, 0, 0));
+    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_left(src, dst, 0, 0));
 }
 
 // Test 5: offset beyond src seq_len must throw.
 TEST(PerLayerInputsCopyTest, OffsetExceedsSrcSeqLenThrows) {
     auto src = make_per_layer_tensor(4, 2, 2);
     auto dst = make_per_layer_tensor(4, 2, 2);
-    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_right(src, dst, /*offset=*/5, /*chunk=*/1));
+    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_left(src, dst, /*offset=*/5, /*chunk=*/1));
 }
 
 // Test 6: offset+chunk exceeds src seq_len must throw.
 TEST(PerLayerInputsCopyTest, ChunkRangeExceedsSrcSeqLenThrows) {
     auto src = make_per_layer_tensor(4, 2, 2);
     auto dst = make_per_layer_tensor(4, 2, 2);
-    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_right(src, dst, /*offset=*/3, /*chunk=*/2));
+    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_left(src, dst, /*offset=*/3, /*chunk=*/2));
 }
 
 // Test 7: chunk_tokens > dst_seq_len must throw.
 TEST(PerLayerInputsCopyTest, ChunkExceedsDstSeqLenThrows) {
     auto src = make_per_layer_tensor(8, 2, 2);
     auto dst = make_per_layer_tensor(2, 2, 2);
-    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_right(src, dst, /*offset=*/0, /*chunk=*/4));
+    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_left(src, dst, /*offset=*/0, /*chunk=*/4));
 }
 
 // Test 8: src and dst have different per-token byte sizes (different num_layers) must throw.
 TEST(PerLayerInputsCopyTest, PerTokenByteMismatchThrows) {
     auto src = make_per_layer_tensor(4, /*num_layers=*/2, 2);
     auto dst = make_per_layer_tensor(4, /*num_layers=*/3, 2);  // different num_layers
-    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_right(src, dst, /*offset=*/0, /*chunk=*/2));
+    EXPECT_ANY_THROW(ov::npuw::util::copy_per_layer_inputs_chunk_to_left(src, dst, /*offset=*/0, /*chunk=*/2));
 }
 
 // --- copy_to_right for per_layer_inputs (inlined path tests) --------------------

--- a/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_left_alignment_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_left_alignment_test.cpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/openvino.hpp"
+#include "pyramid_attention.hpp"
+
+namespace {
+
+std::shared_ptr<ov::Model> build_left_aligned_quantized_attention_model() {
+    using namespace ov;
+
+    constexpr size_t num_heads = 4u;
+    constexpr size_t head_dim = 16u;
+    constexpr size_t past_len = 63u;
+    constexpr size_t query_len = 1u;
+
+    auto make_param = [](const std::string& name, const element::Type& element_type, const Shape& shape) {
+        auto param = std::make_shared<op::v0::Parameter>(element_type, shape);
+        param->set_friendly_name(name);
+        param->output(0).get_tensor().set_names({name});
+        return param;
+    };
+
+    auto query = make_param("query", element::f32, Shape{1, num_heads, query_len, head_dim});
+    auto past_key = make_param("past_key_values.0.key", element::i8, Shape{1, past_len, num_heads, head_dim});
+    auto present_key = make_param("present_key", element::i8, Shape{1, query_len, num_heads, head_dim});
+    auto past_value = make_param("past_key_values.0.value", element::i8, Shape{1, num_heads, head_dim, past_len});
+    auto present_value = make_param("present_value", element::i8, Shape{1, num_heads, head_dim, query_len});
+    auto mask = make_param("attention_mask", element::f32, Shape{1, 1, query_len, past_len + query_len});
+
+    auto key_concat = std::make_shared<op::v0::Concat>(OutputVector{present_key, past_key}, 1);
+    auto key_transpose_order = op::v0::Constant::create(element::i64, Shape{4}, {0, 2, 1, 3});
+    auto key_convert = std::make_shared<op::v0::Convert>(key_concat, element::f32);
+    auto key = std::make_shared<op::v1::Transpose>(key_convert, key_transpose_order);
+
+    auto value_concat = std::make_shared<op::v0::Concat>(OutputVector{present_value, past_value}, 3);
+    auto value_transpose_order = op::v0::Constant::create(element::i64, Shape{4}, {0, 1, 3, 2});
+    auto value_convert = std::make_shared<op::v0::Convert>(value_concat, element::f32);
+    auto value = std::make_shared<op::v1::Transpose>(value_convert, value_transpose_order);
+
+    auto qk = std::make_shared<op::v0::MatMul>(query, key, false, true);
+    auto masked_qk = std::make_shared<op::v1::Add>(qk, mask);
+    auto softmax = std::make_shared<op::v8::Softmax>(masked_qk, 3);
+    auto output = std::make_shared<op::v0::MatMul>(softmax, value);
+
+    auto model = std::make_shared<Model>(ResultVector{std::make_shared<op::v0::Result>(output)},
+                                         ParameterVector{query, past_key, present_key, past_value, present_value, mask},
+                                         "left_aligned_quantized_attention_model");
+    model->validate_nodes_and_infer_types();
+    return model;
+}
+
+TEST(PyramidAttentionLeftAlignmentTest, DetectsQuantizedPresentBeforePastLayout) {
+    auto model = build_left_aligned_quantized_attention_model();
+
+    auto result = ov::npuw::function::validate_and_setup_pyramid_attention(model);
+
+    ASSERT_TRUE(result.has_value());
+    const auto& contiguous = std::get<ov::npuw::function::PyramidValidationContiguousResult>(*result);
+    EXPECT_TRUE(contiguous.data_left_aligned);
+    EXPECT_EQ(contiguous.past_key_sequence_dims.at("past_key_values.0.key"), 1u);
+    EXPECT_EQ(contiguous.past_value_sequence_dims.at("past_key_values.0.value"), 3u);
+}
+
+}  // namespace


### PR DESCRIPTION
### Details:
 - Establish the foundational left-aligned storage contract for chunked prefill KV cache, token inputs, position IDs, attention masks, Block-KV copies, and auxiliary per-layer inputs.
 - Preserve existing whole-prefill and generate behavior.
 - This is the first PR in a three-part review series. Merge order: #37882 -> #37883 -> #37884.
 - PR2: [Support left-aligned KV cache in attention consumers](https://github.com/openvinotoolkit/openvino/pull/37883)
 - PR3: [Select final logits for left-aligned chunked prefill](https://github.com/openvinotoolkit/openvino/pull/37884)
 - The follow-up branches are intentionally cumulative. Review only their incremental changes with `git diff KVAlign-foundation..KVAlign-attention` and `git diff KVAlign-attention..KVAlign-logits`.

### Tickets:
 - CVS-190643

### AI Assistance:
 - AI assistance used: yes
 - AI assistance was used for code-path analysis, implementation, and test design. Human validation: the NPU unit-test target was built and 19 foundation tests passed.