### PR TITLE
[OVC] Fix digit range in input validation regex (')-9' -> '0-9')

### DIFF
--- a/tools/ovc/openvino/tools/ovc/cli_parser.py
+++ b/tools/ovc/openvino/tools/ovc/cli_parser.py
@@ -486,7 +486,7 @@ def parse_input_value(input_value: str):
 
 
 def split_inputs(input_str):
-    pattern = r'^(?:[^[\]()<]*(\[[\.)-9,\-\s?]*\])*,)*[^[\]()<]*(\[[\.0-9,\-\s?]*\])*$'
+    pattern = r'^(?:[^[\]()<]*(\[[\.0-9,\-\s?]*\])*,)*[^[\]()<]*(\[[\.0-9,\-\s?]*\])*$'
     if not re.match(pattern, input_str):
         raise Error(f"input value '{input_str}' is incorrect. Input should be in the following format: "
                     f"{get_convert_model_help_specifics()['input']['description']}")

--- a/tools/ovc/unit_tests/ovc/utils/cli_parser_test.py
+++ b/tools/ovc/unit_tests/ovc/utils/cli_parser_test.py
@@ -303,6 +303,16 @@ class TestShapesParsing(UnitTestWithMockedTelemetry):
             argv_input = parse_inputs("inp1->[1.0]")
             input_to_input_cut_info(argv_input)
 
+    def test_invalid_character_in_shape_not_last_input(self):
+        # a shape containing an invalid character must be rejected no matter
+        # which position the input has in the list
+        argv_input = "inp1[1,2/3],inp2[1,2]"
+        self.assertRaises(Error, parse_inputs, argv_input)
+
+    def test_invalid_character_in_shape_last_input(self):
+        argv_input = "inp1[1,2],inp2[1,2/3]"
+        self.assertRaises(Error, parse_inputs, argv_input)
+
 
 class PathCheckerFunctions(unittest.TestCase):
     READABLE_DIR = tempfile.gettempdir()


### PR DESCRIPTION
### Details:
 - `split_inputs()` in `tools/ovc/.../cli_parser.py` validates the `input` string with a regex whose two bracket character classes are meant to be identical. The first one reads `)-9` where the second reads `0-9`.
 - In a character class the hyphen is a range, so `)-9` spans 0x29 to 0x39 and quietly allows `)`, `*`, `+` and `/` in addition to the digits.
 - That class only covers inputs that are followed by a comma, so validation depended on the position of the input in the list: the same malformed shape was rejected in the final input and accepted anywhere else.
 - The accepted case is the reason this is worth fixing. The shape never gets parsed, the whole `name[shape]` string becomes the tensor name, and the requested shape is silently dropped:

   ```python
   >>> parse_inputs("inp1[1,2/3],inp2[1,2]")
   [('inp1[1,2/3]', None), ('inp2', <PartialShape: [1,2]>)]
   ```

   `inp2` parses into a name and a shape. `inp1` does not. So a typo such as `/` instead of `,` produces a clear error in the last input and silently loses the shape in any other position.
 - Fix is the one character, plus two regression tests (one per position) since `split_inputs` had no direct coverage.

### Tickets:
 - Closes #37888

### AI Assistance:
 - *AI assistance used: yes*
 - Used an AI assistant to help locate the typo and to draft the fix and the two tests. Everything was verified by hand before submitting, and I can explain the regex behaviour and the parsing path end to end.
 - Human validation performed: reproduced against the released 2026.3.1 wheel and master; confirmed the character class difference by diffing which characters each class accepts (`)`, `*`, `+`, `/`); ran the new tests red/green (before the fix `test_invalid_character_in_shape_not_last_input` fails with "Error not raised by parse_inputs" while the last-input test passes, after the fix both pass); ran the full `cli_parser_test.py` suite after the change, 66 passed. Also checked that valid inputs such as `inp1[1,22,333,123],inp2[-1,45,7,1]` and `a[1..10,?],b[-1,3]` are still accepted.
 - Note: I could not run the full ovc suite that needs a locally built OpenVINO, so the tests above were run against the PyPI wheel's compiled bindings with this ovc source overlaid.
