### PR TITLE
[GHA] Increase LLM accuracy GPU job timeout on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ubuntu_24.yml
+++ b/.github/workflows/ubuntu_24.yml
@@ -209,7 +209,7 @@ jobs:
       device: 'GPU'
       test-suffix: 'iGPU'
       use-pip-proxy: false
-      timeout-minutes: 30
+      timeout-minutes: 60
 
   LLM_Accuracy_dGPU:
     name: LLM accuracy dGPU tests
@@ -228,7 +228,7 @@ jobs:
       device: 'GPU'
       test-suffix: 'dGPU'
       use-pip-proxy: false
-      timeout-minutes: 30
+      timeout-minutes: 60
 
   Pytorch_Layer_Tests:
     name: Pytorch Layer Tests


### PR DESCRIPTION
## Summary
- Raise `timeout-minutes` from 30 to 60 for `LLM_Accuracy_iGPU` and `LLM_Accuracy_dGPU` in the Ubuntu 24.04 workflow.
- Mitigates false timeouts on DMZ self-hosted GPU runners where container setup and artifact downloads consume most of the current limit (CVS-193380).

## Test plan
- [ ] Confirm `LLM accuracy iGPU tests` completes on a PR that triggers GPU Smart CI without hitting the job timeout.
- [ ] Monitor `LLM accuracy dGPU tests` on push workflows for similar timeout behavior.