### PR TITLE
NPUW: PA/semi static chunked dispatch

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
@@ -343,6 +343,7 @@ ov::npuw::PAInferRequest::PAInferRequest(const std::shared_ptr<const ov::ICompil
     };
     for (const auto& [token_dim, compiled] : variants) {
         m_chunk_requests.emplace(token_dim, make_chunk_request(compiled));
+        m_variant_token_dims.push_back(token_dim);
     }
     if (!m_chunk_requests.empty()) {
         m_tail_request = make_chunk_request(m_inner_request->get_compiled_model());
@@ -532,9 +533,7 @@ void ov::npuw::PAInferRequest::infer() {
     LOG_VERB("PA dispatch #" << m_dispatch_idx << ": " << dispatch.sequences() << " subsequence(s), "
                              << dispatch.tokens() << " token(s), " << dispatch.sampled_tokens_indices.size()
                              << " sampled");
-    // Chunkability of the model was decided at compile time (variants exist
-    // only for the plain flat-token contract); an empty dispatch runs 1:1.
-    if (!m_chunk_requests.empty() && dispatch.tokens() > 0) {
+    if (pa::variants_serve(dispatch, m_variant_token_dims)) {
         infer_chunked(dispatch);
         m_serve_chunked_logits = true;
     } else {

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
@@ -5,9 +5,12 @@
 #include "pa_compiled_model.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <map>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -33,6 +36,86 @@ std::vector<int64_t> as_i64_vec(const ov::SoPtr<ov::ITensor>& tensor) {
         OPENVINO_THROW("PA: unexpected element type ", tensor->get_element_type(), " for a control tensor");
     }
     return out;
+}
+
+// True when the model matches the plain flat-token LLM contract the chunked
+// path implements: the known control inputs only (embedding inputs, M-RoPE
+// position_ids, per-layer block tables etc. all run 1:1 on the dynamic model),
+// 1-D token streams, and a single logits output with static per-row geometry
+// so the result tensor can be allocated upfront and filled row by row.
+bool is_chunkable_pa_model(const std::shared_ptr<ov::Model>& model) {
+    static const std::unordered_set<std::string> known = {"input_ids",
+                                                          "position_ids",
+                                                          "past_lens",
+                                                          "subsequence_begins",
+                                                          "block_indices",
+                                                          "block_indices_begins",
+                                                          "max_context_len",
+                                                          "score_aggregation_window",
+                                                          "sampled_tokens_indices"};
+    std::unordered_set<std::string> seen;
+    for (const auto& input : model->inputs()) {
+        const auto& name = input.get_any_name();
+        if (ov::npuw::util::is_pa_kv_cache_name(name)) {
+            continue;
+        }
+        if (known.count(name) == 0) {
+            return false;
+        }
+        seen.insert(name);
+    }
+    for (const char* required : {"input_ids", "position_ids", "block_indices", "sampled_tokens_indices"}) {
+        if (seen.count(required) == 0) {
+            return false;
+        }
+    }
+    for (const char* name : {"input_ids", "position_ids"}) {
+        const auto& rank = model->input(name).get_partial_shape().rank();
+        if (rank.is_dynamic() || rank.get_length() != 1) {
+            return false;
+        }
+    }
+    const auto& outputs = model->outputs();
+    if (outputs.size() != 1 || outputs.front().get_any_name() != "logits") {
+        return false;
+    }
+    const auto& lshape = outputs.front().get_partial_shape();
+    return lshape.rank().is_static() && lshape.rank().get_length() == 3 && lshape[1].is_static() &&
+           lshape[2].is_static();
+}
+
+std::shared_ptr<ov::Model> derive_pa_semi_static_model(const std::shared_ptr<ov::Model>& base_model,
+                                                       std::size_t token_dim) {
+    // Only the token-driven inputs get a fixed size (both are 1-D, checked by
+    // is_chunkable_pa_model); the context stays dynamic.
+    auto derived = base_model->clone();
+    derived->reshape({{"input_ids", ov::PartialShape{static_cast<int64_t>(token_dim)}},
+                      {"position_ids", ov::PartialShape{static_cast<int64_t>(token_dim)}}});
+    derived->set_friendly_name(base_model->get_friendly_name() + "_pa_token_" + std::to_string(token_dim));
+    return derived;
+}
+
+std::map<std::size_t, ov::SoPtr<ov::ICompiledModel>> compile_pa_semi_static_variants(
+    const std::shared_ptr<ov::Model>& base_model,
+    const std::shared_ptr<const ov::IPlugin>& plugin,
+    const std::string& device,
+    const ov::AnyMap& inner_config) {
+    std::map<std::size_t, ov::SoPtr<ov::ICompiledModel>> variants;
+    constexpr std::array<std::size_t, 3> kVariantTokenDims = {1024u, 128u, 1u};
+
+    for (const auto token_dim : kVariantTokenDims) {
+        auto derived = derive_pa_semi_static_model(base_model, token_dim);
+        auto compiled = plugin->get_core()->compile_model(derived, device, inner_config);
+        OPENVINO_ASSERT(compiled != nullptr,
+                        "PA semi-static derivation failed to compile token_dim=",
+                        token_dim,
+                        " on ",
+                        device);
+        LOG_INFO("PA: compiled semi-static variant token_dim=" << token_dim << " on " << device);
+        variants.emplace(token_dim, std::move(compiled));
+    }
+
+    return variants;
 }
 
 }  // anonymous namespace
@@ -93,7 +176,17 @@ ov::npuw::PACompiledModel::PACompiledModel(const std::shared_ptr<ov::Model>& mod
             break;
         }
     }
-    LOG_INFO("PA: KV block_size fixed by " << device << ": " << m_block_size);
+
+    // The semi-static variants only make sense for the plain flat-token LLM
+    // contract; anything else (VLM, M-RoPE, per-layer block tables, ...) runs
+    // 1:1 on the dynamic model, so don't spend compile time on variants.
+    if (is_chunkable_pa_model(model)) {
+        m_semi_static_models = compile_pa_semi_static_variants(model, plugin, device, inner_config);
+    } else {
+        LOG_INFO("PA: model is outside the chunkable flat-token contract; every dispatch runs 1:1");
+    }
+    LOG_INFO("PA: KV block_size fixed by " << device << ": " << m_block_size << "; " << m_semi_static_models.size()
+                                           << " semi-static variant(s)");
 }
 
 const std::vector<ov::Output<const ov::Node>>& ov::npuw::PACompiledModel::inputs() const {

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
@@ -224,10 +224,12 @@ ov::npuw::PACompiledModel::PACompiledModel(const std::shared_ptr<ov::Model>& mod
     // NPU_USE_NPUW and NPU_* keys are this plugin's configuration and must not
     // reach the executing device (which would reject them as unsupported);
     // everything else (e.g. KV_CACHE_PRECISION, performance hints) is the
-    // executing device's business and is forwarded.
+    // executing device's business and is forwarded. DEVICE_ID names an NPU
+    // device (e.g. NPU.3600), so it stays behind as well: the fallback device
+    // would reject an id it doesn't have.
     ov::AnyMap inner_config;
     for (const auto& [key, value] : properties) {
-        if (ov::npuw::util::starts_with(key, "NPU")) {
+        if (ov::npuw::util::starts_with(key, "NPU") || key == ov::device::id.name()) {
             continue;
         }
         inner_config.emplace(key, value);

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
@@ -8,7 +8,9 @@
 #include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <map>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -17,6 +19,7 @@
 #include "intel_npu/config/npuw.hpp"
 #include "logging.hpp"
 #include "openvino/runtime/iplugin.hpp"
+#include "openvino/runtime/make_tensor.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "util.hpp"
 
@@ -82,6 +85,77 @@ bool is_chunkable_pa_model(const std::shared_ptr<ov::Model>& model) {
     const auto& lshape = outputs.front().get_partial_shape();
     return lshape.rank().is_static() && lshape.rank().get_length() == 3 && lshape[1].is_static() &&
            lshape[2].is_static();
+}
+
+// Compact one-line digest of a tensor for the per-dispatch I/O trace:
+// element type, shape, then the values for small tensors or min/max/mean for
+// large ones. KV cache pools pass with_data=false -- the data is the whole
+// paged cache, so only the geometry is shown.
+std::string tensor_brief(const ov::SoPtr<ov::ITensor>& tensor, bool with_data = true) {
+    std::ostringstream os;
+    os << tensor->get_element_type() << " " << tensor->get_shape();
+    const auto type = tensor->get_element_type();
+    const auto n = tensor->get_size();
+    const bool readable =
+        type == ov::element::f32 || type == ov::element::f16 || type == ov::element::i32 || type == ov::element::i64;
+    if (!with_data || !readable || n == 0) {
+        return os.str();
+    }
+    const auto value_at = [&](std::size_t i) -> double {
+        if (type == ov::element::f32) {
+            return tensor->data<float>()[i];
+        }
+        if (type == ov::element::f16) {
+            return static_cast<float>(tensor->data<ov::float16>()[i]);
+        }
+        if (type == ov::element::i32) {
+            return tensor->data<int32_t>()[i];
+        }
+        return static_cast<double>(tensor->data<int64_t>()[i]);
+    };
+    constexpr std::size_t kMaxInline = 16u;
+    if (n <= kMaxInline) {
+        os << " {";
+        for (std::size_t i = 0; i < n; ++i) {
+            os << (i ? ", " : "") << value_at(i);
+        }
+        os << "}";
+    } else {
+        auto lo = value_at(0), hi = lo, sum = 0.0;
+        for (std::size_t i = 0; i < n; ++i) {
+            const auto v = value_at(i);
+            lo = std::min(lo, v);
+            hi = std::max(hi, v);
+            sum += v;
+        }
+        os << " min=" << lo << " max=" << hi << " mean=" << sum / static_cast<double>(n);
+    }
+    return os.str();
+}
+
+// A fresh vector tensor with the chunk port's (integer) element type.
+ov::SoPtr<ov::ITensor> make_ctrl_tensor(const ov::Output<const ov::Node>& port, const std::vector<int64_t>& vals) {
+    const auto type = port.get_element_type();
+    auto tensor = ov::get_tensor_impl(ov::Tensor(type, ov::Shape{vals.size()}));
+    if (type == ov::element::i32) {
+        std::transform(vals.begin(), vals.end(), tensor->data<int32_t>(), [](int64_t v) {
+            return static_cast<int32_t>(v);
+        });
+    } else if (type == ov::element::i64) {
+        std::copy(vals.begin(), vals.end(), tensor->data<int64_t>());
+    } else {
+        OPENVINO_THROW("PA: unexpected element type ", type, " for a control tensor");
+    }
+    return tensor;
+}
+
+// [start, start + n) of a 1-D tensor, copied into a fresh same-typed tensor.
+ov::SoPtr<ov::ITensor> slice_1d(const ov::SoPtr<ov::ITensor>& src, int64_t start, int64_t n) {
+    auto out = ov::get_tensor_impl(ov::Tensor(src->get_element_type(), ov::Shape{static_cast<std::size_t>(n)}));
+    const auto esize = src->get_element_type().size();
+    const auto* base = static_cast<const uint8_t*>(src->data());
+    std::memcpy(out->data(), base + static_cast<std::size_t>(start) * esize, static_cast<std::size_t>(n) * esize);
+    return out;
 }
 
 std::shared_ptr<ov::Model> derive_pa_semi_static_model(const std::shared_ptr<ov::Model>& base_model,
@@ -237,17 +311,40 @@ std::shared_ptr<ov::ISyncInferRequest> ov::npuw::PACompiledModel::create_sync_in
     auto self = std::static_pointer_cast<const ov::ICompiledModel>(shared_from_this());
     auto inner_request = m_compiled_model->create_infer_request();
     OPENVINO_ASSERT(inner_request != nullptr, "PACompiledModel requires a valid inner infer request");
-    return std::make_shared<PAInferRequest>(self, std::move(inner_request), m_block_size);
+    return std::make_shared<PAInferRequest>(self, std::move(inner_request), m_block_size, m_semi_static_models);
 }
 
 ov::npuw::PAInferRequest::PAInferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
                                          ov::SoPtr<ov::IAsyncInferRequest> inner_request,
-                                         std::size_t block_size)
+                                         std::size_t block_size,
+                                         const std::map<std::size_t, ov::SoPtr<ov::ICompiledModel>>& variants)
     : ov::ISyncInferRequest(compiled_model),
       m_inner_request(std::move(inner_request)),
       m_block_size(block_size) {
     for (const auto& input : get_inputs()) {
         m_inputs_by_name.emplace(input.get_any_name(), input);
+    }
+
+    // Chunked execution: one request per semi-static variant plus a dynamic
+    // request for residual chunks. They run against the same paged KV cache
+    // tensors as the inner request, so they can be prepared upfront. The
+    // variants only exist for chunkable models (single logits output).
+    const auto make_chunk_request = [](const auto& compiled) {
+        ChunkRequest chunk;
+        chunk.request = compiled->create_infer_request();
+        OPENVINO_ASSERT(chunk.request != nullptr, "PA chunk model requires a valid infer request");
+        for (const auto& input : compiled->inputs()) {
+            chunk.inputs.emplace(input.get_any_name(), input);
+        }
+        chunk.logits = compiled->outputs().front();
+        return chunk;
+    };
+    for (const auto& [token_dim, compiled] : variants) {
+        m_chunk_requests.emplace(token_dim, make_chunk_request(compiled));
+    }
+    if (!m_chunk_requests.empty()) {
+        m_tail_request = make_chunk_request(m_inner_request->get_compiled_model());
+        m_logits_node = get_outputs().front().get_node();
     }
 }
 
@@ -290,17 +387,166 @@ ov::npuw::pa::Dispatch ov::npuw::PAInferRequest::parse_dispatch() const {
     return d;
 }
 
+void ov::npuw::PAInferRequest::run_chunk(ChunkRequest& chunk,
+                                         const pa::Dispatch& d,
+                                         int64_t seq,
+                                         int64_t seq_offset,
+                                         int64_t n_chunk_tokens) {
+    const auto global_start = d.subsequence_begins[seq] + seq_offset;
+    const auto set = [&](const char* name, const ov::SoPtr<ov::ITensor>& tensor) {
+        auto it = chunk.inputs.find(name);
+        OPENVINO_ASSERT(it != chunk.inputs.end(), "PA chunk model has no '", name, "' input");
+        chunk.request->set_tensor(it->second, tensor);
+    };
+    const auto inner = [&](const char* name) {
+        return m_inner_request->get_tensor(m_inputs_by_name.at(name));
+    };
+
+    // Token-driven inputs: this chunk's slice of the caller's flat stream.
+    set("input_ids", slice_1d(inner("input_ids"), global_start, n_chunk_tokens));
+    set("position_ids", slice_1d(inner("position_ids"), global_start, n_chunk_tokens));
+
+    // Per-subsequence controls, rebased to a single subsequence that has
+    // already seen seq_offset of its scheduled tokens. The block table is the
+    // subsequence's full table: context stays dynamic, positions address it.
+    set("past_lens", make_ctrl_tensor(chunk.inputs.at("past_lens"), {d.past_lens[seq] + seq_offset}));
+    set("subsequence_begins", make_ctrl_tensor(chunk.inputs.at("subsequence_begins"), {0, n_chunk_tokens}));
+    const auto blocks_begin = d.block_indices_begins[seq];
+    const auto n_seq_blocks = d.block_indices_begins[seq + 1] - blocks_begin;
+    set("block_indices", slice_1d(inner("block_indices"), blocks_begin, n_seq_blocks));
+    set("block_indices_begins", make_ctrl_tensor(chunk.inputs.at("block_indices_begins"), {0, n_seq_blocks}));
+    if (m_inputs_by_name.count("score_aggregation_window") > 0) {
+        set("score_aggregation_window", slice_1d(inner("score_aggregation_window"), seq, 1));
+    }
+
+    // The whole-batch max_context_len still bounds this chunk's context, and
+    // the paged KV cache pools are shared as-is.
+    set("max_context_len", inner("max_context_len"));
+    for (const auto& [name, port] : chunk.inputs) {
+        if (ov::npuw::util::is_pa_kv_cache_name(name)) {
+            chunk.request->set_tensor(port, m_inner_request->get_tensor(m_inputs_by_name.at(name)));
+        }
+    }
+
+    // Sampled rows falling into this chunk, remembered with their position in
+    // the caller's sampled_tokens_indices order.
+    std::vector<int64_t> local_sti;
+    std::vector<std::size_t> out_rows;
+    for (std::size_t i = 0; i < d.sampled_tokens_indices.size(); ++i) {
+        const auto g = d.sampled_tokens_indices[i];
+        if (g >= global_start && g < global_start + n_chunk_tokens) {
+            local_sti.push_back(g - global_start);
+            out_rows.push_back(i);
+        }
+    }
+    set("sampled_tokens_indices", make_ctrl_tensor(chunk.inputs.at("sampled_tokens_indices"), local_sti));
+
+    // The logits row count is the number of sampled tokens, so the output port
+    // stays dynamic and the executing request cannot allocate it on its own
+    // (NPUW in particular sizes unset outputs from the port's static shape).
+    // The row count is known right here, so pre-set an exact-sized tensor.
+    const auto& oshape = m_chunked_logits->get_shape();
+    const auto out = ov::get_tensor_impl(
+        ov::Tensor(m_chunked_logits->get_element_type(), ov::Shape{local_sti.size(), oshape.at(1), oshape.at(2)}));
+    chunk.request->set_tensor(chunk.logits, out);
+
+    chunk.request->infer();
+
+    if (out_rows.empty()) {
+        return;
+    }
+    const auto row_bytes = oshape.at(1) * oshape.at(2) * m_chunked_logits->get_element_type().size();
+    const auto* src = static_cast<const uint8_t*>(out->data());
+    auto* dst = static_cast<uint8_t*>(m_chunked_logits->data());
+    for (std::size_t j = 0; j < out_rows.size(); ++j) {
+        std::memcpy(dst + out_rows[j] * row_bytes, src + j * row_bytes, row_bytes);
+    }
+}
+
+void ov::npuw::PAInferRequest::infer_chunked(const pa::Dispatch& d) {
+    // One logits row per sampled token, in the caller's order.
+    const auto& logits_port = get_outputs().front();
+    const auto& lshape = logits_port.get_partial_shape();
+    m_chunked_logits = ov::get_tensor_impl(ov::Tensor(logits_port.get_element_type(),
+                                                      ov::Shape{d.sampled_tokens_indices.size(),
+                                                                static_cast<std::size_t>(lshape[1].get_length()),
+                                                                static_cast<std::size_t>(lshape[2].get_length())}));
+
+    const bool verbose = ov::npuw::get_log_level() >= ov::npuw::LogLevel::Verbose;
+    std::ostringstream plan;
+
+    for (int64_t s = 0; s < d.sequences(); ++s) {
+        const auto seq_len = d.subsequence_begins[s + 1] - d.subsequence_begins[s];
+        int64_t off = 0;
+        if (verbose) {
+            plan << (s ? "; " : "") << "seq" << s << "=";
+        }
+        while (off < seq_len) {
+            const auto remaining = seq_len - off;
+            // Largest variant that fits (m_chunk_requests is ordered largest
+            // first); the 1-token model is only right when exactly one token
+            // remains (the generation case). Everything else that no variant
+            // fits goes through the dynamic model.
+            std::size_t pick = 0u;
+            for (const auto& [token_dim, _] : m_chunk_requests) {
+                if (static_cast<int64_t>(token_dim) <= remaining && (token_dim > 1u || remaining == 1)) {
+                    pick = token_dim;
+                    break;
+                }
+            }
+            auto& chunk = pick ? m_chunk_requests.at(pick) : m_tail_request;
+            const auto n = pick ? static_cast<int64_t>(pick) : remaining;
+            if (verbose) {
+                plan << (off ? "+" : "") << (pick ? "" : "dyn:") << n;
+            }
+            run_chunk(chunk, d, s, off, n);
+            off += n;
+        }
+    }
+    if (verbose) {
+        LOG_VERB("PA dispatch #" << m_dispatch_idx << ": chunked " << plan.str());
+    }
+}
+
+void ov::npuw::PAInferRequest::log_dispatch_io(bool outputs) const {
+    if (ov::npuw::get_log_level() < ov::npuw::LogLevel::Verbose) {
+        return;
+    }
+    LOG_VERB("PA dispatch #" << m_dispatch_idx << (outputs ? " outputs:" : " inputs:"));
+    LOG_BLOCK();
+    for (const auto& port : outputs ? get_outputs() : get_inputs()) {
+        const auto& name = port.get_any_name();
+        // On the chunked path the inner request was not inferred; the result
+        // lives in m_chunked_logits (the model's single output).
+        const auto tensor = outputs && m_serve_chunked_logits ? m_chunked_logits : m_inner_request->get_tensor(port);
+        LOG_VERB(name << ": " << tensor_brief(tensor, !ov::npuw::util::is_pa_kv_cache_name(name)));
+    }
+}
+
 void ov::npuw::PAInferRequest::infer() {
+    log_dispatch_io(/*outputs=*/false);
     const auto dispatch = parse_dispatch();
     pa::validate_dispatch(dispatch, m_block_size, m_dispatch_idx);
     LOG_VERB("PA dispatch #" << m_dispatch_idx << ": " << dispatch.sequences() << " subsequence(s), "
                              << dispatch.tokens() << " token(s), " << dispatch.sampled_tokens_indices.size()
                              << " sampled");
-    m_inner_request->infer();
+    // Chunkability of the model was decided at compile time (variants exist
+    // only for the plain flat-token contract); an empty dispatch runs 1:1.
+    if (!m_chunk_requests.empty() && dispatch.tokens() > 0) {
+        infer_chunked(dispatch);
+        m_serve_chunked_logits = true;
+    } else {
+        m_serve_chunked_logits = false;
+        m_inner_request->infer();
+    }
+    log_dispatch_io(/*outputs=*/true);
     ++m_dispatch_idx;
 }
 
 ov::SoPtr<ov::ITensor> ov::npuw::PAInferRequest::get_tensor(const ov::Output<const ov::Node>& port) const {
+    if (m_serve_chunked_logits && port.get_node() == m_logits_node) {
+        return m_chunked_logits;
+    }
     return m_inner_request->get_tensor(port);
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
@@ -4,15 +4,38 @@
 
 #include "pa_compiled_model.hpp"
 
+#include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "intel_npu/config/npuw.hpp"
 #include "logging.hpp"
 #include "openvino/runtime/iplugin.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "util.hpp"
+
+namespace {
+
+// The PA control tensors are small i32/i64 vectors -- widen to i64 for checks.
+std::vector<int64_t> as_i64_vec(const ov::SoPtr<ov::ITensor>& tensor) {
+    const auto n = tensor->get_size();
+    std::vector<int64_t> out(n);
+    if (tensor->get_element_type() == ov::element::i32) {
+        const auto* data = tensor->data<int32_t>();
+        std::copy_n(data, n, out.begin());
+    } else if (tensor->get_element_type() == ov::element::i64) {
+        const auto* data = tensor->data<int64_t>();
+        std::copy_n(data, n, out.begin());
+    } else {
+        OPENVINO_THROW("PA: unexpected element type ", tensor->get_element_type(), " for a control tensor");
+    }
+    return out;
+}
+
+}  // anonymous namespace
 
 ov::npuw::PACompiledModel::PACompiledModel(const std::shared_ptr<ov::Model>& model,
                                            const std::shared_ptr<const ov::IPlugin>& plugin,
@@ -56,6 +79,21 @@ ov::npuw::PACompiledModel::PACompiledModel(const std::shared_ptr<ov::Model>& mod
     LOG_INFO("PA: compiling the dynamic PA model 1:1 on " << device);
     m_compiled_model = plugin->get_core()->compile_model(model, device, inner_config);
     OPENVINO_ASSERT(m_compiled_model != nullptr, "PACompiledModel requires a valid inner compiled model");
+
+    // The device fixes the KV cache geometry at compile time; remember the
+    // block size for validating block-table coverage per dispatch. Identical
+    // across layers by construction, so the first cache input answers it.
+    for (const auto& input : m_compiled_model->inputs()) {
+        if (ov::npuw::util::is_pa_key_cache_name(input.get_any_name())) {
+            const auto& shape = input.get_partial_shape();
+            // [num_blocks (dyn), kv_heads, block_size, head_size]
+            if (shape.rank().is_static() && shape.rank().get_length() == 4 && shape[2].is_static()) {
+                m_block_size = static_cast<std::size_t>(shape[2].get_length());
+            }
+            break;
+        }
+    }
+    LOG_INFO("PA: KV block_size fixed by " << device << ": " << m_block_size);
 }
 
 const std::vector<ov::Output<const ov::Node>>& ov::npuw::PACompiledModel::inputs() const {
@@ -106,16 +144,67 @@ std::shared_ptr<ov::ISyncInferRequest> ov::npuw::PACompiledModel::create_sync_in
     auto self = std::static_pointer_cast<const ov::ICompiledModel>(shared_from_this());
     auto inner_request = m_compiled_model->create_infer_request();
     OPENVINO_ASSERT(inner_request != nullptr, "PACompiledModel requires a valid inner infer request");
-    return std::make_shared<PAInferRequest>(self, std::move(inner_request));
+    return std::make_shared<PAInferRequest>(self, std::move(inner_request), m_block_size);
 }
 
 ov::npuw::PAInferRequest::PAInferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
-                                         ov::SoPtr<ov::IAsyncInferRequest> inner_request)
+                                         ov::SoPtr<ov::IAsyncInferRequest> inner_request,
+                                         std::size_t block_size)
     : ov::ISyncInferRequest(compiled_model),
-      m_inner_request(std::move(inner_request)) {}
+      m_inner_request(std::move(inner_request)),
+      m_block_size(block_size) {
+    for (const auto& input : get_inputs()) {
+        m_inputs_by_name.emplace(input.get_any_name(), input);
+    }
+}
+
+ov::npuw::pa::Dispatch ov::npuw::PAInferRequest::parse_dispatch() const {
+    const auto get = [&](const char* name) {
+        auto it = m_inputs_by_name.find(name);
+        OPENVINO_ASSERT(it != m_inputs_by_name.end(), "PA model has no '", name, "' input");
+        return m_inner_request->get_tensor(it->second);
+    };
+
+    pa::Dispatch d;
+    d.past_lens = as_i64_vec(get("past_lens"));
+    d.subsequence_begins = as_i64_vec(get("subsequence_begins"));
+    const auto mcl_vec = as_i64_vec(get("max_context_len"));
+    OPENVINO_ASSERT(!mcl_vec.empty(), "PA dispatch: max_context_len is not set");
+    d.max_context_len = mcl_vec.front();
+
+    // input_ids is absent on embedding-input models (inputs_embeds);
+    // position_ids may be multi-dimensional (M-RoPE), so its token count is
+    // the last shape dim.
+    if (m_inputs_by_name.count("input_ids") > 0) {
+        d.input_ids_size = static_cast<int64_t>(get("input_ids")->get_size());
+    }
+    const auto& pos_shape = get("position_ids")->get_shape();
+    OPENVINO_ASSERT(!pos_shape.empty(), "PA dispatch: position_ids has no shape");
+    d.position_ids_token_count = static_cast<int64_t>(pos_shape.back());
+
+    // The shared block table. Cache-eviction models carry per-layer
+    // block_indices.<L> inputs instead; those dispatches run 1:1 and only the
+    // common controls are validated.
+    if (m_inputs_by_name.count("block_indices") > 0) {
+        d.has_block_table = true;
+        d.block_indices = as_i64_vec(get("block_indices"));
+        d.block_indices_begins = as_i64_vec(get("block_indices_begins"));
+    }
+    if (m_inputs_by_name.count("sampled_tokens_indices") > 0) {
+        d.has_sampled_tokens = true;
+        d.sampled_tokens_indices = as_i64_vec(get("sampled_tokens_indices"));
+    }
+    return d;
+}
 
 void ov::npuw::PAInferRequest::infer() {
+    const auto dispatch = parse_dispatch();
+    pa::validate_dispatch(dispatch, m_block_size, m_dispatch_idx);
+    LOG_VERB("PA dispatch #" << m_dispatch_idx << ": " << dispatch.sequences() << " subsequence(s), "
+                             << dispatch.tokens() << " token(s), " << dispatch.sampled_tokens_indices.size()
+                             << " sampled");
     m_inner_request->infer();
+    ++m_dispatch_idx;
 }
 
 ov::SoPtr<ov::ITensor> ov::npuw::PAInferRequest::get_tensor(const ov::Output<const ov::Node>& port) const {

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -43,6 +44,11 @@ private:
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
 
     ov::SoPtr<ov::ICompiledModel> m_compiled_model;
+
+    // Pre-compiled semi-static token-size variants keyed by fixed token dim
+    // (1024, 128, 1); consumed by the chunked dispatcher landing in the next
+    // change of this series.
+    std::map<std::size_t, ov::SoPtr<ov::ICompiledModel>> m_semi_static_models;
 
     // KV cache block size as fixed by the device at compile time; 0 if the
     // compiled cache shape is still dynamic in that dimension. Consumed by

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "npuw/compiled_model.hpp"
 #include "pa_dispatch.hpp"
@@ -117,6 +118,8 @@ private:
     // m_inner_request, which holds the caller's dispatch tensors and stays
     // untouched by chunked execution.
     std::map<std::size_t, ChunkRequest, std::greater<std::size_t>> m_chunk_requests;
+    // The variants' fixed token sizes, for the pa::variants_serve routing call.
+    std::vector<std::size_t> m_variant_token_dims;
     ChunkRequest m_tail_request;
 
     // Chunked-execution result for the current dispatch; get_tensor() serves

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -46,8 +47,7 @@ private:
     ov::SoPtr<ov::ICompiledModel> m_compiled_model;
 
     // Pre-compiled semi-static token-size variants keyed by fixed token dim
-    // (1024, 128, 1); consumed by the chunked dispatcher landing in the next
-    // change of this series.
+    // (1024, 128, 1); the infer request dispatches token chunks onto these.
     std::map<std::size_t, ov::SoPtr<ov::ICompiledModel>> m_semi_static_models;
 
     // KV cache block size as fixed by the device at compile time; 0 if the
@@ -56,16 +56,25 @@ private:
     std::size_t m_block_size = 0u;
 };
 
-// 1:1 forwarding request. The ports are shared with the inner request (see
-// PACompiledModel), so every call delegates without translation. Each
-// dispatch is first validated against the PA control-tensor contract
-// (past_lens / subsequence_begins / block_indices(_begins) / max_context_len
-// / sampled_tokens_indices) and summarised at the Verbose log level.
+// The dispatching request. The ports are shared with the inner request (see
+// PACompiledModel), so tensors travel between the request levels without
+// translation. Each dispatch is validated against the PA control-tensor
+// contract (past_lens / subsequence_begins / block_indices(_begins) /
+// max_context_len / sampled_tokens_indices), then executed per subsequence by
+// greedily routing token chunks through the pre-compiled semi-static variants
+// (largest first; the 1-token variant serves the generation case). A residual
+// chunk that no static size fits, or any dispatch outside the supported input
+// contract, goes through the dynamic base model unchanged.
+//
+// Chunks only fix the activation size -- the context stays dynamic, so the
+// KV cache is always addressed through the caller's block tables and no
+// padding is ever written.
 class PAInferRequest final : public ov::ISyncInferRequest {
 public:
     PAInferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
                    ov::SoPtr<ov::IAsyncInferRequest> inner_request,
-                   std::size_t block_size);
+                   std::size_t block_size,
+                   const std::map<std::size_t, ov::SoPtr<ov::ICompiledModel>>& variants);
 
     void infer() override;
 
@@ -77,16 +86,48 @@ public:
     std::vector<ov::ProfilingInfo> get_profiling_info() const override;
 
 private:
+    // A chunk-capable request (semi-static variant or the dynamic tail
+    // request) with its ports resolved by name once.
+    struct ChunkRequest {
+        ov::SoPtr<ov::IAsyncInferRequest> request;
+        std::unordered_map<std::string, ov::Output<const ov::Node>> inputs;
+        ov::Output<const ov::Node> logits;
+    };
+
     // Copies one dispatch's control tensors out of the inner request.
     pa::Dispatch parse_dispatch() const;
+    // Per-dispatch I/O trace (Verbose): one line per input (or output) tensor
+    // with a compact data digest.
+    void log_dispatch_io(bool outputs) const;
+
+    void infer_chunked(const pa::Dispatch& d);
+    // Executes `n_chunk_tokens` of subsequence `seq` starting at token
+    // `seq_offset` on `chunk`, scattering any sampled logits rows into
+    // m_chunked_logits.
+    void run_chunk(ChunkRequest& chunk, const pa::Dispatch& d, int64_t seq, int64_t seq_offset, int64_t n_chunk_tokens);
 
     ov::SoPtr<ov::IAsyncInferRequest> m_inner_request;
 
     // Input ports by tensor name, for reading the control tensors.
     std::unordered_map<std::string, ov::Output<const ov::Node>> m_inputs_by_name;
     std::size_t m_block_size = 0u;
-    // Only infer() touches this, and the async layer serializes infer() per
-    // request, so no lock is needed.
+
+    // Semi-static chunk requests keyed by token size, largest first, plus a
+    // dynamic request for residual chunks. These are separate from
+    // m_inner_request, which holds the caller's dispatch tensors and stays
+    // untouched by chunked execution.
+    std::map<std::size_t, ChunkRequest, std::greater<std::size_t>> m_chunk_requests;
+    ChunkRequest m_tail_request;
+
+    // Chunked-execution result for the current dispatch; get_tensor() serves
+    // it instead of the (not inferred) inner request's logits.
+    ov::SoPtr<ov::ITensor> m_chunked_logits;
+    bool m_serve_chunked_logits = false;
+    const ov::Node* m_logits_node = nullptr;
+
+    // Only infer() and the get_tensor() of the caller consuming its results
+    // touch the members above, under the usual one-request-one-user contract,
+    // so no lock is needed.
     std::size_t m_dispatch_idx = 0u;
 };
 

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.hpp
@@ -4,9 +4,13 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "npuw/compiled_model.hpp"
+#include "pa_dispatch.hpp"
 
 namespace ov::npuw {
 
@@ -39,16 +43,23 @@ private:
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
 
     ov::SoPtr<ov::ICompiledModel> m_compiled_model;
+
+    // KV cache block size as fixed by the device at compile time; 0 if the
+    // compiled cache shape is still dynamic in that dimension. Consumed by
+    // the per-dispatch block-table validation.
+    std::size_t m_block_size = 0u;
 };
 
 // 1:1 forwarding request. The ports are shared with the inner request (see
-// PACompiledModel), so every call delegates without translation, and the
-// request holds no state of its own -- it provides exactly the guarantees of
-// using the inner request directly.
+// PACompiledModel), so every call delegates without translation. Each
+// dispatch is first validated against the PA control-tensor contract
+// (past_lens / subsequence_begins / block_indices(_begins) / max_context_len
+// / sampled_tokens_indices) and summarised at the Verbose log level.
 class PAInferRequest final : public ov::ISyncInferRequest {
 public:
     PAInferRequest(const std::shared_ptr<const ov::ICompiledModel>& compiled_model,
-                   ov::SoPtr<ov::IAsyncInferRequest> inner_request);
+                   ov::SoPtr<ov::IAsyncInferRequest> inner_request,
+                   std::size_t block_size);
 
     void infer() override;
 
@@ -60,7 +71,17 @@ public:
     std::vector<ov::ProfilingInfo> get_profiling_info() const override;
 
 private:
+    // Copies one dispatch's control tensors out of the inner request.
+    pa::Dispatch parse_dispatch() const;
+
     ov::SoPtr<ov::IAsyncInferRequest> m_inner_request;
+
+    // Input ports by tensor name, for reading the control tensors.
+    std::unordered_map<std::string, ov::Output<const ov::Node>> m_inputs_by_name;
+    std::size_t m_block_size = 0u;
+    // Only infer() touches this, and the async layer serializes infer() per
+    // request, so no lock is needed.
+    std::size_t m_dispatch_idx = 0u;
 };
 
 }  // namespace ov::npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "pa_dispatch.hpp"
+
+#include <algorithm>
+
+#include "openvino/core/except.hpp"
+
+void ov::npuw::pa::validate_dispatch(const Dispatch& d, std::size_t block_size, std::size_t dispatch_idx) {
+    const auto expect = [&](bool cond, const char* what) {
+        OPENVINO_ASSERT(cond, "PA dispatch #", dispatch_idx, " violates the PA model expectations: ", what);
+    };
+
+    const auto& past = d.past_lens;
+    const auto& sub = d.subsequence_begins;
+    const auto n_seqs = d.sequences();
+    const auto n_tokens = d.tokens();
+
+    // input_ids is absent on embedding-input models (inputs_embeds), so it is
+    // only cross-checked when present; position_ids may be multi-dimensional
+    // (M-RoPE), so its token count is the last shape dim.
+    if (d.input_ids_size >= 0) {
+        expect(d.input_ids_size == n_tokens, "input_ids size != subsequence_begins token count");
+    }
+    expect(d.position_ids_token_count == n_tokens, "position_ids last dim != subsequence_begins token count");
+    expect(static_cast<int64_t>(sub.size()) == n_seqs + 1, "subsequence_begins size != past_lens size + 1");
+    expect(sub.front() == 0, "subsequence_begins does not start at 0");
+    expect(std::is_sorted(sub.begin(), sub.end()) && std::adjacent_find(sub.begin(), sub.end()) == sub.end(),
+           "subsequence_begins is not strictly increasing");
+
+    // The shared block table. Cache-eviction models carry per-layer
+    // block_indices.<L> inputs instead; those dispatches run 1:1 and only the
+    // common controls above are validated.
+    if (d.has_block_table) {
+        const auto& bib = d.block_indices_begins;
+        expect(static_cast<int64_t>(bib.size()) == n_seqs + 1, "block_indices_begins size != past_lens size + 1");
+        expect(bib.front() == 0 && bib.back() == static_cast<int64_t>(d.block_indices.size()) &&
+                   std::is_sorted(bib.begin(), bib.end()),
+               "block_indices_begins is not a prefix-sum over block_indices");
+    }
+
+    // Per-subsequence: the provided blocks must cover past + scheduled tokens,
+    // and max_context_len bounds every context.
+    for (int64_t s = 0; s < n_seqs; ++s) {
+        const auto ctx_after = past[s] + (sub[s + 1] - sub[s]);
+        expect(past[s] >= 0, "negative past_lens entry");
+        expect(d.max_context_len >= ctx_after, "max_context_len < a subsequence's context length");
+        if (d.has_block_table && block_size > 0) {
+            expect((d.block_indices_begins[s + 1] - d.block_indices_begins[s]) * static_cast<int64_t>(block_size) >=
+                       ctx_after,
+                   "block_indices do not cover a subsequence's context");
+        }
+    }
+
+    // Gather contract: sampled_tokens_indices picks which flat token rows get
+    // logits; an empty selection is legal (intermediate prefill chunks).
+    if (d.has_sampled_tokens) {
+        for (auto idx : d.sampled_tokens_indices) {
+            expect(idx >= 0 && idx < n_tokens, "sampled_tokens_indices out of token range");
+        }
+    }
+}

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.cpp
@@ -62,3 +62,30 @@ void ov::npuw::pa::validate_dispatch(const Dispatch& d, std::size_t block_size, 
         }
     }
 }
+
+bool ov::npuw::pa::variants_serve(const Dispatch& dispatch, const std::vector<std::size_t>& variant_token_dims) {
+    if (variant_token_dims.empty() || dispatch.tokens() == 0) {
+        return false;
+    }
+
+    bool has_one_token_variant = false;
+    std::size_t min_multi_token = 0u;
+    for (const auto token_dim : variant_token_dims) {
+        has_one_token_variant |= (token_dim == 1u);
+        if (token_dim > 1u && (min_multi_token == 0u || token_dim < min_multi_token)) {
+            min_multi_token = token_dim;
+        }
+    }
+
+    if (dispatch.sequences() == 1 && dispatch.tokens() == 1) {
+        return has_one_token_variant;
+    }
+
+    for (int64_t s = 0; min_multi_token > 0u && s < dispatch.sequences(); ++s) {
+        const auto seq_len = dispatch.subsequence_begins[s + 1] - dispatch.subsequence_begins[s];
+        if (seq_len >= static_cast<int64_t>(min_multi_token)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.hpp
@@ -40,4 +40,14 @@ struct Dispatch {
 // dispatch_idx only labels the error message.
 void validate_dispatch(const Dispatch& dispatch, std::size_t block_size, std::size_t dispatch_idx);
 
+// Decides whether a dispatch runs on the pre-compiled semi-static variants
+// (chunked, per subsequence) or 1:1 on the dynamic model, given the variants'
+// fixed token sizes. The dynamic model handles the whole flat dispatch in a
+// single infer, so chunking must earn its decomposition: a dispatch qualifies
+// when some subsequence can fill a multi-token variant, or when it is a
+// single-sequence decode - the 1-token variant's own case, one infer either
+// way. A decode batch and a short prefill run 1:1, where per-subsequence
+// calls would only serialize them.
+bool variants_serve(const Dispatch& dispatch, const std::vector<std::size_t>& variant_token_dims);
+
 }  // namespace ov::npuw::pa

--- a/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.hpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace ov::npuw::pa {
+
+// One dispatch's control tensors, parsed out of the infer request. The
+// vectors are plain copies of the (small, integer) PA control inputs, which
+// keeps the validation below a pure function over host data.
+struct Dispatch {
+    std::vector<int64_t> past_lens;
+    std::vector<int64_t> subsequence_begins;
+    std::vector<int64_t> block_indices;           // meaningful when has_block_table
+    std::vector<int64_t> block_indices_begins;    // meaningful when has_block_table
+    std::vector<int64_t> sampled_tokens_indices;  // meaningful when has_sampled_tokens
+    int64_t max_context_len = 0;
+    int64_t input_ids_size = -1;           // -1 when the model has no input_ids input
+    int64_t position_ids_token_count = 0;  // last dim of position_ids
+    bool has_block_table = false;
+    bool has_sampled_tokens = false;
+
+    // subsequence_begins is the source of truth for the flat token dimension.
+    int64_t tokens() const {
+        return subsequence_begins.empty() ? int64_t{0} : subsequence_begins.back();
+    }
+    int64_t sequences() const {
+        return static_cast<int64_t>(past_lens.size());
+    }
+};
+
+// Validates one dispatch against the PA model expectations; throws with a
+// specific message on the first violation. A block_size of 0 means the cache
+// block geometry is still dynamic, and block-table coverage is not checked.
+// dispatch_idx only labels the error message.
+void validate_dispatch(const Dispatch& dispatch, std::size_t block_size, std::size_t dispatch_idx);
+
+}  // namespace ov::npuw::pa

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -953,8 +953,12 @@ bool ov::npuw::util::starts_with_past_lincache(const std::string& input_name) {
 }
 
 bool ov::npuw::util::is_pa_kv_cache_name(const std::string& input_name) {
-    return ov::npuw::util::starts_with(input_name, "key_cache.") ||
+    return ov::npuw::util::is_pa_key_cache_name(input_name) ||
            ov::npuw::util::starts_with(input_name, "value_cache.");
+}
+
+bool ov::npuw::util::is_pa_key_cache_name(const std::string& input_name) {
+    return ov::npuw::util::starts_with(input_name, "key_cache.");
 }
 void ov::npuw::util::fill_tensor_bytes(ov::SoPtr<ov::ITensor> tensor, uint8_t fill_val) {
     auto* tensor_data = reinterpret_cast<uint8_t*>(tensor->data());

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -231,6 +231,10 @@ bool starts_with_past_lincache(const std::string& input_name);
 // by the SDPAToPagedAttention transformation).
 bool is_pa_kv_cache_name(const std::string& input_name);
 
+// Matches the key half only (key_cache.N) -- the key cache carries the block
+// geometry the device fixes at compile time.
+bool is_pa_key_cache_name(const std::string& input_name);
+
 // Structure to hold SDPA pattern nodes.
 // After SplitKVCacheIntoBlocks the single past_key / past_value parameter is
 // replaced by N block parameters, so both param-node fields are vectors.

--- a/src/plugins/intel_npu/src/plugin/sources.cmake
+++ b/src/plugins/intel_npu/src/plugin/sources.cmake
@@ -158,6 +158,8 @@ set(NPUW_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/orc/schema_npuw.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_compiled_model.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_compiled_model.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_dispatch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_dispatch.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/compiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/compiler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning/online/graph.cpp

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -52,6 +52,7 @@ ov_add_test_target(
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/flux2_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/gqa_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/pa_compiled_model.cpp
+            ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/pa_dispatch.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model_utils.cpp
             ${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -171,6 +172,7 @@ target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/model_builder_lora_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/partitioning_options_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/npuw_options_smoke_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pa_dispatch_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/pre_compute_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/resolve_dynamic_quant_storage_types_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/orc.cpp

--- a/src/plugins/intel_npu/tests/unit/npuw/pa_dispatch_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pa_dispatch_test.cpp
@@ -1,0 +1,170 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Unit tests for the PA dispatch-contract validation (ov::npuw::pa). The
+// contract is a pure function over the parsed control tensors, so the tests
+// construct Dispatch values directly and assert on the specific violation
+// each malformed dispatch must report.
+
+#include "pa_dispatch.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "openvino/core/except.hpp"
+
+namespace {
+
+using ov::npuw::pa::Dispatch;
+using ov::npuw::pa::validate_dispatch;
+
+// A well-formed two-subsequence dispatch: 4 + 2 scheduled tokens on top of
+// 0 / 6 past tokens, a covering block table (block_size 4) and one sampled
+// token per subsequence.
+Dispatch make_valid_dispatch() {
+    Dispatch d;
+    d.past_lens = {0, 6};
+    d.subsequence_begins = {0, 4, 6};
+    d.block_indices = {0, 1, 2};
+    d.block_indices_begins = {0, 1, 3};
+    d.sampled_tokens_indices = {3, 5};
+    d.max_context_len = 8;
+    d.input_ids_size = 6;
+    d.position_ids_token_count = 6;
+    d.has_block_table = true;
+    d.has_sampled_tokens = true;
+    return d;
+}
+
+constexpr std::size_t kBlockSize = 4u;
+
+void expect_violation(const Dispatch& d, const std::string& what, std::size_t block_size = kBlockSize) {
+    try {
+        validate_dispatch(d, block_size, 0u);
+        FAIL() << "expected a dispatch-contract violation: " << what;
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(std::string(ex.what()).find(what), std::string::npos) << ex.what();
+    }
+}
+
+TEST(PADispatchContract, ValidDispatchPasses) {
+    EXPECT_NO_THROW(validate_dispatch(make_valid_dispatch(), kBlockSize, 0u));
+}
+
+TEST(PADispatchContract, TokenAndSequenceCountsDerive) {
+    const auto d = make_valid_dispatch();
+    EXPECT_EQ(d.tokens(), 6);
+    EXPECT_EQ(d.sequences(), 2);
+}
+
+// input_ids is absent on embedding-input models; -1 skips the cross-check.
+TEST(PADispatchContract, AbsentInputIdsIsLegal) {
+    auto d = make_valid_dispatch();
+    d.input_ids_size = -1;
+    EXPECT_NO_THROW(validate_dispatch(d, kBlockSize, 0u));
+}
+
+TEST(PADispatchContract, InputIdsSizeMismatchRejected) {
+    auto d = make_valid_dispatch();
+    d.input_ids_size = 5;
+    expect_violation(d, "input_ids size != subsequence_begins token count");
+}
+
+TEST(PADispatchContract, PositionIdsCountMismatchRejected) {
+    auto d = make_valid_dispatch();
+    d.position_ids_token_count = 7;
+    expect_violation(d, "position_ids last dim != subsequence_begins token count");
+}
+
+TEST(PADispatchContract, SubsequenceBeginsSizeMismatchRejected) {
+    auto d = make_valid_dispatch();
+    d.past_lens = {0};  // now sub.size() != past.size() + 1
+    expect_violation(d, "subsequence_begins size != past_lens size + 1");
+}
+
+TEST(PADispatchContract, SubsequenceBeginsMustStartAtZero) {
+    auto d = make_valid_dispatch();
+    d.subsequence_begins = {1, 4, 6};
+    expect_violation(d, "subsequence_begins does not start at 0");
+}
+
+TEST(PADispatchContract, SubsequenceBeginsMustStrictlyIncrease) {
+    auto d = make_valid_dispatch();
+    d.subsequence_begins = {0, 4, 4};
+    d.input_ids_size = 4;
+    d.position_ids_token_count = 4;
+    d.sampled_tokens_indices = {3, 3};
+    expect_violation(d, "subsequence_begins is not strictly increasing");
+}
+
+TEST(PADispatchContract, NegativePastLenRejected) {
+    auto d = make_valid_dispatch();
+    d.past_lens = {0, -1};
+    expect_violation(d, "negative past_lens entry");
+}
+
+TEST(PADispatchContract, MaxContextLenMustBoundEveryContext) {
+    auto d = make_valid_dispatch();
+    d.max_context_len = 7;  // subsequence 1 context is 6 past + 2 scheduled = 8
+    expect_violation(d, "max_context_len < a subsequence's context length");
+}
+
+TEST(PADispatchContract, BlockIndicesBeginsMustBePrefixSum) {
+    auto d = make_valid_dispatch();
+    d.block_indices_begins = {0, 1, 2};  // back() != block_indices.size()
+    expect_violation(d, "block_indices_begins is not a prefix-sum over block_indices");
+}
+
+TEST(PADispatchContract, BlocksMustCoverEachContext) {
+    auto d = make_valid_dispatch();
+    d.block_indices = {0, 1};
+    d.block_indices_begins = {0, 1, 2};  // one block (4 slots) for a context of 8
+    expect_violation(d, "block_indices do not cover a subsequence's context");
+}
+
+// A block_size of 0 means the cache geometry is still dynamic; coverage is
+// not checked, everything else still is.
+TEST(PADispatchContract, DynamicBlockSizeSkipsCoverageOnly) {
+    auto d = make_valid_dispatch();
+    d.block_indices = {0};
+    d.block_indices_begins = {0, 0, 1};
+    EXPECT_NO_THROW(validate_dispatch(d, 0u, 0u));
+    d.max_context_len = 7;
+    expect_violation(d, "max_context_len < a subsequence's context length", 0u);
+}
+
+TEST(PADispatchContract, AbsentBlockTableSkipsBlockChecks) {
+    auto d = make_valid_dispatch();
+    d.has_block_table = false;
+    d.block_indices.clear();
+    d.block_indices_begins.clear();
+    EXPECT_NO_THROW(validate_dispatch(d, kBlockSize, 0u));
+}
+
+// An empty selection is legal (intermediate prefill chunks gather nothing).
+TEST(PADispatchContract, EmptySampledTokensIsLegal) {
+    auto d = make_valid_dispatch();
+    d.sampled_tokens_indices.clear();
+    EXPECT_NO_THROW(validate_dispatch(d, kBlockSize, 0u));
+}
+
+TEST(PADispatchContract, SampledTokensOutOfRangeRejected) {
+    auto d = make_valid_dispatch();
+    d.sampled_tokens_indices = {6};
+    expect_violation(d, "sampled_tokens_indices out of token range");
+}
+
+TEST(PADispatchContract, ViolationNamesTheDispatch) {
+    auto d = make_valid_dispatch();
+    d.past_lens = {0, -1};
+    try {
+        validate_dispatch(d, kBlockSize, 7u);
+        FAIL() << "expected a dispatch-contract violation";
+    } catch (const ov::Exception& ex) {
+        EXPECT_NE(std::string(ex.what()).find("PA dispatch #7"), std::string::npos) << ex.what();
+    }
+}
+
+}  // namespace

--- a/src/plugins/intel_npu/tests/unit/npuw/pa_dispatch_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pa_dispatch_test.cpp
@@ -19,6 +19,7 @@ namespace {
 
 using ov::npuw::pa::Dispatch;
 using ov::npuw::pa::validate_dispatch;
+using ov::npuw::pa::variants_serve;
 
 // A well-formed two-subsequence dispatch: 4 + 2 scheduled tokens on top of
 // 0 / 6 past tokens, a covering block table (block_size 4) and one sampled
@@ -165,6 +166,48 @@ TEST(PADispatchContract, ViolationNamesTheDispatch) {
     } catch (const ov::Exception& ex) {
         EXPECT_NE(std::string(ex.what()).find("PA dispatch #7"), std::string::npos) << ex.what();
     }
+}
+
+// A dispatch shaped as N subsequences of the given scheduled lengths; only the
+// fields variants_serve reads are populated.
+Dispatch make_dispatch_of(const std::vector<int64_t>& seq_lens) {
+    Dispatch d;
+    d.subsequence_begins = {0};
+    for (const auto len : seq_lens) {
+        d.past_lens.push_back(0);
+        d.subsequence_begins.push_back(d.subsequence_begins.back() + len);
+    }
+    return d;
+}
+
+const std::vector<std::size_t> kVariantDims = {1024u, 128u, 1u};
+
+TEST(PADispatchRouting, SingleSequenceDecodeServedByTheOneTokenVariant) {
+    EXPECT_TRUE(variants_serve(make_dispatch_of({1}), kVariantDims));
+    EXPECT_FALSE(variants_serve(make_dispatch_of({1}), {1024u, 128u}));
+}
+
+TEST(PADispatchRouting, DecodeBatchRunsOneToOne) {
+    EXPECT_FALSE(variants_serve(make_dispatch_of({1, 1, 1, 1}), kVariantDims));
+}
+
+TEST(PADispatchRouting, ShortPrefillRunsOneToOne) {
+    EXPECT_FALSE(variants_serve(make_dispatch_of({32, 32, 32, 32}), kVariantDims));
+    EXPECT_FALSE(variants_serve(make_dispatch_of({127}), kVariantDims));
+}
+
+TEST(PADispatchRouting, LongPrefillIsChunked) {
+    EXPECT_TRUE(variants_serve(make_dispatch_of({128}), kVariantDims));
+    EXPECT_TRUE(variants_serve(make_dispatch_of({7638}), kVariantDims));
+}
+
+TEST(PADispatchRouting, MixedDispatchWithOneLongSubsequenceIsChunked) {
+    EXPECT_TRUE(variants_serve(make_dispatch_of({1, 1, 200, 1}), kVariantDims));
+}
+
+TEST(PADispatchRouting, NoVariantsOrNoTokensRunOneToOne) {
+    EXPECT_FALSE(variants_serve(make_dispatch_of({7638}), {}));
+    EXPECT_FALSE(variants_serve(make_dispatch_of({}), kVariantDims));
 }
 
 }  // namespace


### PR DESCRIPTION
### Details

Extends the PA front-end from #37282 with semi-static model derivation and chunked dispatch. A dynamic dispatch from GenAI's continuous-batching pipeline can now run across fixed token-size variants, with sampled logits assembled back into the caller's order.

- Validate dispatch controls before execution: token and subsequence counts, shared block-table coverage, context bounds, and sampled-token indices. Validation and routing are pure functions in `pa_dispatch.{hpp,cpp}` with device-independent unit tests.
- Derive 1024-, 128-, and 1-token variants by cloning the PA model and fixing only `input_ids` and `position_ids`. KV cache and context dimensions remain dynamic. Models outside the flat-token contract, including embedding inputs, M-RoPE, and per-layer block tables, skip variant compilation and run 1:1 on the dynamic model.
- Execute long subsequences largest-variant-first, using a dynamic request for residual tails. Rebase each chunk's controls, share the existing KV cache pools, and scatter sampled logits into one correctly sized output tensor.
- Preserve batching when the variants would only serialize the work. A dispatch is chunked when a subsequence fills a multi-token variant; single-sequence decode uses the 1-token variant. Decode batches and short prefills run as one dynamic inference.
- Add Verbose-level dispatch summaries, tensor digests, and chunk plans. Filter `DEVICE_ID` alongside NPU properties so an explicit NPU device ID is not forwarded to the CPU compile.

This stage executes the dynamic model and all variants on CPU through the NPUW PA front-end. NPU/CPU partitioning and layout changes are separate follow-up work. The derivation and dispatcher land together so the compiled variants have an execution path.

### Validation

Recorded validation of this branch on September 1:

- All 23 PA unit tests passed: 17 dispatch-contract tests and 6 routing tests.
- Traces confirmed a 7,638-token prefill split into `7 x 1024 + 3 x 128 + 86` dynamic-tail tokens, single-sequence decode through the 1-token variant, and batched decode/short prefills through the 1:1 path.
- The four-stream CPU CB regression returned to approximately 18 ms TPOT, matching the plain-CPU reference, after removing serial per-sequence decode dispatches.

Earlier Qwen3-0.6B int4 checks through `ContinuousBatchingPipeline` covered short, >128-token, and >1024-token prompts with deterministic repeated generation. Chunked and unchunked GEMM shapes can resolve greedy near-ties differently.

### Tickets

- CVS-190137: PA front-end PoC.
- CVS-190716: semi-static model derivation.
