### PR TITLE
[Template plugin] Fix Coverity NULL_FIELD dereference in infer_preprocess 

### DIFF
--- a/src/plugins/template/src/sync_infer_request.cpp
+++ b/src/plugins/template/src/sync_infer_request.cpp
@@ -198,7 +198,7 @@ void ov::template_plugin::InferRequest::infer_preprocess() {
                 get_template_model()->get_template_plugin()->m_backend->create_tensor(tensor->get_element_type(),
                                                                                       tensor->get_shape());
             auto backend_tensor_impl = ov::get_tensor_impl(m_backend_input_tensors[i]);
-            OPENVINO_ASSERT(backend_tensor_impl, "Failed to create backend tensor");
+            OPENVINO_ASSERT(backend_tensor_impl._ptr != nullptr, "Failed to create backend tensor");
             tensor->copy_to(backend_tensor_impl._ptr);
         }
     }

--- a/src/plugins/template/src/sync_infer_request.cpp
+++ b/src/plugins/template/src/sync_infer_request.cpp
@@ -198,7 +198,9 @@ void ov::template_plugin::InferRequest::infer_preprocess() {
                 get_template_model()->get_template_plugin()->m_backend->create_tensor(tensor->get_element_type(),
                                                                                       tensor->get_shape());
             auto backend_tensor_impl = ov::get_tensor_impl(m_backend_input_tensors[i]);
-            OPENVINO_ASSERT(backend_tensor_impl._ptr != nullptr, "Failed to create backend tensor");
+            OPENVINO_ASSERT(backend_tensor_impl, "Failed to create backend tensor");
+            // `OPENVINO_ASSERT' above guarantees `backend_tensor_impl._ptr' is non-null
+            // coverity[null_field:FALSE]
             tensor->copy_to(backend_tensor_impl._ptr);
         }
     }


### PR DESCRIPTION
### Details:
 - Follow up to https://jira.devtools.intel.com/browse/CVS-192629
 - Changed the assert to check `backend_tensor_impl._ptr != nullptr` directly so the checked expression matches the field being dereferenced.

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-193886
 
### AI Assistance:
 - *AI assistance used:  yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
