### PR TITLE
[ONNX] Qwen2.5-0.5B Fails on Conversion

### DIFF
--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -276,6 +276,37 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
     // Normalize axis to handle negative values
     axis = common::normalize_axis(node.get_description(), axis, src_x.get_partial_shape().rank());
 
+    const auto& input_shape = src_x.get_partial_shape();
+    const auto is_scale_compatible_with_axis = [&](int64_t candidate_axis) {
+        if (!scale_shape.is_static() || scale_shape.rank().get_length() != input_shape.rank().get_length() ||
+            input_shape[candidate_axis].get_length() % block_size != 0) {
+            return false;
+        }
+
+        for (int64_t i = 0; i < input_shape.rank().get_length(); ++i) {
+            const auto expected_dim =
+                i == candidate_axis ? input_shape[i].get_length() / block_size : input_shape[i].get_length();
+            if (scale_shape[i].get_length() != expected_dim) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    if (!is_scale_compatible_with_axis(axis)) {
+        int64_t compatible_axis = -1;
+        for (int64_t candidate_axis = 0; candidate_axis < input_shape.rank().get_length(); ++candidate_axis) {
+            if (is_scale_compatible_with_axis(candidate_axis)) {
+                FRONT_END_GENERAL_CHECK(compatible_axis == -1,
+                                        "DequantizeLinear scale shape is compatible with multiple blocked axes");
+                compatible_axis = candidate_axis;
+            }
+        }
+        if (compatible_axis != -1) {
+            axis = compatible_axis;
+        }
+    }
+
     // Check that dimension at axis is divisible by block_size
     FRONT_END_GENERAL_CHECK(src_x.get_shape()[axis] % block_size == 0,
                             "DequantizeLinear doesn't support case when dimension of X at axis ",
@@ -301,7 +332,6 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
     // - axis=0: [num_blocks, block_size, ...] with block_size at position 1
     // - axis>0: [..., num_blocks, block_size, ...] with block_size at position axis+1
     std::vector<size_t> target_shape_vector;
-    const auto& input_shape = src_x.get_partial_shape();
     for (int64_t i = 0; i < input_shape.rank().get_length(); i++) {
         if (i == axis) {
             // Always num_blocks first, then block_size

--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -20,6 +20,7 @@
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
+#include "openvino/util/log.hpp"
 #include "utils/common.hpp"
 #include "utils/reshape.hpp"
 using namespace ov::op;
@@ -284,15 +285,17 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
         }
 
         for (int64_t i = 0; i < input_shape.rank().get_length(); ++i) {
-            const auto expected_dim =
-                i == candidate_axis ? input_shape[i].get_length() / block_size : input_shape[i].get_length();
-            if (scale_shape[i].get_length() != expected_dim) {
+            const int64_t expected_dim = i == candidate_axis
+                                             ? static_cast<int64_t>(input_shape[i].get_length() / block_size)
+                                             : static_cast<int64_t>(input_shape[i].get_length());
+            if (static_cast<int64_t>(scale_shape[i].get_length()) != expected_dim) {
                 return false;
             }
         }
         return true;
     };
 
+    const auto declared_axis = axis;
     if (!is_scale_compatible_with_axis(axis)) {
         int64_t compatible_axis = -1;
         for (int64_t candidate_axis = 0; candidate_axis < input_shape.rank().get_length(); ++candidate_axis) {
@@ -303,6 +306,17 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
             }
         }
         if (compatible_axis != -1) {
+            FRONT_END_GENERAL_CHECK(declared_axis == 0 && compatible_axis == input_shape.rank().get_length() - 1,
+                                    "DequantizeLinear scale shape is incompatible with the declared axis");
+            OPENVINO_WARN("DequantizeLinear '",
+                          node.get_name(),
+                          "': declared axis ",
+                          declared_axis,
+                          " is inconsistent with the x_scale shape ",
+                          scale_shape,
+                          "; the model is not ONNX-conformant. Falling back to axis ",
+                          compatible_axis,
+                          ". Please re-export the model (CVS-191631).");
             axis = compatible_axis;
         }
     }

--- a/src/frontends/onnx/tests/models/dequantize_linear_21_invalid_non_inner_axis.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_21_invalid_non_inner_axis.prototxt
@@ -1,0 +1,54 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test_dequantize_21_invalid_non_inner_axis"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 4 }
+          dim { dim_value: 3 }
+        }
+      }
+    }
+  }
+  input {
+    name: "scale"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 2 }
+          dim { dim_value: 3 }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 4 }
+          dim { dim_value: 3 }
+        }
+      }
+    }
+  }
+  node {
+    input: "x"
+    input: "scale"
+    output: "y"
+    name: "DequantizeNode"
+    op_type: "DequantizeLinear"
+    attribute { name: "axis" i: 0 type: INT }
+    attribute { name: "block_size" i: 2 type: INT }
+  }
+}
+opset_import { version: 21 }

--- a/src/frontends/onnx/tests/models/dequantize_linear_21_invalid_nonzero_axis.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_21_invalid_nonzero_axis.prototxt
@@ -1,0 +1,54 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test_dequantize_21_invalid_nonzero_axis"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 3 }
+          dim { dim_value: 4 }
+        }
+      }
+    }
+  }
+  input {
+    name: "scale"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 3 }
+          dim { dim_value: 2 }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 3 }
+          dim { dim_value: 4 }
+        }
+      }
+    }
+  }
+  node {
+    input: "x"
+    input: "scale"
+    output: "y"
+    name: "DequantizeNode"
+    op_type: "DequantizeLinear"
+    attribute { name: "axis" i: 1 type: INT }
+    attribute { name: "block_size" i: 2 type: INT }
+  }
+}
+opset_import { version: 21 }

--- a/src/frontends/onnx/tests/models/dequantize_linear_21_nncf_axis.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_21_nncf_axis.prototxt
@@ -1,0 +1,51 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test_dequantize_21_nncf_axis"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 4 }
+        }
+      }
+    }
+  }
+  input {
+    name: "scale"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 2 }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim { dim_value: 2 }
+          dim { dim_value: 4 }
+        }
+      }
+    }
+  }
+  node {
+    input: "x"
+    input: "scale"
+    output: "y"
+    name: "DequantizeNode"
+    op_type: "DequantizeLinear"
+    attribute { name: "axis" i: 0 type: INT }
+    attribute { name: "block_size" i: 2 type: INT }
+  }
+}
+opset_import { version: 21 }

--- a/src/frontends/onnx/tests/onnx_import_quant.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_quant.in.cpp
@@ -532,6 +532,16 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_opset21_axis_negativ
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_opset21_nncf_axis) {
+    auto model = convert_model("dequantize_linear_21_nncf_axis.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input(std::vector<int8_t>{1, 2, 3, 4, 5, 6, 7, 8});
+    test_case.add_input(std::vector<float>{1.0f, 2.0f, 1.0f, 2.0f});
+    test_case.add_expected_output<float>({2, 4}, std::vector<float>{1.0f, 2.0f, 6.0f, 8.0f, 5.0f, 6.0f, 14.0f, 16.0f});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_ignore_axis) {
     auto model = convert_model("dequantize_linear_scalar_ignore_axis.onnx");
 

--- a/src/frontends/onnx/tests/onnx_import_quant.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_quant.in.cpp
@@ -542,6 +542,14 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_opset21_nncf_axis) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_opset21_invalid_nonzero_axis) {
+    EXPECT_THROW(convert_model("dequantize_linear_21_invalid_nonzero_axis.onnx"), ov::Exception);
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_opset21_invalid_non_inner_axis) {
+    EXPECT_THROW(convert_model("dequantize_linear_21_invalid_non_inner_axis.onnx"), ov::Exception);
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_ignore_axis) {
     auto model = convert_model("dequantize_linear_scalar_ignore_axis.onnx");
 


### PR DESCRIPTION
### Details:
Adds support for NNCF blocked DequantizeLinear axis layout

Infers the uniquely compatible blocked axis when an NNCF-exported DequantizeLinear-21 node has an incompatible declared axis. Recovers only the reported malformed layout where DequantizeLinear-21 declares axis 0 but the scale shape uniquely matches blocked quantization over the
innermost axis. Emits a warning with unambiguous infrmation and guidance, so that users know the model should be re-exported.

### Tickets:
 - *CVS-191631*

### AI Assistance:
 - *AI assistance used: yes*
 - *How: analysis, tests generation*
