### PR TITLE
[CPU] Update xbyak_riscv to v1.34

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -270,7 +270,7 @@ endif()
 
 if(RISCV64)
     # Set `XBYAK_RISCV_V=1` to compile Xbyak-code for RVV-related instructions
-    target_compile_definitions(xbyak_riscv INTERFACE XBYAK_RISCV_V=1)
+    target_compile_definitions(xbyak_riscv INTERFACE XBYAK_RISCV_V=1 XBYAK_RISCV_VSETV_DEFAULT_OLD=0)
     target_link_libraries(${TARGET_NAME} PRIVATE xbyak_riscv)
     target_include_directories(${TARGET_NAME} SYSTEM INTERFACE $<TARGET_PROPERTY:xbyak_riscv::xbyak_riscv,INTERFACE_INCLUDE_DIRECTORIES>)
 endif()

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/debug_capabilities.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/debug_capabilities.cpp
@@ -111,7 +111,12 @@ void RegPrinter::print_vmm(jit_generator_t& h, const Xbyak_riscv::VReg& vmm, con
     utils::sub_sp(h, stack_bytes);
 
     h.uni_li(Xbyak_riscv::t0, vlen);
-    h.vsetvli(Xbyak_riscv::zero, Xbyak_riscv::t0, Xbyak_riscv::SEW::e8, Xbyak_riscv::LMUL::m1);
+    h.vsetvli(Xbyak_riscv::zero,
+              Xbyak_riscv::t0,
+              Xbyak_riscv::SEW::e8,
+              Xbyak_riscv::LMUL::m1,
+              Xbyak_riscv::VTA::tu,
+              Xbyak_riscv::VMA::mu);
     h.vse8_v(vmm, Xbyak_riscv::sp);
 
     h.uni_li(Xbyak_riscv::a0, name ? to_uintptr(name) : to_uintptr(nullptr));

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_context_helpers.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_context_helpers.cpp
@@ -64,7 +64,12 @@ void save_vregs(jit_generator_t& h,
                 const std::vector<size_t>& vreg_idxs) {
     const auto vlen = get_vlen_bytes();
     h.uni_li(vlen_gpr, vlen);
-    h.vsetvli(Xbyak_riscv::zero, vlen_gpr, Xbyak_riscv::SEW::e8, Xbyak_riscv::LMUL::m1);
+    h.vsetvli(Xbyak_riscv::zero,
+              vlen_gpr,
+              Xbyak_riscv::SEW::e8,
+              Xbyak_riscv::LMUL::m1,
+              Xbyak_riscv::VTA::tu,
+              Xbyak_riscv::VMA::mu);
 
     h.addi(ptr_gpr, Xbyak_riscv::sp, static_cast<int32_t>(stack_offset));
     for (const auto& idx : vreg_idxs) {
@@ -80,7 +85,12 @@ void restore_vregs(jit_generator_t& h,
                    const std::vector<size_t>& vreg_idxs) {
     const auto vlen = get_vlen_bytes();
     h.uni_li(vlen_gpr, vlen);
-    h.vsetvli(Xbyak_riscv::zero, vlen_gpr, Xbyak_riscv::SEW::e8, Xbyak_riscv::LMUL::m1);
+    h.vsetvli(Xbyak_riscv::zero,
+              vlen_gpr,
+              Xbyak_riscv::SEW::e8,
+              Xbyak_riscv::LMUL::m1,
+              Xbyak_riscv::VTA::tu,
+              Xbyak_riscv::VMA::mu);
 
     h.addi(ptr_gpr, Xbyak_riscv::sp, static_cast<int32_t>(stack_offset));
     for (const auto& idx : vreg_idxs) {

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_emitter.hpp
@@ -38,13 +38,13 @@ inline void set_vector_length(ov::intel_cpu::riscv64::jit_generator_t* h,
     // - `vsetivli` for small compile-time AVL values encoded directly in the instruction
     // - `vsetvli` for runtime AVL values, or constants that do not fit that immediate field
     if (avl != nullptr) {
-        h->vsetvli(Xbyak_riscv::zero, *avl, sew, lmul);
+        h->vsetvli(Xbyak_riscv::zero, *avl, sew, lmul, Xbyak_riscv::VTA::tu, Xbyak_riscv::VMA::mu);
         return;
     }
 
     OV_CPU_JIT_EMITTER_ASSERT(vector_length > 0, "set_vector_length requires either vector_length or avl register");
     if (vector_length <= 31) {
-        h->vsetivli(Xbyak_riscv::zero, vector_length, sew, lmul);
+        h->vsetivli(Xbyak_riscv::zero, vector_length, sew, lmul, Xbyak_riscv::VTA::tu, Xbyak_riscv::VMA::mu);
         return;
     }
 
@@ -53,7 +53,7 @@ inline void set_vector_length(ov::intel_cpu::riscv64::jit_generator_t* h,
     OV_CPU_JIT_EMITTER_ASSERT(!aux_gpr_idxs.empty(), "Large vector length requires an auxiliary GPR register");
     const auto vector_length_reg = Xbyak_riscv::Reg(static_cast<int>(aux_gpr_idxs.back()));
     h->uni_li(vector_length_reg, vector_length);
-    h->vsetvli(Xbyak_riscv::zero, vector_length_reg, sew, lmul);
+    h->vsetvli(Xbyak_riscv::zero, vector_length_reg, sew, lmul, Xbyak_riscv::VTA::tu, Xbyak_riscv::VMA::mu);
 }
 
 class jit_emitter : public ov::snippets::Emitter {

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/cpu_isa_traits.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/cpu_isa_traits.cpp
@@ -23,7 +23,7 @@ namespace {
 struct RVVGenerator : public CodeGenerator {
     RVVGenerator() : CodeGenerator(8) {
         // vsetivli is appeared in RVV 1.0
-        vsetivli(a0, 10, SEW::e32);
+        vsetivli(a0, 10, SEW::e32, LMUL::m1, VTA::tu, VMA::mu);
         ret();
     }
 };
@@ -31,7 +31,7 @@ struct RVVGenerator : public CodeGenerator {
 struct ZvfhGenerator : public CodeGenerator {
     ZvfhGenerator() : CodeGenerator(32) {
         // Probe Zvfh instructions used by Snippets Convert emitters.
-        vsetivli(a0, 1, SEW::e16, LMUL::mf2);
+        vsetivli(a0, 1, SEW::e16, LMUL::mf2, VTA::tu, VMA::mu);
         vfwcvt_f_f_v(v0, v0);
         vfncvt_f_f_w(v0, v0);
         li(a0, 1);

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
@@ -243,7 +243,7 @@ void jit_uni_eltwise_generic<isa>::update_vlen(const Xbyak_riscv::Reg& gpr_work_
         return;
     }
 
-    vsetvli(reg_vlen, gpr_work_amount, sew, lmul);
+    vsetvli(reg_vlen, gpr_work_amount, sew, lmul, VTA::tu, VMA::mu);
     current_lmul = lmul;
     current_sew = sew;
 


### PR DESCRIPTION
### Details:
Updated the RISC-V CPU code to use `XBYAK_RISCV_VSETV_DEFAULT_OLD=0` to address verbose note:

```
note: '#pragma message: XBYAK_RISCV_VSETV_DEFAULT_OLD is 0 in the future'
   94 |         #pragma message "XBYAK_RISCV_VSETV_DEFAULT_OLD is 0 in the future"
```

### Tickets:
 - N/A

### AI Assistance:
 - *AI assistance used: yes*
 - Implementation is assisted and after that manually tested and reviewed