### PR TITLE
EISW-231285 NPU plugin L0 memory allocation trace

### DIFF
--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem.hpp
@@ -4,12 +4,34 @@
 
 #pragma once
 
+#include <fstream>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "intel_npu/utils/logger/logger.hpp"
 #include "intel_npu/utils/zero/zero_init.hpp"
+#include "intel_npu/utils/zero/zero_mem_types.hpp"
 
 namespace intel_npu {
+
+class MemoryTracer {
+public:
+    static MemoryTracer& get_instance();
+    void log_allocation(uint64_t id, size_t size, memory_purpose purpose, const std::string& name,
+                       void* ptr, size_t alignment, const char* alloc_type, bool is_input);
+    void log_deallocation(uint64_t id, size_t size, memory_purpose purpose, const std::string& name,
+                         void* ptr, const char* alloc_type);
+    void set_trace_file(const std::string& file_path);
+private:
+    MemoryTracer();
+    ~MemoryTracer();
+    void write_header();
+    
+    std::mutex trace_mutex_;
+    std::ofstream trace_file_;
+    bool enabled_ = false;
+};
 
 namespace zero_mem {
 class ZeroMemPoolManager;
@@ -39,11 +61,15 @@ private:
      * @param alignment Alignment needed for the memory; it must be a multiple of the standard page size
      * @param is_input Optimize reads from this buffer. Specific level zero flags will be used for allocation in case
      * the buffer is intended to be used as an input.
+     * @param purpose Purpose of this memory allocation (for tracking/analysis)
+     * @param name Optional descriptive name for this allocation
      */
     ZeroMem(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
             const size_t bytes,
             const size_t alignment,
-            const bool is_input);
+            const bool is_input,
+            memory_purpose purpose = memory_purpose::unknown,
+            const std::string& name = "");
 
     /**
      * @brief Imports an already allocated memory in the level zero context provided through init_structs.
@@ -54,12 +80,16 @@ private:
      * the buffer is intended to be used as an input.
      * @param standard_allocation If a CPU standard allocation is shared it must be set to true. Otherwise it will try
      * to import DMA-BUF (on Linux) or WIN32 (on Windows) memory.
+     * @param purpose Purpose of this memory allocation (for tracking/analysis)
+     * @param name Optional descriptive name for this allocation
      */
     ZeroMem(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
             const void* data,
             const size_t bytes,
             const bool is_input,
-            const bool standard_allocation);
+            const bool standard_allocation,
+            memory_purpose purpose = memory_purpose::unknown,
+            const std::string& name = "");
 
     /**
      * @brief Return memory id of the allocated memory
@@ -74,6 +104,10 @@ private:
     void* _ptr = nullptr;
     size_t _size = 0;
     uint64_t _id = 0;
+    size_t _alignment = 0;
+    memory_purpose _purpose = memory_purpose::unknown;
+    std::string _name;
+    const char* _alloc_type = "unknown";
 };
 
 /**

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem_pool.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem_pool.hpp
@@ -9,8 +9,8 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
-
 #include "openvino/core/except.hpp"
+#include "intel_npu/utils/zero/zero_mem_types.hpp"
 
 namespace intel_npu {
 
@@ -56,11 +56,15 @@ namespace zero_mem {
  * @param bytes Size in bytes of the memory that must be allocated.
  * @param alignment Alignment needed for the memory; it must be a multiple of the standard page size.
  * @param is_input Memory is used only as input or not.
+ * @param purpose Purpose of this memory allocation (for tracking/analysis).
+ * @param name Optional descriptive name for this allocation.
  */
 std::shared_ptr<ZeroMem> allocate_memory(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                          const size_t bytes,
                                          const size_t alignment,
-                                         const bool is_input = false);
+                                         const bool is_input = false,
+                                         memory_purpose purpose = memory_purpose::unknown,
+                                         const std::string& name = "");
 
 /**
  * @brief Returns an imported shared(CMX-DMA in case of Linux, NT handle in case of Windows) memory in the level
@@ -68,10 +72,14 @@ std::shared_ptr<ZeroMem> allocate_memory(const std::shared_ptr<ZeroInitStructsHo
  * @param init_structs Holder for the level zero structures.
  * @param data Memory to be imported.
  * @param bytes Size in bytes of the memory that must be allocated.
+ * @param purpose Purpose of this memory allocation (for tracking/analysis).
+ * @param name Optional descriptive name for this allocation.
  */
 std::shared_ptr<ZeroMem> import_shared_memory(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                               const void* data,
-                                              const size_t bytes);
+                                              const size_t bytes,
+                                              memory_purpose purpose = memory_purpose::unknown,
+                                              const std::string& name = "");
 
 /**
  * @brief Performs a look-up in the pool to check if the entire range given by [data, data + bytes] was previously
@@ -81,11 +89,15 @@ std::shared_ptr<ZeroMem> import_shared_memory(const std::shared_ptr<ZeroInitStru
  * @param data User memory to be checked.
  * @param bytes Size in bytes of the memory.
  * @param is_input Memory is used only as input or not.
+ * @param purpose Purpose of this memory allocation (for tracking/analysis).
+ * @param name Optional descriptive name for this allocation.
  */
 std::shared_ptr<ZeroMem> import_standard_allocation_memory(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                                            const void* data,
                                                            const size_t bytes,
-                                                           const bool is_input = false);
+                                                           const bool is_input = false,
+                                                           memory_purpose purpose = memory_purpose::unknown,
+                                                           const std::string& name = "");
 
 }  // namespace zero_mem
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem_types.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_mem_types.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+
+namespace intel_npu {
+
+// Memory purpose classification - matches GPU plugin for comparison
+enum class memory_purpose : uint8_t {
+    unknown = 0,
+    weights,
+    kv_cache_key,
+    kv_cache_value,
+    activation,
+    input,
+    output,
+    intermediate,
+    constant,
+    internal_buffer
+};
+
+inline const char* memory_purpose_to_string(memory_purpose purpose) {
+    switch(purpose) {
+        case memory_purpose::weights: return "weights";
+        case memory_purpose::kv_cache_key: return "kv_cache_key";
+        case memory_purpose::kv_cache_value: return "kv_cache_value";
+        case memory_purpose::activation: return "activation";
+        case memory_purpose::input: return "input";
+        case memory_purpose::output: return "output";
+        case memory_purpose::intermediate: return "intermediate";
+        case memory_purpose::constant: return "constant";
+        case memory_purpose::internal_buffer: return "internal_buffer";
+        default: return "unknown";
+    }
+}
+
+}  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_remote_tensor.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_remote_tensor.hpp
@@ -89,6 +89,7 @@ private:
     void update_strides();
     void update_properties();
     void copy_file_data_to_level_zero_memory(const size_t size_to_read);
+    std::string generate_allocation_name(const char* base_name) const;
 
     std::shared_ptr<ov::IRemoteContext> _context;
     std::shared_ptr<ZeroInitStructsHolder> _init_structs;

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_mem.cpp
@@ -4,19 +4,126 @@
 
 #include "intel_npu/utils/zero/zero_mem.hpp"
 
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
 #include "intel_npu/utils/utils.hpp"
 #include "intel_npu/utils/zero/zero_api.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 
 namespace intel_npu {
 
+// MemoryTracer implementation
+MemoryTracer& MemoryTracer::get_instance() {
+    static MemoryTracer instance;
+    return instance;
+}
+
+MemoryTracer::MemoryTracer() {
+    const char* trace_file_env = std::getenv("NPU_MEMORY_TRACE_FILE");
+    if (trace_file_env && trace_file_env[0] != '\0') {
+        set_trace_file(trace_file_env);
+    }
+}
+
+MemoryTracer::~MemoryTracer() {
+    if (trace_file_.is_open()) {
+        trace_file_.close();
+    }
+}
+
+void MemoryTracer::set_trace_file(const std::string& file_path) {
+    std::lock_guard<std::mutex> lock(trace_mutex_);
+    if (!trace_file_.is_open()) {
+        trace_file_.open(file_path, std::ios::out | std::ios::app);
+        if (trace_file_.is_open()) {
+            enabled_ = true;
+            write_header();
+        }
+    }
+}
+
+void MemoryTracer::write_header() {
+    trace_file_ << "timestamp,operation,size_bytes,purpose,name,memory_id,pointer,alignment,alloc_type,is_input\n";
+    trace_file_.flush();
+}
+
+void MemoryTracer::log_allocation(uint64_t id, size_t size, memory_purpose purpose, const std::string& name,
+                                 void* ptr, size_t alignment, const char* alloc_type, bool is_input) {
+    if (!enabled_) return;
+    
+    std::lock_guard<std::mutex> lock(trace_mutex_);
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+    
+    std::tm tm_buf;
+#ifdef _WIN32
+    localtime_s(&tm_buf, &time_t);
+#else
+    localtime_r(&time_t, &tm_buf);
+#endif
+    
+    trace_file_ << std::put_time(&tm_buf, "%Y-%m-%dT%H:%M:%S")
+                << '.' << std::setfill('0') << std::setw(3) << ms.count()
+                << ",alloc," << size
+                << "," << memory_purpose_to_string(purpose)
+                << ",\"" << (name.empty() ? "<unnamed>" : name) << "\""
+                << "," << id
+                << ",0x" << std::hex << reinterpret_cast<uintptr_t>(ptr) << std::dec
+                << "," << alignment
+                << "," << alloc_type
+                << "," << (is_input ? "true" : "false")
+                << "\n";
+    trace_file_.flush();
+}
+
+void MemoryTracer::log_deallocation(uint64_t id, size_t size, memory_purpose purpose, const std::string& name,
+                                   void* ptr, const char* alloc_type) {
+    if (!enabled_) return;
+    
+    std::lock_guard<std::mutex> lock(trace_mutex_);
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+    
+    std::tm tm_buf;
+#ifdef _WIN32
+    localtime_s(&tm_buf, &time_t);
+#else
+    localtime_r(&time_t, &tm_buf);
+#endif
+    
+    trace_file_ << std::put_time(&tm_buf, "%Y-%m-%dT%H:%M:%S")
+                << '.' << std::setfill('0') << std::setw(3) << ms.count()
+                << ",free," << size
+                << "," << memory_purpose_to_string(purpose)
+                << ",\"" << (name.empty() ? "<unnamed>" : name) << "\""
+                << "," << id
+                << ",0x" << std::hex << reinterpret_cast<uintptr_t>(ptr) << std::dec
+                << ",0"  // alignment not relevant for free
+                << "," << alloc_type
+                << ",false"  // is_input not relevant for free
+                << "\n";
+    trace_file_.flush();
+}
+
 ZeroMem::ZeroMem(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                  const size_t bytes,
                  const size_t alignment,
-                 const bool is_input)
+                 const bool is_input,
+                 memory_purpose purpose,
+                 const std::string& name)
     : _init_structs(init_structs),
       _logger("ZeHostMem", Logger::global().level()),
-      _size(bytes == 0 ? alignment : (bytes + alignment - 1) & ~(alignment - 1)) {
+      _size(bytes == 0 ? alignment : (bytes + alignment - 1) & ~(alignment - 1)),
+      _alignment(alignment),
+      _purpose(purpose),
+      _name(name),
+      _alloc_type("host") {
     uint32_t zero_memory_flag = 0;
     if (is_input) {
         zero_memory_flag = ZE_HOST_MEM_ALLOC_FLAG_BIAS_WRITE_COMBINED;
@@ -28,16 +135,25 @@ ZeroMem::ZeroMem(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
 
     _id = zeroUtils::get_l0_context_memory_allocation_id(_init_structs->getContext(), _ptr);
     OPENVINO_ASSERT(_id != 0, "Failed to get memory allocation id of the allocated memory");
+    
+    // Log allocation
+    MemoryTracer::get_instance().log_allocation(_id, _size, _purpose, _name, _ptr, _alignment, _alloc_type, is_input);
 }
 
 ZeroMem::ZeroMem(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                  const void* data,
                  const size_t bytes,
                  const bool is_input,
-                 const bool standard_allocation)
+                 const bool standard_allocation,
+                 memory_purpose purpose,
+                 const std::string& name)
     : _init_structs(init_structs),
       _logger("ZeHostMem", Logger::global().level()),
-      _size(bytes) {
+      _size(bytes),
+      _alignment(utils::STANDARD_PAGE_SIZE),
+      _purpose(purpose),
+      _name(name),
+      _alloc_type(standard_allocation ? "standard_import" : "shared_import") {
     if (standard_allocation) {
         if (!_init_structs->isExternalMemoryStandardAllocationSupported()) {
             throw ZeroMemException("Importing standard allocation is not supported with this driver version");
@@ -98,6 +214,9 @@ ZeroMem::ZeroMem(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
 
     _id = zeroUtils::get_l0_context_memory_allocation_id(_init_structs->getContext(), _ptr);
     OPENVINO_ASSERT(_id != 0, "Failed to get memory allocation id of the imported memory");
+    
+    // Log allocation
+    MemoryTracer::get_instance().log_allocation(_id, _size, _purpose, _name, _ptr, _alignment, _alloc_type, is_input);
 }
 
 void* ZeroMem::data() {
@@ -113,6 +232,9 @@ uint64_t ZeroMem::id() {
 }
 
 ZeroMem::~ZeroMem() {
+    // Log deallocation before freeing
+    MemoryTracer::get_instance().log_deallocation(_id, _size, _purpose, _name, _ptr, _alloc_type);
+    
     auto ze_context = _init_structs->getContext();
     if (ze_context == nullptr) {
         _logger.warning("Context is null while trying to free memory with id %llu. Memory might be already freed.",

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_mem_pool.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_mem_pool.cpp
@@ -24,8 +24,10 @@ public:
     static std::shared_ptr<ZeroMem> allocate_memory(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                                     const size_t bytes,
                                                     const size_t alignment,
-                                                    const bool is_input) {
-        auto zero_memory = std::shared_ptr<ZeroMem>(new ZeroMem(init_structs, bytes, alignment, is_input),
+                                                    const bool is_input,
+                                                    memory_purpose purpose,
+                                                    const std::string& name) {
+        auto zero_memory = std::shared_ptr<ZeroMem>(new ZeroMem(init_structs, bytes, alignment, is_input, purpose, name),
                                                     [init_structs](ZeroMem* ptr) {
                                                         ZeroMemPoolManager::delete_pool_entry(init_structs, ptr);
                                                     });
@@ -42,8 +44,10 @@ public:
 
     static std::shared_ptr<ZeroMem> import_shared_memory(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                                          const void* data,
-                                                         const size_t bytes) {
-        auto zero_memory = std::shared_ptr<ZeroMem>(new ZeroMem(init_structs, data, bytes, false, false),
+                                                         const size_t bytes,
+                                                         memory_purpose purpose,
+                                                         const std::string& name) {
+        auto zero_memory = std::shared_ptr<ZeroMem>(new ZeroMem(init_structs, data, bytes, false, false, purpose, name),
                                                     [init_structs](ZeroMem* ptr) {
                                                         ZeroMemPoolManager::delete_pool_entry(init_structs, ptr);
                                                     });
@@ -62,14 +66,16 @@ public:
         const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
         const void* data,
         const size_t bytes,
-        const bool is_input) {
+        const bool is_input,
+        memory_purpose purpose,
+        const std::string& name) {
         std::lock_guard<std::mutex> lock(init_structs->getZeroMemPool().mem_pool_mutex);
         std::unique_lock<std::mutex> deleter_lock(init_structs->getZeroMemPool().mem_pool_deleter_mutex);
 
         auto memory_id = zeroUtils::get_l0_context_memory_allocation_id(init_structs->getContext(), data);
         if (memory_id == 0) {
             // try to import memory if it isn't part of the same zero context
-            return import_standard_allocation(init_structs, data, bytes, is_input);
+            return import_standard_allocation(init_structs, data, bytes, is_input, purpose, name);
         }
 
         auto& zero_mem_pool = init_structs->getZeroMemPool().mem_pool;
@@ -98,7 +104,7 @@ public:
                 notify_zero_mem_pool.erase(memory_id);
 
                 // import again memory after make sure it is destroyed
-                return ZeroMemPoolManager::import_standard_allocation(init_structs, data, bytes, is_input);
+                return ZeroMemPoolManager::import_standard_allocation(init_structs, data, bytes, is_input, purpose, name);
             }
         }
 
@@ -110,9 +116,11 @@ private:
         const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
         const void* data,
         const size_t bytes,
-        const bool is_input) {
+        const bool is_input,
+        memory_purpose purpose,
+        const std::string& name) {
         auto zero_memory = std::shared_ptr<ZeroMem>(
-            new ZeroMem(init_structs, data, bytes, is_input, true),
+            new ZeroMem(init_structs, data, bytes, is_input, true, purpose, name),
             [init_structs](ZeroMem* ptr) {
                 auto memory_id = ptr->id();
                 auto& notify_zero_mem_pool = init_structs->getZeroMemPool().notify_mem_pool;
@@ -161,21 +169,27 @@ private:
 std::shared_ptr<ZeroMem> allocate_memory(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                          const size_t bytes,
                                          const size_t alignment,
-                                         const bool is_input) {
-    return ZeroMemPoolManager::allocate_memory(init_structs, bytes, alignment, is_input);
+                                         const bool is_input,
+                                         memory_purpose purpose,
+                                         const std::string& name) {
+    return ZeroMemPoolManager::allocate_memory(init_structs, bytes, alignment, is_input, purpose, name);
 }
 
 std::shared_ptr<ZeroMem> import_shared_memory(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                               const void* data,
-                                              const size_t bytes) {
-    return ZeroMemPoolManager::import_shared_memory(init_structs, data, bytes);
+                                              const size_t bytes,
+                                              memory_purpose purpose,
+                                              const std::string& name) {
+    return ZeroMemPoolManager::import_shared_memory(init_structs, data, bytes, purpose, name);
 }
 
 std::shared_ptr<ZeroMem> import_standard_allocation_memory(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                                            const void* data,
                                                            const size_t bytes,
-                                                           const bool is_input) {
-    return ZeroMemPoolManager::import_standard_allocation_memory(init_structs, data, bytes, is_input);
+                                                           const bool is_input,
+                                                           memory_purpose purpose,
+                                                           const std::string& name) {
+    return ZeroMemPoolManager::import_standard_allocation_memory(init_structs, data, bytes, is_input, purpose, name);
 }
 
 }  // namespace zero_mem

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_remote_tensor.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_remote_tensor.cpp
@@ -5,6 +5,7 @@
 #include "intel_npu/utils/zero/zero_remote_tensor.hpp"
 
 #include <fstream>
+#include <sstream>
 
 #include "intel_npu/utils/utils.hpp"
 #include "intel_npu/utils/zero/zero_mem_pool.hpp"
@@ -324,7 +325,9 @@ void ZeroRemoteTensor::copy_file_data_to_level_zero_memory(const size_t size_to_
     _host_memory = zero_mem::allocate_memory(_init_structs,
                                              size_to_read,
                                              utils::STANDARD_PAGE_SIZE,
-                                             _tensor_type == TensorType::INPUT ? true : false);
+                                             _tensor_type == TensorType::INPUT ? true : false,
+                                             memory_purpose::weights,
+                                             generate_allocation_name("file_data"));
     _data = _host_memory->data();
 
     std::streamoff bytes_to_read = static_cast<std::streamoff>(size_to_read);
@@ -342,13 +345,17 @@ void ZeroRemoteTensor::allocate(const size_t bytes) {
         _host_memory = zero_mem::allocate_memory(_init_structs,
                                                  bytes,
                                                  utils::STANDARD_PAGE_SIZE,
-                                                 _tensor_type == TensorType::INPUT ? true : false);
+                                                 _tensor_type == TensorType::INPUT ? true : false,
+                                                 _tensor_type == TensorType::INPUT ? memory_purpose::input : memory_purpose::output,
+                                                 generate_allocation_name("l0"));
         _data = _host_memory->data();
         break;
     }
     case MemType::SHARED_BUF: {
         // set up the request to import the external memory handle
-        _host_memory = zero_mem::import_shared_memory(_init_structs, _mem, bytes);
+        _host_memory = zero_mem::import_shared_memory(_init_structs, _mem, bytes,
+                                                      _tensor_type == TensorType::INPUT ? memory_purpose::input : memory_purpose::output,
+                                                      generate_allocation_name("shared"));
         _data = _host_memory->data();
         break;
     }
@@ -387,7 +394,9 @@ void ZeroRemoteTensor::allocate(const size_t bytes) {
                 zero_mem::import_standard_allocation_memory(_init_structs,
                                                             std::as_const(_mmap_tensor).data(),
                                                             aligned_size,
-                                                            _tensor_type == TensorType::INPUT ? true : false);
+                                                            _tensor_type == TensorType::INPUT ? true : false,
+                                                            memory_purpose::weights,
+                                                            generate_allocation_name("mmap"));
             _data = _host_memory->data();
         } catch (const ZeroMemException&) {
             _logger.info("Failed to import mmaped memory. File data will be copied to the level zero memory");
@@ -400,7 +409,9 @@ void ZeroRemoteTensor::allocate(const size_t bytes) {
         _host_memory = zero_mem::import_standard_allocation_memory(_init_structs,
                                                                    _mem,
                                                                    bytes,
-                                                                   _tensor_type == TensorType::INPUT ? true : false);
+                                                                   _tensor_type == TensorType::INPUT ? true : false,
+                                                                   _tensor_type == TensorType::INPUT ? memory_purpose::input : memory_purpose::output,
+                                                                   generate_allocation_name("cpu_va"));
         _data = _host_memory->data();
         break;
     }
@@ -431,6 +442,33 @@ void ZeroRemoteTensor::update_properties() {
     default:
         OPENVINO_THROW("Unsupported object type ", static_cast<int>(_mem_type));
     }
+}
+
+std::string ZeroRemoteTensor::generate_allocation_name(const char* base_name) const {
+    std::ostringstream oss;
+    oss << "remote_" << base_name;
+    
+    // Add tensor direction
+    if (_tensor_type == TensorType::INPUT) {
+        oss << "_in";
+    } else if (_tensor_type == TensorType::OUTPUT) {
+        oss << "_out";
+    } else {
+        oss << "_bind";
+    }
+    
+    // Add element type
+    oss << "_" << _element_type.get_type_name();
+    
+    // Add shape
+    oss << "_[";
+    for (size_t i = 0; i < _shape.size(); ++i) {
+        if (i > 0) oss << ",";
+        oss << _shape[i];
+    }
+    oss << "]";
+    
+    return oss.str();
 }
 
 void* ZeroRemoteTensor::get_original_memory() const {

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_tensor.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_tensor.cpp
@@ -46,7 +46,10 @@ ZeroTensor::ZeroTensor(const std::shared_ptr<ZeroInitStructsHolder>& init_struct
 
     _bytes_capacity = get_byte_size();
 
-    _mem_ref = zero_mem::allocate_memory(_init_structs, byte_size.value(), utils::STANDARD_PAGE_SIZE, _is_input);
+    _mem_ref = zero_mem::allocate_memory(
+        _init_structs, byte_size.value(), utils::STANDARD_PAGE_SIZE, _is_input,
+        _is_input ? memory_purpose::input : memory_purpose::output,
+        _is_input ? "tensor_input" : "tensor_output");
     auto data = _mem_ref->data();
     OPENVINO_ASSERT(byte_size.value() == 0 || data != nullptr, "Failed to allocate zero memory");
     _ptr = data;
@@ -94,7 +97,10 @@ ZeroTensor::ZeroTensor(const std::shared_ptr<ZeroInitStructsHolder>& init_struct
     // _mem_ref will keep a reference to that allocation. Otherwise the function will try to import it into the level
     // zero context.
     _logger.debug("ZeroTensor::ZeroTensor - get tensor from pool or import it");
-    _mem_ref = zero_mem::import_standard_allocation_memory(_init_structs, _ptr, _bytes_capacity);
+    _mem_ref = zero_mem::import_standard_allocation_memory(
+        _init_structs, _ptr, _bytes_capacity, _is_input,
+        _is_input ? memory_purpose::input : memory_purpose::output,
+        _is_input ? "tensor_user_import_input" : "tensor_user_import_output");
 }
 
 // Note: Override data() members to not used OpenVINO library code to improve performance
@@ -205,7 +211,10 @@ void ZeroTensor::set_shape(ov::Shape new_shape) {
         // allocate buffer and initialize objects from scratch
         const auto byte_size = ov::util::get_memory_size_safe(_element_type, _shape);
         OPENVINO_ASSERT(byte_size, "Cannot allocate memory for type: ", _element_type, " and shape: ", _shape);
-        _mem_ref = zero_mem::allocate_memory(_init_structs, byte_size.value(), utils::STANDARD_PAGE_SIZE, _is_input);
+        _mem_ref = zero_mem::allocate_memory(
+            _init_structs, byte_size.value(), utils::STANDARD_PAGE_SIZE, _is_input,
+            _is_input ? memory_purpose::input : memory_purpose::output,
+            _is_input ? "tensor_reshape_input" : "tensor_reshape_output");
         _ptr = _mem_ref->data();
         OPENVINO_ASSERT(byte_size.value() == 0 || _ptr != nullptr, "Failed to allocate zero memory");
         _bytes_capacity = get_byte_size();
@@ -236,7 +245,10 @@ bool ZeroTensor::can_be_reused() {
 void ZeroTensor::allocate_data() {
     _logger.debug("ZeroTensor::allocate_data - import the tensor data");
     _ptr = _user_tensor->data();
-    _mem_ref = zero_mem::import_standard_allocation_memory(_init_structs, _ptr, _bytes_capacity);
+    _mem_ref = zero_mem::import_standard_allocation_memory(
+        _init_structs, _ptr, _bytes_capacity, _is_input,
+        _is_input ? memory_purpose::input : memory_purpose::output,
+        _is_input ? "tensor_allocate_data_input" : "tensor_allocate_data_output");
 }
 
 void ZeroTensor::detach_imported_allocation_for_custom_tensor() {


### PR DESCRIPTION
### Details:
 - Add MemoryTracer class to NPU Plugin's zero_mem class
 - Use this to maintain a trace CSV recording allocations and deallocations made by NPU Plugin at runtime
 - Instrument calls to zero_mem to allocate/deallocate memory with basic information about whether memory is for standard/remote (shared) tensor memory, tensor shape & datatype

### Tickets:
 - https://jira.devtools.intel.com/browse/EISW-231285

### AI Assistance:
 - *AI assistance used: yes*
 - *Changes made with assistance from Copilot; changes validated by extraction of live NPU plugin memory trace and visualisation/comparison with NPU Driver memory allocation trace*
