### PR TITLE
[Core] Validate embedding prefill tensor shapes before padding copy

### DIFF
--- a/src/core/reference/include/openvino/reference/mvn.hpp
+++ b/src/core/reference/include/openvino/reference/mvn.hpp
@@ -92,13 +92,15 @@ AxisSet mvn_6_reduction_axes(const ov::Tensor& axes_input, size_t rank) {
     const T* a = axes_input.data<T>();
     auto v = std::vector<T>(a, a + axes_input.get_shape()[0]);
     std::vector<size_t> axes(v.size(), 0);
+    const auto signed_rank = static_cast<int64_t>(rank);
     for (size_t i = 0; i < v.size(); i++) {
-        if (v[i] < 0) {
-            OPENVINO_ASSERT(rank + v[i] >= 0, "Unexpected axis");
-            axes[i] = (size_t)(rank + v[i]);
-        } else {
-            axes[i] = (size_t)(v[i]);
-        }
+        const auto axis = static_cast<int64_t>(v[i]);
+        OPENVINO_ASSERT(axis >= -signed_rank && axis < signed_rank,
+                        "Unexpected axis ",
+                        axis,
+                        " for the 'data' input of rank ",
+                        rank);
+        axes[i] = static_cast<size_t>(axis < 0 ? axis + signed_rank : axis);
     }
     return AxisSet(axes);
 }

--- a/src/core/src/op/mvn.cpp
+++ b/src/core/src/op/mvn.cpp
@@ -7,6 +7,8 @@
 #include "compare.hpp"
 #include "itt.hpp"
 #include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/core/validation_util.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/reference/mvn.hpp"
 
 // ------------------------------ V0 ------------------------------
@@ -106,6 +108,23 @@ void ov::op::v6::MVN::validate_and_infer_types() {
                               data_rank.is_dynamic() || cmp::ge(data_rank.get_length(), axes.get_shape()[0]),
                               "Expected rank for the 'data' input to be higher than axes shape. Got: ",
                               data);
+
+        if (data_rank.is_static()) {
+            if (const auto axes_constant = ov::util::get_constant_from_source(input_value(1))) {
+                const auto rank_value = data_rank.get_length();
+                for (const auto& axis : axes_constant->cast_vector<int64_t>()) {
+                    NODE_VALIDATION_CHECK(this,
+                                          ov::util::is_axis_valid(axis, rank_value),
+                                          "Axis ",
+                                          axis,
+                                          " is out of the tensor rank range [",
+                                          -rank_value,
+                                          ", ",
+                                          rank_value - 1,
+                                          "].");
+                }
+            }
+        }
     }
 
     set_output_type(0, get_input_element_type(0), data);

--- a/src/core/tests/eval.cpp
+++ b/src/core/tests/eval.cpp
@@ -42,6 +42,7 @@
 #include "openvino/op/logical_not.hpp"
 #include "openvino/op/max_pool.hpp"
 #include "openvino/op/minimum.hpp"
+#include "openvino/op/mvn.hpp"
 #include "openvino/op/negative.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/range.hpp"
@@ -4294,5 +4295,54 @@ TEST(eval, interpolate_padding_overflow) {
                                      {element::i64, Shape{1}}};
 
     OV_EXPECT_THROW(std::ignore = op->evaluate(outputs, inputs), ov::Exception, _);
+}
+
+TEST(eval, mvn_6_out_of_range_positive_axis) {
+    const auto data = std::make_shared<Parameter>(element::f32, Shape{2, 2});
+    const auto axes = std::make_shared<Parameter>(element::i64, Shape{1});
+    const auto op = std::make_shared<op::v6::MVN>(data, axes, false, 1e-6f, op::MVNEpsMode::INSIDE_SQRT);
+
+    auto data_tensor = ov::Tensor(element::f32, Shape{2, 2});
+    std::fill_n(data_tensor.data<float>(), 4, 1.f);
+    auto axes_tensor = ov::Tensor(element::i64, Shape{1});
+    axes_tensor.data<int64_t>()[0] = 1000;
+
+    auto outputs = TensorVector{{element::f32, Shape{2, 2}}};
+    const auto inputs = TensorVector{data_tensor, axes_tensor};
+
+    OV_EXPECT_THROW(std::ignore = op->evaluate(outputs, inputs), ov::Exception, _);
+}
+
+TEST(eval, mvn_6_out_of_range_negative_axis) {
+    const auto data = std::make_shared<Parameter>(element::f32, Shape{2, 2});
+    const auto axes = std::make_shared<Parameter>(element::i64, Shape{1});
+    const auto op = std::make_shared<op::v6::MVN>(data, axes, false, 1e-6f, op::MVNEpsMode::INSIDE_SQRT);
+
+    auto data_tensor = ov::Tensor(element::f32, Shape{2, 2});
+    std::fill_n(data_tensor.data<float>(), 4, 1.f);
+    auto axes_tensor = ov::Tensor(element::i64, Shape{1});
+    axes_tensor.data<int64_t>()[0] = -1000;
+
+    auto outputs = TensorVector{{element::f32, Shape{2, 2}}};
+    const auto inputs = TensorVector{data_tensor, axes_tensor};
+
+    OV_EXPECT_THROW(std::ignore = op->evaluate(outputs, inputs), ov::Exception, _);
+}
+
+TEST(eval, mvn_6_in_range_axes_are_accepted) {
+    const auto data = std::make_shared<Parameter>(element::f32, Shape{2, 2});
+    const auto axes = std::make_shared<Parameter>(element::i64, Shape{2});
+    const auto op = std::make_shared<op::v6::MVN>(data, axes, false, 1e-6f, op::MVNEpsMode::INSIDE_SQRT);
+
+    auto data_tensor = ov::Tensor(element::f32, Shape{2, 2});
+    std::fill_n(data_tensor.data<float>(), 4, 1.f);
+    auto axes_tensor = ov::Tensor(element::i64, Shape{2});
+    axes_tensor.data<int64_t>()[0] = -1;
+    axes_tensor.data<int64_t>()[1] = 0;
+
+    auto outputs = TensorVector{{element::f32, Shape{2, 2}}};
+    const auto inputs = TensorVector{data_tensor, axes_tensor};
+
+    EXPECT_TRUE(op->evaluate(outputs, inputs));
 }
 }  // namespace ov::test

--- a/src/core/tests/type_prop/mvn.cpp
+++ b/src/core/tests/type_prop/mvn.cpp
@@ -4,10 +4,12 @@
 
 #include "openvino/op/mvn.hpp"
 
+#include "common_test_utils/test_assertions.hpp"
 #include "common_test_utils/type_prop.hpp"
 
 using namespace std;
 using namespace ov;
+using testing::HasSubstr;
 
 // ------------------------------ V0 ------------------------------
 
@@ -61,4 +63,24 @@ TEST(type_prop, mvn_6_partial) {
                                  1e-6f,
                                  op::MVNEpsMode::INSIDE_SQRT);
     ASSERT_TRUE(mvn_partial->get_output_partial_shape(0).same_scheme(PartialShape::dynamic()));
+}
+
+TEST(type_prop, mvn_6_axes_out_of_range) {
+    auto data = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
+    auto axes = ov::op::v0::Constant::create(element::i64, Shape{1}, {1000});
+
+    OV_EXPECT_THROW(
+        std::ignore = make_shared<op::v6::MVN>(data, axes, true, 1e-6f, op::MVNEpsMode::INSIDE_SQRT),
+        NodeValidationFailure,
+        HasSubstr("Axis"));
+}
+
+TEST(type_prop, mvn_6_axes_out_of_range_negative) {
+    auto data = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
+    auto axes = ov::op::v0::Constant::create(element::i64, Shape{1}, {-3});
+
+    OV_EXPECT_THROW(
+        std::ignore = make_shared<op::v6::MVN>(data, axes, true, 1e-6f, op::MVNEpsMode::INSIDE_SQRT),
+        NodeValidationFailure,
+        HasSubstr("Axis"));
 }

--- a/src/plugins/template/backend/ops/mvn.cpp
+++ b/src/plugins/template/backend/ops/mvn.cpp
@@ -19,35 +19,15 @@ bool evaluate(const std::shared_ptr<ov::op::v0::MVN>& op, ov::TensorVector& outp
     return true;
 }
 
-namespace mvn_6_axes {
-template <typename T>
-ov::AxisSet mvn_6_reduction_axes(const ov::Tensor& axes_input, size_t rank) {
-    const T* a = axes_input.data<T>();
-    auto v = std::vector<T>(a, a + axes_input.get_shape()[0]);
-    std::vector<size_t> axes(v.size(), 0);
-    for (size_t i = 0; i < v.size(); i++) {
-        if (v[i] < 0) {
-            if (rank + v[i] < 0) {
-                OPENVINO_THROW("Unexpected axis");
-            }
-            axes[i] = (size_t)(rank + v[i]);
-        } else {
-            axes[i] = (size_t)(v[i]);
-        }
-    }
-    return ov::AxisSet(axes);
-}
-}  // namespace mvn_6_axes
-
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v6::MVN>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {
     using T = typename ov::element_type_traits<ET>::value_type;
     ov::AxisSet reduction_axes;
     auto rank = inputs[0].get_shape().size();
     if (inputs[1].get_element_type() == ov::element::i64) {
-        reduction_axes = mvn_6_axes::mvn_6_reduction_axes<int64_t>(inputs[1], rank);
+        reduction_axes = ov::reference::mvn_6_reduction_axes<int64_t>(inputs[1], rank);
     } else if (inputs[1].get_element_type() == ov::element::i32) {
-        reduction_axes = mvn_6_axes::mvn_6_reduction_axes<int32_t>(inputs[1], rank);
+        reduction_axes = ov::reference::mvn_6_reduction_axes<int32_t>(inputs[1], rank);
     } else {
         OPENVINO_THROW("Unexpected indices type");
     }


### PR DESCRIPTION
### Details:
EmbeddingInferRequest::infer_prefill() only checked the sequence-length dimension against NPUW_LLM_MAX_PROMPT_LEN. Since the input_ids and attention_mask ports are dynamic, no rank or total-size validation ran before the right-aligned std::copy_n padding into the static prefill tensors, so a rank-3 or multi-batch tensor could pass the length check and write out of bounds.

Assert rank 2 and batch size 1 for both tensors before the length check.

### Tickets:
- [CVS-194189](https://jira.devtools.intel.com/browse/CVS-194189)

### AI Assistance:
- AI assistance used: yes
- Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.