### PR TITLE
[AUTO]Fix low power device matching, logging, and telemetry details

### DIFF
--- a/src/inference/include/openvino/runtime/auto/properties.hpp
+++ b/src/inference/include/openvino/runtime/auto/properties.hpp
@@ -102,8 +102,9 @@ static constexpr Property<PerfCurveTable> perf_curve_table{"PERF_CURVE_TABLE"};
 /**
  * @brief Name of the device AUTO should prefer while the platform is in low power mode
  * (as reported by IPF/DTT). Takes precedence over
- * devices_utilization_threshold when the platform is in low power mode. The value must exactly
- * match a candidate DeviceInformation::device_name, for example "CPU", "NPU", or "GPU.0".
+ * devices_utilization_threshold when the platform is in low power mode. The value is matched
+ * against a candidate DeviceInformation::device_name first (e.g. "GPU.0"), then against its base
+ * device name (e.g. "NPU" also matches a candidate named "NPU.5010").
  * On builds without OV_AUTO_ENABLE_IPF, the telemetry backend always returns unknown, so this
  * property has no effect.
  * @ingroup ov_runtime_cpp_prop_api

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -730,9 +730,9 @@ DeviceInformation Plugin::select_device(const std::vector<DeviceInformation>& me
     std::list<DeviceInformation> valid_devices = get_valid_device(meta_devices, model_precision);
 
     if (!perf_curve_table.empty()) {
-        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %u device curves", static_cast<unsigned>(perf_curve_table.size()));
+        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %lu device curves", static_cast<unsigned long>(perf_curve_table.size()));
         for (const auto& [device_key, curve] : perf_curve_table) {
-            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %u points", device_key.c_str(), static_cast<unsigned>(curve.size()));
+            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %lu points", device_key.c_str(), static_cast<unsigned long>(curve.size()));
             for (const auto& [utilization, score] : curve) {
                 LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s]: utilization=%u, score=%lf",
                               device_key.c_str(),

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -730,9 +730,12 @@ DeviceInformation Plugin::select_device(const std::vector<DeviceInformation>& me
     std::list<DeviceInformation> valid_devices = get_valid_device(meta_devices, model_precision);
 
     if (!perf_curve_table.empty()) {
-        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %lu device curves", static_cast<unsigned long>(perf_curve_table.size()));
+        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %s device curves",
+                      std::to_string(perf_curve_table.size()).c_str());
         for (const auto& [device_key, curve] : perf_curve_table) {
-            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %lu points", device_key.c_str(), static_cast<unsigned long>(curve.size()));
+            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %s points",
+                          device_key.c_str(),
+                          std::to_string(curve.size()).c_str());
             for (const auto& [utilization, score] : curve) {
                 LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s]: utilization=%u, score=%lf",
                               device_key.c_str(),

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -496,6 +496,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model_impl(const std::filesy
     auto low_power_device = load_config.get_property(ov::intel_auto::low_power_device);
     if (!low_power_device.empty()) {
         auto_s_context->m_low_power_device = low_power_device;
+        LOG_INFO_TAG("low_power_device is set to %s", low_power_device.c_str());
     }
     auto_s_context->m_startup_fallback = load_config.get_property(ov::intel_auto::enable_startup_fallback);
     auto_s_context->m_runtime_fallback = load_config.get_property(ov::intel_auto::enable_runtime_fallback);
@@ -729,11 +730,11 @@ DeviceInformation Plugin::select_device(const std::vector<DeviceInformation>& me
     std::list<DeviceInformation> valid_devices = get_valid_device(meta_devices, model_precision);
 
     if (!perf_curve_table.empty()) {
-        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %zu device curves", perf_curve_table.size());
+        LOG_DEBUG_TAG("PERF_CURVE_TABLE contains %u device curves", static_cast<unsigned>(perf_curve_table.size()));
         for (const auto& [device_key, curve] : perf_curve_table) {
-            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %zu points", device_key.c_str(), curve.size());
+            LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s] contains %u points", device_key.c_str(), static_cast<unsigned>(curve.size()));
             for (const auto& [utilization, score] : curve) {
-                LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s]: utilization=%u, score=%f",
+                LOG_DEBUG_TAG("PERF_CURVE_TABLE[%s]: utilization=%u, score=%lf",
                               device_key.c_str(),
                               utilization,
                               score);
@@ -950,7 +951,7 @@ std::list<DeviceInformation> Plugin::sort_device_by_perf_curve(
         }
         try {
             scores[i] = interpolate_perf_score(curve_it->second, utilization.value());
-            LOG_DEBUG_TAG("[%s] perf_curve_table: key=%s, utilization=%f, performance_score=%f",
+            LOG_DEBUG_TAG("[%s] perf_curve_table: key=%s, utilization=%lf, performance_score=%lf",
                           device.device_name.c_str(),
                           device_key.logical_key.c_str(),
                           utilization.value(),

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -791,12 +791,17 @@ DeviceInformation Plugin::select_device(const std::vector<DeviceInformation>& me
     };
     // low_power_device (driven by IPF/DTT OnEpoGearChanged) takes precedence over
     // devices_utilization_threshold whenever the platform is in low power mode.
+    // Match by exact device name (e.g. "NPU.5010") first, then fall back to the
+    // base device name (e.g. "NPU"), mirroring find_utilization_threshold.
     auto find_low_power_device = [&]() -> DeviceInformation* {
         if (low_power_device.empty()) {
             return nullptr;
         }
         auto it = std::find_if(valid_devices.begin(), valid_devices.end(), [&](const DeviceInformation& device) {
-            return device.device_name == low_power_device;
+            if (device.device_name == low_power_device) {
+                return true;
+            }
+            return ov::DeviceIDParser(device.device_name).get_device_name() == low_power_device;
         });
         if (it == valid_devices.end() || !get_low_power_mode().value_or(false)) {
             return nullptr;

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -10,6 +10,7 @@
 #    include <cmath>
 #    include <memory>
 #    include <mutex>
+#    include <optional>
 #    include <vector>
 
 #    include "ClientApiC.h"
@@ -24,10 +25,9 @@ inline std::string get_log_tag() {
     return "[IPF]";
 }
 
-// IPF namespace/paths confirmed against the DttSampleEfApp sample (Demo.cpp / Constants.h) and
-// DTT team feedback. Note the registered event path ends in "OnEpoGearChanged", not
-// "OnGearChanged"; the event's own eventPath argument is delivered as the parent node
-// ("...Policy.EPO"), with the real event name/value inside the JSON payload instead.
+// The registered event path ends in "OnEpoGearChanged", not "OnGearChanged"; the event's
+// own eventPath argument is delivered as the parent node ("...Policy.EPO"), with the real
+// event name/value inside the JSON payload instead.
 constexpr const char* k_dtt_root_path = "Platform.Features.DTT";
 constexpr const char* k_dtt_status_path = "Platform.Features.DTT.Software.Status";
 constexpr const char* k_dtt_version_path = "Platform.Features.DTT.Software.Version";
@@ -96,20 +96,38 @@ std::optional<float> parse_utilization_from_aiselector_json_impl(const std::stri
 // Calls into the statically linked IPF ClientApi through the plain-C ABI (ClientApiC.h).
 class TelemetryClient::Impl {
 public:
+    // Rejects anything outside the EPO-defined range so untrusted telemetry cannot force a mode.
+    static std::optional<int> parse_gear(const std::string& gear_str) {
+        int gear = 0;
+        try {
+            gear = std::stoi(gear_str);
+        } catch (const std::exception&) {
+            LOG_WARNING_TAG("TelemetryClient: EPO gear value is not an integer: %s", gear_str.c_str());
+            return std::nullopt;
+        }
+        if (!is_valid_gear(gear)) {
+            LOG_WARNING_TAG("TelemetryClient: EPO gear %d is out of the supported range [%d, %d]",
+                            gear,
+                            k_min_gear,
+                            k_max_gear);
+            return std::nullopt;
+        }
+        return gear;
+    }
+
     static void handle_gear_changed_event(void* context, const std::string& gear_str) {
         auto* sp = static_cast<std::shared_ptr<std::atomic<int>>*>(context);
         if (sp == nullptr || !*sp) {
             return;
         }
-        try {
-            const int gear = std::stoi(gear_str);
-            const int previous_gear = (*sp)->exchange(gear);
-            // Suppress repeated same-gear notifications so a spurious event storm can't flood the log.
-            if (gear != previous_gear) {
-                LOG_INFO_TAG("TelemetryClient: EPO gear changed to %d", gear);
-            }
-        } catch (const std::exception&) {
-            LOG_WARNING_TAG("TelemetryClient: EPO gear value is not an integer: %s", gear_str.c_str());
+        const auto gear = parse_gear(gear_str);
+        if (!gear.has_value()) {
+            return;
+        }
+        const int previous_gear = (*sp)->exchange(*gear);
+        // Suppress repeated same-gear notifications so a spurious event storm can't flood the log.
+        if (*gear != previous_gear) {
+            LOG_INFO_TAG("TelemetryClient: EPO gear changed to %d", *gear);
         }
     }
 
@@ -183,27 +201,28 @@ public:
     }
 
     void on_gear_changed(const std::string& gear_str) {
-        try {
-            const int gear = std::stoi(gear_str);
-            m_shared_gear->store(gear);
-        } catch (const std::exception&) {
-            LOG_WARNING_TAG("TelemetryClient: EPO gear value is not an integer: %s", gear_str.c_str());
+        if (const auto gear = parse_gear(gear_str)) {
+            m_shared_gear->store(*gear);
         }
     }
 
 private:
-    // Retries until registration succeeds; a failed attempt does not permanently disable tracking.
+    // DTT is probed once per client
     void ensure_gear_tracking_registered() {
-        if (m_gear_event_registered) {
+        if (m_gear_tracking_initialized.load(std::memory_order_acquire)) {
             return;
         }
         std::lock_guard<std::mutex> lock(m_low_power_init_mutex);
-        if (m_gear_event_registered) {
+        if (m_gear_tracking_initialized.load(std::memory_order_relaxed)) {
             return;
         }
-        if (!m_shared_gear) {
-            m_shared_gear = std::make_shared<std::atomic<int>>(-1);
-        }
+        initialize_gear_tracking();
+        m_gear_tracking_initialized.store(true, std::memory_order_release);
+    }
+
+    // Must be called while holding m_low_power_init_mutex.
+    void initialize_gear_tracking() {
+        m_shared_gear = std::make_shared<std::atomic<int>>(-1);
         refresh_dtt_nodes();
         if (!is_dtt_available()) {
             LOG_WARNING_TAG("TelemetryClient: DTT unavailable, EPO gear tracking is disabled");
@@ -343,6 +362,7 @@ private:
     }
 
     void* m_handle = nullptr;
+    std::atomic<bool> m_gear_tracking_initialized{false};
     bool m_gear_event_registered = false;
     std::mutex m_low_power_init_mutex;
     std::shared_ptr<std::atomic<int>> m_shared_gear;

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -99,9 +99,15 @@ public:
     // Rejects anything outside the EPO-defined range so untrusted telemetry cannot force a mode.
     static std::optional<int> parse_gear(const std::string& gear_str) {
         int gear = 0;
+        std::size_t parsed_chars = 0;
         try {
-            gear = std::stoi(gear_str);
+            gear = std::stoi(gear_str, &parsed_chars);
         } catch (const std::exception&) {
+            LOG_WARNING_TAG("TelemetryClient: EPO gear value is not an integer: %s", gear_str.c_str());
+            return std::nullopt;
+        }
+        // std::stoi accepts a numeric prefix (e.g. "4garbage"); require the whole string to be consumed.
+        if (parsed_chars != gear_str.size()) {
             LOG_WARNING_TAG("TelemetryClient: EPO gear value is not an integer: %s", gear_str.c_str());
             return std::nullopt;
         }

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -103,8 +103,11 @@ public:
         }
         try {
             const int gear = std::stoi(gear_str);
-            (*sp)->store(gear);
-            LOG_WARNING_TAG("TelemetryClient: EPO gear changed to %d", gear);
+            const int previous_gear = (*sp)->exchange(gear);
+            // Suppress repeated same-gear notifications so a spurious event storm can't flood the log.
+            if (gear != previous_gear) {
+                LOG_INFO_TAG("TelemetryClient: EPO gear changed to %d", gear);
+            }
         } catch (const std::exception&) {
             LOG_WARNING_TAG("TelemetryClient: EPO gear value is not an integer: %s", gear_str.c_str());
         }
@@ -165,34 +168,10 @@ public:
         if (m_handle == nullptr) {
             return std::nullopt;
         }
-        std::call_once(m_low_power_init_once, [this]() {
-            m_shared_gear = std::make_shared<std::atomic<int>>(-1);
-            refresh_dtt_nodes();
-            if (!is_dtt_available()) {
-                LOG_WARNING_TAG("TelemetryClient: DTT unavailable, EPO gear tracking is disabled");
-                return;
-            }
-            log_dtt_version();
-            // Seed the gear only while EPO is enabled; otherwise CurrentGear may be stale.
-            if (is_epo_enabled()) {
-                log_current_gear();
-            }
-            // Context is kept alive here; raw pointer passed to IPF and freed only after confirmed unregister.
-            m_callback_context = std::make_unique<std::shared_ptr<std::atomic<int>>>(m_shared_gear);
-            const ipf_err_t reg_status =
-                IpfRegisterEvent(m_handle, k_dtt_gear_changed_path, gear_changed_callback, m_callback_context.get());
-            if (reg_status != IpfError::IPF_ERR_OK) {
-                LOG_WARNING_TAG("TelemetryClient: failed to register for %s: %s: %s",
-                                k_dtt_gear_changed_path,
-                                ipf_ef_error_str(reg_status),
-                                IpfGetLastErrorMessage());
-                m_callback_context.reset();
-            } else {
-                m_gear_event_registered = true;
-                LOG_INFO_TAG("TelemetryClient: registered for %s", k_dtt_gear_changed_path);
-            }
-        });
-        // After first init, this is an atomic read; the call_once body does not re-run.
+        ensure_gear_tracking_registered();
+        if (!m_shared_gear) {
+            return std::nullopt;
+        }
         const int gear = m_shared_gear->load();
         if (gear < 0) {
             LOG_DEBUG_TAG("TelemetryClient: EPO gear unknown, low power mode unavailable");
@@ -213,6 +192,44 @@ public:
     }
 
 private:
+    // Retries until registration succeeds; a failed attempt does not permanently disable tracking.
+    void ensure_gear_tracking_registered() {
+        if (m_gear_event_registered) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(m_low_power_init_mutex);
+        if (m_gear_event_registered) {
+            return;
+        }
+        if (!m_shared_gear) {
+            m_shared_gear = std::make_shared<std::atomic<int>>(-1);
+        }
+        refresh_dtt_nodes();
+        if (!is_dtt_available()) {
+            LOG_WARNING_TAG("TelemetryClient: DTT unavailable, EPO gear tracking is disabled");
+            return;
+        }
+        log_dtt_version();
+        // Seed the gear only while EPO is enabled; otherwise CurrentGear may be stale.
+        if (is_epo_enabled()) {
+            log_current_gear();
+        }
+        // Context is kept alive here; raw pointer passed to IPF and freed only after confirmed unregister.
+        m_callback_context = std::make_unique<std::shared_ptr<std::atomic<int>>>(m_shared_gear);
+        const ipf_err_t reg_status =
+            IpfRegisterEvent(m_handle, k_dtt_gear_changed_path, gear_changed_callback, m_callback_context.get());
+        if (reg_status != IpfError::IPF_ERR_OK) {
+            LOG_WARNING_TAG("TelemetryClient: failed to register for %s: %s: %s",
+                            k_dtt_gear_changed_path,
+                            ipf_ef_error_str(reg_status),
+                            IpfGetLastErrorMessage());
+            m_callback_context.reset();
+            return;
+        }
+        m_gear_event_registered = true;
+        LOG_INFO_TAG("TelemetryClient: registered for %s", k_dtt_gear_changed_path);
+    }
+
     using IpfQueryFn = ipf_err_t (*)(void*, const char*, char*, size_t*);
 
     // Query IPF node/value data with the two-call buffer-size protocol.
@@ -327,7 +344,7 @@ private:
 
     void* m_handle = nullptr;
     bool m_gear_event_registered = false;
-    std::once_flag m_low_power_init_once;
+    std::mutex m_low_power_init_mutex;
     std::shared_ptr<std::atomic<int>> m_shared_gear;
     // Owns the heap-allocated shared_ptr passed to IpfRegisterEvent; freed only after confirmed unregister.
     std::unique_ptr<std::shared_ptr<std::atomic<int>>> m_callback_context;

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -99,7 +99,9 @@ public:
             return;
         }
         try {
-            (*sp)->store(std::stoi(gear_str));
+            const int gear = std::stoi(gear_str);
+            (*sp)->store(gear);
+            LOG_WARNING_TAG("TelemetryClient: EPO gear changed to %d", gear);
         } catch (const std::exception&) {
             LOG_WARNING_TAG("TelemetryClient: EPO gear value is not an integer: %s", gear_str.c_str());
         }

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -109,7 +109,9 @@ public:
         const ipf_err_t status = IpfCreate(nullptr, &m_handle);
         if (status != IpfError::IPF_ERR_OK) {
             m_handle = nullptr;
-            LOG_WARNING_TAG("TelemetryClient: IPF ClientApi initialization failed: %s", ipf_ef_error_str(status));
+            LOG_WARNING_TAG("TelemetryClient: IPF ClientApi initialization failed: %s: %s",
+                            ipf_ef_error_str(status),
+                            IpfGetLastErrorMessage());
             return;
         }
         LOG_INFO_TAG("TelemetryClient: IPF ClientApi initialized successfully");
@@ -124,8 +126,9 @@ public:
                     m_callback_context.reset();
                 } else {
                     // Unregister failed: intentionally leak context to prevent use-after-free.
-                    LOG_WARNING_TAG("TelemetryClient: IpfUnregisterEvent failed: %s, leaking callback context",
-                                    ipf_ef_error_str(unreg_status));
+                    LOG_WARNING_TAG("TelemetryClient: IpfUnregisterEvent failed: %s: %s, leaking callback context",
+                                    ipf_ef_error_str(unreg_status),
+                                    IpfGetLastErrorMessage());
                     (void)m_callback_context.release();
                 }
             }
@@ -166,9 +169,10 @@ public:
             const ipf_err_t reg_status =
                 IpfRegisterEvent(m_handle, k_dtt_gear_changed_path, gear_changed_callback, m_callback_context.get());
             if (reg_status != IpfError::IPF_ERR_OK) {
-                LOG_WARNING_TAG("TelemetryClient: failed to register for %s: %s",
+                LOG_WARNING_TAG("TelemetryClient: failed to register for %s: %s: %s",
                                 k_dtt_gear_changed_path,
-                                ipf_ef_error_str(reg_status));
+                                ipf_ef_error_str(reg_status),
+                                IpfGetLastErrorMessage());
                 m_callback_context.reset();
             } else {
                 m_gear_event_registered = true;
@@ -200,13 +204,19 @@ private:
         size_t len = 0;
         ipf_err_t status = query_fn(m_handle, path, nullptr, &len);
         if (status != IpfError::IPF_ERR_BUFFERTOOSMALL || len == 0) {
-            LOG_WARNING_TAG("TelemetryClient: IPF query(%s) size query failed: %s", path, ipf_ef_error_str(status));
+            LOG_WARNING_TAG("TelemetryClient: IPF query(%s) size query failed: %s: %s",
+                            path,
+                            ipf_ef_error_str(status),
+                            IpfGetLastErrorMessage());
             return {};
         }
         std::vector<char> buf(len);
         status = query_fn(m_handle, path, buf.data(), &len);
         if (status != IpfError::IPF_ERR_OK) {
-            LOG_WARNING_TAG("TelemetryClient: IPF query(%s) failed: %s", path, ipf_ef_error_str(status));
+            LOG_WARNING_TAG("TelemetryClient: IPF query(%s) failed: %s: %s",
+                            path,
+                            ipf_ef_error_str(status),
+                            IpfGetLastErrorMessage());
             return {};
         }
         std::string result(buf.data(), len);

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -28,7 +28,10 @@ inline std::string get_log_tag() {
 // DTT team feedback. Note the registered event path ends in "OnEpoGearChanged", not
 // "OnGearChanged"; the event's own eventPath argument is delivered as the parent node
 // ("...Policy.EPO"), with the real event name/value inside the JSON payload instead.
+constexpr const char* k_dtt_root_path = "Platform.Features.DTT";
+constexpr const char* k_dtt_status_path = "Platform.Features.DTT.Software.Status";
 constexpr const char* k_dtt_version_path = "Platform.Features.DTT.Software.Version";
+constexpr const char* k_dtt_epo_status_path = "Platform.Features.DTT.Policy.EPO.Status";
 constexpr const char* k_dtt_current_gear_path = "Platform.Features.DTT.Policy.EPO.CurrentGear";
 constexpr const char* k_dtt_gear_changed_path = "Platform.Features.DTT.Policy.EPO.OnEpoGearChanged";
 
@@ -164,8 +167,16 @@ public:
         }
         std::call_once(m_low_power_init_once, [this]() {
             m_shared_gear = std::make_shared<std::atomic<int>>(-1);
+            refresh_dtt_nodes();
+            if (!is_dtt_available()) {
+                LOG_WARNING_TAG("TelemetryClient: DTT unavailable, EPO gear tracking is disabled");
+                return;
+            }
             log_dtt_version();
-            log_current_gear();
+            // Seed the gear only while EPO is enabled; otherwise CurrentGear may be stale.
+            if (is_epo_enabled()) {
+                log_current_gear();
+            }
             // Context is kept alive here; raw pointer passed to IPF and freed only after confirmed unregister.
             m_callback_context = std::make_unique<std::shared_ptr<std::atomic<int>>>(m_shared_gear);
             const ipf_err_t reg_status =
@@ -184,9 +195,12 @@ public:
         // After first init, this is an atomic read; the call_once body does not re-run.
         const int gear = m_shared_gear->load();
         if (gear < 0) {
+            LOG_DEBUG_TAG("TelemetryClient: EPO gear unknown, low power mode unavailable");
             return std::nullopt;
         }
-        return is_low_power_gear(gear);
+        const bool low_power = is_low_power_gear(gear);
+        LOG_DEBUG_TAG("TelemetryClient: EPO gear=%d, low_power_mode=%s", gear, low_power ? "true" : "false");
+        return low_power;
     }
 
     void on_gear_changed(const std::string& gear_str) {
@@ -205,11 +219,16 @@ private:
     std::string query_ipf_string(IpfQueryFn query_fn, const char* path) {
         size_t len = 0;
         ipf_err_t status = query_fn(m_handle, path, nullptr, &len);
-        if (status != IpfError::IPF_ERR_BUFFERTOOSMALL || len == 0) {
+        if (status != IpfError::IPF_ERR_BUFFERTOOSMALL) {
+            // IpfGetLastErrorMessage() is only meaningful for a real failure; do not report it otherwise.
             LOG_WARNING_TAG("TelemetryClient: IPF query(%s) size query failed: %s: %s",
                             path,
                             ipf_ef_error_str(status),
                             IpfGetLastErrorMessage());
+            return {};
+        }
+        if (len == 0) {
+            LOG_WARNING_TAG("TelemetryClient: IPF query(%s) returned an empty value", path);
             return {};
         }
         std::vector<char> buf(len);
@@ -236,34 +255,70 @@ private:
         return query_ipf_string(&IpfGetValue, path);
     }
 
-    // Best-effort one-shot reads; failures are already logged by query_ipf_string/get_value.
-    void log_dtt_version() {
-        const std::string json_str = get_value(k_dtt_version_path);
+    // DTT requires reading its root node once to refresh the subtree before individual value queries.
+    void refresh_dtt_nodes() {
+        const std::string json_str = get_node(k_dtt_root_path);
+        LOG_DEBUG_TAG("TelemetryClient: DTT root node refresh %s", json_str.empty() ? "failed" : "succeeded");
+    }
+
+    // DTT values arrive as JSON; non-string nodes are dumped verbatim so they stay loggable.
+    std::optional<std::string> get_value_as_string(const char* path) {
+        const std::string json_str = get_value(path);
         if (json_str.empty()) {
-            return;
+            return std::nullopt;
         }
+        LOG_DEBUG_TAG("TelemetryClient: raw IPF value at %s: %s", path, json_str.c_str());
         try {
             const auto parsed = nlohmann::json::parse(json_str);
-            const std::string version = parsed.is_string() ? parsed.get<std::string>() : parsed.dump();
-            LOG_INFO_TAG("TelemetryClient: DTT version = %s", version.c_str());
+            return parsed.is_string() ? parsed.get<std::string>() : parsed.dump();
         } catch (const nlohmann::json::exception& e) {
-            LOG_WARNING_TAG("TelemetryClient: failed to parse DTT version: %s", e.what());
+            LOG_WARNING_TAG("TelemetryClient: failed to parse value at %s: %s", path, e.what());
+            return std::nullopt;
+        }
+    }
+
+    // DTT publishes its own health here; an unreadable status means the driver is missing or stopped.
+    bool is_dtt_available() {
+        const auto status = get_value_as_string(k_dtt_status_path);
+        if (!status.has_value()) {
+            LOG_WARNING_TAG("TelemetryClient: DTT status unavailable, DTT driver may not be installed or running");
+            return false;
+        }
+        LOG_INFO_TAG("TelemetryClient: DTT status = %s", status->c_str());
+        return true;
+    }
+
+    // CurrentGear only reflects the live platform state while EPO is enabled.
+    bool is_epo_enabled() {
+        const auto status = get_value_as_string(k_dtt_epo_status_path);
+        if (!status.has_value()) {
+            LOG_WARNING_TAG("TelemetryClient: EPO status unavailable, treating low power mode as unknown");
+            return false;
+        }
+        LOG_INFO_TAG("TelemetryClient: EPO status = %s", status->c_str());
+        if (*status != "Enabled") {
+            LOG_WARNING_TAG("TelemetryClient: EPO is not enabled, ignoring current EPO gear");
+            return false;
+        }
+        return true;
+    }
+
+    // Best-effort one-shot reads; failures are already logged by query_ipf_string/get_value_as_string.
+    void log_dtt_version() {
+        const auto version = get_value_as_string(k_dtt_version_path);
+        if (version.has_value()) {
+            LOG_INFO_TAG("TelemetryClient: DTT version = %s", version->c_str());
         }
     }
 
     void log_current_gear() {
-        const std::string json_str = get_value(k_dtt_current_gear_path);
-        if (json_str.empty()) {
+        const auto gear_str = get_value_as_string(k_dtt_current_gear_path);
+        if (!gear_str.has_value()) {
+            LOG_WARNING_TAG("TelemetryClient: current EPO gear unavailable");
             return;
         }
-        try {
-            const auto parsed = nlohmann::json::parse(json_str);
-            const std::string gear_str = parsed.is_string() ? parsed.get<std::string>() : parsed.dump();
-            LOG_INFO_TAG("TelemetryClient: current EPO gear = %s", gear_str.c_str());
-            on_gear_changed(gear_str);
-        } catch (const nlohmann::json::exception& e) {
-            LOG_WARNING_TAG("TelemetryClient: failed to parse current EPO gear: %s", e.what());
-        }
+        LOG_INFO_TAG("TelemetryClient: current EPO gear = %s", gear_str->c_str());
+        on_gear_changed(*gear_str);
     }
 
     void* m_handle = nullptr;

--- a/src/plugins/auto/src/utils/device_telemetry.cpp
+++ b/src/plugins/auto/src/utils/device_telemetry.cpp
@@ -270,6 +270,10 @@ private:
         LOG_DEBUG_TAG("TelemetryClient: raw IPF value at %s: %s", path, json_str.c_str());
         try {
             const auto parsed = nlohmann::json::parse(json_str);
+            if (parsed.is_null()) {
+                LOG_WARNING_TAG("TelemetryClient: IPF value at %s is null", path);
+                return std::nullopt;
+            }
             return parsed.is_string() ? parsed.get<std::string>() : parsed.dump();
         } catch (const nlohmann::json::exception& e) {
             LOG_WARNING_TAG("TelemetryClient: failed to parse value at %s: %s", path, e.what());

--- a/src/plugins/auto/src/utils/device_telemetry.hpp
+++ b/src/plugins/auto/src/utils/device_telemetry.hpp
@@ -52,12 +52,19 @@ inline constexpr std::string_view k_igpu_utilization_metric = "IGPUUtilization";
 inline constexpr std::string_view k_igpu_utilization_fallback_metric = "GPUUtilization";
 inline constexpr std::string_view k_dgpu_utilization_metric = "DGPUUtilization";
 inline constexpr std::string_view k_npu_utilization_metric = "NPUUtilization";
-// EPO gears 1-3 request low-latency/performance operation (perf_curve_table);
-// gears 4-7 request low power operation (low_power_device).
+// EPO defines gears 1-7: gears 1-3 request low-latency/performance operation
+// (perf_curve_table), gears 4-7 request low power operation (low_power_device).
+inline constexpr int k_min_gear = 1;
+inline constexpr int k_max_gear = 7;
 inline constexpr int k_low_power_mode_min_gear = 4;
+inline constexpr int k_low_power_mode_max_gear = k_max_gear;
+
+inline constexpr bool is_valid_gear(int gear) {
+    return gear >= k_min_gear && gear <= k_max_gear;
+}
 
 inline constexpr bool is_low_power_gear(int gear) {
-    return gear >= k_low_power_mode_min_gear;
+    return gear >= k_low_power_mode_min_gear && gear <= k_low_power_mode_max_gear;
 }
 
 inline constexpr bool has_prefix(std::string_view value, std::string_view prefix) {

--- a/src/plugins/auto/src/utils/device_telemetry.hpp
+++ b/src/plugins/auto/src/utils/device_telemetry.hpp
@@ -15,6 +15,13 @@ namespace ov {
 namespace auto_plugin {
 namespace device_monitor {
 
+// IPF (Intel(R) Innovation Platform Framework): Intel's telemetry/policy client API used
+//     here to query platform state and subscribe to runtime platform events (e.g. DTT gear changes).
+// DTT (Intel(R) Dynamic Tuning Technology): Intel driver/service that manages platform
+//     power/thermal policy and exposes its state (status, version, current EPO gear) through IPF.
+// EPO (Energy Performance Optimizer): one of DTT's policies; its "gear" (1-7) indicates whether
+//     the platform currently favors low-latency/performance (gears 1-3) or low power (gears 4-7).
+
 #ifdef OV_AUTO_ENABLE_IPF
 void gear_changed_callback(const char* path, const char* event, void* context);
 #endif

--- a/src/plugins/auto/src/utils/device_telemetry.hpp
+++ b/src/plugins/auto/src/utils/device_telemetry.hpp
@@ -45,9 +45,10 @@ inline constexpr std::string_view k_igpu_utilization_metric = "IGPUUtilization";
 inline constexpr std::string_view k_igpu_utilization_fallback_metric = "GPUUtilization";
 inline constexpr std::string_view k_dgpu_utilization_metric = "DGPUUtilization";
 inline constexpr std::string_view k_npu_utilization_metric = "NPUUtilization";
-inline constexpr int k_low_power_mode_min_gear = 1;
+// EPO gears 1-3 request low-latency/performance operation (perf_curve_table);
+// gears 4-7 request low power operation (low_power_device).
+inline constexpr int k_low_power_mode_min_gear = 4;
 
-// EPO gear 0 is baseline; positive gears request reduced-power operation.
 inline constexpr bool is_low_power_gear(int gear) {
     return gear >= k_low_power_mode_min_gear;
 }

--- a/src/plugins/auto/tests/unit/device_telemetry_test.cpp
+++ b/src/plugins/auto/tests/unit/device_telemetry_test.cpp
@@ -57,10 +57,15 @@ INSTANTIATE_TEST_SUITE_P(smoke_Auto_BehaviorTests,
                          DeviceMonitorKeyTest::getTestCaseName);
 
 TEST(DeviceMonitorTest, low_power_mode_gear_mapping_matches_expected_policy) {
+    // Gears 1-3 request low-latency/performance operation (perf_curve_table); only
+    // gears 4-7 request low power operation (low_power_device).
     EXPECT_FALSE(device_monitor::is_low_power_gear(-1));
     EXPECT_FALSE(device_monitor::is_low_power_gear(0));
-    EXPECT_TRUE(device_monitor::is_low_power_gear(1));
-    EXPECT_TRUE(device_monitor::is_low_power_gear(2));
+    EXPECT_FALSE(device_monitor::is_low_power_gear(1));
+    EXPECT_FALSE(device_monitor::is_low_power_gear(2));
+    EXPECT_FALSE(device_monitor::is_low_power_gear(3));
+    EXPECT_TRUE(device_monitor::is_low_power_gear(4));
+    EXPECT_TRUE(device_monitor::is_low_power_gear(7));
 }
 
 TEST(DeviceMonitorTest, telemetry_client_low_power_mode_is_safe) {

--- a/src/plugins/auto/tests/unit/device_telemetry_test.cpp
+++ b/src/plugins/auto/tests/unit/device_telemetry_test.cpp
@@ -66,6 +66,19 @@ TEST(DeviceMonitorTest, low_power_mode_gear_mapping_matches_expected_policy) {
     EXPECT_FALSE(device_monitor::is_low_power_gear(3));
     EXPECT_TRUE(device_monitor::is_low_power_gear(4));
     EXPECT_TRUE(device_monitor::is_low_power_gear(7));
+    // Gears above the EPO-defined range are not low power.
+    EXPECT_FALSE(device_monitor::is_low_power_gear(8));
+    EXPECT_FALSE(device_monitor::is_low_power_gear(100));
+}
+
+TEST(DeviceMonitorTest, valid_gear_range_matches_epo_specification) {
+    // EPO defines gears 1-7; anything outside that range is not a valid gear.
+    EXPECT_FALSE(device_monitor::is_valid_gear(-1));
+    EXPECT_FALSE(device_monitor::is_valid_gear(0));
+    EXPECT_TRUE(device_monitor::is_valid_gear(1));
+    EXPECT_TRUE(device_monitor::is_valid_gear(7));
+    EXPECT_FALSE(device_monitor::is_valid_gear(8));
+    EXPECT_FALSE(device_monitor::is_valid_gear(100));
 }
 
 TEST(DeviceMonitorTest, telemetry_client_low_power_mode_is_safe) {

--- a/src/plugins/auto/tests/unit/select_device_test.cpp
+++ b/src/plugins/auto/tests/unit/select_device_test.cpp
@@ -815,6 +815,19 @@ TEST_F(SelectDeviceWithLowPowerDevicePrecedenceTest, lowPowerDeviceOverridesThre
     EXPECT_EQ(result.unique_name, "NPU_01");
 }
 
+TEST_F(SelectDeviceWithLowPowerDevicePrecedenceTest, lowPowerDeviceMatchesViaBaseNameFallback) {
+    // low_power_device="NPU" must still match a candidate whose device_name carries a HW id suffix.
+    std::vector<std::string> npuHwIdCapability = {"FP32", "FP16", "INT8", "BIN"};
+    ON_CALL(*core, get_property(StrEq("NPU.5010"), StrEq(ov::device::capabilities.name()), _))
+        .WillByDefault(RETURN_MOCK_VALUE(npuHwIdCapability));
+    std::vector<DeviceInformation> devicesWithHwId = {{"CPU", {}, -1, "01", "CPU_01", 0},
+                                                       {"NPU.5010", {}, -1, "01", "NPU_01", 0}};
+    EXPECT_CALL(*plugin, get_low_power_mode()).WillOnce(Return(true));
+    auto result = plugin->select_device(devicesWithHwId, netPrecision, 0, {thresholds, {}}, "NPU");
+    selectedUniqueName = result.unique_name;
+    EXPECT_EQ(result.unique_name, "NPU_01");
+}
+
 TEST_F(SelectDeviceWithLowPowerDevicePrecedenceTest, fallsBackToThresholdWhenNotInLowPowerMode) {
     EXPECT_CALL(*plugin, get_low_power_mode()).WillOnce(Return(false));
     auto result = plugin->select_device(devices, netPrecision, 0, {thresholds, {}}, "NPU");


### PR DESCRIPTION
Ported from https://github.com/openvinotoolkit/openvino/pull/37687
### Details:
- Fix `low_power_device` matching in `select_device()`: only exact `device_name` matched, so a base device name (e.g. `"NPU"`) didn't match candidates like `"NPU.5010"`. Now falls back to base device name matching, same as find_utilization_threshold`. Update the `LOW_POWER_DEVICE` API doc to describe this base-name fallback (previously documented as exact-match only).
- Fix `is_low_power_gear()` threshold: gears 1-3 mean performance mode, only gears 4-7 mean low power mode, but code treated `gear >= 1` as low power. Changed threshold from 1 to 4, and added `is_valid_gear()` to reject gears outside EPO's defined 1-7 range.
- Fix invalid `%zu`/`%f` log format specifiers in `PERF_CURVE_TABLE` and perf-curve interpolation debug logs (unsupported by the AUTO logger, silently printed "format ... is not valid in log"); changed to `%u`/`std::to_string()`/`%lf`.
- Fix EPO gear parsing to reject malformed telemetry: `std::stoi` accepts a numeric prefix (e.g. `"4garbage"` parsed as gear 4), so the consumed-character count is now checked to require the whole string be a valid integer before applying the range check.
- Only subscribe to DTT gear-changed events after confirming DTT is running and EPO is enabled, instead of always registering; avoids acting on stale/unavailable driver state.
- Surface `IpfGetLastErrorMessage()` detail in IPF telemetry warning logs (init/unregister/query failures) for easier diagnosis.
- Suppress repeated same-gear log noise: only log at INFO when the EPO gear actually changes value.
- Log the configured `low_power_device` value at INFO level for easier debugging.
- Updated/added unit tests covering all of the above (gear range/threshold boundaries, base-name
fallback matching, malformed gear parsing).

### Tickets:
 - CVS-191309

### AI Assistance:
 - AI assistance used: yes
 - Iimplement fixes, and update/add tests. Validated by human.
