### PR TITLE
[ONNX FE] Unguarded border[1]/border[0] read before length check in crop

### DIFF
--- a/src/frontends/onnx/frontend/src/op/crop.cpp
+++ b/src/frontends/onnx/frontend/src/op/crop.cpp
@@ -26,6 +26,12 @@ ov::OutputVector crop(const ov::frontend::onnx::Node& node) {
     // Spec defines four borders (left, top, right, bottom); when scale is present only left/top are used.
     const auto border = node.get_attribute_value<std::vector<std::int64_t>>("border");
 
+    // border[0] and border[1] are read below to build `begin`, regardless of whether 'scale' is set.
+    CHECK_VALID_NODE(node,
+                     border.size() >= 2,
+                     "ONNX Crop expects at least 2 values in 'border' attribute, found: ",
+                     border.size());
+
     std::shared_ptr<ov::Node> end;
 
     // Set slice begin values to border values (note order of indexes)
@@ -35,10 +41,6 @@ ov::OutputVector crop(const ov::frontend::onnx::Node& node) {
     // If scale is given, then start crop at left/top `border`
     // and end on left/top `border` + `scale`.
     if (node.has_attribute("scale")) {
-        CHECK_VALID_NODE(node,
-                         border.size() >= 2,
-                         "ONNX Crop with 'scale' expects at least 2 values in 'border' attribute, found: ",
-                         border.size());
         // List of ints height, width
         const auto scale = node.get_attribute_value<std::vector<std::int64_t>>("scale");
 

--- a/src/frontends/onnx/tests/convert_tests.cpp
+++ b/src/frontends/onnx/tests/convert_tests.cpp
@@ -95,3 +95,17 @@ TEST(ONNXFeConvertException, exception_if_scan_body_fewer_outputs_than_initial_v
                     ov::frontend::OpConversionFailure,
                     testing::HasSubstr("num_scan_outputs can't be negative"));
 }
+
+/// Tests that Crop rejects a 'border' attribute with fewer than 2 values, since border[0] and
+/// border[1] are read to build the slice 'begin' constant regardless of the 'scale' attribute.
+TEST(ONNXFeConvertException, exception_if_crop_border_too_short) {
+    OV_EXPECT_THROW(convert_model("crop_border_too_short.onnx"),
+                    ov::AssertFailure,
+                    testing::HasSubstr("expects at least 2 values in 'border' attribute, found: 1"));
+}
+
+TEST(ONNXFeConvertException, exception_if_crop_border_empty) {
+    OV_EXPECT_THROW(convert_model("crop_border_empty.onnx"),
+                    ov::AssertFailure,
+                    testing::HasSubstr("expects at least 2 values in 'border' attribute, found: 0"));
+}

--- a/src/frontends/onnx/tests/models/crop_border_empty.prototxt
+++ b/src/frontends/onnx/tests/models/crop_border_empty.prototxt
@@ -1,0 +1,61 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Crop"
+    attribute {
+      name: "border"
+      type: INTS
+    }
+  }
+  name: "test_model"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/crop_border_too_short.prototxt
+++ b/src/frontends/onnx/tests/models/crop_border_too_short.prototxt
@@ -1,0 +1,62 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Crop"
+    attribute {
+      name: "border"
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test_model"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 1
+}


### PR DESCRIPTION
### Details:
Add a CHECK_VALID_NODE guard on `border.size() >= 2` immediately after reading the ONNX `Crop` node's `border` attribute in crop.cpp, before it is indexed to build the slice `begin` constant, preventing an out-of-bounds heap read on a crafted ONNX model.

One out-of-bounds read path is fixed:

- `border[1]` and `border[0]` used at line 33 to construct `begin` without a preceding non-empty/size check — the existing `border.size() >= 2` guard only lived inside the `if (node.has_attribute("scale"))` branch, and was reached after line 33 had already executed.

### Tickets:
- *CVS-194198*

### AI Assistance:
- *AI assistance used: yes*
- *Bug root cause was found by AI.*