### PR TITLE
[ONNX FE] Add validation for Dropout training_mode constant element count

### DIFF
--- a/src/frontends/onnx/frontend/src/op/dropout.cpp
+++ b/src/frontends/onnx/frontend/src/op/dropout.cpp
@@ -43,7 +43,10 @@ ov::OutputVector dropout(const ov::frontend::onnx::Node& node) {
         CHECK_VALID_NODE(node,
                          ov::op::util::is_constant(ng_inputs.at(2).get_node_shared_ptr()),
                          "Non-constant training_mode input is not supported.");
-        training_mode = ov::as_type_ptr<v0::Constant>(ng_inputs.at(2).get_node_shared_ptr())->cast_vector<bool>()[0];
+        const auto training_mode_values =
+            ov::as_type_ptr<v0::Constant>(ng_inputs.at(2).get_node_shared_ptr())->cast_vector<bool>();
+        CHECK_VALID_NODE(node, training_mode_values.size() == 1, "training_mode input must contain one element.");
+        training_mode = training_mode_values[0];
     }
     return build_dropout(node, training_mode);
 }

--- a/src/frontends/onnx/tests/graph_iterator.cpp
+++ b/src/frontends/onnx/tests/graph_iterator.cpp
@@ -744,3 +744,38 @@ INSTANTIATE_TEST_SUITE_P(OnnxConvertEquivalence,
                              }
                              return n;
                          });
+
+TEST(FrontEndGraphIteratorTest, rejects_empty_dropout_training_mode) {
+    auto model = std::make_shared<ONNX_NAMESPACE::ModelProto>();
+    model->set_ir_version(13);
+    auto* opset = model->add_opset_import();
+    opset->set_version(12);
+    auto* graph = model->mutable_graph();
+    auto* node = graph->add_node();
+    node->set_op_type("Dropout");
+    node->add_input("X");
+    node->add_input("");
+    node->add_input("training_mode");
+    node->add_output("Y");
+    auto* init = graph->add_initializer();
+    init->set_name("training_mode");
+    init->set_data_type(ONNX_NAMESPACE::TensorProto_DataType_BOOL);
+    init->add_dims(0);
+    auto* input = graph->add_input();
+    input->set_name("X");
+    input->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    input->mutable_type()->mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+    auto* output = graph->add_output();
+    output->set_name("Y");
+    output->mutable_type()->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    output->mutable_type()->mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+    auto iterator = std::make_shared<ov::frontend::onnx::GraphIteratorProto>(
+        ov::frontend::onnx::GraphIteratorProtoMemoryManagementMode::External_Stream);
+    iterator->initialize(model);
+    iterator->reset();
+    auto frontend = ov::frontend::FrontEndManager().load_by_framework("onnx");
+    ASSERT_NE(frontend, nullptr);
+    auto input_model = frontend->load(std::dynamic_pointer_cast<ov::frontend::onnx::GraphIterator>(iterator));
+    ASSERT_NE(input_model, nullptr);
+    EXPECT_THROW(frontend->convert(input_model), ov::Exception);
+}


### PR DESCRIPTION
### Details:
Add element count validation for the training_mode input in the Dropout opset_12 handler before unchecked vector indexing, preventing OOB-read and UB on crafted ONNX models with zero-element constant tensors.

The dropout handler (src/frontends/onnx/frontend/src/op/dropout.cpp:46) performs unchecked index access on the cast_vector result without validating that the Constant tensor contains at least one element. If a zero-shape Constant [0] is passed as training_mode, cast_vector<bool>() returns an empty vector, and accessing [0] triggers out-of-bounds read.

Fix: Extract cast_vector result to a local variable, add CHECK_VALID_NODE guard requiring size()==1, then access element safely.

### Tickets:
- *CVS-194200*

### AI Assistance:
- *AI assistance used: yes*
- *Bug root cause was found by security scanner analysis*