### PR TITLE
Validate ScatterElementsUpdate indices in the reference kernel

### DIFF
--- a/src/core/reference/include/openvino/reference/scatter_elements_update.hpp
+++ b/src/core/reference/include/openvino/reference/scatter_elements_update.hpp
@@ -20,9 +20,21 @@ namespace ov {
 namespace reference {
 template <typename T>
 size_t normalize_index(const T idx, const size_t dim_value) {
+    // Per the operator specification the index must lie within [-dim_value, dim_value - 1]. 
     if (idx < 0) {
-        return static_cast<size_t>(idx + dim_value);
+        const int64_t normalized = static_cast<int64_t>(idx) + static_cast<int64_t>(dim_value);
+        OPENVINO_ASSERT(normalized >= 0,
+                        "ScatterElementsUpdate index ",
+                        static_cast<int64_t>(idx),
+                        " is out of bounds for the axis of size ",
+                        dim_value);
+        return static_cast<size_t>(normalized);
     } else {
+        OPENVINO_ASSERT(static_cast<size_t>(idx) < dim_value,
+                        "ScatterElementsUpdate index ",
+                        static_cast<int64_t>(idx),
+                        " is out of bounds for the axis of size ",
+                        dim_value);
         return static_cast<size_t>(idx);
     }
 }

--- a/src/core/reference/include/openvino/reference/scatter_elements_update.hpp
+++ b/src/core/reference/include/openvino/reference/scatter_elements_update.hpp
@@ -20,7 +20,7 @@ namespace ov {
 namespace reference {
 template <typename T>
 size_t normalize_index(const T idx, const size_t dim_value) {
-    // Per the operator specification the index must lie within [-dim_value, dim_value - 1]. 
+    // Per the operator specification the index must lie within [-dim_value, dim_value - 1].
     if (idx < 0) {
         const int64_t normalized = static_cast<int64_t>(idx) + static_cast<int64_t>(dim_value);
         OPENVINO_ASSERT(normalized >= 0,

--- a/src/core/tests/eval.cpp
+++ b/src/core/tests/eval.cpp
@@ -1517,12 +1517,62 @@ TYPED_TEST_P(ScatterElementsUpdateEvalTest, evaluate_dynamic_scatter_elements_up
     ASSERT_EQ(cval, out);
 }
 
+TYPED_TEST_P(ScatterElementsUpdateEvalTest, evaluate_scatter_elements_update_out_of_bounds_positive_index) {
+    const Shape data_shape{3, 3};
+    const Shape indices_shape{2, 3};
+
+    auto arg1 = make_shared<ov::op::v0::Parameter>(element::f32, data_shape);
+    auto arg2 = make_shared<ov::op::v0::Parameter>(element::i32, indices_shape);
+    auto arg3 = make_shared<ov::op::v0::Parameter>(element::f32, indices_shape);
+    auto arg4 = make_shared<ov::op::v0::Parameter>(element::i64, Shape{});
+
+    auto scatter_elements_update = make_shared<TypeParam>(arg1, arg2, arg3, arg4);
+    auto model = make_shared<Model>(OutputVector{scatter_elements_update}, ParameterVector{arg1, arg2, arg3, arg4});
+    auto result_tensor = ov::Tensor();
+    auto out_vector = ov::TensorVector{result_tensor};
+    // Index value 3 is out of range for axis 0 whose dimension is 3 (valid range is [-3, 2]).
+    auto in_vector =
+        ov::TensorVector{make_tensor<element::Type_t::f32>(data_shape, {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}),
+                         make_tensor<element::Type_t::i32>(indices_shape, {1, 0, 3, 0, 2, 1}),
+                         make_tensor<element::Type_t::f32>(indices_shape, {1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f}),
+                         make_tensor<element::Type_t::i64>({}, {0})};
+    OV_EXPECT_THROW(model->evaluate(out_vector, in_vector),
+                    ov::AssertFailure,
+                    HasSubstr("is out of bounds for the axis of size"));
+}
+
+TYPED_TEST_P(ScatterElementsUpdateEvalTest, evaluate_scatter_elements_update_out_of_bounds_negative_index) {
+    const Shape data_shape{3, 3};
+    const Shape indices_shape{2, 3};
+
+    auto arg1 = make_shared<ov::op::v0::Parameter>(element::f32, data_shape);
+    auto arg2 = make_shared<ov::op::v0::Parameter>(element::i32, indices_shape);
+    auto arg3 = make_shared<ov::op::v0::Parameter>(element::f32, indices_shape);
+    auto arg4 = make_shared<ov::op::v0::Parameter>(element::i64, Shape{});
+
+    auto scatter_elements_update = make_shared<TypeParam>(arg1, arg2, arg3, arg4);
+    auto model = make_shared<Model>(OutputVector{scatter_elements_update}, ParameterVector{arg1, arg2, arg3, arg4});
+    auto result_tensor = ov::Tensor();
+    auto out_vector = ov::TensorVector{result_tensor};
+    // Index value -4 is out of range for axis 0 whose dimension is 3 (valid range is [-3, 2]).
+    auto in_vector =
+        ov::TensorVector{make_tensor<element::Type_t::f32>(data_shape, {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}),
+                         make_tensor<element::Type_t::i32>(indices_shape, {1, 0, -4, 0, 2, 1}),
+                         make_tensor<element::Type_t::f32>(indices_shape, {1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f}),
+                         make_tensor<element::Type_t::i64>({}, {0})};
+    OV_EXPECT_THROW(model->evaluate(out_vector, in_vector),
+                    ov::AssertFailure,
+                    HasSubstr("is out of bounds for the axis of size"));
+}
+
 REGISTER_TYPED_TEST_SUITE_P(ScatterElementsUpdateEvalTest,
                             evaluate_dynamic_scatter_elements_update_one_elem_i32,
                             evaluate_dynamic_scatter_elements_update_1d_axis,
                             evaluate_dynamic_scatter_elements_update_negative_axis,
                             evaluate_dynamic_scatter_elements_update_basic,
-                            evaluate_static_scatter_elements_update_basic);
+                            evaluate_static_scatter_elements_update_basic,
+                            evaluate_scatter_elements_update_out_of_bounds_positive_index,
+                            evaluate_scatter_elements_update_out_of_bounds_negative_index);
 
 using OpVersions = ::testing::Types<ov::op::v3::ScatterElementsUpdate, ov::op::v12::ScatterElementsUpdate>;
 INSTANTIATE_TYPED_TEST_SUITE_P(eval, ScatterElementsUpdateEvalTest, OpVersions);

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scatter_nd_update.cpp
@@ -210,7 +210,7 @@ const std::vector<ScatterUpdateLayerParams> scatterNDParams = {
 const std::vector<ScatterUpdateLayerParams> scatterElementsParams = {
     ScatterUpdateLayerParams{
         ScatterUpdateShapes{
-            {{-1, -1, -1, -1, -1}, {{10, 9, 10, 9, 10}, {10, 5, 11, 4, 5}, {10, 15, 8, 1, 7}}},
+            {{-1, -1, -1, -1, -1}, {{10, 9, 10, 9, 10}, {10, 9, 11, 4, 5}, {10, 15, 8, 1, 7}}},
             {{-1, -1, -1, -1, -1 }, {{3, 2, 1, 2, 1}, {3, 2, 1, 2, 1}, {3, 2, 1, 2, 1}}},
             {{-1, -1, -1, -1, -1 }, {{3, 2, 1, 2, 1}, {3, 2, 1, 2, 1}, {3, 2, 1, 2, 1}}},
             {{1}, {{1}}}


### PR DESCRIPTION
### Details:
`ov::reference::normalize_index()` only normalized negative indices and never checked them against the axis size. An out-of-range index (>= dim or < -dim) produced an out-of-bounds offset that was then dereferenced for a read/write. 

### Tickets:
 - *CVS-194197*

### AI Assistance:
 - *AI assistance used: yes*
 - *build/tests/manual checks*
