### PR TITLE
[NPUW] Harden pyramid attention deserialization validation

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -916,6 +916,27 @@ void PyramidAttentionContiguous::validate_port_indices() const {
                        _compiled_models.size(),
                        ")");
     }
+    if (_context_lengths.size() != _compiled_models.size()) {
+        OPENVINO_THROW("NPU NPUW: pyramid attention context length count (",
+                       _context_lengths.size(),
+                       ") does not match compiled model count (",
+                       _compiled_models.size(),
+                       ")");
+    }
+    const auto main_model_idx = _compiled_models.size() - 1;
+    if (!_compiled_models[main_model_idx]) {
+        OPENVINO_THROW("NPU NPUW: main compiled model at index ",
+                       main_model_idx,
+                       " is null while validating pyramid attention metadata");
+    }
+    const auto main_inputs_size = _compiled_models[main_model_idx]->inputs().size();
+    if (global_mask_idx >= main_inputs_size) {
+        OPENVINO_THROW("NPU NPUW: pyramid attention global_mask_idx (",
+                       global_mask_idx,
+                       ") out of bounds for main compiled model with ",
+                       main_inputs_size,
+                       " inputs");
+    }
     for (size_t i = 0; i < _compiled_models.size(); ++i) {
         if (!_compiled_models[i]) {
             continue;
@@ -941,6 +962,17 @@ void PyramidAttentionContiguous::validate_port_indices() const {
                                inputs_size,
                                " inputs");
             }
+            const auto& rank = _compiled_models[i]->inputs()[param.idx].get_partial_shape().rank();
+            if (rank.is_static() && param.dim >= static_cast<size_t>(rank.get_length())) {
+                OPENVINO_THROW("NPU NPUW: pyramid attention param dim (",
+                               param.dim,
+                               ") out of bounds for model ",
+                               i,
+                               " input ",
+                               param.idx,
+                               " with rank ",
+                               rank.get_length());
+            }
         }
     }
 }
@@ -952,6 +984,13 @@ void PyramidAttentionBlock::validate_port_indices() const {
     if (_attention_infos.size() != _compiled_models.size()) {
         OPENVINO_THROW("NPU NPUW: pyramid attention info count (",
                        _attention_infos.size(),
+                       ") does not match compiled model count (",
+                       _compiled_models.size(),
+                       ")");
+    }
+    if (_context_lengths.size() != _compiled_models.size()) {
+        OPENVINO_THROW("NPU NPUW: pyramid attention context length count (",
+                       _context_lengths.size(),
                        ") does not match compiled model count (",
                        _compiled_models.size(),
                        ")");
@@ -975,6 +1014,13 @@ void PyramidAttentionBlock::validate_port_indices() const {
         }
 
         const auto main_inputs_size = _compiled_models[main_model_idx]->inputs().size();
+        if (global_mask_idx >= main_inputs_size) {
+            OPENVINO_THROW("NPU NPUW: pyramid attention global_mask_idx (",
+                           global_mask_idx,
+                           ") out of bounds for main compiled model with ",
+                           main_inputs_size,
+                           " inputs");
+        }
         for (const auto global_idx : past_key_block_global_param_indices) {
             if (global_idx >= main_inputs_size) {
                 OPENVINO_THROW("NPU NPUW: pyramid attention key block global param idx (",
@@ -1010,10 +1056,6 @@ void PyramidAttentionBlock::validate_port_indices() const {
                            inputs_size,
                            " inputs");
         }
-        // param_port_map values and the block port sets are LOCAL indices used to bind tensors
-        // to this variant's inputs(); validate them too since they are read verbatim from the blob.
-        // param_port_map has no "no port" sentinel — a dropped block is an absent entry, so every
-        // present value is a real port that bind_function_input dereferences unconditionally.
         for (const auto& kv : info.param_port_map) {
             if (kv.second >= inputs_size) {
                 OPENVINO_THROW("NPU NPUW: pyramid attention param_port_map value (",

--- a/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/pyramid_attention.cpp
@@ -906,6 +906,9 @@ void PyramidAttentionContiguous::collect_strided_input_names(const ov::Model& mo
 }
 
 void PyramidAttentionContiguous::validate_port_indices() const {
+    if (_compiled_models.empty()) {
+        OPENVINO_THROW("NPU NPUW: pyramid attention has no compiled models");
+    }
     if (_attention_infos.size() != _compiled_models.size()) {
         OPENVINO_THROW("NPU NPUW: pyramid attention info count (",
                        _attention_infos.size(),
@@ -943,6 +946,9 @@ void PyramidAttentionContiguous::validate_port_indices() const {
 }
 
 void PyramidAttentionBlock::validate_port_indices() const {
+    if (_compiled_models.empty()) {
+        OPENVINO_THROW("NPU NPUW: pyramid attention has no compiled models");
+    }
     if (_attention_infos.size() != _compiled_models.size()) {
         OPENVINO_THROW("NPU NPUW: pyramid attention info count (",
                        _attention_infos.size(),
@@ -951,12 +957,13 @@ void PyramidAttentionBlock::validate_port_indices() const {
                        ")");
     }
 
-    if (past_key_block_global_param_indices.size() != past_value_block_global_param_indices.size()) {
-        OPENVINO_THROW("NPU NPUW: pyramid attention block global metadata mismatch: key indices count (",
+    if (past_key_block_global_param_indices.empty() ||
+        past_key_block_global_param_indices.size() != past_value_block_global_param_indices.size()) {
+        OPENVINO_THROW("NPU NPUW: pyramid attention block global metadata invalid: key indices count (",
                        past_key_block_global_param_indices.size(),
-                       ") does not match value indices count (",
+                       "), value indices count (",
                        past_value_block_global_param_indices.size(),
-                       ")");
+                       ") must be non-empty and equal");
     }
 
     if (!_compiled_models.empty()) {
@@ -1002,6 +1009,43 @@ void PyramidAttentionBlock::validate_port_indices() const {
                            " with ",
                            inputs_size,
                            " inputs");
+        }
+        // param_port_map values and the block port sets are LOCAL indices used to bind tensors
+        // to this variant's inputs(); validate them too since they are read verbatim from the blob.
+        // param_port_map has no "no port" sentinel — a dropped block is an absent entry, so every
+        // present value is a real port that bind_function_input dereferences unconditionally.
+        for (const auto& kv : info.param_port_map) {
+            if (kv.second >= inputs_size) {
+                OPENVINO_THROW("NPU NPUW: pyramid attention param_port_map value (",
+                               kv.second,
+                               ") out of bounds for model ",
+                               i,
+                               " with ",
+                               inputs_size,
+                               " inputs");
+            }
+        }
+        for (const auto port : info.past_key_block_port_set) {
+            if (port >= inputs_size) {
+                OPENVINO_THROW("NPU NPUW: pyramid attention key block port (",
+                               port,
+                               ") out of bounds for model ",
+                               i,
+                               " with ",
+                               inputs_size,
+                               " inputs");
+            }
+        }
+        for (const auto port : info.past_value_block_port_set) {
+            if (port >= inputs_size) {
+                OPENVINO_THROW("NPU NPUW: pyramid attention value block port (",
+                               port,
+                               ") out of bounds for model ",
+                               i,
+                               " with ",
+                               inputs_size,
+                               " inputs");
+            }
         }
     }
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -473,6 +473,13 @@ ov::SoPtr<ov::ITensor> ov::npuw::util::view(const ov::SoPtr<ov::ITensor>& src,
     // Sub-byte views are not supported here
     NPUW_ASSERT(type != ov::element::u4 && type != ov::element::i4);
 
+    // Bounds guard: from[d] <= to[d] <= shape[d] (prevents OOB views and unsigned wrap below).
+    const auto& shape = src->get_shape();
+    NPUW_ASSERT(from.size() == shape.size());
+    for (std::size_t d = 0; d < from.size(); ++d) {
+        NPUW_ASSERT(from[d] <= to[d] && to[d] <= shape[d]);
+    }
+
     const auto num_dims = from.size();
     ov::Shape view_shape;
     for (auto d = 0u; d < num_dims; d++) {

--- a/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_test.cpp
@@ -1185,8 +1185,6 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
     }
 
     {
-        // param_port_map values are this variant's LOCAL ports, used to index inputs() at bind
-        // time but read verbatim from the blob; an out-of-range value must be rejected at import.
         ov::npuw::compiled::PyramidAttentionBlock src;
         src.query_size = 1;
         src.full_context_size = 64;
@@ -1201,8 +1199,6 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
     }
 
     {
-        // param_port_map has no "no port" sentinel: a dropped block is an absent entry, so even
-        // size_t::max() is a real (out-of-range) port that bind_function_input would dereference.
         ov::npuw::compiled::PyramidAttentionBlock src;
         src.query_size = 1;
         src.full_context_size = 64;
@@ -1217,8 +1213,6 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
     }
 
     {
-        // past_key_block_port_set holds this variant's LOCAL block ports, also used to index
-        // inputs(); an out-of-range element from the blob must be rejected at import.
         ov::npuw::compiled::PyramidAttentionBlock src;
         src.query_size = 1;
         src.full_context_size = 64;
@@ -1247,8 +1241,6 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
     }
 
     {
-        // A block-type blob with empty global KV vectors is malformed: runtime unconditionally
-        // dereferences global element 0 during request setup, so validation must reject it.
         ov::npuw::compiled::PyramidAttentionBlock src;
         src.query_size = 1;
         src.full_context_size = 64;
@@ -1260,11 +1252,70 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
     }
 
     {
-        // A pyramid with zero models is malformed and must be rejected outright.
         ov::npuw::compiled::PyramidAttentionBlock block;
         EXPECT_THROW(block.validate_port_indices(), ov::Exception);
         ov::npuw::compiled::PyramidAttentionContiguous contig;
         EXPECT_THROW(contig.validate_port_indices(), ov::Exception);
+    }
+
+    {
+        ov::npuw::compiled::PyramidAttentionContiguous src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        ContigInfo info;
+        info.mask_idx_local = 0;
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 0u, {3}, "contiguous context length count mismatch");
+    }
+
+    {
+        ov::npuw::compiled::PyramidAttentionBlock src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src.past_key_block_global_param_indices = {0};
+        src.past_value_block_global_param_indices = {0};
+        BlockInfo info;
+        info.mask_idx_local = 0;
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 1u, {4}, "block context length count mismatch");
+    }
+
+    {
+        ov::npuw::compiled::PyramidAttentionContiguous src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        src.global_mask_idx = 0xFF;
+        ContigInfo info;
+        info.mask_idx_local = 0;
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 0u, {3}, "contiguous global_mask_idx out of range");
+    }
+
+    {
+        ov::npuw::compiled::PyramidAttentionBlock src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        src.past_key_block_global_param_indices = {0};
+        src.past_value_block_global_param_indices = {0};
+        src.global_mask_idx = 0xFF;
+        BlockInfo info;
+        info.mask_idx_local = 0;
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 1u, {4}, "block global_mask_idx out of range");
+    }
+
+    {
+        ov::npuw::compiled::PyramidAttentionContiguous src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        ContigInfo info;
+        info.mask_idx_local = 0;
+        info.params = {{0, 5}};
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 0u, {3}, "contiguous param dim out of range");
     }
 
     {
@@ -1282,6 +1333,21 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         ASSERT_NE(pyramid, nullptr);
 
         // Keep model count aligned with _attention_infos, but make the main model null.
+        pyramid->_compiled_models = {ov::SoPtr<ov::ICompiledModel>{}};
+        EXPECT_THROW(pyramid->validate_port_indices(), ov::Exception);
+    }
+
+    {
+        ov::npuw::compiled::PyramidAttentionContiguous src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        ContigInfo info;
+        info.mask_idx_local = 0;
+        src._attention_infos = {info};
+
+        auto pyramid = import_pyramid_from_stream(src, 0u);
+        ASSERT_NE(pyramid, nullptr);
         pyramid->_compiled_models = {ov::SoPtr<ov::ICompiledModel>{}};
         EXPECT_THROW(pyramid->validate_port_indices(), ov::Exception);
     }

--- a/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npuw/pyramid_attention_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -1098,8 +1099,8 @@ TEST(PyramidAttentionTest, ZeroModelPyramidStateIsRejectedOnDeserialize) {
             FAIL() << "Pyramid metadata with num_models == 0 must be rejected during deserialization";
         } catch (const ov::Exception& ex) {
             const std::string msg = ex.what();
-            EXPECT_NE(msg.find("pyramid attention info count"), std::string::npos)
-                << "Expected validate_port_indices info-count mismatch, got: " << msg;
+            EXPECT_NE(msg.find("pyramid attention has no compiled models"), std::string::npos)
+                << "Expected validate_port_indices zero-model rejection, got: " << msg;
         }
     }
 }
@@ -1136,6 +1137,8 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         src.query_size = 1;
         src.full_context_size = 64;
         src._context_lengths = {64};
+        src.past_key_block_global_param_indices = {0};
+        src.past_value_block_global_param_indices = {0};
         BlockInfo info;
         info.mask_idx_local = 0xFF;
         src._attention_infos = {info};
@@ -1179,6 +1182,89 @@ TEST(PyramidAttentionTest, InvalidPortIndicesAreRejected) {
         info.mask_idx_local = 0;
         src._attention_infos = {info};
         expect_invalid_port_indices_rejected(src, 1u, {4}, "block value global idx out of range");
+    }
+
+    {
+        // param_port_map values are this variant's LOCAL ports, used to index inputs() at bind
+        // time but read verbatim from the blob; an out-of-range value must be rejected at import.
+        ov::npuw::compiled::PyramidAttentionBlock src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        src.past_key_block_global_param_indices = {0};
+        src.past_value_block_global_param_indices = {0};
+        BlockInfo info;
+        info.mask_idx_local = 0;
+        info.param_port_map = {{0, 0xFF}};
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 1u, {4}, "block param_port_map value out of range");
+    }
+
+    {
+        // param_port_map has no "no port" sentinel: a dropped block is an absent entry, so even
+        // size_t::max() is a real (out-of-range) port that bind_function_input would dereference.
+        ov::npuw::compiled::PyramidAttentionBlock src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        src.past_key_block_global_param_indices = {0};
+        src.past_value_block_global_param_indices = {0};
+        BlockInfo info;
+        info.mask_idx_local = 0;
+        info.param_port_map = {{0, std::numeric_limits<size_t>::max()}};
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 1u, {4}, "block param_port_map size_t::max value");
+    }
+
+    {
+        // past_key_block_port_set holds this variant's LOCAL block ports, also used to index
+        // inputs(); an out-of-range element from the blob must be rejected at import.
+        ov::npuw::compiled::PyramidAttentionBlock src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        src.past_key_block_global_param_indices = {0};
+        src.past_value_block_global_param_indices = {0};
+        BlockInfo info;
+        info.mask_idx_local = 0;
+        info.past_key_block_port_set = {0xFF};
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 1u, {4}, "block key port_set element out of range");
+    }
+
+    {
+        ov::npuw::compiled::PyramidAttentionBlock src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        src.past_key_block_global_param_indices = {0};
+        src.past_value_block_global_param_indices = {0};
+        BlockInfo info;
+        info.mask_idx_local = 0;
+        info.past_value_block_port_set = {0xFF};
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 1u, {4}, "block value port_set element out of range");
+    }
+
+    {
+        // A block-type blob with empty global KV vectors is malformed: runtime unconditionally
+        // dereferences global element 0 during request setup, so validation must reject it.
+        ov::npuw::compiled::PyramidAttentionBlock src;
+        src.query_size = 1;
+        src.full_context_size = 64;
+        src._context_lengths = {64};
+        BlockInfo info;
+        info.mask_idx_local = 0;
+        src._attention_infos = {info};
+        expect_invalid_port_indices_rejected(src, 1u, {4}, "block empty global KV vectors");
+    }
+
+    {
+        // A pyramid with zero models is malformed and must be rejected outright.
+        ov::npuw::compiled::PyramidAttentionBlock block;
+        EXPECT_THROW(block.validate_port_indices(), ov::Exception);
+        ov::npuw::compiled::PyramidAttentionContiguous contig;
+        EXPECT_THROW(contig.validate_port_indices(), ov::Exception);
     }
 
     {


### PR DESCRIPTION
### Details:
Hardens pyramid attention deserialization so that the indices, sizes and model references read verbatim from an imported compiled blob are validated before use — at the import boundary where possible, and as a runtime backstop in the shared tensor-view helper — in both contiguous and block modes. This turns malformed or corrupted blobs that previously survived import (only to fault, throw late, or index out of range once inference began) into a clear early rejection, with no behavior change for valid blobs and regression tests for each case.

### Tickets:
 - [CVS-193641](https://jira.devtools.intel.com/browse/CVS-193641)

### AI Assistance:
- AI assistance used: yes
- Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
