### PR TITLE
[GPU][COVERITY] Avoid temporary weak_ptr in try_get_cached_memory

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -267,7 +267,8 @@ cldnn::memory::ptr RemoteContextImpl::try_get_cached_memory(size_t hash) {
     if (!m_memory_cache.has(hash))
         return nullptr;
 
-    if (auto memory = m_memory_cache.get(hash).lock())
+    auto cached_memory = m_memory_cache.get(hash);
+    if (auto memory = cached_memory.lock())
         return memory;
 
     // The last tensor which wrapped that memory is gone, so the entry is erased instead of being kept as the most recently used one


### PR DESCRIPTION
### Details:
 - Coverity `RETURN_LOCAL` (CID 2550784) is reported in `RemoteContextImpl::try_get_cached_memory()`.
 - `cldnn::LruCache::get()` returns the `std::weak_ptr<cldnn::memory>` **by value**, so `m_memory_cache.get(hash).lock()` calls `lock()` on a temporary. Coverity models `weak_ptr::lock()` as an identity transfer and therefore reports the resulting `shared_ptr` as pointing to an out-of-scope temporary.
 - The report is a false positive (`lock()` returns an independent owning `shared_ptr`), but holding the cached `weak_ptr` in a named local keeps the analysis clean and costs nothing.
 - No functional change.

### Tickets:
 - 194077

### AI Assistance:
- AI assistance used: yes
- AI: find root-cause, fix
- Human: review
