### PR TITLE
[GPU][COVERITY] Drop redundant null check in RemoteTensorImpl::allocate

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_tensor.cpp
@@ -457,7 +457,8 @@ void RemoteTensorImpl::allocate() {
     update_properties();
     update_strides();
 
-    if (enable_caching && m_memory_object)
+    // update_properties() already asserts that m_memory_object is allocated
+    if (enable_caching)
         context->add_to_cache(m_hash, m_memory_object);
 }
 


### PR DESCRIPTION
### Details:
 - Coverity `REVERSE_INULL` (CID 2550785) is reported in `RemoteTensorImpl::allocate()`.
 - `update_properties()` starts with `OPENVINO_ASSERT(is_allocated(), ...)` and then dereferences `m_memory_object`, so the pointer is already guaranteed to be non-null on every path that reaches the caching branch below.
 - The extra `&& m_memory_object` check is therefore dead code and is reported as a dereference before null check. Removed it.
 - No functional change.

### Tickets:
 - 194078

### AI Assistance:
- AI assistance used: yes
- AI: find root-cause, fix
- Human: review
