### PR TITLE
[GPU] Fix GPU tests compile issues

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/transpose_split_vlsdpa.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/transpose_split_vlsdpa.cpp
@@ -449,7 +449,6 @@ protected:
 
 private:
     std::vector<int32_t> m_cu_seqlens;
-    AttentionType m_attn_type;
     ov::TensorVector inputs_ref;
 };
 

--- a/src/plugins/intel_gpu/tests/unit/passes/basic_memory_dependencies_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/basic_memory_dependencies_test.cpp
@@ -108,7 +108,7 @@ TEST(basic_memory_dependencies, optimized_resample_to_onednn_sum_reuse_correctne
     tests::random_generator rg;
     rg.set_seed("optimized_resample_to_onednn_sum_reuse_correctness");
     {
-        auto rnd = rg.generate_random_1d<ov::float16>(weight_layout.count(), -0.25f, 0.25f);
+        auto rnd = rg.generate_random_1d<ov::float16>(weight_layout.count(), 0, 0);
         set_values(weight_mem, rnd);
     }
 
@@ -138,7 +138,7 @@ TEST(basic_memory_dependencies, optimized_resample_to_onednn_sum_reuse_correctne
 
     auto input_mem = engine.allocate_memory(in_layout);
     {
-        auto rnd = rg.generate_random_1d<ov::float16>(in_layout.count(), -0.25f, 0.25f);
+        auto rnd = rg.generate_random_1d<ov::float16>(in_layout.count(), 0, 0);
         set_values(input_mem, rnd);
     }
 

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -3278,7 +3278,7 @@ TEST(prepare_buffer_fusing, in_place_crop_split_axis1_three_crops_vlsdpa_consume
     auto splits_len_mem   = engine.allocate_memory({{F}, data_types::i64, format::bfyx});
     auto scale_mem        = engine.allocate_memory({{1}, data_types::f16, format::bfyx});
 
-    auto input_data = rg.generate_random_1d<ov::float16>(L * F * H * S, -0.5f, 0.5f);
+    auto input_data = rg.generate_random_1d<ov::float16>(L * F * H * S, 0, 0);
     set_values(input_mem, input_data);
     set_values(cu_seqlens_mem, cu_seqlens);
     set_values<int64_t>(axis_mem, {1});

--- a/src/plugins/intel_gpu/tests/unit/test_cases/bf16_onednn_ops_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/bf16_onednn_ops_gpu_test.cpp
@@ -555,8 +555,8 @@ TEST(bf16_onednn_ops, moe_gemm_bf16) {
     const int num_experts = 1, num_tokens = 4, hidden = 64, out_N = 32;
 
     tests::random_generator rg("bf16_moe_gemm");
-    auto input_f32 = rg.generate_random_1d<float>(num_tokens * hidden, -0.5f, 0.5f);
-    auto weight_f32 = rg.generate_random_1d<float>(num_experts * out_N * hidden, -0.5f, 0.5f);
+    auto input_f32 = rg.generate_random_1d<float>(num_tokens * hidden, 0, 0);
+    auto weight_f32 = rg.generate_random_1d<float>(num_experts * out_N * hidden, 0, 0);
 
     ov::op::internal::MOECompressed::Config moe_config;
     moe_config.top_k = 1;
@@ -647,10 +647,10 @@ TEST(bf16_onednn_ops, gated_mlp_bf16) {
     tests::random_generator rg("bf16_gated_mlp");
     const int batch = 2, ifm = 32, hidden = 16;
 
-    auto src_f32 = rg.generate_random_1d<float>(batch * ifm, -0.5f, 0.5f);
-    auto gate_f32 = rg.generate_random_1d<float>(ifm * hidden, -0.5f, 0.5f);
-    auto up_f32 = rg.generate_random_1d<float>(ifm * hidden, -0.5f, 0.5f);
-    auto down_f32 = rg.generate_random_1d<float>(hidden * ifm, -0.5f, 0.5f);
+    auto src_f32 = rg.generate_random_1d<float>(batch * ifm, 0, 0);
+    auto gate_f32 = rg.generate_random_1d<float>(ifm * hidden, 0, 0);
+    auto up_f32 = rg.generate_random_1d<float>(ifm * hidden, 0, 0);
+    auto down_f32 = rg.generate_random_1d<float>(hidden * ifm, 0, 0);
 
     auto run_gated_mlp = [&](data_types dt) -> std::vector<float> {
         auto src_mem = engine.allocate_memory({{batch, 1, 1, ifm}, dt, format::bfyx});

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -3170,8 +3170,8 @@ TEST(deconvolution_gpu_onednn, input_b_fs_zyx_fsv16_output_bfzyx_stride2_nopad) 
 
     tests::random_generator rg(GET_SUITE_NAME);
     auto input_data = rg.generate_random_1d<float>(input->count(), -1.0f, 1.0f);
-    auto weights_data = rg.generate_random_1d<float>(weights->count(), -0.5f, 0.5f);
-    auto bias_data = rg.generate_random_1d<float>(biases->count(), -0.1f, 0.1f);
+    auto weights_data = rg.generate_random_1d<float>(weights->count(), 0, 0);
+    auto bias_data = rg.generate_random_1d<float>(biases->count(), 0, 0);
 
     set_values(input, input_data);
     set_values(weights, weights_data);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -3996,7 +3996,7 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         // dq_scale ~= 0.75 / 127 = 0.0059, so the true result stays finite:
         //   243840 (scales_group_size: 128 * int8: 127 * u4: 15) * 0.0059 * 20 ~= 28.8K < 65504.
         // The old code still overflows because it first converts the large int accumulator to fp16.
-        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0.25f, 0.75f);
+        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0, 0);
         set_values(input_mem, input_data);
 
         auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
@@ -4124,7 +4124,7 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         auto scale_mem = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
 
         // Positive activations keep int accumulators large while the final fp32 result stays finite.
-        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0.25f, 0.75f);
+        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0, 0);
         set_values(input_mem, input_data);
 
         auto weights_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 15);
@@ -4258,7 +4258,7 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         // INT8 weights [0,255] produce large int_acc ~690K >> 65504 per group.
         // True result = 690K * 0.004 * 4 ~ 10K << 65504: always FP16-safe.
         // Old code: convert_half(690K) = INF → NaN cascade.
-        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0.25f, 0.5f);
+        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, 0, 0);
         set_values(input_mem, input_data);
 
         // UINT8 weights [0, 255]: large range ensures int_acc >> 65504.
@@ -6312,7 +6312,7 @@ struct fc_bf_tiled_dyn_b_accuracy_test : public ::testing::TestWithParam<std::tu
         set_values(weights_mem, weights_data);
         auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -1.0f, 1.0f);
         set_values(scale_mem, scale_data);
-        auto zp_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -0.5f, 0.5f);
+        auto zp_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 0, 0);
         set_values(dcomp_zp_mem, zp_data);
 
         auto dyn_layout = layout{ {-1, ifm_num}, data_types::f16, format::bfyx };
@@ -6470,12 +6470,12 @@ TEST_P(fully_connected_gpu_u2_validation, various_sizes) {
     }
     set_values(weights_mem, packed_weights);
 
-    auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 0.5f, 2.0f);
+    auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 0, 2);
     set_values(scale_mem, scale_data);
 
     std::vector<ov::float16> zp_data;
     if (use_zp) {
-        zp_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 0.5f, 1.5f);
+        zp_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, 0, 1);
         set_values(zp_mem, zp_data);
     }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -4001,8 +4001,8 @@ TEST(grouped_matmul_gpu_tests, smoke_2d_3d_f16) {
         offsets[i] = offsets[i - 1] + tokens_per_expert[i];
 
     tests::random_generator rg("grouped_matmul_smoke");
-    auto mat_a_f32 = rg.generate_random_1d<float>(total_tokens * K, -0.5f, 0.5f);
-    auto mat_b_f32 = rg.generate_random_1d<float>(G * N * K, -0.5f, 0.5f);
+    auto mat_a_f32 = rg.generate_random_1d<float>(total_tokens * K, 0, 0);
+    auto mat_b_f32 = rg.generate_random_1d<float>(G * N * K, 0, 0);
 
     std::vector<ov::float16> mat_a_f16(mat_a_f32.size());
     std::vector<ov::float16> mat_b_f16(mat_b_f32.size());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_3gemm_gpu_test.cpp
@@ -464,7 +464,7 @@ TEST_P(moe_3gemm_compressed_gpu_random, moe_accuracy_test_random) {
 
     auto hidden_states_mem = create_f16_tensor_3d(hidden_states, config.batch_size, config.seq_len, config.hidden_size);
     auto routing_weights_mem = create_f16_tensor_3d(routing_weights, config.batch_size, config.seq_len, config.num_experts);
-    auto routing_bias_data = rg.generate_random_1d<ov::float16>(config.num_experts, -0.5f, 0.5f, 1000);
+    auto routing_bias_data = rg.generate_random_1d<ov::float16>(config.num_experts, 0, 0, 1000);
     auto routing_bias_mem = create_f16_tensor(routing_bias_data, 1, 1, 1, config.num_experts);
     ov::float16 routing_eps_val = ov::float16(1e-6f);
 
@@ -1156,7 +1156,7 @@ TEST_P(moe_3gemm_compressed_gpu_symmetric_random, moe_accuracy_test_symmetric) {
 
     auto hidden_states_mem = create_f16_tensor_3d(hidden_states, config.batch_size, config.seq_len, config.hidden_size);
     auto routing_weights_mem = create_f16_tensor_3d(routing_weights, config.batch_size, config.seq_len, config.num_experts);
-    auto routing_bias_data = rg.generate_random_1d<ov::float16>(config.num_experts, -0.5f, 0.5f, 1000);
+    auto routing_bias_data = rg.generate_random_1d<ov::float16>(config.num_experts, 0, 0, 1000);
     auto routing_bias_mem = create_f16_tensor(routing_bias_data, 1, 1, 1, config.num_experts);
     ov::float16 routing_eps_val = ov::float16(1e-6f);
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/moe_router_fused_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/moe_router_fused_gpu_test.cpp
@@ -142,7 +142,7 @@ TEST_P(moe_router_fused_sigmoid_bias_gpu, router_accuracy_test) {
 
     // Generate random data
     auto logits_data = rg.generate_random_1d<ov::float16>(num_tokens * num_experts, -2.0f, 2.0f, 1000);
-    auto bias_data = rg.generate_random_1d<ov::float16>(num_experts, -0.5f, 0.5f, 1000);
+    auto bias_data = rg.generate_random_1d<ov::float16>(num_experts, 0, 0, 1000);
     ov::float16 eps_val = ov::float16(1e-6f);
 
     // Create memories

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_causal_conv1d.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_causal_conv1d.cpp
@@ -295,7 +295,7 @@ struct paged_causal_conv1d_gpu_test : public ::testing::TestWithParam<paged_caus
         auto conv_weight = rg.generate_random_1d<T>(ov::shape_size(weight_layout.get_shape()), -1.0f, 1.0f, 256);
         std::vector<T> conv_bias;
         if (p.with_bias) {
-            conv_bias = rg.generate_random_1d<T>(ov::shape_size(bias_layout.get_shape()), -0.5f, 0.5f, 256);
+            conv_bias = rg.generate_random_1d<T>(ov::shape_size(bias_layout.get_shape()), 0, 0, 256);
         }
 
         auto ref_state = conv_state_table;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/vlsdpa_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/vlsdpa_gpu_test.cpp
@@ -438,9 +438,9 @@ static void run_mixed_pitch_case(const mixed_pitch_case_params& p,
     auto attn_mask_mem = engine.allocate_memory(attn_mask_static);
     auto cu_mem = engine.allocate_memory(cu_static);
 
-    auto q_data = rg.generate_random_1d<ov::float16>(L * H * S, -0.5f, 0.5f);
-    auto k_data = rg.generate_random_1d<ov::float16>(L * H * S, -0.5f, 0.5f);
-    auto v_data = rg.generate_random_1d<ov::float16>(L * H * S, -0.5f, 0.5f);
+    auto q_data = rg.generate_random_1d<ov::float16>(L * H * S, 0, 0);
+    auto k_data = rg.generate_random_1d<ov::float16>(L * H * S, 0, 0);
+    auto v_data = rg.generate_random_1d<ov::float16>(L * H * S, 0, 0);
     set_values(q_mem, q_data);
     set_values(k_mem, k_data);
     set_values(v_mem, v_data);


### PR DESCRIPTION
### Details:
- The GPU unit test use generator which input parameters min, max are int
```cpp
template<typename ReturnType>
    ReturnType generate_random_val(int min, int max, int k = 8)
```
In test code the limits are set as float which cause implicit cast to int (can trigger compilation warning as error). The real generator limits e.g. will be not [-0.5, 0.5] but [0, 0]. The changes don't change test but show issue.

### Tickets:
 - N/A

### AI Assistance:
 - *yes*
