### PR TITLE
[GPU] Fix PReLU NaN propagation

### DIFF
--- a/.github/workflows/dev_cpu_linux_snippets_libxsmm.yml
+++ b/.github/workflows/dev_cpu_linux_snippets_libxsmm.yml
@@ -25,9 +25,6 @@ concurrency:
 
 permissions: read-all
 
-env:
-
-
 jobs:
   Smart_CI:
     runs-on: ubuntu-latest

--- a/src/plugins/intel_gpu/src/graph/common_utils/jit_term.hpp
+++ b/src/plugins/intel_gpu/src/graph/common_utils/jit_term.hpp
@@ -248,6 +248,9 @@ inline JitTerm ternary(const JitTerm& condition, const JitTerm& true_expr, const
 inline JitTerm isinf(const JitTerm& arg) {
     return JitTerm{"isinf(" + arg.str() + ")"};
 }
+inline JitTerm isnan(const JitTerm& arg) {
+    return JitTerm{"isnan(" + arg.str() + ")"};
+}
 inline JitTerm exp(const JitTerm& arg) {
     return JitTerm{"exp(" + arg.str() + ")"};
 }

--- a/src/plugins/intel_gpu/src/graph/common_utils/jit_term.hpp
+++ b/src/plugins/intel_gpu/src/graph/common_utils/jit_term.hpp
@@ -251,6 +251,11 @@ inline JitTerm isinf(const JitTerm& arg) {
 inline JitTerm isnan(const JitTerm& arg) {
     return JitTerm{"isnan(" + arg.str() + ")"};
 }
+inline JitTerm select(const JitTerm& a, const JitTerm& b, const JitTerm& cond) {
+    // Vector-safe alternative to ternary with a vector condition:
+    // select(a, b, c) returns c ? b : a per component.
+    return JitTerm{"(select(" + a.str() + ", " + b.str() + ", " + cond.str() + "))"};
+}
 inline JitTerm exp(const JitTerm& arg) {
     return JitTerm{"exp(" + arg.str() + ")"};
 }

--- a/src/plugins/intel_gpu/src/graph/common_utils/jit_term.hpp
+++ b/src/plugins/intel_gpu/src/graph/common_utils/jit_term.hpp
@@ -251,11 +251,6 @@ inline JitTerm isinf(const JitTerm& arg) {
 inline JitTerm isnan(const JitTerm& arg) {
     return JitTerm{"isnan(" + arg.str() + ")"};
 }
-inline JitTerm select(const JitTerm& a, const JitTerm& b, const JitTerm& cond) {
-    // Vector-safe alternative to ternary with a vector condition:
-    // select(a, b, c) returns c ? b : a per component.
-    return JitTerm{"(select(" + a.str() + ", " + b.str() + ", " + cond.str() + "))"};
-}
 inline JitTerm exp(const JitTerm& arg) {
     return JitTerm{"exp(" + arg.str() + ")"};
 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -840,7 +840,11 @@ JitConstants make_activation_jit_constants(const std::string& suffix,
         break;
     case activation_func::relu_negative_slope: {
         const JitTerm slope = convert_to_type("m"_jit, calc_dt);
-        jit.add(make_jit_constant(macro_def, ternary(isinf(slope), ternary(input.ge(zero), input, neg(slope)), max(input, zero) + (slope * min(input, zero)))));
+        // OpenCL max/min may drop the NaN operand, so branch on the input
+        // explicitly to keep NaN propagating instead of turning into zero.
+        jit.add(make_jit_constant(
+            macro_def,
+            ternary(isnan(input), input, ternary(isinf(slope), ternary(input.ge(zero), input, neg(slope)), max(input, zero) + (slope * min(input, zero))))));
         break;
     }
     case activation_func::elu: {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -840,11 +840,12 @@ JitConstants make_activation_jit_constants(const std::string& suffix,
         break;
     case activation_func::relu_negative_slope: {
         const JitTerm slope = convert_to_type("m"_jit, calc_dt);
-        // OpenCL max/min may drop the NaN operand, so branch on the input
+        // OpenCL max/min may drop the NaN operand, so select on the input
         // explicitly to keep NaN propagating instead of turning into zero.
-        jit.add(make_jit_constant(
-            macro_def,
-            ternary(isnan(input), input, ternary(isinf(slope), ternary(input.ge(zero), input, neg(slope)), max(input, zero) + (slope * min(input, zero))))));
+        // select() stays valid when the fused activation operates on a vector.
+        const JitTerm prelu_body =
+            ternary(isinf(slope), ternary(input.ge(zero), input, neg(slope)), max(input, zero) + (slope * min(input, zero)));
+        jit.add(make_jit_constant(macro_def, select(prelu_body, input, isnan(input))));
         break;
     }
     case activation_func::elu: {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -842,10 +842,12 @@ JitConstants make_activation_jit_constants(const std::string& suffix,
         const JitTerm slope = convert_to_type("m"_jit, calc_dt);
         // OpenCL max/min may drop the NaN operand, so select on the input
         // explicitly to keep NaN propagating instead of turning into zero.
-        // select() stays valid when the fused activation operates on a vector.
-        const JitTerm prelu_body =
-            ternary(isinf(slope), ternary(input.ge(zero), input, neg(slope)), max(input, zero) + (slope * min(input, zero)));
-        jit.add(make_jit_constant(macro_def, select(prelu_body, input, isnan(input))));
+        // A ternary is used for the NaN branch instead of select(): select()
+        // requires the condition to be a signed integer of the same width as
+        // the operands (short for half), while isnan() returns int, so f16
+        // kernels do not compile with select().
+        const JitTerm prelu_body = ternary(isinf(slope), ternary(input.ge(zero), input, neg(slope)), max(input, zero) + (slope * min(input, zero)));
+        jit.add(make_jit_constant(macro_def, ternary(isnan(input), input, prelu_body)));
         break;
     }
     case activation_func::elu: {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -88,6 +88,11 @@ JitTerm isinf(const JitTerm& arg) {
     return jit_term;
 }
 
+JitTerm isnan(const JitTerm& arg) {
+    JitTerm jit_term{"(isnan(" + arg.str() + "))"};
+    return jit_term;
+}
+
 JitTerm exp(const JitTerm& arg) {
     JitTerm jit_term{"(exp(" + arg.str() + "))"};
     return jit_term;
@@ -1176,11 +1181,16 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
             break;
         case ActivationFunction::RELU_NEGATIVE_SLOPE: {
             const JitTerm slope = disable_type_conversion ? "m"_jit : to_type("m"_jit);
+            // OpenCL fmax/fmin return the non-NaN operand, so the naive
+            // fmax(x, 0) + slope * fmin(x, 0) form silently turns a NaN input
+            // into zero. Branch on the input explicitly to keep NaN propagating.
             jitConstants.AddConstant(MakeJitConstant(
                 macro_def,
-                ternary(isinf(slope),
-                        ternary(input.ge(zero), input, neg(slope)),
-                        max_func(input, zero) + (slope * min_func(input, zero)))
+                ternary(isnan(input),
+                        input,
+                        ternary(isinf(slope),
+                                ternary(input.ge(zero), input, neg(slope)),
+                                max_func(input, zero) + (slope * min_func(input, zero))))
                     .str()));
             break;
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -93,6 +93,14 @@ JitTerm isnan(const JitTerm& arg) {
     return jit_term;
 }
 
+JitTerm select(const JitTerm& a, const JitTerm& b, const JitTerm& cond) {
+    // OpenCL select() is vector-safe, unlike the ternary operator with a
+    // vector condition: select(a, b, c) returns c ? b : a per component and
+    // works for both scalar and vector types.
+    JitTerm jit_term{"(select(" + a.str() + ", " + b.str() + ", " + cond.str() + "))"};
+    return jit_term;
+}
+
 JitTerm exp(const JitTerm& arg) {
     JitTerm jit_term{"(exp(" + arg.str() + "))"};
     return jit_term;
@@ -1183,15 +1191,13 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
             const JitTerm slope = disable_type_conversion ? "m"_jit : to_type("m"_jit);
             // OpenCL fmax/fmin return the non-NaN operand, so the naive
             // fmax(x, 0) + slope * fmin(x, 0) form silently turns a NaN input
-            // into zero. Branch on the input explicitly to keep NaN propagating.
-            jitConstants.AddConstant(MakeJitConstant(
-                macro_def,
-                ternary(isnan(input),
-                        input,
-                        ternary(isinf(slope),
-                                ternary(input.ge(zero), input, neg(slope)),
-                                max_func(input, zero) + (slope * min_func(input, zero))))
-                    .str()));
+            // into zero. Select on the input explicitly to keep NaN propagating.
+            // select() is used instead of the ternary operator so the code stays
+            // valid when the activation is applied to a vector type.
+            const JitTerm prelu_body = ternary(isinf(slope),
+                                               ternary(input.ge(zero), input, neg(slope)),
+                                               max_func(input, zero) + (slope * min_func(input, zero)));
+            jitConstants.AddConstant(MakeJitConstant(macro_def, select(prelu_body, input, isnan(input)).str()));
             break;
         }
         case ActivationFunction::ELU: {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -93,14 +93,6 @@ JitTerm isnan(const JitTerm& arg) {
     return jit_term;
 }
 
-JitTerm select(const JitTerm& a, const JitTerm& b, const JitTerm& cond) {
-    // OpenCL select() is vector-safe, unlike the ternary operator with a
-    // vector condition: select(a, b, c) returns c ? b : a per component and
-    // works for both scalar and vector types.
-    JitTerm jit_term{"(select(" + a.str() + ", " + b.str() + ", " + cond.str() + "))"};
-    return jit_term;
-}
-
 JitTerm exp(const JitTerm& arg) {
     JitTerm jit_term{"(exp(" + arg.str() + "))"};
     return jit_term;
@@ -1192,12 +1184,14 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
             // OpenCL fmax/fmin return the non-NaN operand, so the naive
             // fmax(x, 0) + slope * fmin(x, 0) form silently turns a NaN input
             // into zero. Select on the input explicitly to keep NaN propagating.
-            // select() is used instead of the ternary operator so the code stays
-            // valid when the activation is applied to a vector type.
+            // A ternary is used for the NaN branch instead of select(): select()
+            // requires the condition to be a signed integer of the same width as
+            // the operands (short for half), while isnan() returns int, so f16
+            // kernels do not compile with select().
             const JitTerm prelu_body = ternary(isinf(slope),
                                                ternary(input.ge(zero), input, neg(slope)),
                                                max_func(input, zero) + (slope * min_func(input, zero)));
-            jitConstants.AddConstant(MakeJitConstant(macro_def, select(prelu_body, input, isnan(input)).str()));
+            jitConstants.AddConstant(MakeJitConstant(macro_def, ternary(isnan(input), input, prelu_body).str()));
             break;
         }
         case ActivationFunction::ELU: {

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/prelu_nan.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/prelu_nan.cpp
@@ -1,0 +1,135 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <vector>
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "openvino/core/type/float16.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/prelu.hpp"
+#include "openvino/op/result.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace {
+
+using PReluNaNPropagationParams = std::tuple<ov::Shape,           // input data shape
+                                             ov::Shape,           // slope shape
+                                             ov::element::Type>;  // input precision
+
+// PReLU must propagate NaN from the input to the output. The GPU kernel
+// returned the finite bound for a NaN input instead (ticket 37731).
+class PReluNaNPropagationTest : public testing::WithParamInterface<PReluNaNPropagationParams>, virtual public ov::test::SubgraphBaseStaticTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<PReluNaNPropagationParams>& obj) {
+        const auto& [data_shape, slope_shape, precision] = obj.param;
+        std::ostringstream result;
+        result << "data_shape=" << ov::test::utils::vec2str(data_shape) << "_";
+        result << "slope_shape=" << ov::test::utils::vec2str(slope_shape) << "_";
+        result << "precision=" << precision.get_type_name();
+        return result.str();
+    }
+
+protected:
+    std::shared_ptr<ov::Model> init_subgraph(const ov::Shape& data_shape, const ov::Shape& slope_shape, const ov::element::Type precision) {
+        auto data = std::make_shared<ov::op::v0::Parameter>(precision, data_shape);
+        data->set_friendly_name("data");
+        std::vector<float> slope_values(ov::shape_size(slope_shape), 0.5f);
+        auto slope = std::make_shared<ov::op::v0::Constant>(precision, slope_shape, slope_values);
+        auto prelu = std::make_shared<ov::op::v0::PRelu>(data, slope);
+        prelu->set_friendly_name("prelu");
+        auto result = std::make_shared<ov::op::v0::Result>(prelu);
+        return std::make_shared<ov::Model>(result, ov::ParameterVector{data}, "PReluNaNPropagation");
+    }
+
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+
+        const auto& [data_shape, slope_shape, precision] = GetParam();
+
+        inType = outType = precision;
+        function = init_subgraph(data_shape, slope_shape, precision);
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& funcInputs = function->inputs();
+        for (size_t i = 0; i < funcInputs.size(); ++i) {
+            const auto& funcInput = funcInputs[i];
+            const auto& shape = targetInputStaticShapes[i];
+            auto tensor = ov::Tensor(funcInput.get_element_type(), shape);
+            const size_t size = tensor.get_size();
+            // Negative, positive and NaN values exercise every PReLU branch.
+            std::vector<float> values;
+            values.reserve(size);
+            for (size_t j = 0; j < size; ++j) {
+                if (j % 3 == 0) {
+                    values.push_back(-std::sqrt(static_cast<float>(j + 1)));
+                } else if (j % 3 == 1) {
+                    values.push_back(std::sqrt(static_cast<float>(j + 1)));
+                } else {
+                    values.push_back(std::numeric_limits<float>::quiet_NaN());
+                }
+            }
+            if (funcInput.get_element_type() == ov::element::f32) {
+                std::copy(values.begin(), values.end(), tensor.data<float>());
+            } else if (funcInput.get_element_type() == ov::element::f16) {
+                for (size_t j = 0; j < size; ++j) {
+                    tensor.data<ov::float16>()[j] = ov::float16(values[j]);
+                }
+            } else {
+                OPENVINO_THROW("Unsupported precision: ", funcInput.get_element_type());
+            }
+            inputs.insert({funcInput.get_node_shared_ptr(), tensor});
+        }
+    }
+
+    // The default comparator may not match NaN against NaN, so compare here:
+    // NaN must stay NaN, everything else must match the reference value.
+    void compare(const std::vector<ov::Tensor>& expected, const std::vector<ov::Tensor>& actual) override {
+        ASSERT_EQ(expected.size(), actual.size());
+        for (size_t j = 0; j < expected.size(); ++j) {
+            ASSERT_EQ(expected[j].get_element_type(), actual[j].get_element_type());
+            const size_t size = expected[j].get_size();
+            const float tolerance = expected[j].get_element_type() == ov::element::f16 ? 2e-3f : 1e-6f;
+            for (size_t i = 0; i < size; ++i) {
+                const float exp_value = get_value(expected[j], i);
+                const float act_value = get_value(actual[j], i);
+                if (std::isnan(exp_value)) {
+                    ASSERT_TRUE(std::isnan(act_value)) << "at index " << i << ": expected NaN, got " << act_value;
+                } else {
+                    ASSERT_NEAR(exp_value, act_value, tolerance) << "at index " << i;
+                }
+            }
+        }
+    }
+
+private:
+    static float get_value(const ov::Tensor& tensor, size_t index) {
+        if (tensor.get_element_type() == ov::element::f32) {
+            return tensor.data<const float>()[index];
+        }
+        return static_cast<float>(tensor.data<const ov::float16>()[index]);
+    }
+};
+
+TEST_P(PReluNaNPropagationTest, NansArePropagated) {
+    run();
+}
+
+const std::vector<PReluNaNPropagationParams> preluNaNParams = {
+    {{1, 8}, {8}, ov::element::f32},
+    {{2, 3, 4}, {4}, ov::element::f32},
+    {{1, 4, 5, 6}, {4}, ov::element::f32},
+    {{6}, {1}, ov::element::f32},
+    {{1, 8}, {8}, ov::element::f16},
+    {{2, 3, 4}, {4}, ov::element::f16},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_PRelu_NaN_Propagation, PReluNaNPropagationTest, ::testing::ValuesIn(preluNaNParams), PReluNaNPropagationTest::getTestCaseName);
+}  // namespace

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/prelu_nan.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/prelu_nan.cpp
@@ -129,6 +129,10 @@ const std::vector<PReluNaNPropagationParams> preluNaNParams = {
     {{6}, {1}, ov::element::f32},
     {{1, 8}, {8}, ov::element::f16},
     {{2, 3, 4}, {4}, ov::element::f16},
+    // Single-value slope goes through the separate CreateUnaryEltwiseOp lowering
+    // path, while the cases above use an activation primitive with a slope
+    // dependency - cover both for f16 as well.
+    {{6}, {1}, ov::element::f16},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_PRelu_NaN_Propagation, PReluNaNPropagationTest, ::testing::ValuesIn(preluNaNParams), PReluNaNPropagationTest::getTestCaseName);

--- a/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
@@ -15,6 +15,7 @@
 #include <intel_gpu/primitives/concatenation.hpp>
 
 #include <cmath>
+#include <limits>
 
 using namespace cldnn;
 using namespace ::tests;
@@ -1151,6 +1152,87 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_fp32_prelu_eltwise, ::testing::Values
     convolution_test_params{ CASE_CONV_FP16_2, 2, 2, 4 },
     convolution_test_params{ CASE_CONV_FP16_3, 2, 2, 4 },
     convolution_test_params{ CASE_CONV_FP16_4, 2, 2, 4 },
+}));
+
+// Fused PReLU must propagate NaN the same way the standalone activation kernel
+// does: a NaN reaching the activation input (carried here through the
+// convolution) must reach the output unchanged whether the PReLU is fused into
+// the conv kernel or executed standalone.
+class conv_prelu_nan : public ConvFusingTest {};
+TEST_P(conv_prelu_nan, basic) {
+    auto p = GetParam();
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        // Small weights and bias keep the finite outputs well inside the f16 range,
+        // so only the injected NaN values show up as special values in the output.
+        data("weights", get_mem(get_weights_layout(p), -1, 1)),
+        data("bias", get_mem(get_per_channel_layout(p), 0.25f)),
+        data("slope_data", get_mem(get_per_channel_layout(p), 0.5f)),
+        convolution("conv_prim", input_info("input"), "weights", "bias", p.groups, p.stride, p.dilation, p.pad, p.pad, format::is_grouped(get_weights_layout(p).format)),
+        activation("activation", input_info("conv_prim"), "slope_data", activation_func::relu_negative_slope),
+        reorder("reorder_bfyx", input_info("activation"), p.default_format, data_types::f32)
+    );
+
+    // Force the OCL conv implementation so the PReLU is fused into the CL kernel
+    // and the fused activation code generation is exercised, not a oneDNN post-op.
+    ov::intel_gpu::ImplementationDesc conv_impl = { p.input_format, "", impl_types::ocl };
+    cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
+
+    tolerance = default_tolerance(p.data_type);
+
+    // Fill the input so that the convolution output carries both NaN and finite
+    // values: one spatial half of the input is NaN, the other half is finite.
+    auto in_layout = get_input_layout(p);
+    auto input_prim = engine.allocate_memory(in_layout);
+    const size_t width = static_cast<size_t>(in_layout.spatial(0));
+    const size_t size = in_layout.count();
+    if (in_layout.data_type == data_types::f16) {
+        std::vector<ov::float16> input_vals(size);
+        for (size_t i = 0; i < size; ++i) {
+            input_vals[i] = ov::float16((i % width < width / 2) ? std::numeric_limits<float>::quiet_NaN() : -1.0f - static_cast<float>(i % 7));
+        }
+        set_values(input_prim, input_vals);
+    } else {
+        std::vector<float> input_vals(size);
+        for (size_t i = 0; i < size; ++i) {
+            input_vals[i] = (i % width < width / 2) ? std::numeric_limits<float>::quiet_NaN() : -1.0f - static_cast<float>(i % 7);
+        }
+        set_values(input_prim, input_vals);
+    }
+
+    network network_not_fused(this->engine, this->topology_non_fused, cfg_not_fused);
+    network network_fused(this->engine, this->topology_fused, cfg_fused);
+    network_fused.set_input_data("input", input_prim);
+    network_not_fused.set_input_data("input", input_prim);
+
+    // Verify the PReLU is actually fused into the conv kernel before checking outputs.
+    check_fusions_correctness(network_fused, {{"conv_prim", {"activation"}}});
+
+    auto outputs_ref = network_not_fused.execute();
+    auto outputs_fused = network_fused.execute();
+    auto val_ref = get_output_values_to_float(network_not_fused, outputs_ref.begin()->second);
+    auto val_opt = get_output_values_to_float(network_fused, outputs_fused.begin()->second);
+    ASSERT_EQ(val_ref.size(), val_opt.size());
+
+    // ASSERT_NEAR fails on NaN == NaN, so compare NaN and finite lanes separately.
+    bool has_nan = false;
+    bool has_finite = false;
+    for (size_t i = 0; i < val_ref.size(); ++i) {
+        if (std::isnan(val_ref[i])) {
+            has_nan = true;
+            ASSERT_TRUE(std::isnan(val_opt[i])) << "i = " << i << ": expected NaN, got " << val_opt[i];
+        } else {
+            has_finite = true;
+            ASSERT_NEAR(val_ref[i], val_opt[i], tolerance) << "i = " << i;
+        }
+    }
+    ASSERT_TRUE(has_nan) << "no NaN reached the output - input injection failed";
+    ASSERT_TRUE(has_finite) << "no finite value reached the output - input injection failed";
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_prelu_nan, ::testing::ValuesIn(std::vector<convolution_test_params>{
+    convolution_test_params{ CASE_CONV_FP32_1, 2, 2 },
+    convolution_test_params{ CASE_CONV_FP16_2, 2, 2 },
 }));
 
 class conv_fp32_multi_eltwise_2 : public ConvFusingTest {};

--- a/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
@@ -1182,20 +1182,49 @@ TEST_P(conv_prelu_nan, basic) {
 
     // Fill the input so that the convolution output carries both NaN and finite
     // values: one spatial half of the input is NaN, the other half is finite.
+    // The fill is done by logical (b, f, y, x) coordinates via get_linear_offset,
+    // so it stays correct for blocked layouts such as b_fs_yx_fsv16 where a
+    // linear index does not correspond to the x coordinate.
     auto in_layout = get_input_layout(p);
     auto input_prim = engine.allocate_memory(in_layout);
-    const size_t width = static_cast<size_t>(in_layout.spatial(0));
-    const size_t size = in_layout.count();
+    const ov::Shape logical_shape = in_layout.get_shape();
+    const int64_t batch = static_cast<int64_t>(logical_shape[0]);
+    const int64_t feature = static_cast<int64_t>(logical_shape[1]);
+    const int64_t height = logical_shape.size() > 3 ? static_cast<int64_t>(logical_shape[2]) : 1;
+    const int64_t width = logical_shape.size() > 3 ? static_cast<int64_t>(logical_shape[3])
+                                                   : static_cast<int64_t>(logical_shape.back());
+    const size_t phys_size = in_layout.get_linear_size();
+    auto logical_value = [&](int64_t b, int64_t f, int64_t y, int64_t x) -> float {
+        const int64_t logical_idx = ((b * feature + f) * height + y) * width + x;
+        if (x < width / 2) {
+            return std::numeric_limits<float>::quiet_NaN();
+        }
+        return -1.0f - static_cast<float>(logical_idx % 7);
+    };
     if (in_layout.data_type == data_types::f16) {
-        std::vector<ov::float16> input_vals(size);
-        for (size_t i = 0; i < size; ++i) {
-            input_vals[i] = ov::float16((i % width < width / 2) ? std::numeric_limits<float>::quiet_NaN() : -1.0f - static_cast<float>(i % 7));
+        std::vector<ov::float16> input_vals(phys_size, ov::float16(0.0f));
+        for (int64_t b = 0; b < batch; ++b) {
+            for (int64_t f = 0; f < feature; ++f) {
+                for (int64_t y = 0; y < height; ++y) {
+                    for (int64_t x = 0; x < width; ++x) {
+                        const size_t offset = in_layout.get_linear_offset(tensor(b, f, x, y));
+                        input_vals[offset] = ov::float16(logical_value(b, f, y, x));
+                    }
+                }
+            }
         }
         set_values(input_prim, input_vals);
     } else {
-        std::vector<float> input_vals(size);
-        for (size_t i = 0; i < size; ++i) {
-            input_vals[i] = (i % width < width / 2) ? std::numeric_limits<float>::quiet_NaN() : -1.0f - static_cast<float>(i % 7);
+        std::vector<float> input_vals(phys_size, 0.0f);
+        for (int64_t b = 0; b < batch; ++b) {
+            for (int64_t f = 0; f < feature; ++f) {
+                for (int64_t y = 0; y < height; ++y) {
+                    for (int64_t x = 0; x < width; ++x) {
+                        const size_t offset = in_layout.get_linear_offset(tensor(b, f, x, y));
+                        input_vals[offset] = logical_value(b, f, y, x);
+                    }
+                }
+            }
         }
         set_values(input_prim, input_vals);
     }


### PR DESCRIPTION
### Details:
 - PReLU is compiled on GPU to the `RELU_NEGATIVE_SLOPE` activation expression `fmax(x, 0) + slope * fmin(x, 0)`.
 - OpenCL `fmax`/`fmin` (and `max`/`min`) return the **non-NaN** operand, so a NaN input produced `fmax(NaN, 0) = 0` and `slope * fmin(NaN, 0) = 0` — PReLU silently turned NaN into zero while the CPU plugin preserves NaN.
 - Fix: branch on the input explicitly (`isnan(input) ? input : <existing expression>`) in both jit generators (legacy kernel_selector jitter and the ocl_v2 fused-ops jitter used for fusions), so NaN propagates and the finite-input / infinite-slope behavior is unchanged.
 - Added a GPU functional test `PReluNaNPropagationTest` with negative, positive and NaN inputs for f32/f16 covering per-channel and shared slopes.

### Tickets:
 - Fixes #37731

### AI Assistance:
 - *AI assistance used: yes*
 - *An AI coding agent (ZCode) was used to locate the code paths, draft the fix and the test, and run local verification. Human validation performed: reviewed every changed line; simulated the old vs. new expression against the OpenVINO reference implementation over finite/infinite/NaN inputs (new expression matches reference for all finite values, preserves NaN, keeps the inf-slope behavior); compiled the real jit codegen helpers standalone to verify the generated OpenCL text; syntax-checked all touched sources with MSVC 19.44 (`cl /Zs`): jitter.cpp, fused_ops_jitter.cpp and the new test file all compile clean; verified clang-format cleanliness for all touched lines/files with the repo style configs.*