### PR TITLE
[NPU] Fix integer overflow in ZeroTensor::set_shape capacity check

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_dynamic_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_dynamic_pipeline.cpp
@@ -7,7 +7,9 @@
 #include <level_zero/ze_api.h>
 #include <ze_graph_ext.h>
 
+#include <algorithm>
 #include <sstream>
+#include <vector>
 
 #include "intel_npu/common/itt.hpp"
 #include "intel_npu/config/options.hpp"
@@ -25,6 +27,7 @@
 namespace intel_npu {
 struct MemRefTypeImpl {
     npu_vm_runtime_mem_ref_handle_t _memRef;
+    int64_t _dimsCapacity = 0;
     bool _ptrUpdated = false;
     bool _shapeUpdated = false;
     bool _strideUpdated = false;
@@ -40,15 +43,31 @@ struct MemRefTypeImpl {
             return;
         }
 
+        // The runtime writes back up to the rank the handle was created with, which may differ from the rank of
+        // memref. Parse into scratch buffers sized after the handle and validate the reported rank before copying.
+        std::vector<int64_t> sizes(static_cast<size_t>(_dimsCapacity));
+        std::vector<int64_t> strides(static_cast<size_t>(_dimsCapacity));
+        int64_t dimsCount = 0;
+
         if (npuVMRuntimeParseMemRef(_memRef,
                                     &memref._basePtr,
                                     &memref._data,
                                     &memref._offset,
-                                    memref._sizes.data(),
-                                    memref._strides.data(),
-                                    &memref._dimsCount) != NPU_VM_RUNTIME_RESULT_SUCCESS) {
+                                    sizes.data(),
+                                    strides.data(),
+                                    &dimsCount) != NPU_VM_RUNTIME_RESULT_SUCCESS) {
             OPENVINO_THROW("Failed to parse MemRef handle");
         }
+
+        if (dimsCount < 0 || static_cast<size_t>(dimsCount) > sizes.size() ||
+            static_cast<size_t>(dimsCount) > memref._sizes.size() ||
+            static_cast<size_t>(dimsCount) > memref._strides.size()) {
+            OPENVINO_THROW("MemRef handle reported an invalid tensor rank: ", dimsCount);
+        }
+
+        std::copy_n(sizes.begin(), dimsCount, memref._sizes.begin());
+        std::copy_n(strides.begin(), dimsCount, memref._strides.begin());
+        memref._dimsCount = dimsCount;
     }
 
     void UpdateMemRefHandleStatus(MemRefType& memref) {
@@ -86,6 +105,11 @@ struct MemRefTypeImpl {
                 _strideUpdated = false;
             }
         }
+        if (memref._dimsCount < 0 || static_cast<size_t>(memref._dimsCount) > memref._sizes.size() ||
+            static_cast<size_t>(memref._dimsCount) > memref._strides.size()) {
+            OPENVINO_THROW("MemRef rank ", memref._dimsCount, " does not match the described tensor");
+        }
+
         auto result = npuVMRuntimeSetMemRef(_memRef,
                                             memref._basePtr,
                                             memref._data,
@@ -101,10 +125,14 @@ struct MemRefTypeImpl {
 private:
     void createMemRef(int64_t dimsCount) {
         if (_memRef == nullptr) {
+            if (dimsCount < 0) {
+                OPENVINO_THROW("Cannot create a MemRef handle with a negative tensor rank: ", dimsCount);
+            }
             auto result = npuVMRuntimeCreateMemRef(dimsCount, &_memRef);
             if (result != NPU_VM_RUNTIME_RESULT_SUCCESS) {
                 OPENVINO_THROW("Failed to create MemRef handle");
             }
+            _dimsCapacity = dimsCount;
         }
     }
 
@@ -472,10 +500,24 @@ std::vector<ov::Shape> DynamicPipeline::predict_output_shapes(
     std::vector<ov::Shape> predictedShapes(outputsMemRefs.size());
     bool outputShapeChanged = false;
     for (size_t i = 0; i < outputsMemRefs.size(); ++i) {
+        const auto& memRef = outputsMemRefs[i];
+        OPENVINO_ASSERT(memRef._dimsCount >= 0 && static_cast<size_t>(memRef._dimsCount) <= memRef._sizes.size(),
+                        "Predicted output ",
+                        i,
+                        " has an invalid rank: ",
+                        memRef._dimsCount);
+
         ov::Shape shape;
-        shape.reserve(static_cast<size_t>(outputsMemRefs[i]._dimsCount));
-        for (int64_t j = 0; j < outputsMemRefs[i]._dimsCount; ++j) {
-            shape.push_back(static_cast<size_t>(outputsMemRefs[i]._sizes[j]));
+        shape.reserve(static_cast<size_t>(memRef._dimsCount));
+        for (int64_t j = 0; j < memRef._dimsCount; ++j) {
+            OPENVINO_ASSERT(memRef._sizes[static_cast<size_t>(j)] >= 0,
+                            "Predicted output ",
+                            i,
+                            " has a negative dimension at index ",
+                            j,
+                            ": ",
+                            memRef._sizes[static_cast<size_t>(j)]);
+            shape.push_back(static_cast<size_t>(memRef._sizes[static_cast<size_t>(j)]));
         }
 
         predictedShapes[i] = std::move(shape);

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_tensor.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_tensor.cpp
@@ -189,9 +189,16 @@ void ZeroTensor::set_shape(ov::Shape new_shape) {
         return;
     }
 
+    const auto new_byte_size = ov::util::get_memory_size_safe(_element_type, new_shape);
+    OPENVINO_ASSERT(new_byte_size,
+                    "Cannot set shape: the byte size is not representable for type: ",
+                    _element_type,
+                    " and shape: ",
+                    new_shape);
+
     _shape = std::move(new_shape);
 
-    if (get_byte_size() > _bytes_capacity) {
+    if (new_byte_size.value() > _bytes_capacity) {
         OPENVINO_ASSERT(_init_structs->getMutableCommandListExtVersion() >= ZE_MAKE_VERSION(1, 0),
                         "Re-shaping the tensor with a larger shape is not available using this driver version. "
                         "Please update the driver to the latest version.");
@@ -203,12 +210,11 @@ void ZeroTensor::set_shape(ov::Shape new_shape) {
         _ptr = nullptr;
 
         // allocate buffer and initialize objects from scratch
-        const auto byte_size = ov::util::get_memory_size_safe(_element_type, _shape);
-        OPENVINO_ASSERT(byte_size, "Cannot allocate memory for type: ", _element_type, " and shape: ", _shape);
-        _mem_ref = zero_mem::allocate_memory(_init_structs, byte_size.value(), utils::STANDARD_PAGE_SIZE, _is_input);
+        _mem_ref =
+            zero_mem::allocate_memory(_init_structs, new_byte_size.value(), utils::STANDARD_PAGE_SIZE, _is_input);
         _ptr = _mem_ref->data();
-        OPENVINO_ASSERT(byte_size.value() == 0 || _ptr != nullptr, "Failed to allocate zero memory");
-        _bytes_capacity = get_byte_size();
+        OPENVINO_ASSERT(new_byte_size.value() == 0 || _ptr != nullptr, "Failed to allocate zero memory");
+        _bytes_capacity = new_byte_size.value();
 
         _reset_tensor_memory = true;
     }

--- a/src/plugins/intel_npu/tests/functional/internal/backend/zero_tensor_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/backend/zero_tensor_tests.cpp
@@ -165,6 +165,20 @@ TEST_P(ZeroTensorTests, CheckSetBiggerShape) {
     }
 }
 
+TEST_P(ZeroTensorTests, CheckSetOverflowingShape) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    auto shape = Shape{1, 1, 1, 1};
+    auto zero_tensor = std::make_shared<::intel_npu::ZeroTensor>(init_struct, element_type, shape, false);
+
+    // A shape whose element count overflows size_t must be rejected instead of silently wrapping to a small byte size.
+    constexpr size_t overflowing_dim = size_t{1} << 32;
+    auto new_shape = Shape{overflowing_dim, overflowing_dim, 1, 1};
+
+    ASSERT_THROW(zero_tensor->set_shape(new_shape), ov::Exception);
+    EXPECT_EQ(shape, zero_tensor->get_shape());
+}
+
 TEST_P(ZeroTensorTests, CheckIsContinuousZeroTensorScalar) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 


### PR DESCRIPTION
### Details:
ZeroTensor::set_shape assigned the new shape before comparing an unchecked get_byte_size() against _bytes_capacity. A shape whose element count wraps size_t made the comparison pass, skipping reallocation and validation and leaving the tensor backed by an undersized Level Zero allocation.

Compute the byte size with get_memory_size_safe before mutating state, and validate the VM-reported rank and dimensions in DynamicPipeline before they are used to index or resize MemRef buffers.

### Tickets:
- [CVS-194277](https://jira.devtools.intel.com/browse/CVS-194277)

### AI Assistance:
- AI assistance used: yes
- Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
