### PR TITLE
[GPU] Ensure user tensor is contiguous before processing in SyncInferRequest

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -47,6 +47,16 @@ bool same_host_mem(cldnn::memory::cptr memory, const uint8_t* host_ptr) {
     return device_ptr == host_ptr;
 }
 
+std::shared_ptr<ov::ITensor> ensure_contiguous(const std::shared_ptr<ov::ITensor>& tensor) {
+    if (std::dynamic_pointer_cast<ov::IRemoteTensor>(tensor) != nullptr || tensor->is_continuous()) {
+        return tensor;
+    }
+
+    auto packed = ov::make_tensor(tensor->get_element_type(), tensor->get_shape());
+    tensor->copy_to(packed);
+    return packed;
+}
+
 inline bool all_remote_buffers(const std::vector<ov::SoPtr<ov::ITensor>>& tensors) {
     return std::all_of(tensors.begin(), tensors.end(), [](const ov::SoPtr<ov::ITensor>& tensor) {
         if (auto remote_ptr = std::dynamic_pointer_cast<ov::intel_gpu::RemoteTensorImpl>(tensor._ptr)) {
@@ -1010,6 +1020,12 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
     auto user_tensor = user_tensor_wrapper.ptr;
     auto element_type = user_tensor->get_element_type();
 
+    // ensure user tensor is contiguous
+    const auto contiguous_tensor = ensure_contiguous(user_tensor);
+    const bool is_repacked = contiguous_tensor != user_tensor;
+    const TensorWrapper contiguous_tensor_wrapper = is_repacked ? TensorWrapper(contiguous_tensor, TensorOwner::PLUGIN) : user_tensor_wrapper;
+    user_tensor = contiguous_tensor;
+
     auto remote_tensor_impl_ptr = std::dynamic_pointer_cast<RemoteTensorImpl>(user_tensor);
     auto iremote_tensor_ptr = std::dynamic_pointer_cast<IRemoteTensor>(user_tensor);
     auto usm_host_ptr = std::dynamic_pointer_cast<USMHostTensor>(user_tensor);
@@ -1018,7 +1034,7 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
     bool is_usm_host_tensor = usm_host_ptr != nullptr && usm_host_ptr->get_impl()->get_context() == m_context;
 
     GPU_DEBUG_TRACE_DETAIL << "Prepare input for " << internal_name << " (is_remote_tensor_impl ? " << is_remote_tensor_impl << ", is_usm_host_tensor ? "
-                           << is_usm_host_tensor << ", is_generic_remote ? " << is_generic_remote << ")" << std::endl;
+                           << is_usm_host_tensor << ", is_repacked ? " << is_repacked << ", is_generic_remote ? " << is_generic_remote << ")" << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "    port shape       : " << pshape.to_string() << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "    user_tensor shape: " << user_tensor->get_shape().to_string() << std::endl;
 
@@ -1079,7 +1095,7 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
     if (update_device_tensor) {
         // If device input hasn't been created, then try to use user memory if it's usm_host, or allocate new device buffer
         m_plugin_inputs[input_idx] =
-            create_or_share_device_tensor(user_tensor_wrapper, internal_name, pshape, device_tensor_et, convert_needed || need_lockable_mem);
+            create_or_share_device_tensor(contiguous_tensor_wrapper, internal_name, pshape, device_tensor_et, convert_needed || need_lockable_mem);
     } else if (!is_remote_tensor_impl) {
         // Device memory has been created on previous iterations. Try to reuse whenever it's possible
         auto device_tensor_wrapper = m_plugin_inputs.at(input_idx);
@@ -1143,7 +1159,9 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
                 // The current input_layout (wait_for_events) does not provide proper synchronization for subsequent CPU implementations
                 // For IOQ, it creates an already set user event, leading to accessing memory that hasn't completed copying
                 // For OOOQ, it enqueues a barrier that is ignored by the memory_lock functions, also causing access to not ready memory
-                ret_event = memory->copy_from(stream, src_ptr, need_lockable_mem);
+                // A repacked tensor is a local staging copy that is released when this function returns,
+                // so its upload must complete before then (blocking copy)
+                ret_event = memory->copy_from(stream, src_ptr, need_lockable_mem || is_repacked);
             }
         } else if (is_generic_remote) {
             user_tensor->copy_to(device_tensor);

--- a/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
@@ -503,6 +503,85 @@ TEST(TensorTest, smoke_canReallocateDeviceInputForHostTensor) {
     OV_ASSERT_NO_THROW(inf_req.infer());
 }
 
+// An ROI tensor shares the parent's strides and may not be contiguous.
+// Inference must match a contiguous tensor with the same values, whether the ROI is the first input
+// (allocating device memory) or follows a contiguous input (reusing existing device memory).
+using InferRequestNonContiguousInputParams = std::tuple<ov::PartialShape,                           // Model input shape
+                                                        std::pair<ov::Coordinate, ov::Coordinate>,  // ROI begin and end in the parent tensor
+                                                        std::string>;                               // Device name
+
+class InferRequestNonContiguousInput : public ::testing::TestWithParam<InferRequestNonContiguousInputParams> {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<InferRequestNonContiguousInputParams>& obj) {
+        const auto& [input_shape, roi, target_device] = obj.param;
+
+        std::ostringstream result;
+        result << "IS=" << ov::test::utils::partialShape2str({input_shape}) << "_";
+        result << "begin=" << ov::test::utils::vec2str(roi.first) << "_";
+        result << "end=" << ov::test::utils::vec2str(roi.second) << "_";
+        result << "trgDev=" << target_device;
+        return result.str();
+    }
+};
+
+TEST_P(InferRequestNonContiguousInput, Inference) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    const auto& [input_shape, roi, target_device] = GetParam();
+
+    // Give the parent elements distinct values so that a sheared read cannot pass by chance
+    ov::Tensor parent(ov::element::f32, {1, 3, 16, 16});
+    for (size_t i = 0; i < parent.get_size(); ++i) {
+        parent.data<float>()[i] = static_cast<float>(i);
+    }
+    auto view = ov::Tensor(parent, roi.first, roi.second);
+    ASSERT_FALSE(view.is_continuous());
+
+    // The reference input: the same values in a contiguous tensor
+    ov::Tensor packed(view.get_element_type(), view.get_shape());
+    view.copy_to(packed);
+
+    auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape);
+    auto add = std::make_shared<ov::op::v1::Add>(param, ov::op::v0::Constant::create(ov::element::f32, {1}, {1.f}));
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{param});
+    auto core = ov::Core();
+    auto compiled_model = core.compile_model(model, target_device);
+
+    // Returns a copy of the output, which the request may overwrite on its next run
+    auto infer = [](ov::InferRequest& request, const ov::Tensor& input) {
+        request.set_input_tensor(input);
+        request.infer();
+        auto output = request.get_output_tensor();
+        ov::Tensor copy(output.get_element_type(), output.get_shape());
+        output.copy_to(copy);
+        return copy;
+    };
+
+    // Reused device memory: the request has already run the contiguous tensor
+    auto request = compiled_model.create_infer_request();
+    auto expected = infer(request, packed);
+    ov::test::utils::compare(expected, infer(request, view), 0.0, 0.0);
+
+    // Fresh request: the view is its very first input
+    auto fresh_request = compiled_model.create_infer_request();
+    ov::test::utils::compare(expected, infer(fresh_request, view), 0.0, 0.0);
+}
+
+const std::vector<ov::PartialShape> input_shapes = {
+    {1, 3, 8, 8},    // static
+    {1, 3, -1, -1},  // dynamic
+};
+
+// 8x8 views into the {1, 3, 16, 16} parent. Neither is contiguous; the second one starts at the parent's data()
+const std::vector<std::pair<ov::Coordinate, ov::Coordinate>> rois = {
+    {{0, 0, 4, 6}, {1, 3, 12, 14}},
+    {{0, 0, 0, 0}, {1, 3, 8, 8}},
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_GPU_BehaviorTests,
+                         InferRequestNonContiguousInput,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes), ::testing::ValuesIn(rois), ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                         InferRequestNonContiguousInput::getTestCaseName);
+
 TEST(VariablesTest, smoke_canSetStateTensor) {
     auto ov = ov::Core();
     const ov::Shape virable_shape = {1, 3, 2, 4};

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference.cpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "behavior/ov_infer_request/inference.hpp"
+
+namespace {
+
+using namespace ov::test::behavior;
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
+                         OVInferRequestInferenceTests,
+                         ::testing::Combine(::testing::Values(tensor_roi::roi_nchw(), tensor_roi::roi_1d()), ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                         OVInferRequestInferenceTests::getTestCaseName);
+
+}  // namespace


### PR DESCRIPTION
### Details:
 - **Problem.** A user tensor may be non-contiguous. While working with dlstreamer, an ROI view created with `ov::Tensor(parent, begin, end)` returned `data()` pointing at the ROI origin but inherits the parent's strides, and `ITensor::is_continuous()` is false for it. `SyncInferRequest::prepare_input` treats user host memory as a flat blob. Feeding such a tensor therefore uploads sheared data: the device reads `shape` elements linearly from the ROI origin and runs off into the neighbouring rows of the parent.
 - **Fix.** Add a `ensure_contiguous()` helper in `sync_infer_request.cpp`. For a non-remote tensor that is not contiguous it allocates a contiguous host tensor of the same shape and element type and fills it with `ITensor::copy_to`. Remote tensors and contiguous tensors are untouched, so the common path only pays one `is_continuous()` check per input (a loop over the rank).
 - **Why the upload is blocking for a repacked tensor.** The staging tensor is a local of `prepare_input`, so the `memory->copy_from(...)` that reads it must complete before the function returns. Contiguous user tensors keep the existing non-blocking behaviour.
- **Tests**
   - `smoke_BehaviorTests/OVInferRequestInferenceTests.Inference_ROI_Tensor` is now instantiated for GPU (`shared_tests_instances/behavior/ov_infer_request/inference.cpp`), as CPU, TEMPLATE and NPU already do. It feeds a 3x3 ROI of a 5x5 NCHW parent and a 1-D ROI and checks the output against hard-coded expected values.
   - New `smoke_GPU_BehaviorTests/InferRequestNonContiguousInput.Inference` (`behavior/infer_request.cpp`) infers through an ROI view of a `{1,3,16,16}` parent and compares the result with inference through a contiguous tensor holding the same values. 
   - Without the repack, 5 of the 6 cases fail on an Arc B70 (`roi_1d` is contiguous and passes); With the repack all 6 pass, and the surrounding GPU behavior suites (`TensorTest.*`, `VariablesTest.*`, `*OVInferRequest*`, `*RemoteTensor*`, `*USM*`, `*Batched*`) show no new failures.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: Yes
 - Used for reviewing and improving the change, running the verification on-device, and drafting this description. Human validation: the code was written and reviewed by the author, built in Release and verified on an Arc B70.

---

### Possible follow-ups

- **Faster repack.** `ITensor::copy_to` copies one element at a time along the innermost dimension whenever the two strides differ. A row-wise `memcpy` implementation (`copy_strided`) could be added, either in core `ITensor::copy_to` or with a GPU-plugin helper.
- **Non-blocking upload.** Keeping the staging tensor alive per input port would let the host->device copy stay asynchronous instead of blocking.
