### PR TITLE
[GPU] Route U4 BY_CHANNEL PagedAttention MIXED to OCL

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/paged_attention_opt.cl
@@ -181,7 +181,8 @@ KERNEL(pa_sdpa_opt)(
 
     const uint total_blocks_num = CEIL_DIV(seq_len, PAGED_ATTENTION_BLOCK_SIZE);
 
-#if SWA_BLOCK_SKIP_ENABLED && !MULTI_TOKENS_PROCESSING
+// In MULTI_TOKENS_PROCESSING each work group handles one query token, so seq_len is exact here too.
+#if SWA_BLOCK_SKIP_ENABLED
     const uint swa_start_block = (seq_len > SLIDING_WINDOW_SIZE) ? ((seq_len - SLIDING_WINDOW_SIZE) / PAGED_ATTENTION_BLOCK_SIZE) : 0;
     const uint swa_start_token = swa_start_block * PAGED_ATTENTION_BLOCK_SIZE;
     const uint effective_blocks_num = total_blocks_num - swa_start_block;
@@ -658,7 +659,7 @@ KERNEL(pa_sdpa_opt)(
         MAKE_VECTOR_TYPE(OUTPUT_TYPE, QUERIES_PER_WI) acc = OUTPUT_VAL_ZERO;
 #endif
 
-#if SWA_BLOCK_SKIP_ENABLED && !MULTI_TOKENS_PROCESSING
+#if SWA_BLOCK_SKIP_ENABLED
         const uint effective_seq_len = seq_len - swa_start_token;
 #else
         const uint effective_seq_len = seq_len;
@@ -1028,7 +1029,8 @@ KERNEL(pa_sdpa_finalization_stage)(
     const uint seq_len = past_lens[seq_idx] + 1;
 #endif
 
-#if SWA_BLOCK_SKIP_ENABLED && !MULTI_TOKENS_PROCESSING
+// Keep finalization's partition count aligned with the stage-0 SWA block range.
+#if SWA_BLOCK_SKIP_ENABLED
     const uint swa_start_block = (seq_len > SLIDING_WINDOW_SIZE) ? ((seq_len - SLIDING_WINDOW_SIZE) / PAGED_ATTENTION_BLOCK_SIZE) : 0;
     const uint effective_seq_len = seq_len - swa_start_block * PAGED_ATTENTION_BLOCK_SIZE;
 #else

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -9,6 +9,7 @@
 // clang-format on
 #include "paged_attention_opt.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <memory>
@@ -1386,7 +1387,17 @@ public:
     // only in the PREFILL kernels, and in MIXED neither micro SDPA nor paged_attention_opt.cl consumes token_type_ids.
     // TODO: implement bidirectional attention for MIXED with token_type_ids
     bool can_use_micro_sdpa_for(const kernel_impl_params& params, const PagedAttentionStage& stage) const {
-        const auto can_use_micro_sdpa = supports_micro_sdpa(params) && valid_micro_stage(stage);
+        if (!supports_micro_sdpa(params) || !valid_micro_stage(stage))
+            return false;
+
+        const auto desc = params.typed_desc<paged_attention>();
+        const auto kv_cache_dt = params.get_program().get_config().get_kv_cache_precision();
+        // U4 BY_CHANNEL MIXED has shown concurrency-sensitive output instability in production workloads.
+        // Keep micro SDPA for PREFILL and route only the affected MIXED configuration to OCL.
+        const auto use_ocl_for_u4_by_channel_mixed = stage == PagedAttentionStage::MIXED &&
+                                                     data_type_traits::is_i4_u4(kv_cache_dt) &&
+                                                     desc->is_key_by_channel;
+        const auto can_use_micro_sdpa = !use_ocl_for_u4_by_channel_mixed;
         GPU_DEBUG_TRACE_DETAIL << "can_use_micro_sdpa_for: stage = " << static_cast<size_t>(stage)
                                << ", token_type_ids = " << params.get_input_layout(PagedAttentionInputIdx::TOKEN_TYPE_IDS).to_short_string()
                                << ", can_use_micro_sdpa = " << can_use_micro_sdpa << std::endl;
@@ -1482,13 +1493,14 @@ public:
         rt_params->partition_size = get_partitioning_size(params, desc->v_head_size, rt_params->stage);
 
         auto effective_context_len = rt_params->max_context_len;
-        // scores_output is only used in SnapKV path, and it doesn't yet handle the SWA block skip offset
-        if (desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE && !desc->has_scores_output()) {
-            auto total_blocks = ceil_div(rt_params->max_context_len, paged_attention_block_size);
-            auto swa_start_block =
-                rt_params->max_context_len > desc->sliding_window ? (rt_params->max_context_len - desc->sliding_window) / paged_attention_block_size : 0;
-            auto effective_blocks = total_blocks - swa_start_block;
-            effective_context_len = effective_blocks * paged_attention_block_size;
+        // scores_output is only used in SnapKV path, and it doesn't yet handle the SWA block skip offset.
+        if (desc->sliding_window > 0 && !desc->has_scores_output() &&
+            (rt_params->stage == PagedAttentionStage::GENERATE || rt_params->stage == PagedAttentionStage::MIXED)) {
+            const auto total_blocks = ceil_div(rt_params->max_context_len, paged_attention_block_size);
+            // MIXED shares one partition count across tokens whose context lengths can have different block
+            // alignments. ceil(window / block) + 1 is the alignment-independent upper bound.
+            const auto max_window_blocks = ceil_div(desc->sliding_window, paged_attention_block_size) + 1;
+            effective_context_len = std::min(total_blocks, max_window_blocks) * paged_attention_block_size;
         }
         rt_params->num_of_partitions = ceil_div(effective_context_len, rt_params->partition_size);
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1395,7 +1395,7 @@ public:
         // U4 BY_CHANNEL MIXED has shown concurrency-sensitive output instability in production workloads.
         // Keep micro SDPA for PREFILL and route only the affected MIXED configuration to OCL.
         const auto use_ocl_for_u4_by_channel_mixed = stage == PagedAttentionStage::MIXED &&
-                                                     data_type_traits::is_i4_u4(kv_cache_dt) &&
+                                                     kv_cache_dt == ov::element::u4 &&
                                                      desc->is_key_by_channel;
         const auto can_use_micro_sdpa = !use_ocl_for_u4_by_channel_mixed;
         GPU_DEBUG_TRACE_DETAIL << "can_use_micro_sdpa_for: stage = " << static_cast<size_t>(stage)

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -50,8 +50,11 @@ TEST_P(paged_attention_u4_mixed_ocl_test, matches_cpu_reference) {
     auto* impl = pa_inst->get_impl();
     ASSERT_NE(impl, nullptr);
     const auto dump_info = impl->get_kernels_dump_info(*pa_inst->get_impl_params());
-    EXPECT_EQ(dump_info.get_entries().find("sdpa_micro"), std::string::npos)
+    // SDPAMicroGenerator(false), which implements PA MIXED, has the historical "_generate" suffix.
+    EXPECT_EQ(dump_info.get_entries().find("sdpa_micro__generate"), std::string::npos)
         << "U4 BY_CHANNEL MIXED must not exercise micro SDPA: " << dump_info.get_entries();
+    EXPECT_NE(dump_info.get_entries().find("paged_attention_opt__multi_tokens"), std::string::npos)
+        << "U4 BY_CHANNEL MIXED must exercise OCL PagedAttention: " << dump_info.get_entries();
 
     this->tolerance = 1e-2f;
     const auto reference = PagedAttentionReference(pam).get_reference(result.key_cache_mem);
@@ -61,9 +64,7 @@ TEST_P(paged_attention_u4_mixed_ocl_test, matches_cpu_reference) {
 INSTANTIATE_TEST_SUITE_P(
     regression_paged_attention_u4_mixed_ocl,
     paged_attention_u4_mixed_ocl_test,
-    ::testing::Values(
-        paged_attention_test_params{{{25, 34}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4},
-        paged_attention_test_params{{{25, 128}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
+    ::testing::Values(paged_attention_test_params{{{25, 128}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
 
 class paged_attention_u4_prefill_micro_test : public PagedAttentionTest<paged_attention_test_params> {};
 
@@ -81,14 +82,45 @@ TEST_P(paged_attention_u4_prefill_micro_test, keeps_micro_route) {
     auto* impl = pa_inst->get_impl();
     ASSERT_NE(impl, nullptr);
     const auto dump_info = impl->get_kernels_dump_info(*pa_inst->get_impl_params());
-    ASSERT_NE(dump_info.get_entries().find("sdpa_micro"), std::string::npos)
+    ASSERT_NE(dump_info.get_entries().find("sdpa_micro__prefill"), std::string::npos)
         << "U4 BY_CHANNEL PREFILL must continue to exercise micro SDPA: " << dump_info.get_entries();
+
+    const auto reference = PagedAttentionReference(pam).get_reference(result.key_cache_mem);
+    compare(result.outputs.at("output_data").get_memory(), nullptr, nullptr, reference);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     regression_paged_attention_u4_prefill_micro,
     paged_attention_u4_prefill_micro_test,
     ::testing::Values(paged_attention_test_params{{{25, 0}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
+
+class paged_attention_u8_mixed_micro_test : public PagedAttentionTest<paged_attention_test_params> {};
+
+TEST_P(paged_attention_u8_mixed_micro_test, keeps_micro_route) {
+    if (!tests::get_test_engine().get_device_info().supports_immad)
+        GTEST_SKIP() << "Micro SDPA requires DPAS/XMX support";
+
+    auto p = GetParam();
+    ASSERT_TRUE(this->pam.has_value());
+    auto& pam = *this->pam;
+    auto result = run_gpu_inference(pam, p);
+
+    auto pa_inst = result.network->get_primitive("paged_attention");
+    ASSERT_NE(pa_inst, nullptr);
+    auto* impl = pa_inst->get_impl();
+    ASSERT_NE(impl, nullptr);
+    const auto dump_info = impl->get_kernels_dump_info(*pa_inst->get_impl_params());
+    ASSERT_NE(dump_info.get_entries().find("sdpa_micro__generate"), std::string::npos)
+        << "The fallback must remain limited to U4 BY_CHANNEL MIXED: " << dump_info.get_entries();
+
+    const auto reference = PagedAttentionReference(pam).get_reference(result.key_cache_mem);
+    compare(result.outputs.at("output_data").get_memory(), nullptr, nullptr, reference);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    regression_paged_attention_u8_mixed_micro,
+    paged_attention_u8_mixed_micro_test,
+    ::testing::Values(paged_attention_test_params{{{25, 128}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u8}));
 #endif
 
 class paged_attention_u4_swa_tail_test : public PagedAttentionTest<paged_attention_test_params> {};

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -12,11 +12,11 @@ TEST_P(paged_attention_test, basic) {
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
-class paged_attention_u4_mixed_micro_test : public PagedAttentionTest<paged_attention_test_params> {};
+class paged_attention_u4_mixed_ocl_test : public PagedAttentionTest<paged_attention_test_params> {};
 
-TEST_P(paged_attention_u4_mixed_micro_test, matches_cpu_reference) {
+TEST_P(paged_attention_u4_mixed_ocl_test, matches_cpu_reference) {
     if (!tests::get_test_engine().get_device_info().supports_immad)
-        GTEST_SKIP() << "Micro SDPA requires DPAS/XMX support";
+        GTEST_SKIP() << "Routing regression requires a micro SDPA-capable device";
 
     auto p = GetParam();
     ASSERT_TRUE(this->pam.has_value());
@@ -50,8 +50,8 @@ TEST_P(paged_attention_u4_mixed_micro_test, matches_cpu_reference) {
     auto* impl = pa_inst->get_impl();
     ASSERT_NE(impl, nullptr);
     const auto dump_info = impl->get_kernels_dump_info(*pa_inst->get_impl_params());
-    ASSERT_NE(dump_info.get_entries().find("sdpa_micro"), std::string::npos)
-        << "Regression must exercise micro SDPA: " << dump_info.get_entries();
+    EXPECT_EQ(dump_info.get_entries().find("sdpa_micro"), std::string::npos)
+        << "U4 BY_CHANNEL MIXED must not exercise micro SDPA: " << dump_info.get_entries();
 
     this->tolerance = 1e-2f;
     const auto reference = PagedAttentionReference(pam).get_reference(result.key_cache_mem);
@@ -59,11 +59,36 @@ TEST_P(paged_attention_u4_mixed_micro_test, matches_cpu_reference) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    regression_paged_attention_u4_mixed_micro,
-    paged_attention_u4_mixed_micro_test,
+    regression_paged_attention_u4_mixed_ocl,
+    paged_attention_u4_mixed_ocl_test,
     ::testing::Values(
         paged_attention_test_params{{{25, 34}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4},
         paged_attention_test_params{{{25, 128}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
+
+class paged_attention_u4_prefill_micro_test : public PagedAttentionTest<paged_attention_test_params> {};
+
+TEST_P(paged_attention_u4_prefill_micro_test, keeps_micro_route) {
+    if (!tests::get_test_engine().get_device_info().supports_immad)
+        GTEST_SKIP() << "Micro SDPA requires DPAS/XMX support";
+
+    auto p = GetParam();
+    ASSERT_TRUE(this->pam.has_value());
+    auto& pam = *this->pam;
+    auto result = run_gpu_inference(pam, p);
+
+    auto pa_inst = result.network->get_primitive("paged_attention");
+    ASSERT_NE(pa_inst, nullptr);
+    auto* impl = pa_inst->get_impl();
+    ASSERT_NE(impl, nullptr);
+    const auto dump_info = impl->get_kernels_dump_info(*pa_inst->get_impl_params());
+    ASSERT_NE(dump_info.get_entries().find("sdpa_micro"), std::string::npos)
+        << "U4 BY_CHANNEL PREFILL must continue to exercise micro SDPA: " << dump_info.get_entries();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    regression_paged_attention_u4_prefill_micro,
+    paged_attention_u4_prefill_micro_test,
+    ::testing::Values(paged_attention_test_params{{{25, 0}}, 32, 2, 128, 128, 16, 0, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
 #endif
 
 class paged_attention_u4_swa_tail_test : public PagedAttentionTest<paged_attention_test_params> {};
@@ -100,7 +125,9 @@ TEST_P(paged_attention_u4_swa_tail_test, ignores_invalid_value_cache_rows) {
 INSTANTIATE_TEST_SUITE_P(
     regression_paged_attention_u4_swa_tail,
     paged_attention_u4_swa_tail_test,
-    ::testing::Values(paged_attention_test_params{{{1, 35}}, 8, 2, 128, 128, 16, 16, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
+    ::testing::Values(
+        paged_attention_test_params{{{1, 35}}, 8, 2, 128, 128, 16, 16, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4},
+        paged_attention_test_params{{{25, 35}}, 8, 2, 128, 128, 16, 16, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
 
 class paged_attention_swa_partition_finalization_test : public PagedAttentionTest<paged_attention_test_params> {};
 
@@ -112,7 +139,9 @@ TEST_P(paged_attention_swa_partition_finalization_test, ignores_inactive_partiti
 INSTANTIATE_TEST_SUITE_P(
     regression_paged_attention_swa_partition_finalization,
     paged_attention_swa_partition_finalization_test,
-    ::testing::Values(paged_attention_test_params{{{1, 511}, {1, 512}}, 8, 2, 128, 128, 16, 256, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false}));
+    ::testing::Values(
+        paged_attention_test_params{{{1, 511}, {1, 512}}, 8, 2, 128, 128, 16, 256, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false},
+        paged_attention_test_params{{{25, 511}, {10, 512}}, 8, 2, 128, 128, 16, 256, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_CHANNEL, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false, {}, {}, ov::element::u4}));
 
 class xattention_test : public PagedAttentionTest<paged_attention_test_params> {};
 TEST_P(xattention_test, basic) {


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
- Concurrent execution with U4 BY_CHANNEL KV cache shows run-to-run accuracy regression in the PagedAttention micro SDPA MIXED path.
- Route only the affected U4 BY_CHANNEL MIXED path to the OCL implementation. Other precisions and PREFILL retain micro SDPA.
- Enable sliding-window block skipping for OCL multi-token processing and align its partition allocation.

#### The code and line that caused this issue (if it is not changed directly)
- `PagedAttentionOptImpl::can_use_micro_sdpa_for()`
- `paged_attention_opt.cl` multi-token sliding-window processing

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
- Reproduced with internal concurrent continuous-batching workloads.

#### Problematic graph
- PagedAttention with U4 KV cache, BY_CHANNEL key-cache quantization, and MIXED execution.

#### Checklist
- [ ] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario?
  - Extended `paged_attention_gpu_test.cpp`.

### Tickets:
- CVS-192784