### PR TITLE
[GPU] prevent dequantize operations to run in f32 precision

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -647,9 +647,44 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             return does_support_fusings;
         };
 
-        auto mvn_supports_fusings = [](mvn_node& node) -> bool {
+        // An MVN which requires alignment is executed on a virtually flattened iteration space:
+        // mvn_impl::static_canonicalize_shapes() folds every axis below the first reduced axis into batch and
+        // every reduced axis into the innermost one, e.g. [6,108,108,256] with axes={3} becomes [69984,1,1,256].
+        // Post-op peer tensors keep their original shape, so a peer may only be fused when its element index
+        // survives that fold:
+        //   - the reduced axes are always the trailing contiguous block (see the MVN6Decomposition callback in
+        //     transformations_pipeline.cpp, which is the only way a non-decomposed MVN reaches this point), so
+        //     the innermost axis keeps unit stride inside the folded innermost dim;
+        //   - MVNKernelBfyxOpt indexes peers with FUSED_OP_n_INPUTm_GET_INDEX_SAFE(b, f, y, x), which takes each
+        //     index modulo that axis' size, so `x % peer_size_x` still yields the original innermost index.
+        // A peer which varies along any other axis (e.g. a full-shape eltwise peer) would be indexed with a
+        // batch value that runs over the whole folded outer dim and must not be fused.
+        auto mvn_flattened_peer_is_indexable = [](const mvn_node& node, const layout& peer_layout) -> bool {
+            const auto& in_pshape = node.get_input_layout(0).get_partial_shape();
+            const auto& peer_pshape = peer_layout.get_partial_shape();
+            if (in_pshape.is_dynamic() || peer_pshape.is_dynamic())
+                return false;
+            // Scalar peers are broadcast without any index calculation
+            if (peer_layout.count() == 1)
+                return true;
+            if (peer_pshape.size() != in_pshape.size())
+                return false;
+            const auto last_axis = peer_pshape.size() - 1;
+            for (size_t i = 0; i < last_axis; i++) {
+                if (peer_pshape[i].get_length() != 1)
+                    return false;
+            }
+            return peer_pshape[last_axis].get_length() == in_pshape[last_axis].get_length();
+        };
+
+        auto mvn_supports_fusings = [&](mvn_node& node, const std::vector<layout>& peer_layouts) -> bool {
             auto in_layout = node.get_input_layout(0);
-            return !node.get_primitive()->requires_alignment(in_layout.get_partial_shape());
+            if (!node.get_primitive()->requires_alignment(in_layout.get_partial_shape()))
+                return true;
+
+            return std::all_of(peer_layouts.begin(), peer_layouts.end(), [&](const layout& peer_layout) {
+                return mvn_flattened_peer_is_indexable(node, peer_layout);
+            });
         };
 
         auto dts_supports_fusings = [](depth_to_space_node& node) -> bool {
@@ -941,6 +976,17 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             auto out_layout = quantize_node.get_output_layout();
             auto in_layout = input_data.get_output_layout();
 
+            // Layouts of the quantize parameters, i.e. of every fused-op tensor the post-op code may index.
+            // program::fuse_nodes() drops the per-tensor ones before they can be indexed, but they are reported
+            // here as well rather than duplicating that drop logic - per-tensor parameters are scalars in
+            // practice, which every consumer of this list accepts anyway.
+            auto quantize_param_layouts = [&]() {
+                std::vector<layout> layouts;
+                for (size_t i = 1; i < quantize_node.get_dependencies().size(); i++)
+                    layouts.push_back(quantize_node.get_dependency(i).get_output_layout());
+                return layouts;
+            };
+
             // In dynamic shape, quantize-fusion is disable in only cldnn convolution
             if ((in_layout.is_dynamic() || out_layout.is_dynamic()) &&
                 (input_data.is_type<convolution>() && !lo.has_all_enabled_onednn_impls_optimization_attribute()))
@@ -975,7 +1021,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                            quantize_node.get_scale_shift_opt() &&
                            out_dt_is_i8_u8;
 
-            should_fuse |= input_data.is_type<mvn>() && mvn_supports_fusings(input_data.as<mvn>()) &&
+            should_fuse |= input_data.is_type<mvn>() &&
+                           mvn_supports_fusings(input_data.as<mvn>(), quantize_param_layouts()) &&
                            quantize_node.get_scale_shift_opt();
 
             should_fuse |= input_data.is_type<activation>() && quantize_node.get_scale_shift_opt();
@@ -1060,7 +1107,8 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 can_fuse_parents[i] = (parents[i].first->is_type<convolution>() &&
                                        conv_supports_fusings(parents[i].first->as<convolution>())) ||
                                       (parents[i].first->is_type<mvn>() &&
-                                       mvn_supports_fusings(parents[i].first->as<mvn>())) ||
+                                       mvn_supports_fusings(parents[i].first->as<mvn>(),
+                                                            { parents[parents.size() - 1 - i].first->get_output_layout() })) ||
                                       (parents[i].first->is_type<group_normalization>()) ||
                                       (parents[i].first->is_type<rms>()) ||
                                       (parents[i].first->is_type<deconvolution>()) ||

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -657,6 +657,9 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
         //     the innermost axis keeps unit stride inside the folded innermost dim;
         //   - MVNKernelBfyxOpt indexes peers with FUSED_OP_n_INPUTm_GET_INDEX_SAFE(b, f, y, x), which takes each
         //     index modulo that axis' size, so `x % peer_size_x` still yields the original innermost index.
+        //     In ACROSS_CHANNELS mode, idx_order similarly indexes the innermost dim with
+        //     ((in_data_set_idx + iteration_in_data_set_offset) % OUTPUT_SIZE_X), so x % peer_size_x recovers the
+        //     same innermost index as well.
         // A peer which varies along any other axis (e.g. a full-shape eltwise peer) would be indexed with a
         // batch value that runs over the whole folded outer dim and must not be fused.
         auto mvn_flattened_peer_is_indexable = [](const mvn_node& node, const layout& peer_layout) -> bool {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/mvn/mvn_kernel_bfyx_opt.cpp
@@ -69,6 +69,20 @@ MVNKernelBfyxOpt::Parent::DispatchData MVNKernelBfyxOpt::SetDefault(const mvn_pa
             dispatchData.itemsNum /= 2;
         }
 
+        // One loop iteration of the kernel stores lws[0] contiguous output elements. When that spans less than a
+        // cache line the store is a partial write, which costs extra read-modify-write traffic. It shows up most
+        // clearly when a fused quantize narrows the output to 1 byte per element while the input stays at 2:
+        // a 256-element data set picks lws[0]=32 above, i.e. a 32-byte store into a 64-byte line.
+        // Keep doubling the work group until an iteration covers a full line. This can only raise lws[0], so
+        // data sets that already store a full line or more keep their previous dispatch.
+        const size_t bytes_per_cache_line = 64;
+        const size_t output_elem_size = BytesPerElement(params.outputs[0].GetDType());
+        while (dispatchData.lws[0] * output_elem_size < bytes_per_cache_line &&
+               2 * dispatchData.lws[0] <= std::min<uint64_t>(max_lws, dispatchData.dataSetSize)) {
+            dispatchData.lws[0] *= 2;
+            dispatchData.itemsNum /= 2;
+        }
+
         dispatchData.gws[0] = dispatchData.lws[0];
         dispatchData.leftovers = dispatchData.dataSetSize % dispatchData.lws[0];
     }

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -36,6 +36,7 @@
 #include "low_precision/mvn.hpp"
 #include "low_precision/network_helper.hpp"
 #include "low_precision/recurrent_cell.hpp"
+#include "low_precision/reshape.hpp"
 #include "low_precision/prelu.hpp"
 #include "low_precision/transpose.hpp"
 #include "low_precision/variadic_split.hpp"
@@ -1432,6 +1433,36 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         lptPassConfig->disable<ov::pass::low_precision::PReluTransformation>();
         lptPassConfig->set_callback<SplitTransformation, VariadicSplitTransformation>([](const_node_ptr& node) -> bool {
             return !has_dequantization_absorbing_consumer(node);
+        });
+        auto isFp32LptAddWithFp16Scale = [defaultPrecisions](const_node_ptr& node) -> bool {
+            const auto dequantization = NetworkHelper::getDequantization(node, defaultPrecisions);
+            if (dequantization.subtract != nullptr || dequantization.multiply == nullptr || dequantization.data.get_element_type() != element::f32) {
+                return false;
+            }
+
+            const auto relaxed_add = std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(dequantization.data.get_node_shared_ptr());
+            const auto relaxed_multiply = std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(dequantization.multiply);
+            return ov::is_type<ov::opset1::Add>(dequantization.data.get_node_shared_ptr()) && relaxed_add != nullptr &&
+                   relaxed_add->get_overridden_output_type() == element::f32 && relaxed_multiply != nullptr &&
+                   relaxed_multiply->get_origin_input_type(0) == element::f32 && relaxed_multiply->get_origin_input_type(1) == element::f32 &&
+                   relaxed_multiply->get_overridden_output_type() == element::f16;
+        };
+        // Keep this scale before normalization paths; moving it exposes the FP32 inner Add to GPU.
+        lptPassConfig->set_callback<MVNTransformation>([infer_precision, isFp32LptAddWithFp16Scale](const_node_ptr& node) -> bool {
+            return infer_precision == element::f16 && node->get_input_element_type(0) == element::f16 && isFp32LptAddWithFp16Scale(node);
+        });
+        lptPassConfig->set_callback<ReshapeTransformation>([infer_precision, isFp32LptAddWithFp16Scale](const_node_ptr& node) -> bool {
+            if (infer_precision != element::f16 || node->get_input_element_type(0) != element::f16 || !isFp32LptAddWithFp16Scale(node)) {
+                return false;
+            }
+
+            const auto consumers = node->get_output_target_inputs(0);
+            if (consumers.size() != 1) {
+                return false;
+            }
+
+            const auto consumer = consumers.begin()->get_node()->shared_from_this();
+            return ov::is_type<ov::op::v0::MVN>(consumer) || ov::is_type<ov::op::v6::MVN>(consumer);
         });
         lptPassConfig->set_callback<ConvolutionBackpropDataTransformation>([func, defaultPrecisions](const_node_ptr& node) -> bool {
             auto fillStaticChannel = [func](const ov::PartialShape& shape, size_t& channel) -> bool {

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -38,11 +38,13 @@
 #include "low_precision/recurrent_cell.hpp"
 #include "low_precision/prelu.hpp"
 #include "low_precision/transpose.hpp"
+#include "low_precision/variadic_split.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/validation_util.hpp"
 #include "openvino/core/partial_shape.hpp"
 #include "openvino/core/shape.hpp"
+#include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/gated_delta_net.hpp"
@@ -449,6 +451,47 @@ bool is_hybrid_linear_attention_model(const ov::Model& model) {
         if (ov::is_type<ov::op::internal::GatedDeltaNet>(op) ||
             ov::is_type<ov::op::internal::PagedGatedDeltaNet>(op)) {
             return true;
+        }
+    }
+    return false;
+}
+
+// LPT's Split/VariadicSplitTransformation moves the dequantization from above the split to
+// below it, once per split output. That only pays off if the moved dequantization can be
+// absorbed by one of the consumers (a layer with quantized weights). If it cannot, the plugin
+// is left with one standalone per-channel eltwise per split output and, on top of that, the
+// single original dequantization can no longer be fused into the producer.
+// Typical case: the QKV VariadicSplit of a transformer block, whose outputs feed
+// bias Add -> Reshape -> SDPA and whose producer is the quantized QKV MatMul.
+bool has_dequantization_absorbing_consumer(const std::shared_ptr<const ov::Node>& split) {
+    constexpr size_t max_visited = 32;
+    std::deque<std::shared_ptr<ov::Node>> queue;
+    for (const auto& user : split->get_users()) {
+        queue.push_back(user);
+    }
+
+    for (size_t visited = 0; !queue.empty() && visited < max_visited; ++visited) {
+        const auto node = queue.front();
+        queue.pop_front();
+
+        if (is_type_any_of<ov::op::v0::MatMul,
+                           ov::op::v1::Convolution,
+                           ov::op::v1::GroupConvolution,
+                           ov::op::v1::ConvolutionBackpropData,
+                           ov::op::v1::GroupConvolutionBackpropData>(node)) {
+            return true;
+        }
+
+        // Data movement ops LPT propagates the dequantization further through, so a quantized
+        // layer behind them is still reachable.
+        if (is_type_any_of<ov::op::v0::Concat,
+                           ov::op::v1::Reshape,
+                           ov::op::v1::Transpose,
+                           ov::op::v0::Squeeze,
+                           ov::op::v0::Unsqueeze>(node)) {
+            for (const auto& user : node->get_users()) {
+                queue.push_back(user);
+            }
         }
     }
     return false;
@@ -1387,6 +1430,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         lptPassConfig->disable<ov::pass::low_precision::RecurrentCellTransformation>();
         // Ticket 168015: Low precision PRelu is not supported on GPU
         lptPassConfig->disable<ov::pass::low_precision::PReluTransformation>();
+        lptPassConfig->set_callback<SplitTransformation, VariadicSplitTransformation>([](const_node_ptr& node) -> bool {
+            return !has_dequantization_absorbing_consumer(node);
+        });
         lptPassConfig->set_callback<ConvolutionBackpropDataTransformation>([func, defaultPrecisions](const_node_ptr& node) -> bool {
             auto fillStaticChannel = [func](const ov::PartialShape& shape, size_t& channel) -> bool {
                 const auto rank = shape.rank();

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/prevent_f32_dequantize.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/prevent_f32_dequantize.cpp
@@ -1,0 +1,448 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "common_test_utils/node_builders/fake_quantize.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/core/type/float16.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/mvn.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/variadic_split.hpp"
+#include "openvino/runtime/exec_model_info.hpp"
+#include "openvino/runtime/properties.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace {
+
+// GPU_OPTIMIZE_DATA is an internal property, so Core::compile_model cannot set it through AnyMap.
+class ScopedOptimizeData {
+public:
+    explicit ScopedOptimizeData(bool enabled) {
+        const char* value = std::getenv("OV_GPU_OPTIMIZE_DATA");
+        if (value != nullptr) {
+            was_set = true;
+            previous_value = value;
+        }
+        OPENVINO_ASSERT(set_value(enabled ? "1" : "0") == 0, "Failed to set OV_GPU_OPTIMIZE_DATA");
+    }
+
+    ~ScopedOptimizeData() {
+        EXPECT_EQ(was_set ? set_value(previous_value.c_str()) : unset_value(), 0) << "Failed to restore OV_GPU_OPTIMIZE_DATA";
+    }
+
+    ScopedOptimizeData(const ScopedOptimizeData&) = delete;
+    ScopedOptimizeData& operator=(const ScopedOptimizeData&) = delete;
+
+private:
+    static int set_value(const char* value) {
+#ifdef _WIN32
+        return _putenv_s("OV_GPU_OPTIMIZE_DATA", value);
+#else
+        return setenv("OV_GPU_OPTIMIZE_DATA", value, 1);
+#endif
+    }
+
+    static int unset_value() {
+#ifdef _WIN32
+        return _putenv_s("OV_GPU_OPTIMIZE_DATA", "");
+#else
+        return unsetenv("OV_GPU_OPTIMIZE_DATA");
+#endif
+    }
+
+    bool was_set = false;
+    std::string previous_value;
+};
+
+std::string runtime_info(const std::shared_ptr<ov::Node>& node, const std::string& key) {
+    const auto& info = node->get_rt_info();
+    const auto it = info.find(key);
+    return it == info.end() ? std::string{} : it->second.as<std::string>();
+}
+
+bool has_original_name(const std::shared_ptr<ov::Node>& node, const std::string& expected) {
+    std::istringstream names(runtime_info(node, ov::exec_model_info::ORIGINAL_NAMES));
+    std::string name;
+    while (std::getline(names, name, ',')) {
+        if (name == expected) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<std::shared_ptr<ov::Node>> find_runtime_nodes(const std::shared_ptr<const ov::Model>& model,
+                                                          const std::string& layer_type,
+                                                          const std::string& original_name = {}) {
+    std::vector<std::shared_ptr<ov::Node>> nodes;
+    for (const auto& node : model->get_ordered_ops()) {
+        if (runtime_info(node, ov::exec_model_info::LAYER_TYPE) == layer_type && (original_name.empty() || has_original_name(node, original_name))) {
+            nodes.push_back(node);
+        }
+    }
+    return nodes;
+}
+
+std::shared_ptr<ov::Node> find_runtime_node(const std::shared_ptr<const ov::Model>& model,
+                                            const std::string& layer_type,
+                                            const std::string& original_name = {}) {
+    const auto nodes = find_runtime_nodes(model, layer_type, original_name);
+    EXPECT_EQ(nodes.size(), 1u) << "Expected one " << layer_type << " node with original name '" << original_name << "'";
+    return nodes.size() == 1 ? nodes.front() : nullptr;
+}
+
+std::string describe_runtime_model(const std::shared_ptr<const ov::Model>& model) {
+    std::ostringstream description;
+    description << "Runtime graph:\n";
+    for (const auto& node : model->get_ordered_ops()) {
+        description << node->get_friendly_name() << " [" << runtime_info(node, ov::exec_model_info::LAYER_TYPE)
+                    << "] originals=" << runtime_info(node, ov::exec_model_info::ORIGINAL_NAMES) << " inputs:";
+        for (const auto& input : node->input_values()) {
+            description << " " << input.get_node()->get_friendly_name() << ":" << input.get_element_type();
+        }
+        description << " outputs:";
+        for (const auto& output : node->outputs()) {
+            description << " " << output.get_element_type();
+        }
+        description << "\n";
+    }
+    return description.str();
+}
+
+std::shared_ptr<ov::Node> make_quantized_input(const ov::Shape& shape, const std::string& name, ov::ParameterVector& parameters) {
+    const auto type = ov::element::f16;
+    auto input = std::make_shared<ov::op::v0::Parameter>(type, shape);
+    input->set_friendly_name(name);
+    parameters.push_back(input);
+    // The quantization step (1/128) and both endpoints are exactly representable in f16.
+    auto fq = ov::test::utils::make_fake_quantize(input, type, 256ul, {}, {0.0f}, {255.0f / 128}, {0.0f}, {255.0f / 128});
+    fq->set_friendly_name(name + "_fq");
+    return fq;
+}
+
+class PreventF32DequantizeTestBase : public ov::test::SubgraphBaseStaticTest {
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+        configuration[ov::hint::inference_precision.name()] = ov::element::f16.get_type_name();
+    }
+
+    void compile_model() override {
+        const ScopedOptimizeData scoped_optimize_data(optimize_data);
+        ov::test::SubgraphBaseStaticTest::compile_model();
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) override {
+        inputs.clear();
+        const auto& parameters = function->get_parameters();
+        ASSERT_EQ(parameters.size(), target_input_static_shapes.size());
+        for (size_t input_index = 0; input_index < parameters.size(); ++input_index) {
+            ov::Tensor tensor(ov::element::f16, target_input_static_shapes[input_index]);
+            auto* data = tensor.data<ov::float16>();
+            for (size_t i = 0; i < tensor.get_size(); ++i) {
+                // Independent, deterministic permutations of the quantization grid.
+                // For the Add inputs: x[i] = (i % 256)/128, y[i] = ((17*i + 29) % 256)/128.
+                const auto quantized_value = (i * (16 * input_index + 1) + 29 * input_index) % 256;
+                data[i] = ov::float16(static_cast<float>(quantized_value) / 128.0f);
+            }
+            inputs.emplace(parameters[input_index], tensor);
+        }
+    }
+
+    bool optimize_data = true;
+};
+
+class PreventF32DequantizeAddBase : public PreventF32DequantizeTestBase {
+protected:
+    enum class Consumer { MVN, ReshapeWithMVN, ReshapeNonMVN };
+
+    void set_up_model(Consumer consumer_type) {
+        PreventF32DequantizeTestBase::SetUp();
+        consumer = consumer_type;
+        ov::ParameterVector parameters;
+        const ov::Shape shape{1, 4, 16, 16};
+        auto x = make_quantized_input(shape, "input_x", parameters);
+        auto y = make_quantized_input(shape, "input_y", parameters);
+
+        // Two non-constant inputs produce the TypeRelaxed Add(f32) -> Multiply(f16) LPT pattern.
+        auto add = std::make_shared<ov::op::v1::Add>(x, y);
+        add->set_friendly_name("inner_add");
+        std::shared_ptr<ov::Node> output = add;
+        if (consumer != Consumer::MVN) {
+            auto target_shape = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 1024});
+            output = std::make_shared<ov::op::v1::Reshape>(output, target_shape, false);
+            output->set_friendly_name("reshape");
+        }
+        if (consumer == Consumer::ReshapeNonMVN) {
+            output = std::make_shared<ov::op::v0::Relu>(output);
+            output->set_friendly_name("relu");
+        } else {
+            const std::vector<int64_t> axes_values = consumer == Consumer::MVN ? std::vector<int64_t>{2, 3} : std::vector<int64_t>{1};
+            auto axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{axes_values.size()}, axes_values);
+            output = std::make_shared<ov::op::v6::MVN>(output, axes, true, 1e-5f, ov::op::MVNEpsMode::INSIDE_SQRT);
+            output->set_friendly_name("mvn");
+        }
+        auto result = std::make_shared<ov::op::v0::Result>(output);
+        function = std::make_shared<ov::Model>(ov::ResultVector{result}, parameters, "PreventF32DequantizeAdd");
+    }
+
+    void validate() override {
+        ov::test::SubgraphBaseStaticTest::validate();
+        const auto runtime_model = compiledModel.get_runtime_model();
+        ASSERT_NE(runtime_model, nullptr);
+        SCOPED_TRACE(describe_runtime_model(runtime_model));
+        SCOPED_TRACE(optimize_data ? "optimize_data=true" : "optimize_data=false");
+
+        const auto add = find_runtime_node(runtime_model, "Eltwise", "inner_add");
+        ASSERT_NE(add, nullptr);
+        // runtimePrecision can be f32 even when the fused Add produces f16.
+        EXPECT_EQ(add->get_output_element_type(0), optimize_data ? ov::element::f16 : ov::element::f32);
+
+        std::shared_ptr<ov::Node> boundary;
+        if (consumer != Consumer::MVN) {
+            // In the Relu case, later passes move Reshape after Relu and transfer its friendly name.
+            boundary = find_runtime_node(runtime_model, "Reshape", consumer == Consumer::ReshapeWithMVN ? "reshape" : "");
+            ASSERT_NE(boundary, nullptr);
+        }
+        if (consumer != Consumer::ReshapeNonMVN) {
+            const auto mvn = find_runtime_node(runtime_model, "MVN", "mvn");
+            ASSERT_NE(mvn, nullptr);
+            ASSERT_EQ(mvn->get_input_size(), 1u);
+            EXPECT_EQ(mvn->get_input_element_type(0), ov::element::f16);
+            EXPECT_EQ(mvn->get_output_element_type(0), ov::element::f16);
+            if (consumer == Consumer::MVN) {
+                boundary = mvn;
+            } else {
+                EXPECT_EQ(mvn->input_value(0).get_node_shared_ptr(), boundary);
+            }
+        }
+        ASSERT_NE(boundary, nullptr);
+        ASSERT_EQ(boundary->get_input_size(), 1u);
+        EXPECT_EQ(boundary->get_input_element_type(0), ov::element::f16);
+        EXPECT_EQ(boundary->get_output_element_type(0), ov::element::f16);
+
+        if (optimize_data) {
+            // The scale is fused into Add, whose f16 output feeds MVN or Reshape.
+            EXPECT_EQ(boundary->input_value(0).get_node_shared_ptr(), add);
+        } else {
+            auto scale_input = add;
+            if (consumer == Consumer::ReshapeNonMVN) {
+                // Negative control: dequantization moves through Relu, which then operates in f32.
+                const auto relu = find_runtime_node(runtime_model, "Activation");
+                ASSERT_NE(relu, nullptr);
+                ASSERT_EQ(relu->get_input_size(), 1u);
+                EXPECT_EQ(relu->input_value(0).get_node_shared_ptr(), add);
+                EXPECT_EQ(relu->get_input_element_type(0), ov::element::f32);
+                EXPECT_EQ(relu->get_output_element_type(0), ov::element::f32);
+                scale_input = relu;
+            }
+            // With fusion disabled, check the standalone f32 -> f16 scale at the boundary.
+            const auto scale = boundary->input_value(0).get_node_shared_ptr();
+            ASSERT_EQ(runtime_info(scale, ov::exec_model_info::LAYER_TYPE), "Eltwise");
+            ASSERT_EQ(scale->get_input_size(), 1u);
+            EXPECT_EQ(scale->input_value(0).get_node_shared_ptr(), scale_input);
+            EXPECT_EQ(scale->get_input_element_type(0), ov::element::f32);
+            EXPECT_EQ(scale->get_output_element_type(0), ov::element::f16);
+        }
+    }
+
+private:
+    Consumer consumer = Consumer::MVN;
+};
+
+class PreventF32DequantizeMVN : public PreventF32DequantizeAddBase {
+protected:
+    void SetUp() override {
+        set_up_model(Consumer::MVN);
+    }
+};
+
+TEST_F(PreventF32DequantizeMVN, smoke_GPU_PreventF32DequantizeMVN) {
+    run();
+}
+
+TEST_F(PreventF32DequantizeMVN, smoke_GPU_PreventF32DequantizeMVN_WithoutFusion) {
+    optimize_data = false;
+    run();
+}
+
+class PreventF32DequantizeReshapeWithMVN : public PreventF32DequantizeAddBase {
+protected:
+    void SetUp() override {
+        set_up_model(Consumer::ReshapeWithMVN);
+    }
+};
+
+TEST_F(PreventF32DequantizeReshapeWithMVN, smoke_GPU_PreventF32DequantizeReshapeWithMVN) {
+    run();
+}
+
+TEST_F(PreventF32DequantizeReshapeWithMVN, smoke_GPU_PreventF32DequantizeReshapeWithMVN_WithoutFusion) {
+    optimize_data = false;
+    run();
+}
+
+class PreventF32DequantizeReshapeNonMVN : public PreventF32DequantizeAddBase {
+protected:
+    void SetUp() override {
+        set_up_model(Consumer::ReshapeNonMVN);
+    }
+};
+
+TEST_F(PreventF32DequantizeReshapeNonMVN, smoke_GPU_PreventF32DequantizeReshapeNonMVN) {
+    run();
+}
+
+TEST_F(PreventF32DequantizeReshapeNonMVN, smoke_GPU_PreventF32DequantizeReshapeNonMVN_WithoutFusion) {
+    optimize_data = false;
+    run();
+}
+
+class PreventF32DequantizeVariadicSplitBase : public PreventF32DequantizeTestBase {
+protected:
+    void set_up_model(bool with_absorber, size_t concat_count, ov::element::Type expected_split_type) {
+        PreventF32DequantizeTestBase::SetUp();
+        has_absorber = with_absorber;
+        split_type = expected_split_type;
+        const auto type = ov::element::f16;
+        ov::ParameterVector parameters;
+        auto fq = make_quantized_input({1, 64}, "source", parameters);
+        auto axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
+        auto split_lengths = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {32, 32});
+        auto split = std::make_shared<ov::op::v1::VariadicSplit>(fq, axis, split_lengths);
+        split->set_friendly_name("split");
+
+        ov::Output<ov::Node> branch0 = split->output(0);
+        ov::Shape current_shape{1, 32};
+        for (size_t i = 0; i < concat_count; ++i) {
+            // Alternating axes prevent CommonOptimizations from flattening the Concat chain.
+            const auto concat_axis = i % 2;
+            auto extra_shape = current_shape;
+            extra_shape[concat_axis] = 1;
+            auto extra = make_quantized_input(extra_shape, "concat_input_" + std::to_string(i), parameters);
+            auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{branch0, extra}, static_cast<int64_t>(concat_axis));
+            concat->set_friendly_name("budget_concat_" + std::to_string(i));
+            branch0 = concat->output(0);
+            ++current_shape[concat_axis];
+        }
+
+        if (has_absorber) {
+            auto weights = ov::op::v0::Constant::create(type, ov::Shape{current_shape[1], 16}, {0.5f});
+            auto weights_fq = ov::test::utils::make_fake_quantize(weights, type, 256ul, {}, {-1.0f}, {127.0f / 128}, {-1.0f}, {127.0f / 128});
+            auto matmul = std::make_shared<ov::op::v0::MatMul>(branch0, weights_fq);
+            matmul->set_friendly_name("matmul");
+            branch0 = matmul->output(0);
+        } else {
+            auto bias = ov::op::v0::Constant::create(type, ov::Shape{}, {1.0f});
+            auto add = std::make_shared<ov::op::v1::Add>(branch0, bias);
+            add->set_friendly_name("branch0_add");
+            branch0 = add->output(0);
+        }
+
+        // This non-absorbing branch consumes one visit in the split callback's BFS budget.
+        auto bias = ov::op::v0::Constant::create(type, ov::Shape{}, {2.0f});
+        auto branch1 = std::make_shared<ov::op::v1::Add>(split->output(1), bias);
+        branch1->set_friendly_name("branch1_add");
+        auto result0 = std::make_shared<ov::op::v0::Result>(branch0);
+        auto result1 = std::make_shared<ov::op::v0::Result>(branch1);
+        function = std::make_shared<ov::Model>(ov::ResultVector{result0, result1}, parameters, "PreventF32DequantizeSplit");
+    }
+
+    void validate() override {
+        ov::test::SubgraphBaseStaticTest::validate();
+        const auto runtime_model = compiledModel.get_runtime_model();
+        ASSERT_NE(runtime_model, nullptr);
+        SCOPED_TRACE(describe_runtime_model(runtime_model));
+
+        const auto source_fq = find_runtime_node(runtime_model, "Quantize", "source_fq");
+        ASSERT_NE(source_fq, nullptr);
+        ASSERT_GE(source_fq->get_output_size(), 1u);
+        for (const auto& output : source_fq->outputs()) {
+            EXPECT_EQ(output.get_element_type(), split_type);
+        }
+
+        // VariadicSplit is lowered to two Crop nodes. Check both outputs and their producer.
+        const auto crops = find_runtime_nodes(runtime_model, "Crop", "split");
+        ASSERT_EQ(crops.size(), 2u);
+        for (const auto& crop : crops) {
+            SCOPED_TRACE(crop->get_friendly_name());
+            ASSERT_EQ(crop->get_input_size(), 1u);
+            EXPECT_EQ(crop->input_value(0).get_node_shared_ptr(), source_fq);
+            EXPECT_EQ(crop->get_input_element_type(0), split_type);
+            EXPECT_EQ(crop->get_output_element_type(0), split_type);
+        }
+
+        if (has_absorber) {
+            const auto matmul = find_runtime_node(runtime_model, "FullyConnected", "matmul");
+            ASSERT_NE(matmul, nullptr);
+            ASSERT_GE(matmul->get_input_size(), 1u);
+            EXPECT_EQ(matmul->get_input_element_type(0), split_type);
+        }
+    }
+
+private:
+    bool has_absorber = false;
+    ov::element::Type split_type = ov::element::dynamic;
+};
+
+class PreventF32DequantizeVariadicSplitNoAbsorbingConsumer : public PreventF32DequantizeVariadicSplitBase {
+protected:
+    void SetUp() override {
+        set_up_model(false, 0, ov::element::f16);
+    }
+};
+
+TEST_F(PreventF32DequantizeVariadicSplitNoAbsorbingConsumer, smoke_GPU_VariadicSplitNoAbsorber) {
+    run();
+}
+
+class PreventF32DequantizeVariadicSplitWithAbsorbingConsumer : public PreventF32DequantizeVariadicSplitBase {
+protected:
+    void SetUp() override {
+        set_up_model(true, 0, ov::element::u8);
+    }
+};
+
+TEST_F(PreventF32DequantizeVariadicSplitWithAbsorbingConsumer, smoke_GPU_VariadicSplitWithAbsorber) {
+    run();
+}
+
+class PreventF32DequantizeVariadicSplitWithinBudget : public PreventF32DequantizeVariadicSplitBase {
+protected:
+    void SetUp() override {
+        // 30 Concats + the other branch's Add + MatMul fit exactly in the 32-visit budget.
+        set_up_model(true, 30, ov::element::u8);
+    }
+};
+
+TEST_F(PreventF32DequantizeVariadicSplitWithinBudget, smoke_GPU_VariadicSplitWithinBudget) {
+    run();
+}
+
+class PreventF32DequantizeVariadicSplitBudgetExhaustion : public PreventF32DequantizeVariadicSplitBase {
+protected:
+    void SetUp() override {
+        // 31 Concats + the other branch's Add exhaust the budget before MatMul is visited.
+        set_up_model(true, 31, ov::element::f16);
+    }
+};
+
+TEST_F(PreventF32DequantizeVariadicSplitBudgetExhaustion, smoke_GPU_VariadicSplitBudgetExhaustion) {
+    run();
+}
+
+}  // namespace

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/prevent_f32_dequantize.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/prevent_f32_dequantize.cpp
@@ -438,6 +438,10 @@ protected:
     void SetUp() override {
         // 31 Concats + the other branch's Add exhaust the budget before MatMul is visited.
         set_up_model(true, 31, ov::element::f16);
+        // When the budget is exhausted, MatMul executes in FP16 without quantization.
+        // Summing 47 FP16 products accumulates minor ULP differences (~0.26% / 4 ULPs)
+        // between CPU reference (accumulated in FP32) and discrete GPU (accumulated in FP16).
+        rel_threshold = 0.01;
     }
 };
 

--- a/src/plugins/intel_gpu/tests/unit/fusions/mvn_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/mvn_fusion_test.cpp
@@ -55,6 +55,13 @@ public:
     layout get_per_channel_layout(mvn_test_params& p) {
         return layout{ p.default_type, p.default_format, tensor{ 1, p.input_size.feature[0], 1, 1 } };
     }
+
+    // Per-element layout along the innermost (X) axis, i.e. the axis a last-axis MVN normalizes over.
+    // This is the only broadcast pattern that survives the iteration-space flattening applied to an MVN
+    // which requires alignment (see mvn_impl::static_canonicalize_shapes).
+    layout get_per_last_axis_layout(mvn_test_params& p) {
+        return layout{ p.default_type, p.default_format, tensor{ 1, 1, p.input_size.spatial[0], 1 } };
+    }
 };
 }  // namespace
 
@@ -98,6 +105,18 @@ public:
 #define CASE_MVN_3D_U8_3    { 2, 16, 8, 8, 8 }, { 2, 1, 1, 1, 1 },  data_types::u8, format::bfzyx, {1, 2, 3, 4}, true, data_types::f32, format::bfzyx
 #define CASE_MVN_3D_U8_4    { 2, 16, 8, 8, 8 }, { 1, 1, 1, 1, 1 },  data_types::u8, format::bfzyx, {2, 3, 4}, true, data_types::f32, format::bfzyx
 #define CASE_MVN_3D_U8_5    { 2, 16, 1, 8, 8 }, { 1, 1, 8, 1, 1 },  data_types::u8, format::bfzyx, {2, 3, 4}, true, data_types::f32, format::bfzyx
+
+// Last-axis (LayerNorm-like) MVN on a 4D tensor: reduction_axes={3} while Y > 1, so mvn::requires_alignment()
+// is true and the kernel runs on a flattened [B*F*Y, 1, 1, X] iteration space. Post-op peers broadcast along
+// the innermost axis only, which is the pattern that stays correctly indexable after the flatten.
+// tensor{} is (batch, feature, x, y), so X is the third entry.
+#define CASE_MVN_LAST_AXIS_F16_1   { 2, 3, 32, 4 },  { 1, 1, 32, 1 },  data_types::f16, format::bfyx, {3}, true, data_types::f16, format::bfyx
+// X is not a multiple of the selected LWS, so the kernel takes its leftover path with fused ops enabled
+#define CASE_MVN_LAST_AXIS_F16_2   { 2, 3, 33, 4 },  { 1, 1, 33, 1 },  data_types::f16, format::bfyx, {3}, true, data_types::f16, format::bfyx
+#define CASE_MVN_LAST_AXIS_F32_1   { 2, 3, 32, 4 },  { 1, 1, 32, 1 },  data_types::f32, format::bfyx, {3}, true, data_types::f32, format::bfyx
+// Negative control: same aligned MVN, but the peer broadcasts along the feature axis, which the flatten
+// destroys - fusion must stay disabled.
+#define CASE_MVN_LAST_AXIS_F16_NEG { 2, 3, 32, 4 },  { 1, 3, 1, 1 },   data_types::f16, format::bfyx, {3}, true, data_types::f16, format::bfyx
 
 // F16 with blocked formats (fsv16/fsv32) - covers new float support in mvn_gpu_b_fs_yx_fsv16 kernel
 #define CASE_MVN_F16_FSV16_1  { 1, 16, 8, 8 },    { 1, 16, 8, 8 },    data_types::f16, format::b_fs_yx_fsv16, {2, 3}, true, data_types::f16, format::bfyx
@@ -195,6 +214,37 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, mvn_scale_quantize_i8, ::testing::ValuesIn
     mvn_test_params{ CASE_MVN_U8_4, 2, 2, 4 },
     mvn_test_params{ CASE_MVN_3D_U8_1, 2, 2, 4 },
     mvn_test_params{ CASE_MVN_3D_U8_2, 2, 2, 4 },
+}));
+
+// Same shape as mvn_scale_quantize_i8, but on a last-axis MVN which requires alignment and with every post-op
+// parameter broadcast along the innermost axis. The per-axis in_low/in_high make prepare_quantization emit
+// non-per-tensor _in_scale/_in_shift, so the fused quantize really does index its parameter tensors through
+// the flattened iteration space.
+class mvn_last_axis_scale_quantize_i8 : public MVNFusingTest {};
+TEST_P(mvn_last_axis_scale_quantize_i8, basic) {
+    auto p = GetParam();
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        mvn("mvn", input_info("input"), p.normalize_variance, 1e-10f, false, p.reduction_axes),
+        data("scale_data", get_mem(get_per_last_axis_layout(p))),
+        eltwise("scale", { input_info("mvn"), input_info("scale_data") }, eltwise_mode::prod, p.default_type),
+        data("in_low", get_mem(get_per_last_axis_layout(p), min_random, 0)),
+        data("in_high", get_mem(get_per_last_axis_layout(p), 1, max_random)),
+        data("out_low", get_mem(get_single_element_layout(p), -128)),
+        data("out_high", get_mem(get_single_element_layout(p), 127)),
+        quantize("quant", input_info("scale"), input_info("in_low"), input_info("in_high"),
+                 input_info("out_low"), input_info("out_high"), 256, data_types::i8),
+        reorder("reorder_bfyx", input_info("quant"), format::bfyx, data_types::f32)
+    );
+
+    tolerance = 1.f;
+    execute(p);
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, mvn_last_axis_scale_quantize_i8, ::testing::ValuesIn(std::vector<mvn_test_params>{
+    mvn_test_params{ CASE_MVN_LAST_AXIS_F16_1, 2, 2, 4 },
+    mvn_test_params{ CASE_MVN_LAST_AXIS_F16_2, 2, 2, 4 },
+    mvn_test_params{ CASE_MVN_LAST_AXIS_F32_1, 2, 2, 4 },
 }));
 
 class mvn_scale_activation_eltwise_fp32_quantize_i8 : public MVNFusingTest {};
@@ -315,4 +365,8 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, mvn_eltwise_f16, ::testing::ValuesIn(std::
     mvn_test_params{ CASE_MVN_F16_1, 2, 2, 3},
     mvn_test_params{ CASE_MVN_F16_FSV16_1, 2, 2, 3},
     mvn_test_params{ CASE_MVN_F16_FSV32_1, 2, 2, 3},
+    mvn_test_params{ CASE_MVN_LAST_AXIS_F16_1, 2, 2, 3},
+    mvn_test_params{ CASE_MVN_LAST_AXIS_F16_2, 2, 2, 3},
+    // Peer broadcasts along the feature axis of an aligned MVN - must not fuse
+    mvn_test_params{ CASE_MVN_LAST_AXIS_F16_NEG, 3, 3, 3},
 }));

--- a/src/plugins/intel_gpu/tests/unit/fusions/mvn_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/mvn_fusion_test.cpp
@@ -60,6 +60,9 @@ public:
     // This is the only broadcast pattern that survives the iteration-space flattening applied to an MVN
     // which requires alignment (see mvn_impl::static_canonicalize_shapes).
     layout get_per_last_axis_layout(mvn_test_params& p) {
+        if (p.default_format == format::bfzyx) {
+            return layout{ p.default_type, p.default_format, tensor{ 1, 1, p.input_size.spatial[0], 1, 1 } };
+        }
         return layout{ p.default_type, p.default_format, tensor{ 1, 1, p.input_size.spatial[0], 1 } };
     }
 };
@@ -117,6 +120,20 @@ public:
 // Negative control: same aligned MVN, but the peer broadcasts along the feature axis, which the flatten
 // destroys - fusion must stay disabled.
 #define CASE_MVN_LAST_AXIS_F16_NEG { 2, 3, 32, 4 },  { 1, 3, 1, 1 },   data_types::f16, format::bfyx, {3}, true, data_types::f16, format::bfyx
+
+// 4D last-axis MVN with ACROSS_CHANNELS: axes={1, 3} (feature and X), Y > 1.
+// across_channels() is true (reduction includes axis 1), and requires_alignment() is true (Y is not reduced).
+// Kernel uses ACROSS_CHANNELS idx_order, flattening [B, 1, 1, F*Y*X].
+#define CASE_MVN_LAST_AXIS_ACROSS_CHANNELS_F16 { 2, 3, 32, 4 },  { 1, 1, 32, 1 },  data_types::f16, format::bfyx, {1, 3}, true, data_types::f16, format::bfyx
+#define CASE_MVN_LAST_AXIS_ACROSS_CHANNELS_F32 { 2, 3, 32, 4 },  { 1, 1, 32, 1 },  data_types::f32, format::bfyx, {1, 3}, true, data_types::f32, format::bfyx
+
+// 5D last-axis MVN (bfzyx) with WITHIN_CHANNELS: axes={4} (innermost X), Z > 1, Y > 1.
+// requires_alignment() is true. Exercises rank-5 WITHIN_CHANNELS idx_order branch in GetJitConstants().
+#define CASE_MVN_5D_LAST_AXIS_F16              { 2, 3, 32, 4, 4 }, { 1, 1, 32, 1, 1 }, data_types::f16, format::bfzyx, {4}, true, data_types::f16, format::bfzyx
+
+// 5D last-axis MVN (bfzyx) with ACROSS_CHANNELS: axes={1, 4} (feature and X), Z > 1, Y > 1.
+// across_channels() is true and requires_alignment() is true. Exercises rank-5 ACROSS_CHANNELS idx_order branch.
+#define CASE_MVN_5D_LAST_AXIS_ACROSS_CHANNELS_F16 { 2, 3, 32, 4, 4 }, { 1, 1, 32, 1, 1 }, data_types::f16, format::bfzyx, {1, 4}, true, data_types::f16, format::bfzyx
 
 // F16 with blocked formats (fsv16/fsv32) - covers new float support in mvn_gpu_b_fs_yx_fsv16 kernel
 #define CASE_MVN_F16_FSV16_1  { 1, 16, 8, 8 },    { 1, 16, 8, 8 },    data_types::f16, format::b_fs_yx_fsv16, {2, 3}, true, data_types::f16, format::bfyx
@@ -234,7 +251,7 @@ TEST_P(mvn_last_axis_scale_quantize_i8, basic) {
         data("out_high", get_mem(get_single_element_layout(p), 127)),
         quantize("quant", input_info("scale"), input_info("in_low"), input_info("in_high"),
                  input_info("out_low"), input_info("out_high"), 256, data_types::i8),
-        reorder("reorder_bfyx", input_info("quant"), format::bfyx, data_types::f32)
+        reorder("reorder_bfyx", input_info("quant"), p.default_format, data_types::f32)
     );
 
     tolerance = 1.f;
@@ -245,6 +262,8 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, mvn_last_axis_scale_quantize_i8, ::testing
     mvn_test_params{ CASE_MVN_LAST_AXIS_F16_1, 2, 2, 4 },
     mvn_test_params{ CASE_MVN_LAST_AXIS_F16_2, 2, 2, 4 },
     mvn_test_params{ CASE_MVN_LAST_AXIS_F32_1, 2, 2, 4 },
+    mvn_test_params{ CASE_MVN_LAST_AXIS_ACROSS_CHANNELS_F16, 2, 2, 4 },
+    mvn_test_params{ CASE_MVN_LAST_AXIS_ACROSS_CHANNELS_F32, 2, 2, 4 },
 }));
 
 class mvn_scale_activation_eltwise_fp32_quantize_i8 : public MVNFusingTest {};
@@ -367,6 +386,9 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, mvn_eltwise_f16, ::testing::ValuesIn(std::
     mvn_test_params{ CASE_MVN_F16_FSV32_1, 2, 2, 3},
     mvn_test_params{ CASE_MVN_LAST_AXIS_F16_1, 2, 2, 3},
     mvn_test_params{ CASE_MVN_LAST_AXIS_F16_2, 2, 2, 3},
+    mvn_test_params{ CASE_MVN_LAST_AXIS_ACROSS_CHANNELS_F16, 2, 2, 3 },
+    mvn_test_params{ CASE_MVN_5D_LAST_AXIS_F16, 2, 2, 3 },
+    mvn_test_params{ CASE_MVN_5D_LAST_AXIS_ACROSS_CHANNELS_F16, 2, 2, 3 },
     // Peer broadcasts along the feature axis of an aligned MVN - must not fuse
     mvn_test_params{ CASE_MVN_LAST_AXIS_F16_NEG, 3, 3, 3},
 }));


### PR DESCRIPTION
### Details:
 - In quantized models, there was an issue where dequantize operations (e.g., add -> mul) were executed in f32 when they could not be fused with subsequent nodes.
- This PR addresses the issue by preventing dequantize operations from being moved further when there are no eligible nodes available for fusion. 

### Tickets:
 - 193540

### AI Assistance:
 - *AI assistance used: yes