### PR TITLE
[GPU] reduce not quantized layers in quantized models

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
@@ -8,6 +8,8 @@
 #include "pass_manager.h"
 #include "program_node.h"
 #include "permute_inst.h"
+#include "reorder_inst.h"
+#include "reshape_inst.h"
 #include "openvino/core/except.hpp"
 #include "intel_gpu/primitives/deconvolution.hpp"
 #include "intel_gpu/runtime/engine.hpp"
@@ -114,6 +116,46 @@ static void optimize_permute_conv(program_node& node) {
     }
 }
 
+static void optimize_conv_reshape_reorder(program_node& node) {
+    // A rank-changing ov::Reshape is lowered to "reorder(planar) -> reshape" at plugin build time
+    // (see CreateCommonReshapeOp in plugin/ops/reshape.cpp), because cldnn reshape assumes a planar
+    // input. If the producing convolution emits that planar format itself, the reorder becomes a
+    // pure buffer reinterpret and remove_redundant_reorders drops it.
+    // ex) conv (b_fs_yx_fsv16 [b:6, f:256, y:108, x:108]) -> reorder (bfyx [b:6, f:256, y:11664, x:1]) -> reshape
+    //     becomes conv (bfyx) -> (reorder optimized out) -> reshape
+    if (node.is_output() || node.get_users().size() != 1)
+        return;
+
+    auto& user = *node.get_users().front();
+    if (!user.is_type<reorder>() || user.is_output() || user.get_users().size() != 1)
+        return;
+
+    auto& r_node = user.as<reorder>();
+    if (!r_node.is_simple_reorder() || !r_node.get_users().front()->is_type<reshape>())
+        return;
+
+    const auto& conv_layout = node.get_output_layout(false);
+    const auto& reorder_layout = r_node.get_output_layout(false);
+    if (conv_layout.is_dynamic() || reorder_layout.is_dynamic())
+        return;
+
+    // Mirror the default-format branch of layout::compatible(), which is what lets
+    // remove_redundant_reorders reinterpret the buffer instead of copying it.
+    if (!format::is_default_format(reorder_layout.format))
+        return;
+
+    if (conv_layout.data_type != reorder_layout.data_type)
+        return;
+
+    if (conv_layout.data_padding || reorder_layout.data_padding)
+        return;
+
+    if (conv_layout.get_linear_size() != reorder_layout.get_linear_size())
+        return;
+
+    node.set_preferred_output_fmt(0, reorder_layout.format);
+}
+
 } // namespace
 
 void select_preferred_formats::run(program& p) {
@@ -172,6 +214,7 @@ void select_preferred_formats::run(program& p) {
                 if (factory->get_impl_type() == impl_types::onednn && (n->is_type<convolution>() || n->is_type<deconvolution>())) {
                     optimize_conv_permute(*n);
                     optimize_permute_conv(*n);
+                    optimize_conv_reshape_reorder(*n);
                 }
             } catch (std::exception& exception) {
                 GPU_DEBUG_LOG << "WARNING(select_preferred_formats): " << exception.what() << std::endl;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/select_preferred_formats.cpp
@@ -144,6 +144,9 @@ static void optimize_conv_reshape_reorder(program_node& node) {
     if (!format::is_default_format(reorder_layout.format))
         return;
 
+    if (conv_layout.get_rank() != reorder_layout.format.dimension())
+        return;
+
     if (conv_layout.data_type != reorder_layout.data_type)
         return;
 

--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -71,7 +71,7 @@ static void CreateMatMulOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::
         // (see get_gemm_primitive_descriptor in impls/onednn/gemm_onednn.cpp), so a materialized
         // permute is pure data movement. The heuristics below target the OCL gemm_tiled_opt
         // kernel, which is not selected when oneDNN is available.
-        if (p.get_engine().get_device_info().supports_immad)
+        if (p.get_engine().get_device_info().supports_immad && type != ov::element::f32)
             return false;
 
         // don't transpose inputs if they're aligned to 16

--- a/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/matmul.cpp
@@ -67,6 +67,13 @@ static void CreateMatMulOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::
         if (shapes[0].size() < 2 || shapes[1].size() < 2)
             return false;
 
+        // oneDNN matmul applies transpose_a/transpose_b by swapping the operand strides
+        // (see get_gemm_primitive_descriptor in impls/onednn/gemm_onednn.cpp), so a materialized
+        // permute is pure data movement. The heuristics below target the OCL gemm_tiled_opt
+        // kernel, which is not selected when oneDNN is available.
+        if (p.get_engine().get_device_info().supports_immad)
+            return false;
+
         // don't transpose inputs if they're aligned to 16
         bool inputsAligned = std::all_of(shapes[0].rbegin(), shapes[0].rbegin() + 2,
                                             [] (const ov::Dimension& dim) { return dim.is_static() && dim.get_length() % 16 == 0; }) &&

--- a/src/plugins/intel_gpu/tests/unit/passes/select_preferred_formats_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/select_preferred_formats_test.cpp
@@ -10,6 +10,7 @@
 #include "intel_gpu/primitives/convolution.hpp"
 #include "intel_gpu/primitives/eltwise.hpp"
 #include "intel_gpu/primitives/permute.hpp"
+#include "intel_gpu/primitives/reshape.hpp"
 #include "intel_gpu/graph/program.hpp"
 #include "data_inst.h"
 #include "convolution_inst.h"
@@ -288,4 +289,57 @@ TEST(test_select_preferred_formats, permute_conv_accuracy) {
         ASSERT_TRUE(perm_node.has_fused_primitives());
         ASSERT_FALSE(perm_node.can_be_optimized());
     }
+}
+
+TEST(test_select_preferred_formats, conv_reshape_reorder_planar_output) {
+    // optimize_conv_reshape_reorder: a rank-changing ov::Reshape is lowered to
+    // "reorder(planar) -> reshape" at plugin build time, so the reorder is a full copy of the
+    // convolution output. Letting the oneDNN convolution emit that planar format itself makes
+    // the reorder a buffer reinterpret that remove_redundant_reorders can drop.
+    //
+    //   conv [1,32,16,16] -> flatten_reorder (bfyx [1,32,256,1]) -> flatten (reshape) -> out
+    //
+    // The negative case drops the reshape so the pattern must not trigger, and the convolution
+    // keeps the forced blocked output format. Like optimize_conv_permute, the pattern
+    // optimization takes precedence over an explicitly forced output format.
+    auto& engine = get_test_engine();
+    if (!engine.get_device_info().supports_immad)
+        return;
+
+    auto build = [&engine](bool with_reshape) {
+        auto input = engine.allocate_memory({data_types::f16, format::bfyx, {1, 32, 16, 16}});
+        auto weights = engine.allocate_memory({data_types::f16, format::bfyx, {32, 32, 1, 1}});
+
+        // Same element count as the convolution output, flattened over the spatial axes.
+        const auto flat_layout = layout{data_types::f16, format::bfyx, tensor{1, 32, 1, 256}};
+
+        topology topo;
+        topo.add(data("weights", weights));
+        topo.add(input_layout("input", input->get_layout()));
+        topo.add(convolution("conv1", input_info("input"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+        topo.add(reorder("flatten_reorder", input_info("conv1"), flat_layout));
+        if (with_reshape) {
+            topo.add(reshape("flatten", input_info("flatten_reorder"), tensor{1, 32, 1, 256}));
+            topo.add(reorder("out", input_info("flatten"), format::bfyx, data_types::f32));
+        } else {
+            topo.add(reorder("out", input_info("flatten_reorder"), format::bfyx, data_types::f32));
+        }
+
+        ExecutionConfig config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        ov::intel_gpu::ImplementationDesc impl = {format::b_fs_yx_fsv16, std::string(""), impl_types::onednn};
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv1", impl}}));
+
+        auto prog = program::build_program(engine, topo, config, false, true);
+        prog->get_layout_optimizer().add_all_onednn_impls_optimization_attribute();
+
+        // Initializes output_layout, necessary because this test runs the pass alone.
+        prog->get_node("conv1").get_output_layouts(false);
+        prog->get_node("flatten_reorder").get_output_layouts(false);
+        program_wrapper::apply_opt_pass<select_preferred_formats>(*prog);
+        return prog;
+    };
+
+    ASSERT_EQ(build(true)->get_node("conv1").get_preferred_output_fmt(0), format::bfyx);
+    ASSERT_EQ(build(false)->get_node("conv1").get_preferred_output_fmt(0), format::b_fs_yx_fsv16);
 }


### PR DESCRIPTION
### Details:
 - It was observed that, in some integer-quantized models, non-quantized layers such as `permute` and `eltwise` consumed more execution time than `convolution` or `matmul`, significantly reducing the benefits of quantization.
- To address this issue, this PR enables transpose fusion into oneDNN `matmul` and allows `convolution` to produce planar outputs in specific cases.

### Tickets:
 - 193542

### AI Assistance:
 - *AI assistance used: yes