### PR TITLE
[Snippets] Improved PRs labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,6 +43,16 @@
 
 'category: snippets':
 - 'src/common/snippets/**/*'
+- 'src/plugins/intel_cpu/src/emitters/snippets/**/*'
+- 'src/plugins/intel_cpu/src/emitters/tpp/**/*'
+- 'src/plugins/intel_cpu/src/transformations/snippets/**/*'
+- 'src/plugins/intel_cpu/src/transformations/tpp/**/*'
+- 'src/plugins/intel_cpu/src/nodes/**/subgraph.*'
+- 'src/plugins/intel_cpu/tests/unit/snippets_transformations/**/*'
+- 'src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/**/*'
+- 'src/tests/functional/plugin/shared/src/snippets/**/*'
+- 'src/tests/functional/plugin/shared/include/snippets/**/*'
+- 'src/tests/ov_helpers/ov_snippets_models/**/*'
 
 'category: dependency_changes':
 - '**/requirement*.txt'


### PR DESCRIPTION
### Details:
 - *Extend category: snippets labeler rules to cover Snippets-related paths in intel_cpu and shared test infrastructure, since 143/200 recent [Snippets]-titled PRs were missing this label.*

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to analyze snippets PR, created in last 6 months, and prepare a draft improvements. The changes were then manually adapted by the component owner*
