### PR TITLE
[CPU][DOCS] Document conditional compilation related macroses in selective_build.md

### DIFF
--- a/.github/agents-prototype/skills/add-cpu-op/step2-implementation.md
+++ b/.github/agents-prototype/skills/add-cpu-op/step2-implementation.md
@@ -392,13 +392,7 @@ Verify no compilation errors before proceeding.
 
 ## Type Dispatch Pattern (OV_SWITCH — Mandatory for Conditional Compilation)
 
-For ops that need to handle multiple element types, **always** use the `OV_SWITCH`
-macro for precision dispatch. This is **required** for the CPU plugin's
-conditional compilation feature — `OV_SWITCH` allows the build system to
-eliminate unused type specialisations at compile time, reducing binary size.
-
-**Do NOT** use manual `if/else` or `switch` chains on element type — they break
-conditional compilation.
+See [In-code conditional compilation](../../../../src/plugins/intel_cpu/docs/selective_build.md#in-code-conditional-compilation) for why `OV_SWITCH` is mandatory instead of a manual `if/else`/`switch` chain.
 
 ```cpp
 namespace {

--- a/src/plugins/intel_cpu/docs/selective_build.md
+++ b/src/plugins/intel_cpu/docs/selective_build.md
@@ -2,6 +2,22 @@
 ## Introduction
 Selective build or conditional compilation can significantly reduce OpenVINO™ binaries size by excluding unnecessary components for particular model's inference.
 
+## In-code conditional compilation
+Two families of macros let CPU plugin code participate in conditional compilation. They are the in-code counterpart of the build workflow described below: the COLLECT build records which branches are actually exercised, and the selective build then drops the rest.
+
+**`OV_SWITCH` / `OV_CASE`** — runtime element-type dispatch that the build system can prune. Defined in the shared conditional-compilation component, [`openvino/cc/selective_build.h`](../../../common/conditional_compilation/include/openvino/cc/selective_build.h). Inside the CPU plugin they are pulled in via [`selective_build.h`](../src/selective_build.h). Use them for per-precision dispatch instead of a manual `if/else`/`switch` on the element type — a manual chain compiles in every type unconditionally and defeats selective build.
+
+```cpp
+OV_SWITCH(intel_cpu, OpNameExecute, ctx, precision,
+          OV_CASE(ov::element::f32, float),
+          OV_CASE(ov::element::bf16, ov::bfloat16),
+          OV_CASE(ov::element::i32, int32_t))
+```
+
+**`OV_CPU_INSTANCE_*`** — architecture/backend guards for executor implementation lists, defined in [`src/utils/arch_macros.h`](../src/utils/arch_macros.h): `OV_CPU_INSTANCE_COMMON`, `OV_CPU_INSTANCE_X64`, `OV_CPU_INSTANCE_ARM64`, `OV_CPU_INSTANCE_ACL`, `OV_CPU_INSTANCE_ACL32`, `OV_CPU_INSTANCE_ACL64`, `OV_CPU_INSTANCE_DNNL`, `OV_CPU_INSTANCE_DNNL_X64`, `OV_CPU_INSTANCE_DNNL_ARM64`, `OV_CPU_INSTANCE_MLAS_X64`, `OV_CPU_INSTANCE_MLAS_ARM64`, `OV_CPU_INSTANCE_RISCV64`, `OV_CPU_INSTANCE_KLEIDIAI`. Each wraps an `ExecutorImplementation` so code for unavailable platforms is compiled away.
+
+For the OpenVINO-wide conditional-compilation guide see [docs/dev/conditional_compilation.md](../../../../docs/dev/conditional_compilation.md).
+
 ## Workflow
 
 Onednn path in OpenVINO:


### PR DESCRIPTION
### Details:
Move the OV_SWITCH mandate out of the add-cpu-op skill and into an `In-code conditional compilation` section of selective_build.md, covering the two macro families CPU plugin code uses to participate in selective build

### Tickets:
 - *N\A*

### AI Assistance:
 - *AI assistance used: yes*
 - *The transition was done by the AI agent and then manually reviewed*
