### PR TITLE
[ONNX FE] MatMulNBits: bfloat16 support, group_idx reordering, and weight_prepacked rejection

### DIFF
--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <algorithm>
 #include <cmath>
 #include <numeric>
 
@@ -152,6 +153,25 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                          k_padded,
                          "), got: ",
                          g_idx_size);
+        // group_idx is consumed as a Gather index below; OV's Gather silently normalizes negative
+        // indices and zero-fills out-of-range ones instead of throwing, so an invalid model would
+        // otherwise import and dequantize with the wrong scale/zero-point. Require it constant (same
+        // convention as B/zero_points above) and validate every value is in [0, n_blocks_per_col).
+        CHECK_VALID_NODE(node,
+                         ov::as_type<v0::Constant>(group_idx.get_node()) != nullptr,
+                         "MatMulNBits limitation: accepting only a constant as a group_idx");
+        const auto group_idx_const = ov::as_type_ptr<v0::Constant>(group_idx.get_node_shared_ptr());
+        const auto group_idx_values = group_idx_const->cast_vector<int32_t>();
+        const auto minmax = std::minmax_element(group_idx_values.begin(), group_idx_values.end());
+        CHECK_VALID_NODE(node,
+                         *minmax.first >= 0 && *minmax.second < static_cast<int32_t>(n_blocks_per_col),
+                         "group_idx values must be within [0, n_blocks_per_col=",
+                         n_blocks_per_col,
+                         "), got range [",
+                         *minmax.first,
+                         ", ",
+                         *minmax.second,
+                         "]");
     }
 
     if (common::is_input_valid(node, 5)) {

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -301,13 +301,10 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
             }
         }
 
-        // Possible issue with slice implementation, had to move conversion before slice, instead of slicing uint4
-        // TODO: Ticket
-        // Comments: it is still there, so need to convert b to fp16 first.
-
-        // TODO: Need to collect performance data in case constant folding is applied. Possible some perf/mem-gap
-        // Comments: in this latest code, the const folding is gone; it triggers the oneDNN kernel
-        //           and use u2/u4/u8 weights as the kernel's input, won't do const folding anymore.
+        // OV core has no Slice evaluate()/constant-fold path for packed sub-byte types (u4/u2/i4/nf4/
+        // f4e2m1) by design (CVS-173497, PR #32388 "[Core/Op] Disable Slice constant folding and
+        // evaluate for LP"), so casted_b must be dequantized to a.get_element_type() first; any Slice
+        // (padding trim) has to run after that conversion, never directly on the raw packed data.
 
         // compute in input A's precision (FP32/FP16/BF16)
         const auto scales_converted = std::make_shared<v0::Convert>(scales, a.get_element_type());

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -58,6 +58,9 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
     const auto bits = node.get_attribute_value<int64_t>(
         "bits",
         4);  // required, in docs: number of bits used for weight quantization (default 4)
+    // optional, default 0 (not prepacked). 1/2 mean B is prepacked into a CUDA-specific
+    // (CUTLASS SM80/SM90 fpA_intB) byte layout that this frontend does not decode.
+    const auto weight_prepacked = node.get_attribute_value<int64_t>("weight_prepacked", 0);
 
     // Validate attributes before any arithmetic to prevent division-by-zero and signed overflow
     CHECK_VALID_NODE(node, K > 0, "Wrong K attribute value: ", K);
@@ -68,6 +71,11 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                      block_size);
     CHECK_VALID_NODE(node, bits == 2 || bits == 4 || bits == 8, "Unsupported bits value: ", bits);
     CHECK_VALID_NODE(node, accuracy_level >= 0 && accuracy_level <= 4, "Unsupported accuracy level: ", accuracy_level);
+    CHECK_VALID_NODE(node,
+                     weight_prepacked == 0,
+                     "MatMulNBits limitation: weight_prepacked != 0 requires decoding an EP-specific "
+                     "(CUDA CUTLASS) prepacked weight layout, which is not supported, got: ",
+                     weight_prepacked);
 
     const auto u_K = static_cast<uint64_t>(K);
     const auto u_block_size = static_cast<uint64_t>(block_size);

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -106,8 +106,8 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
         b_shape);
     CHECK_VALID_NODE(node,
                      a.get_element_type() == ov::element::f16 || a.get_element_type() == ov::element::f32 ||
-                         a.get_element_type() == ov::element::dynamic,
-                     "Unsupported input A type, accepted dynamic, FP16, FP32, got: ",
+                         a.get_element_type() == ov::element::bf16 || a.get_element_type() == ov::element::dynamic,
+                     "Unsupported input A type, accepted dynamic, FP16, FP32, BF16, got: ",
                      a.get_element_type());
     CHECK_VALID_NODE(
         node,
@@ -121,8 +121,9 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                          zero_points.get_element_type() == ov::element::u8 ||
                              zero_points.get_element_type() == ov::element::i32 ||
                              zero_points.get_element_type() == ov::element::f32 ||
-                             zero_points.get_element_type() == ov::element::f16,
-                         "Unsupported input zero_points type, accepted U8, I32, FP16, FP32, got: ",
+                             zero_points.get_element_type() == ov::element::f16 ||
+                             zero_points.get_element_type() == ov::element::bf16,
+                         "Unsupported input zero_points type, accepted U8, I32, FP16, FP32, BF16, got: ",
                          zero_points.get_element_type());
     }
 
@@ -289,12 +290,13 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
         // Comments: in this latest code, the const folding is gone; it triggers the oneDNN kernel
         //           and use u2/u4/u8 weights as the kernel's input, won't do const folding anymore.
 
-        // use fp16 for compute
+        // compute in input A's precision (FP32/FP16/BF16)
 
         // sub and scale via the shared low-precision dequantization helper
-        const auto scales_fp16 = std::make_shared<v0::Convert>(scales, a.get_element_type());
+        const auto scales_converted = std::make_shared<v0::Convert>(scales, a.get_element_type());
         const auto scales_reshaped =
-            op::util::reshape(scales_fp16, ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col), 1});
+            op::util::reshape(scales_converted,
+                              ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col), 1});
 
         auto scaled_b = ov::decomposition::low_precision_dequantize(casted_b, scales_reshaped, converted_zero_points);
 

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -13,6 +13,7 @@
 #include "openvino/op/add.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
+#include "openvino/op/gather.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/reshape.hpp"
@@ -133,6 +134,24 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                          group_idx.get_element_type() == ov::element::i32,
                          "Unsupported input group_idx type, accepted I32, got: ",
                          group_idx.get_element_type());
+        // group_idx[k] gives the block/group index dequantizing element k should use, replacing the
+        // usual floor(k / block_size) assignment (act-order/GPTQ-style non-sequential grouping).
+        // Per onnxruntime's own validator (matmul_nbits_helper.h): 1D, sized K or block-padded K.
+        const auto& g_idx_shape = group_idx.get_partial_shape();
+        CHECK_VALID_NODE(node,
+                         g_idx_shape.rank().is_static() && g_idx_shape.size() == 1 && g_idx_shape[0].is_static(),
+                         "Expected input group_idx to be a 1D tensor with a static size, got: ",
+                         g_idx_shape);
+        const auto g_idx_size = static_cast<uint64_t>(g_idx_shape[0].get_length());
+        const auto k_padded = n_blocks_per_col * u_block_size;
+        CHECK_VALID_NODE(node,
+                         g_idx_size == u_K || g_idx_size == k_padded,
+                         "Wrong group_idx size, expected K (",
+                         K,
+                         ") or block-padded K (",
+                         k_padded,
+                         "), got: ",
+                         g_idx_size);
     }
 
     if (common::is_input_valid(node, 5)) {
@@ -291,27 +310,72 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
         //           and use u2/u4/u8 weights as the kernel's input, won't do const folding anymore.
 
         // compute in input A's precision (FP32/FP16/BF16)
-
-        // sub and scale via the shared low-precision dequantization helper
         const auto scales_converted = std::make_shared<v0::Convert>(scales, a.get_element_type());
-        const auto scales_reshaped =
-            op::util::reshape(scales_converted,
-                              ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col), 1});
 
-        auto scaled_b = ov::decomposition::low_precision_dequantize(casted_b, scales_reshaped, converted_zero_points);
+        if (group_idx.get_node_shared_ptr()) {
+            // group_idx present: element k's scale/zero-point comes from block group_idx[k], not
+            // floor(k / block_size). There is no shared contiguous block left to broadcast over, so
+            // flatten B/scales/zero_points along the block axis and Gather each K-column's group
+            // directly (this mirrors onnxruntime's own reorder_idx dequant path, which is likewise a
+            // per-element lookup rather than a block-broadcast fast path).
+            auto flat_shape = v0::Constant::create(ov::element::i32, ov::Shape{2}, {0, -1});
+            ov::Output<ov::Node> b_flat = std::make_shared<v1::Reshape>(casted_b, flat_shape, true);  // [N, k_padded]
 
-        // reshape b to [N, K]
-        auto shape_b = v0::Constant::create(ov::element::i32, ov::Shape{2}, {0, -1});
-        auto reshaped_b = std::make_shared<v1::Reshape>(scaled_b, shape_b, true);
+            const auto k_padded = n_blocks_per_col * u_block_size;
+            const auto g_idx_size = static_cast<uint64_t>(group_idx.get_partial_shape()[0].get_length());
+            const bool g_idx_is_full_k = (g_idx_size == u_K);
+            // group_idx sized K: trim B to K first so it lines up with group_idx for the gather below.
+            // group_idx sized block-padded K: gather stays block-padded; trim to K (if any) happens
+            // after dequantization instead (see below).
+            if (g_idx_is_full_k && k_padded != u_K) {
+                b_flat = std::make_shared<v8::Slice>(b_flat, zero, elements, one, axis);
+            }
 
-        // if n_blocks_per_col*blob_size*X != K
-        // need slice it to K
-        // to produce b = [N, K]
-        const bool slice_needed = (K % block_size != 0);
-        if (slice_needed) {
-            b = std::make_shared<v8::Slice>(reshaped_b, zero, elements, one, axis);
+            const auto gather_axis = v0::Constant::create(ov::element::i32, ov::Shape{}, {1});
+            auto scales_flat =
+                op::util::reshape(scales_converted,
+                                  ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col)});
+            ov::Output<ov::Node> scale_per_k = std::make_shared<v8::Gather>(scales_flat, group_idx, gather_axis);
+
+            ov::Output<ov::Node> zp_per_k = converted_zero_points;
+            if (zero_points.get_node_shared_ptr()) {
+                // converted_zero_points is [N, n_blocks_per_col, 1] here; drop the trailing 1 to gather.
+                auto zp_flat =
+                    op::util::reshape(converted_zero_points,
+                                      ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col)});
+                zp_per_k = std::make_shared<v8::Gather>(zp_flat, group_idx, gather_axis);
+            }
+            // else: converted_zero_points already holds the default zp as a [1]-shaped scalar, which
+            // broadcasts naturally against the [N, len(group_idx)] tensors above.
+
+            auto dequant = ov::decomposition::low_precision_dequantize(b_flat, scale_per_k, zp_per_k);
+            if (!g_idx_is_full_k && k_padded != u_K) {
+                b = std::make_shared<v8::Slice>(dequant, zero, elements, one, axis);
+            } else {
+                b = dequant;
+            }
         } else {
-            b = reshaped_b;
+            // sub and scale via the shared low-precision dequantization helper
+            const auto scales_reshaped =
+                op::util::reshape(scales_converted,
+                                  ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col), 1});
+
+            auto scaled_b =
+                ov::decomposition::low_precision_dequantize(casted_b, scales_reshaped, converted_zero_points);
+
+            // reshape b to [N, K]
+            auto shape_b = v0::Constant::create(ov::element::i32, ov::Shape{2}, {0, -1});
+            auto reshaped_b = std::make_shared<v1::Reshape>(scaled_b, shape_b, true);
+
+            // if n_blocks_per_col*blob_size*X != K
+            // need slice it to K
+            // to produce b = [N, K]
+            const bool slice_needed = (K % block_size != 0);
+            if (slice_needed) {
+                b = std::make_shared<v8::Slice>(reshaped_b, zero, elements, one, axis);
+            } else {
+                b = reshaped_b;
+            }
         }
 
         // mm = matmul(a,b)

--- a/src/frontends/onnx/tests/convert_tests.cpp
+++ b/src/frontends/onnx/tests/convert_tests.cpp
@@ -78,6 +78,12 @@ TEST(ONNXFeConvertException, exception_if_qlinear_concat_invalid_x_input_triplet
                     testing::AllOf(testing::HasSubstr("expected 2 + 3*N inputs"), testing::HasSubstr(" got: 6")));
 }
 
+TEST(ONNXFeConvertException, exception_if_matmulnbits_weight_prepacked_unsupported) {
+    OV_EXPECT_THROW(convert_model("com.microsoft/matmulnbits_weight_prepacked_unsupported.onnx"),
+                    ov::AssertFailure,
+                    testing::HasSubstr("weight_prepacked != 0"));
+}
+
 TEST(ONNXFeConvertException, exception_if_scan_num_scan_inputs_exceeds_body_inputs) {
     OV_EXPECT_THROW(convert_model("scan15_num_scan_inputs_exceeds_body_inputs.onnx"),
                     ov::frontend::OpConversionFailure,

--- a/src/frontends/onnx/tests/convert_tests.cpp
+++ b/src/frontends/onnx/tests/convert_tests.cpp
@@ -84,6 +84,12 @@ TEST(ONNXFeConvertException, exception_if_matmulnbits_weight_prepacked_unsupport
                     testing::HasSubstr("weight_prepacked != 0"));
 }
 
+TEST(ONNXFeConvertException, exception_if_matmulnbits_group_idx_out_of_range) {
+    OV_EXPECT_THROW(convert_model("com.microsoft/matmulnbits_group_idx_out_of_range.onnx"),
+                    ov::AssertFailure,
+                    testing::HasSubstr("group_idx values must be within"));
+}
+
 TEST(ONNXFeConvertException, exception_if_scan_num_scan_inputs_exceeds_body_inputs) {
     OV_EXPECT_THROW(convert_model("scan15_num_scan_inputs_exceeds_body_inputs.onnx"),
                     ov::frontend::OpConversionFailure,

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_bf16.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_bf16.prototxt
@@ -1,0 +1,96 @@
+ir_version: 10
+producer_name: "OpenVINO ONNX Frontend"
+producer_version: ""
+model_version: 0
+graph {
+  name: "test_matmulnbits_bf16"
+  node {
+    input: "a"
+    input: "b_Q4"
+    input: "b_scales"
+    input: "b_zp"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 8
+    data_type: 2
+    name: "b_Q4"
+    raw_data: "\x98\xba\x00\x00\x00\x00\x00\x00"
+  }
+  initializer {
+    dims: 1
+    data_type: 16
+    name: "b_scales"
+    raw_data: "\x80\x3f"
+  }
+  initializer {
+    dims: 1
+    data_type: 16
+    name: "b_zp"
+    raw_data: "\x00\x40"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 21
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx.prototxt
@@ -1,0 +1,96 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "a"
+    input: "b_Q4"
+    input: "b_scales"
+    input: ""
+    input: "g_idx"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 32
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 8
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  name: "test_matmulnbits_group_idx"
+  initializer {
+    dims: 1
+    dims: 2
+    dims: 16
+    data_type: 2
+    name: "b_Q4"
+    raw_data: "\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224"
+  }
+  initializer {
+    dims: 1
+    dims: 2
+    data_type: 1
+    name: "b_scales"
+    raw_data: "\000\000\200?\000\000\000@"
+  }
+  initializer {
+    dims: 32
+    data_type: 6
+    name: "g_idx"
+    raw_data: "\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx_explicit_zp.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx_explicit_zp.prototxt
@@ -1,0 +1,103 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "a"
+    input: "b_q"
+    input: "b_scales"
+    input: "b_zp"
+    input: "g_idx"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 32
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 8
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  name: "matmulnbits_group_idx_explicit_zp"
+  initializer {
+    dims: 1
+    dims: 2
+    dims: 16
+    data_type: 2
+    name: "b_q"
+    raw_data: "\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224"
+  }
+  initializer {
+    dims: 1
+    dims: 2
+    data_type: 1
+    name: "b_scales"
+    raw_data: "\000\000\200?\000\000\000@"
+  }
+  initializer {
+    dims: 32
+    data_type: 6
+    name: "g_idx"
+    raw_data: "\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+  }
+  initializer {
+    dims: 1
+    dims: 2
+    data_type: 1
+    name: "b_zp"
+    raw_data: "\000\000\310B\000\000\014C"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx_k_boundary_full.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx_k_boundary_full.prototxt
@@ -1,0 +1,96 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "a"
+    input: "b_q"
+    input: "b_scales"
+    input: ""
+    input: "g_idx"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 17
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 8
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  name: "matmulnbits_group_idx_k_boundary_full"
+  initializer {
+    dims: 1
+    dims: 2
+    dims: 16
+    data_type: 2
+    name: "b_q"
+    raw_data: "\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224"
+  }
+  initializer {
+    dims: 1
+    dims: 2
+    data_type: 1
+    name: "b_scales"
+    raw_data: "\000\000\200?\000\000\000@"
+  }
+  initializer {
+    dims: 17
+    data_type: 6
+    name: "g_idx"
+    raw_data: "\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 17
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx_k_boundary_padded.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx_k_boundary_padded.prototxt
@@ -1,0 +1,96 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "a"
+    input: "b_q"
+    input: "b_scales"
+    input: ""
+    input: "g_idx"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 17
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 8
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  name: "matmulnbits_group_idx_k_boundary_padded"
+  initializer {
+    dims: 1
+    dims: 2
+    dims: 16
+    data_type: 2
+    name: "b_q"
+    raw_data: "\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224"
+  }
+  initializer {
+    dims: 1
+    dims: 2
+    data_type: 1
+    name: "b_scales"
+    raw_data: "\000\000\200?\000\000\000@"
+  }
+  initializer {
+    dims: 32
+    data_type: 6
+    name: "g_idx"
+    raw_data: "\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 17
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx_out_of_range.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_group_idx_out_of_range.prototxt
@@ -1,0 +1,96 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "a"
+    input: "b_q"
+    input: "b_scales"
+    input: ""
+    input: "g_idx"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 32
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 8
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  name: "matmulnbits_group_idx_out_of_range"
+  initializer {
+    dims: 1
+    dims: 2
+    dims: 16
+    data_type: 2
+    name: "b_q"
+    raw_data: "\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\212\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224\224"
+  }
+  initializer {
+    dims: 1
+    dims: 2
+    data_type: 1
+    name: "b_scales"
+    raw_data: "\000\000\200?\000\000\000@"
+  }
+  initializer {
+    dims: 32
+    data_type: 6
+    name: "g_idx"
+    raw_data: "\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\002\000\000\000"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}
+opset_import {
+  domain: "com.microsoft"
+  version: 1
+}

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_weight_prepacked_unsupported.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_weight_prepacked_unsupported.prototxt
@@ -1,0 +1,92 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+producer_version: ""
+model_version: 0
+graph {
+  name: "test_matmulnbits_weight_prepacked_unsupported"
+  node {
+    input: "a"
+    input: "b_Q4"
+    input: "b_scales"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 3
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    attribute {
+      name: "weight_prepacked"
+      i: 1
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  initializer {
+    dims: 3
+    dims: 1
+    dims: 8
+    data_type: 2
+    name: "b_Q4"
+    raw_data: "&P\000\000\000\000\000\000\005b\000\000\000\000\000\000\004\204\000\000\000\000\000\000"
+  }
+  initializer {
+    dims: 3
+    data_type: 1
+    name: "b_scales"
+    raw_data: "\000\000 \277\000\000 \277\000\000@\277"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 7
+}
+opset_import {
+  version: 1
+}

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -2478,6 +2478,24 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_no_zp_block_size) 
     test_case.run_with_tolerance_as_fp(0.1f);
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_group_idx) {
+    // g_idx (group_idx) reorders which block/scale each K-element uses instead of the usual
+    // floor(k / block_size) assignment. K=32, block_size=16 -> 2 groups: group0 has raw quantized
+    // value 138 (dequant 10 with default 8-bit zp=128) and scale 1.0; group1 has raw value 148
+    // (dequant 20) and scale 2.0. g_idx swaps the group assignment of the two halves of K (first
+    // 16 elements use group1, last 16 use group0), so every dequantized element becomes
+    // 10*2.0 = 20*1.0 = 20. With A all-ones, the matmul reduces to sum(20 for 32 elements) = 640.
+    // If g_idx were ignored (falling back to sequential grouping) the result would instead be
+    // 16*10 + 16*40 = 800, so this test fails loudly on a regression.
+    const auto model = convert_model("com.microsoft/matmulnbits_group_idx.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_input<float>(std::vector<float>(32, 1.f));
+    test_case.add_expected_output<float>(Shape{1, 1}, {640.f});
+
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_bf16) {
     // bfloat16 A/scales/zero_points/output (spec parity: T1/T3 allow bfloat16). Values are chosen
     // to be exactly representable in bf16 so the comparison can be bit-exact.

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -2478,6 +2478,18 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_no_zp_block_size) 
     test_case.run_with_tolerance_as_fp(0.1f);
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_bf16) {
+    // bfloat16 A/scales/zero_points/output (spec parity: T1/T3 allow bfloat16). Values are chosen
+    // to be exactly representable in bf16 so the comparison can be bit-exact.
+    const auto model = convert_model("com.microsoft/matmulnbits_bf16.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_input<ov::bfloat16>({1.f, 2.f, 3.f, 4.f});
+    test_case.add_expected_output<ov::bfloat16>(Shape{1, 1}, {80.f});
+
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_quickgelu) {
     const auto model = convert_model("com.microsoft/quick_gelu.onnx");
     auto test_case = ov::test::TestCase(model, s_device);

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -2496,6 +2496,49 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_group_idx) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_group_idx_k_boundary_full) {
+    // K=17 is not block-aligned (block_size=16 -> n_blocks_per_col=2, k_padded=32). group_idx here
+    // is sized exactly K=17, exercising the "trim B to K before gather" branch. k0..8 (9 elems, raw
+    // block0 dequant=10) use group1 (scale=2.0) => 20; k9..15 (7 elems, raw block0) use group0
+    // (scale=1.0) => 10; k16 (1 elem, raw block1 dequant=20) uses group0 => 20.
+    // Expected sum = 9*20 + 7*10 + 1*20 = 270.
+    const auto model = convert_model("com.microsoft/matmulnbits_group_idx_k_boundary_full.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_input<float>(std::vector<float>(17, 1.f));
+    test_case.add_expected_output<float>(Shape{1, 1}, {270.f});
+
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_group_idx_k_boundary_padded) {
+    // Same K=17 scenario as the _full variant above, but group_idx is sized block-padded K=32
+    // instead (trailing 15 entries are discarded by the post-gather Slice), exercising the other
+    // Slice branch. Must produce the identical result: 270.
+    const auto model = convert_model("com.microsoft/matmulnbits_group_idx_k_boundary_padded.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_input<float>(std::vector<float>(17, 1.f));
+    test_case.add_expected_output<float>(Shape{1, 1}, {270.f});
+
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_group_idx_explicit_zp) {
+    // Same group_idx swap as onnx_com_microsoft_matmulnbits_group_idx, but with explicit non-default
+    // same-type-as-A zero_points (group0 zp=100, group1 zp=140), exercising the zero_points Gather
+    // branch that group_idx dequantization was missing test coverage for. k0..15 (raw block0=138)
+    // use group1 (scale2.0, zp140) => (138-140)*2=-4; k16..31 (raw block1=148) use group0 (scale1.0,
+    // zp100) => (148-100)*1=48. Expected sum = 16*-4 + 16*48 = 704.
+    const auto model = convert_model("com.microsoft/matmulnbits_group_idx_explicit_zp.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_input<float>(std::vector<float>(32, 1.f));
+    test_case.add_expected_output<float>(Shape{1, 1}, {704.f});
+
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_bf16) {
     // bfloat16 A/scales/zero_points/output (spec parity: T1/T3 allow bfloat16). Values are chosen
     // to be exactly representable in bf16 so the comparison can be bit-exact.


### PR DESCRIPTION
## Description

Closes the remaining spec-parity gaps found auditing this frontend's `com.microsoft.MatMulNBits` decomposition against onnxruntime's own spec doc and kernels. Before this change: `group_idx` was parsed and type-checked but never used anywhere in the decomposition, silently falling back to sequential `floor(k / block_size)` grouping even though onnxruntime's own CPU kernel honors it (in its slow unpacked-compute path, for act-order/GPTQ-style exports) - silently wrong numerics, no diagnostic. `bfloat16` was rejected for input A / scales / bias / output and for zero_points even though the spec lists it for both. `weight_prepacked != 0` (meaning B holds an EP-specific CUDA CUTLASS interleaved byte layout) was read nowhere, so such a model would be silently misinterpreted as plain packed weights.

ONNX Runtime references:
- **Spec:** https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.MatMulNBits
- **CPU (MLAS) kernel:** https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits.cc
- **CPU shape/input validation:** https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/contrib_ops/cpu/quantization/matmul_nbits_helper.h
- **MLAS blockwise (de)quantizer:** https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/mlas/lib/q4_dq.cpp
- **CUDA kernel:** https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cc

## Approach

**group_idx (non-sequential block grouping).** `group_idx[k]` gives the block/group index element `k` should dequantize with, replacing the usual `floor(k / block_size)` assignment (act-order/GPTQ-style exports). An arbitrary reorder has no shared contiguous block left to broadcast a scale/zero-point over, so when present, B/scales/zero_points are flattened along the block axis and `Gather`ed per K-column directly, then dequantized through the same shared `low_precision_dequantize` helper the non-reorder path already uses - not a separate, hand-rolled formula. Validated against onnxruntime's own contract (`matmul_nbits_helper.h`): `group_idx` must be 1D, static, sized either `K` or block-padded `K`; both are handled (trimming B to `K` before the gather in the first case, after dequantization in the second).

**bfloat16 (T1/T3).** The existing `Convert`/`Subtract`/`Multiply` decomposition is already dtype-generic via `a.get_element_type()`, so this only required widening the two type-check allow-lists (input A / scales / bias / output, and zero_points) to include `bf16` - no decomposition changes needed.

**weight_prepacked.** `weight_prepacked` values 1/2 mean B is prepacked into a CUDA SM80/SM90 CUTLASS `fpA_intB` byte layout, not the plain per-block packed format this frontend decodes. Decoding that layout is out of scope for a CPU/GPU/NPU frontend, so non-zero values are now rejected explicitly instead of silently misinterpreted.

**Stale TODOs resolved.** One comment referencing an unlinked "TODO: Ticket" for a Slice-before-convert workaround now cites the actual OV core ticket (CVS-173497 / PR #32388, "Disable Slice constant folding and evaluate for LP") - confirmed still current and correct: OV core has no `Slice` evaluate()/constant-fold path for packed sub-byte types (`u4`/`u2`/`i4`/`nf4`/`f4e2m1`) by design, so casted B must be dequantized before any Slice runs on it. A second TODO about constant-folding perf data was removed - its own follow-up comment already said the premise (constant folding happening) no longer applied to this code.

No changes to the zero_point initializer-name-preservation logic from #37308.

## Scope

In scope (verified against onnxruntime's MLAS CPU kernel and spec): `bfloat16` for T1/T3, `group_idx` reordering for both documented sizes, `weight_prepacked` rejection.

Out of scope / deliberately left as-is: `B`/`zero_points` accepting `i32` (a pre-existing OV superset of the spec's `uint8`-only constraint - untested, harmless, not removed since it could be a breaking change for anyone relying on it); `block_size` accepting any power-of-two ≥16 rather than onnxruntime's kernel-enumerated `{16,32,64,128,256}` (that enum is an MLAS/CUTLASS SIMD-tiling artifact, not a schema rule - OV's decomposition has no such tiling constraint, so the broader range is a real, legitimate capability, not a gap); `accuracy_level`'s int8-activation compute path (onnxruntime's MLAS can trade accuracy for speed at `accuracy_level==4` - OV always computes at full input precision, which is spec-legal since levels are a minimum accuracy floor, but is a plugin-level performance question, not an ONNX FE correctness gap).

## Tests
- `ov_onnx_frontend_tests` (`onnx_import_com_microsoft`) - new `onnx_com_microsoft_matmulnbits_group_idx` (numeric, exact value: group_idx swaps which half of K uses which block/scale so every dequantized element becomes identical; would produce a different, wrong value if group_idx were ignored) and `onnx_com_microsoft_matmulnbits_bf16` (bit-exact, all-integer values chosen to be exactly representable in bf16).
- `ov_onnx_frontend_tests` (`convert_tests`) - new `exception_if_matmulnbits_weight_prepacked_unsupported`.
- Full existing `matmulnbits_*` + `onnx_tensor_names` matmulnbits suite re-run after every commit: 26/27, one pre-existing, unrelated `IE_GPU` numeric-tolerance flake on `matmulnbits_3x17` (present before this branch, confirmed unrelated to any changed code path).
- Manually verified via `OV_CPU_EXEC_GRAPH_PATH` execution-graph dumps that the decomposition still fuses into a single compressed-weight `FullyConnected` (`brgemm_avx2_f32`, `u4`/`u8` weight fed directly, never dequantized to fp32 in the graph) on CPU, both for a synthetic model and a real production LLM `lm_head` (K=2048, N=200032, 4-bit, block_size=32); cross-checked numerically against onnxruntime's CPU EP; confirmed correct execution on GPU and NPU as well.

### Tickets
- https://jira.devtools.intel.com/browse/CVS-194336

### AI Assistance:
- Yes - spec/kernel audit, implementation, and cross-device verification against onnxruntime.