### PR TITLE
[ONNX FE] Fix Tile on scalar input with empty repeats (#37958)

### DIFF
--- a/src/frontends/onnx/frontend/src/op/tile.cpp
+++ b/src/frontends/onnx/frontend/src/op/tile.cpp
@@ -6,6 +6,7 @@
 
 #include "core/operator_set.hpp"
 #include "openvino/op/convert.hpp"
+#include "utils/common.hpp"
 
 using namespace ov::op;
 
@@ -17,6 +18,21 @@ namespace opset_1 {
 ov::OutputVector tile(const ov::frontend::onnx::Node& node) {
     auto input = node.get_ov_inputs().at(0);
     auto repeats = node.get_ov_inputs().at(1);
+
+    const auto& in_pshape = input.get_partial_shape();
+    const bool is_scalar_input = in_pshape.rank().is_static() && in_pshape.rank().get_length() == 0;
+
+    const auto& repeats_pshape = repeats.get_partial_shape();
+    const bool is_empty_1d_repeats =
+        common::is_failsafe_node(repeats.get_node_shared_ptr()) ||
+        (repeats_pshape.is_static() && repeats_pshape.rank().get_length() == 1 && repeats_pshape[0] == 0);
+
+    // In ONNX, tiling a rank-0 scalar with length-0 (1-D) repeats is an identity operation.
+    // Length-0 repeats are converted to failsafe nodes or empty 1-D constants by the frontend.
+    if (is_scalar_input && is_empty_1d_repeats) {
+        common::mark_as_optimized_out(input);
+        return {input};
+    }
 
     // Workaround for backends which require repeats to be i64.
     // Remove the following line when no longer needed.

--- a/src/frontends/onnx/tests/models/tile_scalar_empty_repeats.prototxt
+++ b/src/frontends/onnx/tests/models/tile_scalar_empty_repeats.prototxt
@@ -1,0 +1,41 @@
+ir_version: 13
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test_graph"
+  node {
+    input: "input"
+    input: "repeats"
+    output: "output"
+    name: "_0"
+    op_type: "Tile"
+  }
+  initializer {
+    dims: 0
+    data_type: 7
+    name: "repeats"
+    raw_data: ""
+  }
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -5971,6 +5971,16 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_expand_scalar_failsafe_node_ort_mem) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_tile_scalar_empty_repeats) {
+    const auto model = convert_model("tile_scalar_empty_repeats.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    const auto input_data = std::vector<float>{3.5f};
+    test_case.add_input<float>(input_data);
+    test_case.add_expected_output<float>(input_data);
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_scan15_fib_like) {
     const auto model = convert_model("scan15_fib_like.onnx");
 


### PR DESCRIPTION
### Details:
 - Handle rank-0 scalar inputs with length-0 repeats in ONNX Tile frontend translator (`src/frontends/onnx/frontend/src/op/tile.cpp`) as an identity operation per ONNX Tile-13 specification.
 - Prevent node validation check failure (`Tile repeats must be of rank 1`) caused by length-0 initializers being converted to failsafe/empty scalar constants.
 - Avoid downstream segmentation faults and underflow in CPU (`intel_cpu/src/nodes/tile.cpp`) and reference backends when encountering rank-0 inputs.
 - Mark input via `common::mark_as_optimized_out` to retain output tensor names in `translate_session`.
 - Add test model `tile_scalar_empty_repeats.prototxt` and test case in `onnx_import.in.cpp`.

### Tickets:
 - Fixes #37958

### AI Assistance:
 - AI assistance used: yes
 - AI was used for static trace analysis across ONNX frontend translation and backend shape inference paths, and drafting the minimal translator bypass.
 - Human validation performed: verified code against ONNX Tile-13 specification, verified tensor naming retention in `translate_session`, checked for conflicts against open PRs (#37706), and verified test fixtures.
