### PR TITLE
[NPU] Bound recursion depth in compatibility string parser

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/compat_string_parser.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/compat_string_parser.hpp
@@ -156,6 +156,10 @@ private:
     std::string_view::iterator _captureEnd;
     int _nesting = 0;   // Nesting level for current capture mode
     int _optional = 0;  // Tracks top-level optional attributes
+    int _depth = 0;     // parseString recursion depth, capped by kMaxNestingDepth
+
+    // Legitimate nesting is only a few SW layers deep; far below any stack limit.
+    static constexpr int kMaxNestingDepth = 32;
 
     attr_map_type _attributes;
     attr_map_type _optional_attributes;
@@ -230,6 +234,7 @@ inline void Parser::reset(std::string_view input, CaptureMode mode) {
     _end = input.end();
     _optional = 0;
     _nesting = 0;
+    _depth = 0;
     _captureMode = mode;
     _captureStart = _end;
     _captureEnd = _end;
@@ -257,13 +262,20 @@ inline std::string_view Parser::stopCapture(CaptureMode mode) {
 
 // string ::= expr (';' expr)*
 inline std::string_view Parser::parseString() {
+    // '{' and '[' both re-enter parseString; without a bound, deep nesting
+    // exhausts the stack, which no try/catch can intercept.
+    if (++_depth > kMaxNestingDepth) {
+        throw errorAt("maximum nesting depth exceeded");
+    }
     startCapture(CaptureMode::STRING);
     parseExpr();
     while (peek() == ';') {
         nextc();  // ';'
         parseExpr();
     }
-    return stopCapture(CaptureMode::STRING);
+    auto result = stopCapture(CaptureMode::STRING);
+    --_depth;
+    return result;
 }
 
 // expr ::= attr | '{' string '}'

--- a/src/plugins/intel_npu/src/al/include/intel_npu/compat_string_parser.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/compat_string_parser.hpp
@@ -75,8 +75,8 @@
     versions.
 
     Version history:
+        2026-05-28 Limit recursion depth.
         2026-05-06 Initial version.
-
 */
 
 #pragma once
@@ -122,10 +122,13 @@ public:
 
 private:
     enum class CaptureMode { ATTR, STRING };
+    constexpr static int MAX_NESTING = 20;
 
     char peek() const;
     char nextc();
     void expect(char c);
+    void nest();
+    void unnest();
     void reset(std::string_view input, CaptureMode mode = CaptureMode::ATTR);
     void startCapture(CaptureMode mode);
     std::string_view stopCapture(CaptureMode mode);
@@ -156,10 +159,7 @@ private:
     std::string_view::iterator _captureEnd;
     int _nesting = 0;   // Nesting level for current capture mode
     int _optional = 0;  // Tracks top-level optional attributes
-    int _depth = 0;     // parseString recursion depth, capped by kMaxNestingDepth
-
-    // Legitimate nesting is only a few SW layers deep; far below any stack limit.
-    static constexpr int kMaxNestingDepth = 32;
+    int _depth = 0;     // Tracks total nesting depth to prevent stack overflow on malicious input
 
     attr_map_type _attributes;
     attr_map_type _optional_attributes;
@@ -173,8 +173,6 @@ Parser::Parser(std::string_view input, const Iterable& legalAttributeNames) {
 template <typename Iterable>
 void Parser::parse(std::string_view input, const Iterable& legalAttributeNames) {
     reset(input);
-    _attributes.clear();
-    _optional_attributes.clear();
     parseString();
     if (peek() != 0) {
         throw errorAt("at the end of the string");
@@ -229,6 +227,17 @@ inline void Parser::expect(char c) {
     nextc();
 }
 
+inline void Parser::nest() {
+    if (++_depth > MAX_NESTING) {
+        throw errorAt("Maximum nesting depth exceeded");
+    }
+}
+
+inline void Parser::unnest() {
+    assert(_depth > 0);
+    --_depth;
+}
+
 inline void Parser::reset(std::string_view input, CaptureMode mode) {
     _current = input.begin();
     _end = input.end();
@@ -238,6 +247,8 @@ inline void Parser::reset(std::string_view input, CaptureMode mode) {
     _captureMode = mode;
     _captureStart = _end;
     _captureEnd = _end;
+    _attributes.clear();
+    _optional_attributes.clear();
 }
 
 inline void Parser::startCapture(CaptureMode mode) {
@@ -262,30 +273,25 @@ inline std::string_view Parser::stopCapture(CaptureMode mode) {
 
 // string ::= expr (';' expr)*
 inline std::string_view Parser::parseString() {
-    // '{' and '[' both re-enter parseString; without a bound, deep nesting
-    // exhausts the stack, which no try/catch can intercept.
-    if (++_depth > kMaxNestingDepth) {
-        throw errorAt("maximum nesting depth exceeded");
-    }
     startCapture(CaptureMode::STRING);
     parseExpr();
     while (peek() == ';') {
         nextc();  // ';'
         parseExpr();
     }
-    auto result = stopCapture(CaptureMode::STRING);
-    --_depth;
-    return result;
+    return stopCapture(CaptureMode::STRING);
 }
 
 // expr ::= attr | '{' string '}'
 inline void Parser::parseExpr() {
     if (peek() == '{') {
+        nest();
         ++_optional;
         nextc();  // '{'
         parseString();
         expect('}');
         --_optional;
+        unnest();
     } else {
         parseAttr();
     }
@@ -296,12 +302,14 @@ inline void Parser::parseAttr() {
     auto name = parseName();
     expect('=');
     if (peek() == '[') {
+        nest();
         startCapture(CaptureMode::ATTR);
         parseList();
         auto list = stopCapture(CaptureMode::ATTR);
         if (!list.empty()) {
             setAttribute(name, list);
         }
+        unnest();
         return;
     }
     auto value = parseValue();

--- a/src/plugins/intel_npu/tests/unit/npu/metadata/metadata_text.hpp
+++ b/src/plugins/intel_npu/tests/unit/npu/metadata/metadata_text.hpp
@@ -162,6 +162,19 @@ TEST_F(MetadataHumanReadableTests, allTextFields) {
     EXPECT_EQ(storedMeta->get_compatibility_descriptor().value(), compatDesc);
 }
 
+TEST_F(MetadataHumanReadableTests, rejectsExcessiveNesting) {
+    const auto make = [](size_t depth) {
+        return std::string("meta=2.0;ov=2026.1.0;") + std::string(depth, '{') + "future_field=FUTURE_VAL" +
+               std::string(depth, '}');
+    };
+    // Shallow nesting is accepted.
+    OV_ASSERT_NO_THROW((void)::read_as_text(make(8)));
+    // Nesting past the depth limit must throw. A moderate depth (above the limit,
+    // well below a stack overflow) keeps this deterministic: without the guard the
+    // input parses cleanly, so its absence is a clean failure, not a crash.
+    ASSERT_ANY_THROW((void)::read_as_text(make(100)));
+}
+
 TEST_P(MetadataTextTest, Format) {
     std::unique_ptr<MetadataBase> meta;
     if (isValid) {


### PR DESCRIPTION
### Details:
 - Bound recursion depth in the NPU compatibility string parser (`intel_npu::compat::Parser`). Nested `{...}` optional attributes and `inner=[...]` lists re-enter the parser, so a deeply nested compatibility string exhausts the stack — a crash the surrounding `try/catch` cannot intercept, since stack overflow is not a C++ exception.
 - Cap nesting at `MAX_NESTING = 20` via `nest()`/`unnest()` at the `{` and `[` entry points, throwing (→ rejected as unsupported) instead of recursing past it.
 - Ports the existing VPUX-side fix https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/26748 verbatim to keep the two copies of this parser in sync. Adds a regression test.

### Tickets:
 - CVS-194343

### AI Assistance:
- AI assistance used: yes
- Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
