### PR TITLE
[CPU] Enable RoPE for Flux

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -147,6 +147,7 @@ RoPEFusionFlux::RoPEFusionFlux(bool num_heads_transposed) {
         config.rotary_ndims = config.head_size;
         config.is_interleaved = true;
         config.output_trans0213 = false;
+        config.cos_sin_ndims = static_cast<size_t>(head_size.i());
 
         OutputVector new_args;
         new_args.push_back(pattern_map.at(x));
@@ -536,6 +537,8 @@ RoPEFusionGPTJ::RoPEFusionGPTJ() {
                               pattern_map.at(rotary_emb).get_node_shared_ptr(),
                               pattern_map.at(result).get_node_shared_ptr()};
         config.rotary_ndims = static_cast<size_t>(ndims.i());
+        config.use_rope_cache = true;
+        config.cos_sin_ndims = static_cast<size_t>(ndims_over_2.i());
 
         // Fuse output transpose to Rope.
         auto root_target_inputs = root->output(0).get_target_inputs();

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -559,14 +559,16 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ) {
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
                                                     {"config.is_qwen", false},
-                                                    {"config.use_rope_cache", false},
+                                                    {"config.use_rope_cache", true},
                                                     {"config.is_ltx_video", false},
                                                     {"config.head_cnt", 0},
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", rotary_ndims / 2},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, cos_sin});
     }
+    comparator.enable(FunctionsComparator::ATTRIBUTES);
 }
 
 // Parametrized ConvertToROPE_chatGLM tests to check both unpack->output(0) and unpack->output(1)
@@ -910,14 +912,16 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_Slice) {
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
                                                     {"config.is_qwen", false},
-                                                    {"config.use_rope_cache", false},
+                                                    {"config.use_rope_cache", true},
                                                     {"config.is_ltx_video", false},
                                                     {"config.head_cnt", 0},
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", rotary_ndims / 2},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, cos_sin});
     }
+    comparator.enable(FunctionsComparator::ATTRIBUTES);
 }
 
 TEST_F(TransformationTestsF, ConvertToROPE_chatGLM_2d_rope) {
@@ -1467,6 +1471,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_mul) {
         config.rotary_ndims = ndims;
         config.head_cnt = num_heads;
         config.head_size = ndims;
+        config.cos_sin_ndims = ndims;
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{x, t_cos, t_sin}, config);
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
     }
@@ -1521,6 +1526,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_squeeze_mul_unsqueeze) {
         config.rotary_ndims = ndims;
         config.head_cnt = num_heads;
         config.head_size = ndims;
+        config.cos_sin_ndims = ndims;
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{x, t_cos, t_sin}, config);
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
     }
@@ -1575,6 +1581,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_mul_squeeze_unsqueeze) {
         config.rotary_ndims = ndims;
         config.head_cnt = num_heads;
         config.head_size = ndims;
+        config.cos_sin_ndims = ndims;
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{x, t_cos, t_sin}, config);
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
     }
@@ -1631,6 +1638,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_mul_squeeze_unsqueeze_num_heads)
         config.rotary_ndims = ndims;
         config.head_cnt = num_heads;
         config.head_size = ndims;
+        config.cos_sin_ndims = ndims;
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{x, t_cos, t_sin}, config);
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
     }
@@ -1879,11 +1887,12 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_PagedAttention) {
                                                     {"config.output_trans0213", false},
                                                     {"config.is_interleaved", true},
                                                     {"config.rotary_ndims", rotary_ndims},
+                                                    {"config.cos_sin_ndims", rotary_ndims / 2},
                                                     {"config.is_chatglm", false},
                                                     {"config.support_2d_rope", false},
                                                     {"config.support_3d_rope", false},
                                                     {"config.is_qwen", false},
-                                                    {"config.use_rope_cache", false},
+                                                    {"config.use_rope_cache", true},
                                                     {"config.is_ltx_video", false},
                                                     {"config.head_cnt", 0},
                                                     {"config.head_size", 0},
@@ -1891,6 +1900,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_PagedAttention) {
         model_ref =
             std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, aten_gather_GatherElements});
     }
+    comparator.enable(FunctionsComparator::ATTRIBUTES);
 }
 
 TEST_F(TransformationTestsF, ConvertToROPE_chatGLM4_PagedAttention) {

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.cpp
@@ -122,27 +122,51 @@ void jit_rotary_kernel<isa>::rotary_interleave(size_t step) {
     //     dst[i] = cos[j] * x[i] - sin[j] * x[i + 1];
     //     dst[i + 1] = cos[j] * x[i + 1] + sin[j] * x[i];
     // }
+    // cos/sin table sized to rotary_ndims (not shared between the two halves of a pair) means every
+    // element of a pair needs its own angle, matching Flux-style RoPE fusion output.
+    const bool no_share_halves = (m_jcp.cos_sin_ndims != 0 && m_jcp.cos_sin_ndims != m_jcp.rotary_ndims / 2);
     load(vmm_src0, reg_src, m_jcp.src_prc, step, false);
     load(vmm_src1, reg_src, m_jcp.src_prc, step, false, step * m_jcp.src_prc.size());
     deinterlace(vmm_src0, vmm_src1, vmm_dst0, vmm_dst1);
-    // cos[j]
-    load(vmm_cos, reg_cos, ov::element::f32, step, false);
-    // sin[j]
-    if (m_jcp.mix_cos_sin) {
-        load(vmm_sin, reg_cos, ov::element::f32, step, false, step * sizeof(float));
-        deinterlace(vmm_cos, vmm_sin, vmm_dst0, vmm_dst1);
-    } else {
+    if (no_share_halves) {
+        // load cos
+        load(vmm_cos, reg_cos, ov::element::f32, step, false);
+        load(vmm_cos1, reg_cos, ov::element::f32, step, false, step * ov::element::f32.size());
+        deinterlace(vmm_cos, vmm_cos1, vmm_dst0, vmm_dst1);
+        // load sin
         load(vmm_sin, reg_sin, ov::element::f32, step, false);
-    }
-    // sin[j] * src1
-    uni_vmulps(vmm_dst0, vmm_sin, vmm_src1);
-    // cos[j] * src0 - sin[j] * src1
-    vfmsub231ps(vmm_dst0, vmm_cos, vmm_src0);
+        load(vmm_sin1, reg_sin, ov::element::f32, step, false, step * ov::element::f32.size());
+        deinterlace(vmm_sin, vmm_sin1, vmm_dst0, vmm_dst1);
 
-    // cos[j] * src1
-    uni_vmulps(vmm_dst1, vmm_cos, vmm_src1);
-    // cos[j] * src1 + sin[j] * src0
-    vfmadd231ps(vmm_dst1, vmm_sin, vmm_src0);
+        // sin[i] * src1
+        uni_vmulps(vmm_dst0, vmm_sin, vmm_src1);
+        // cos[i] * src0 - sin[i] * src1
+        vfmsub231ps(vmm_dst0, vmm_cos, vmm_src0);
+
+        // cos[i+1] * src1
+        uni_vmulps(vmm_dst1, vmm_cos1, vmm_src1);
+        // cos[i+1] * src1 + sin[i+1] * src0
+        vfmadd231ps(vmm_dst1, vmm_sin1, vmm_src0);
+    } else {
+        // cos[j]
+        load(vmm_cos, reg_cos, ov::element::f32, step, false);
+        // sin[j]
+        if (m_jcp.mix_cos_sin) {
+            load(vmm_sin, reg_cos, ov::element::f32, step, false, step * sizeof(float));
+            deinterlace(vmm_cos, vmm_sin, vmm_dst0, vmm_dst1);
+        } else {
+            load(vmm_sin, reg_sin, ov::element::f32, step, false);
+        }
+        // sin[j] * src1
+        uni_vmulps(vmm_dst0, vmm_sin, vmm_src1);
+        // cos[j] * src0 - sin[j] * src1
+        vfmsub231ps(vmm_dst0, vmm_cos, vmm_src0);
+
+        // cos[j] * src1
+        uni_vmulps(vmm_dst1, vmm_cos, vmm_src1);
+        // cos[j] * src1 + sin[j] * src0
+        vfmadd231ps(vmm_dst1, vmm_sin, vmm_src0);
+    }
     if (isa == cpu_isa_t::avx2) {
         // dst0: 0 2 4 6 8 10 12 14
         // dst1: 1 3 5 7 9 11 13 15
@@ -170,11 +194,16 @@ void jit_rotary_kernel<isa>::rotary_interleave(size_t step) {
     store(reg_dst, vmm_dst1, m_jcp.dst_prc, step, step * m_jcp.dst_prc.size());
     add(reg_src, m_jcp.src_prc.size() * step * 2);
     add(reg_dst, m_jcp.dst_prc.size() * step * 2);
-    if (m_jcp.mix_cos_sin) {
-        add(reg_cos, 2 * sizeof(float) * step);
+    if (no_share_halves) {
+        add(reg_cos, sizeof(float) * step * 2);
+        add(reg_sin, sizeof(float) * step * 2);
     } else {
-        add(reg_cos, sizeof(float) * step);
-        add(reg_sin, sizeof(float) * step);
+        if (m_jcp.mix_cos_sin) {
+            add(reg_cos, 2 * sizeof(float) * step);
+        } else {
+            add(reg_cos, sizeof(float) * step);
+            add(reg_sin, sizeof(float) * step);
+        }
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.cpp
@@ -199,7 +199,7 @@ void jit_rotary_kernel<isa>::rotary_interleave(size_t step) {
         add(reg_sin, sizeof(float) * step * 2);
     } else {
         if (m_jcp.mix_cos_sin) {
-            add(reg_cos, 2 * sizeof(float) * step);
+            add(reg_cos, sizeof(float) * step * 2);
         } else {
             add(reg_cos, sizeof(float) * step);
             add(reg_sin, sizeof(float) * step);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.hpp
@@ -84,9 +84,11 @@ private:
     const Vmm vmm_src1 = Vmm(1);
     const Vmm vmm_cos = Vmm(2);
     const Vmm vmm_sin = Vmm(3);
-    const Vmm vmm_dst0 = Vmm(4);
-    const Vmm vmm_dst1 = Vmm(5);
-    const Vmm vmm_idx = Vmm(7);
+    const Vmm vmm_cos1 = Vmm(4);
+    const Vmm vmm_sin1 = Vmm(5);
+    const Vmm vmm_dst0 = Vmm(6);
+    const Vmm vmm_dst1 = Vmm(7);
+    const Vmm vmm_idx = Vmm(8);
     const Xbyak::Reg64 reg_src = r8;
     const Xbyak::Reg64 reg_cos = r10;
     const Xbyak::Reg64 reg_sin = r11;
@@ -95,7 +97,7 @@ private:
 
     std::unordered_map<size_t, std::unique_ptr<jit_emitter>> emitters;
     const std::vector<size_t> pool_aux_gpr_idxs = {static_cast<size_t>(rax.getIdx()), static_cast<size_t>(r9.getIdx())};
-    const std::vector<size_t> pool_aux_vmm_idxs = {6};
+    const std::vector<size_t> pool_aux_vmm_idxs = {9};
 };
 
 #endif

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -205,6 +205,7 @@ struct RoPE::RoPEExecutorInterleaved : public RoPE::Executor {
         jcp.rotary_ndims = config.rotary_ndims;
         jcp.mode = jit_rotary_compile_params::Mode::INTERLEAVE;
         jcp.mix_cos_sin = false;
+        jcp.cos_sin_ndims = config.cos_sin_ndims;
         m_rotaryKernel = createJitKernel(jcp, true);
     }
 
@@ -213,34 +214,59 @@ struct RoPE::RoPEExecutorInterleaved : public RoPE::Executor {
                  const std::vector<MemoryPtr>& outputs,
                  const CpuParallelPtr& cpu_parallel) override {
         ov::intel_cpu::PlainTensor t_src(inputs[0]);
-        ov::intel_cpu::PlainTensor t_sin_cos(inputs[1]);
         ov::intel_cpu::PlainTensor t_dst(outputs[0]);
-
-        auto batch_size = t_src.size(0);
-        auto seq_len = t_src.size(1);
-        auto head_cnt = t_src.size(2);
-        auto head_dims = t_src.size(3);
 
         auto rotary_dims = m_config.rotary_ndims;
         auto half_rotary_dims = rotary_dims / 2;
 
-        cpu_parallel->parallel_for3d(batch_size, seq_len, head_cnt, [&](size_t b, size_t p, size_t h) {
-            auto* x = t_src.ptr<T>(b, p, h);
-            float* sin = &t_sin_cos.at<float>({b, p, 0}, true);
-            float* cos = &t_sin_cos.at<float>({b, p, half_rotary_dims}, true);
-            auto* dst = m_config.output_trans0213 ? t_dst.ptr<T>(b, h, p) : t_dst.ptr<T>(b, p, h);
+        if (m_config.use_rope_cache) {
+            ov::intel_cpu::PlainTensor t_sin_cos(inputs[1]);
+            const auto batch_size = t_src.size(0);
+            const auto seq_len = t_src.size(1);
+            const auto head_cnt = t_src.size(2);
+            const auto head_dims = t_src.size(3);
+            cpu_parallel->parallel_for3d(batch_size, seq_len, head_cnt, [&](size_t b, size_t p, size_t h) {
+                auto* x = t_src.ptr<T>(b, p, h);
+                float* sin = &t_sin_cos.at<float>({b, p, 0}, true);
+                float* cos = &t_sin_cos.at<float>({b, p, half_rotary_dims}, true);
+                auto* dst = m_config.output_trans0213 ? t_dst.ptr<T>(b, h, p) : t_dst.ptr<T>(b, p, h);
 
-            if (m_rotaryKernel) {
-                execJitKernel(m_rotaryKernel, x, dst, cos, sin);
-            } else {
-                size_t i = 0;
-                for (size_t j = 0; i < rotary_dims; i += 2, j++) {
-                    dst[i] = cos[j] * x[i] - sin[j] * x[i + 1];
-                    dst[i + 1] = cos[j] * x[i + 1] + sin[j] * x[i];
+                if (m_rotaryKernel) {
+                    execJitKernel(m_rotaryKernel, x, dst, cos, sin);
+                } else {
+                    size_t i = 0;
+                    for (size_t j = 0; i < rotary_dims; i += 2, j++) {
+                        dst[i] = cos[j] * x[i] - sin[j] * x[i + 1];
+                        dst[i + 1] = cos[j] * x[i + 1] + sin[j] * x[i];
+                    }
                 }
-            }
-            memcpy(dst + rotary_dims, x + rotary_dims, (head_dims - rotary_dims) * sizeof(T));
-        });
+                memcpy(dst + rotary_dims, x + rotary_dims, (head_dims - rotary_dims) * sizeof(T));
+            });
+        } else {
+            // Flux-style RoPE: separate full-width cos/sin tensors, one distinct angle per element
+            // (dims 1 & 2 align 1:1 with x regardless of BHLS/BLHS layout).
+            const auto batch_size = t_src.size(0);
+            const auto dim_1 = t_src.size(1);
+            const auto dim_2 = t_src.size(2);
+            const auto head_dims = t_src.size(3);
+            ov::intel_cpu::PlainTensor t_cos(inputs[1]);
+            ov::intel_cpu::PlainTensor t_sin(inputs[2]);
+            cpu_parallel->parallel_for3d(batch_size, dim_1, dim_2, [&](size_t b, size_t d_1, size_t d_2) {
+                auto* x = t_src.ptr<T>(b, d_1, d_2);
+                float* sin = &t_sin.at<float>({b, d_1, d_2}, true);
+                float* cos = &t_cos.at<float>({b, d_1, d_2}, true);
+                auto* dst = m_config.output_trans0213 ? t_dst.ptr<T>(b, d_2, d_1) : t_dst.ptr<T>(b, d_1, d_2);
+                if (m_rotaryKernel) {
+                    execJitKernel(m_rotaryKernel, x, dst, cos, sin);
+                } else {
+                    for (size_t i = 0; i < rotary_dims; i += 2) {
+                        dst[i] = cos[i] * x[i] - sin[i] * x[i + 1];
+                        dst[i + 1] = cos[i + 1] * x[i + 1] + sin[i + 1] * x[i];
+                    }
+                }
+                memcpy(dst + rotary_dims, x + rotary_dims, (head_dims - rotary_dims) * sizeof(T));
+            });
+        }
     }
 };
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1138,7 +1138,6 @@ void Transformations::PostLpt() {
 
     CPU_REGISTER_PASS_X64(postLPTPassManager, ov::pass::RoPEFusion, true);
     CPU_REGISTER_PASS_ARM64(postLPTPassManager, ov::pass::RoPEFusion, true);
-    CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionFlux);
     CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionCohere);
     CPU_REGISTER_PASS_X64(postLPTPassManager, CausalMaskPreprocessFusion);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
@@ -92,5 +92,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_RoPETestLtxVideo,
                                             ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          RoPETestLtxVideo::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_RoPETestFlux,
+                         RoPETestFlux,
+                         ::testing::Combine(::testing::Values(ov::element::f32),
+                                            ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                         RoPETestFlux::getTestCaseName);
+
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
## Summary
Port the CPU kernel + test changes from #33147 ("[CPU] Extend RoPEFusionFlux to support BLHS layout") to current master. The BLHS pattern-matching itself was already fixed independently upstream, so this PR only carries over the kernel/executor work and enables it end-to-end.
### Details:
- **Enable `RoPEFusionFlux` for CPU** (`transformation_pipeline.cpp`) — was previously registered but disabled for the CPU plugin, so the pattern never fired.
- **`fuse_rotary_positional_embeddings.cpp`**: set `config.cos_sin_ndims` in `RoPEFusionFlux` so the executor/kernel know Flux's cos/sin tables are full-width (one distinct value per element, not shared across the interleaved pair).
- **`rope_kernel.hpp/.cpp`**: extend the interleaved JIT kernel with a full-width ("no-share-halves") cos/sin load path alongside the existing shared-halves path. Also fixes a register-collision bug from the upstream renumbering (`vmm_dst0` overlapped the aux scratch pool — masked upstream because its test only covers f32, which never touches the aux register).
- **`rope.cpp`**: split `RoPEExecutorInterleaved::execute()` into two paths selected by `config.use_rope_cache`:
  - combined-cache path (legacy): reads cos/sin from one packed tensor — used by GPTJ.
  - separate-tensor path (new): reads distinct full-width cos/sin tensors — used by Flux.
- **`RoPEFusionGPTJ`**: added `config.use_rope_cache = true` and `config.cos_sin_ndims`. Without this, GPTJ (which passes the same tensor as both cos/sin args) would silently fall into the new separate-tensor branch and produce wrong output — this matches what #33147 itself did for GPTJ.
- **Tests**: instantiated `smoke_RoPETestFlux` for CPU (`rotary_pos_emb.cpp`); updated the transformation unit tests (`fuse_rotary_positional_embeddings.cpp`) to assert the new `cos_sin_ndims`/`use_rope_cache` config values for both Flux and GPTJ so a future regression on either would be caught structurally, not just via kernel output.

### Tickets:

- CVS-177686

## Testing

`ov_transformations_tests --gtest_filter="*RoPE*:*ROPE*"` — 44/44 passed.


### AI Assistance:
 - *AI assistance used: yes*
 - *Help port PR*
