### PR TITLE
[JS API] Avoid releasing closed ThreadSafeFunctions

### DIFF
--- a/src/bindings/js/node/include/helper.hpp
+++ b/src/bindings/js/node/include/helper.hpp
@@ -196,3 +196,5 @@ ov::AnyMap to_anyMap(const Napi::Env&, const Napi::Value&);
 std::string buffer_to_string(const Napi::Value& value);
 
 uint32_t get_optimal_number_of_requests(const ov::CompiledModel& actual);
+
+void release_tsfn_after_blocking_call(const Napi::ThreadSafeFunction& tsfn, napi_status call_status) noexcept;

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -202,10 +202,7 @@ void compile_model_thread(TsfnCompileModelContext* context) {
     };
 
     const auto status = context->tsfn.BlockingCall(context, callback);
-    if (status != napi_ok) {
-        std::cerr << "Error: ThreadSafeFunction::BlockingCall failed in compile_model_thread function\n";
-    }
-    context->tsfn.Release();
+    release_tsfn_after_blocking_call(context->tsfn, status);
 }
 
 Napi::Value CoreWrap::compile_model_async(const Napi::CallbackInfo& info) {
@@ -351,10 +348,7 @@ void import_model_thread(ImportModelContext* context, std::mutex& mutex) {
     };
 
     const auto status = context->tsfn.BlockingCall(context, callback);
-    if (status != napi_ok) {
-        std::cerr << "Error: ThreadSafeFunction::BlockingCall failed in import_model_thread function\n";
-    }
-    context->tsfn.Release();
+    release_tsfn_after_blocking_call(context->tsfn, status);
 }
 
 Napi::Value CoreWrap::import_model_async(const Napi::CallbackInfo& info) {

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -4,6 +4,7 @@
 
 #include "node/include/helper.hpp"
 
+#include <cassert>
 #include <sstream>
 
 #include "node/include/compiled_model.hpp"
@@ -13,6 +14,16 @@
 #include "node/include/type_validation.hpp"
 #include "openvino/runtime/make_tensor.hpp"
 #include "openvino/util/common_util.hpp"
+
+void release_tsfn_after_blocking_call(const Napi::ThreadSafeFunction& tsfn, napi_status call_status) noexcept {
+    assert((call_status == napi_ok || call_status == napi_closing) &&
+           "Unexpected ThreadSafeFunction::BlockingCall status");
+
+    if (call_status == napi_ok) {
+        [[maybe_unused]] const auto release_status = tsfn.Release();
+        assert(release_status == napi_ok && "ThreadSafeFunction::Release failed");
+    }
+}
 
 const std::vector<std::string>& get_supported_types() {
     static const std::vector<std::string> supported_element_types =

--- a/src/bindings/js/node/src/infer_request.cpp
+++ b/src/bindings/js/node/src/infer_request.cpp
@@ -263,10 +263,7 @@ void perform_inference_thread(TsfnContext* context) {
     };
 
     const auto status = context->tsfn.BlockingCall(context, callback);
-    if (status != napi_ok && status != napi_closing) {
-        std::cerr << "ThreadSafeFunction::BlockingCall failed with status " << status << '\n';
-    }
-    context->tsfn.Release();
+    release_tsfn_after_blocking_call(context->tsfn, status);
 }
 }  // namespace
 


### PR DESCRIPTION
### Details:
 - Add a shared helper that releases TSFN only after a successful BlockingCall().
 - Handle `napi_closing` without further TSFN access and remove stderr logging from async operations.

### Tickets:
 - [CVS-193240](https://jira.devtools.intel.com/browse/CVS-193240)

### AI Assistance:
 - *AI assistance used: yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
