### PR TITLE
[GPU] Expose PA block size property and validate block_indices consistency

### DIFF
--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -186,6 +186,16 @@ static constexpr Property<bool> enable_large_allocations{"GPU_ENABLE_LARGE_ALLOC
 static constexpr Property<size_t, PropertyMutability::RW> offload_ratio{"OFFLOAD_RATIO"};
 
 /**
+ * @brief Read-only property to get the PagedAttention block size used by the compiled model.
+ * Block size is device-specific (e.g., 16 for standard PA on GPU, 256 under XAttention)
+ * and is required for correct logical-to-physical block mapping when driving the PA graph directly.
+ * Returns 0 if the model does not use PagedAttention.
+ * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
+ */
+static constexpr Property<uint64_t, PropertyMutability::RO> paged_attention_block_size{
+    "GPU_PAGED_ATTENTION_BLOCK_SIZE"};
+
+/**
  * @brief These keys instruct the GPU plugin to use surface/buffer memory type.
  */
 namespace memory_type {

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp
@@ -106,6 +106,7 @@ private:
     std::vector<std::shared_ptr<Graph>> m_graphs;
     bool m_loaded_from_cache;
     std::string m_runtime_requirements;
+    uint64_t m_pa_block_size = 0;  // 0 if model has no PA, 16 or 256 otherwise
     std::shared_ptr<ov::Tensor> _backing_tensor;
 };
 

--- a/src/plugins/intel_gpu/src/graph/include/paged_attention_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/paged_attention_inst.h
@@ -22,6 +22,8 @@ public:
     std::set<size_t> get_lockable_input_ids() const override {
         std::set<size_t> input_ports = { PagedAttentionInputIdx::PAST_LENS,
                                          PagedAttentionInputIdx::SUBSEQUENCE_BEGINS,
+                                         PagedAttentionInputIdx::BLOCK_INDICES,
+                                         PagedAttentionInputIdx::BLOCK_INDICES_BEGINS,
                                          PagedAttentionInputIdx::XATTENTION_THRESHOLD,
                                          PagedAttentionInputIdx::XATTENTION_BLOCK_SIZE,
                                          PagedAttentionInputIdx::MAX_CONTEXT_LEN };

--- a/src/plugins/intel_gpu/src/graph/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/paged_attention.cpp
@@ -116,6 +116,42 @@ std::vector<layout> paged_attention_inst::calc_output_layouts(paged_attention_no
         }
     }
 
+    // Validate block_indices consistency: if block_indices is shorter than
+    // the context implied by past_lens, the PA kernel will read out-of-bounds,
+    // causing CL_OUT_OF_RESOURCES (error -5) which kills the process.
+    // Catch this early with a clear error message. (See issue #37662, Request 6)
+    const auto block_indices_idx = cldnn::paged_attention::PagedAttentionInputIdx::BLOCK_INDICES;
+    const auto block_indices_begins_idx = cldnn::paged_attention::PagedAttentionInputIdx::BLOCK_INDICES_BEGINS;
+    const auto past_lens_idx_val = cldnn::paged_attention::PagedAttentionInputIdx::PAST_LENS;
+    const auto& block_indices_layout = impl_param.get_input_layout(block_indices_idx);
+    const auto& block_indices_begins_layout = impl_param.get_input_layout(block_indices_begins_idx);
+    const auto& past_lens_layout = impl_param.get_input_layout(past_lens_idx_val);
+
+    if (block_indices_layout.is_static() && block_indices_begins_layout.is_static() && past_lens_layout.is_static()) {
+        const auto& memory_deps = impl_param.memory_deps;
+        if (memory_deps.count(past_lens_idx_val) && memory_deps.count(block_indices_begins_idx) && memory_deps.count(block_indices_idx)) {
+            auto past_lens_mem = memory_deps.at(past_lens_idx_val);
+            auto block_indices_begins_mem = memory_deps.at(block_indices_begins_idx);
+            mem_lock<int32_t, mem_lock_type::read> past_lens_lock(past_lens_mem, *impl_param.strm);
+            mem_lock<int32_t, mem_lock_type::read> bi_begins_lock(block_indices_begins_mem, *impl_param.strm);
+
+            const auto num_sequences = past_lens_lock.size();
+            const auto block_indices_count = static_cast<size_t>(block_indices_layout.get_shape()[0]);
+            const auto pa_block_sz = desc->has_xattention ? paged_attention::block_size_xattn : paged_attention::block_size;
+
+            if (num_sequences > 0 && bi_begins_lock.size() > num_sequences) {
+                // block_indices_begins[last] should equal the total number of block indices
+                const auto expected_block_indices = static_cast<size_t>(bi_begins_lock[num_sequences]);
+                OPENVINO_ASSERT(block_indices_count >= expected_block_indices,
+                    "[GPU] PagedAttention: block_indices length (", block_indices_count,
+                    ") is smaller than required by block_indices_begins (", expected_block_indices,
+                    "). This will cause the kernel to read out-of-bounds memory. "
+                    "Ensure block_indices has at least ceil(sum(past_lens + new_tokens) / block_size=", pa_block_sz,
+                    ") entries per sequence.");
+            }
+        }
+    }
+
     return output_layouts;
 }
 

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -9,6 +9,8 @@
 #include "openvino/core/version.hpp"
 
 #include "intel_gpu/graph/serialization/binary_buffer.hpp"
+#include "intel_gpu/primitives/paged_attention.hpp"
+#include "openvino/op/paged_attention.hpp"
 #include "intel_gpu/runtime/itt.hpp"
 #include "intel_gpu/plugin/graph.hpp"
 #include "intel_gpu/plugin/compiled_model.hpp"
@@ -62,6 +64,22 @@ CompiledModel::CompiledModel(std::shared_ptr<ov::Model> model,
       m_outputs(ov::ICompiledModel::outputs()),
       m_loaded_from_cache(false) {
     m_runtime_requirements = build_runtime_requirements(m_context->get_engine().get_device_info());
+
+    // Detect PA block size from the model
+    for (const auto& op : model->get_ordered_ops()) {
+        if (auto pa_op = std::dynamic_pointer_cast<ov::op::PagedAttentionExtension>(op)) {
+            auto value_cache_ps = pa_op->get_input_partial_shape(4);
+            if (value_cache_ps.rank().is_static() && value_cache_ps.rank().get_length() > 2 &&
+                value_cache_ps[2].is_static() &&
+                static_cast<size_t>(value_cache_ps[2].get_length()) == cldnn::paged_attention::block_size_xattn) {
+                m_pa_block_size = cldnn::paged_attention::block_size_xattn;
+            } else {
+                m_pa_block_size = cldnn::paged_attention::block_size;
+            }
+            break;
+        }
+    }
+
     auto graph_base = std::make_shared<Graph>(model, m_context, m_config, 0);
     for (uint16_t n = 0; n < m_config.get_num_streams(); n++) {
         auto graph = n == 0 ? graph_base : std::make_shared<Graph>(graph_base, n);
@@ -341,6 +359,7 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
             ov::PropertyName{ov::intel_gpu::offload_ratio.name(), PropertyMutability::RO},
             ov::PropertyName{ov::device::id.name(), PropertyMutability::RO},
             ov::PropertyName{ov::execution_devices.name(), PropertyMutability::RO},
+            ov::PropertyName{ov::intel_gpu::paged_attention_block_size.name(), PropertyMutability::RO},
             ov::PropertyName{ov::runtime_requirements.name(), PropertyMutability::RO},
         };
     }
@@ -355,6 +374,9 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
         if (m_config.get_performance_mode() != ov::hint::PerformanceMode::LATENCY)
             nr *= 2;
         return decltype(ov::optimal_number_of_infer_requests)::value_type {nr};
+    }
+    if (name == ov::intel_gpu::paged_attention_block_size) {
+        return decltype(ov::intel_gpu::paged_attention_block_size)::value_type{m_pa_block_size};
     }
     if (name == ov::execution_devices) {
         return decltype(ov::execution_devices)::value_type{m_context->get_device_name()};

--- a/src/plugins/intel_gpu/tests/functional/behavior/properties.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/properties.cpp
@@ -130,4 +130,15 @@ TEST(KVCachePrecisionAutoDetection, U8NormalizedToI8) {
     auto kv_prec = compiled_model.get_property(ov::hint::kv_cache_precision);
     ASSERT_EQ(kv_prec, ov::element::i8);
 }
-} // namespace
+
+TEST_F(TestPropertiesGPU, PagedAttentionBlockSizeNonPAModel) {
+    ov::Core core;
+    ov::CompiledModel compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU));
+
+    uint64_t block_size = 0;
+    OV_ASSERT_NO_THROW(block_size = compiled_model.get_property(ov::intel_gpu::paged_attention_block_size));
+    ASSERT_EQ(block_size, 0u) << "Non-PA model must report block_size == 0";
+}
+
+}  // namespace


### PR DESCRIPTION
Addresses Requests 4 and 6 from #37662.

### Request 4 — Expose PA block size via `compiled_model.get_property()`

The block size (`16` for standard PA, `256` for XAttention) is required for correct logical-to-physical block mapping when driving the PA graph directly. Previously, users had to reverse-engineer it from internal headers (`kv_cache_manager.hpp`). Getting it wrong silently produces wrong output.

**Changes:**
- `properties.hpp`: Declare `ov::intel_gpu::paged_attention_block_size` as a read-only `uint64_t` property
- `compiled_model.cpp`: Return `cldnn::paged_attention::block_size` from `get_property()`, add to `supported_properties` list

### Request 6 — Validate `block_indices` consistency before dispatch

When `block_indices` is shorter than the context implied by `past_lens`, the PA kernel reads out-of-bounds memory, causing `CL_OUT_OF_RESOURCES` (error -5) which crashes the process. This is indistinguishable from an OOM condition and cost significant diagnosis time.

**Changes:**
- `paged_attention_inst.h`: Add `BLOCK_INDICES` and `BLOCK_INDICES_BEGINS` to lockable inputs so their values are available during shape inference
- `paged_attention.cpp`: Add validation in `calc_output_layouts()` that checks `block_indices` length against `block_indices_begins` — throws `ov::Exception` with a clear, actionable message instead of letting the kernel crash

### Files changed
| File | Change |
|------|--------|
| `src/inference/include/openvino/runtime/intel_gpu/properties.hpp` | New RO property declaration |
| `src/plugins/intel_gpu/src/plugin/compiled_model.cpp` | Return block size from `get_property()` |
| `src/plugins/intel_gpu/src/graph/include/paged_attention_inst.h` | Add block_indices to lockable inputs |
| `src/plugins/intel_gpu/src/graph/paged_attention.cpp` | Runtime block_indices validation |
