### PR TITLE
[Docs] Document ONNX Dropout training_mode=true limitation (CVS-194273)

### DIFF
--- a/docs/articles_en/documentation/compatibility-and-support/supported-operations.rst
+++ b/docs/articles_en/documentation/compatibility-and-support/supported-operations.rst
@@ -120,7 +120,7 @@ Data as of OpenVINO 2025.4.1 (December 18, 2025).
        DequantizeLinear
        DFT
        Div
-       Dropout
+       Dropout                                     Training mode (training_mode=true) is not supported.
        DynamicQuantizeLinear
        Einsum
        Elu


### PR DESCRIPTION
### Details:
 - *Add a Limitations note to the ONNX Dropout row in the supported operations table clarifying that training_mode=true is not supported, per CVS-48052 (no plans to support training in OpenVINO).*

### Tickets:
 - *CVS-48052*

### AI Assistance:
 - *AI assistance used: no*
