### PR TITLE
[NPU] Validate dynamic graph metadata rank

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/include/dynamic_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/dynamic_graph.hpp
@@ -16,6 +16,10 @@
 #include "openvino/runtime/so_ptr.hpp"
 
 namespace intel_npu {
+
+IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
+                             const std::optional<ze_graph_argument_metadata_t>& metadata);
+
 class DynamicGraph final : public IGraph {
 public:
     DynamicGraph(const std::shared_ptr<ZeroInitStructsHolder>& zeroInitStruct,

--- a/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/dynamic_graph.cpp
@@ -39,13 +39,26 @@ void DynamicGraph::create_execution_engine() {
  * the referenced attribute.
  * @returns A descriptor object containing the metadata converted in OpenVINO specific structures.
  */
-static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
-                                    const std::optional<ze_graph_argument_metadata_t>& metadata) {
+IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
+                             const std::optional<ze_graph_argument_metadata_t>& metadata) {
     auto logger = Logger::global().clone("getIODescriptor");
     ov::element::Type_t precision = zeroUtils::toOVElementType(arg.devicePrecision);
     ov::Shape shapeFromCompiler;
     ov::PartialShape shapeFromIRModel;
     std::unordered_set<std::string> outputTensorNames;
+
+    if (arg.associated_tensor_names_count > std::size(arg.associated_tensor_names)) {
+        OPENVINO_THROW("Associated tensor name count exceeds dynamic graph metadata capacity");
+    }
+    if (arg.dims_count > std::size(arg.dims)) {
+        OPENVINO_THROW("Compiler shape rank exceeds dynamic graph metadata capacity");
+    }
+    if (metadata.has_value() && metadata->shape_size > std::size(metadata->shape)) {
+        OPENVINO_THROW("IR shape rank exceeds dynamic graph metadata capacity");
+    }
+    if (metadata.has_value() && metadata->shape_size != arg.dims_count) {
+        OPENVINO_THROW("Inconsistent tensor ranks in dynamic graph metadata");
+    }
 
     for (uint32_t id = 0; id < arg.associated_tensor_names_count; id++) {
         outputTensorNames.insert(arg.associated_tensor_names[id]);

--- a/src/plugins/intel_npu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/unit/CMakeLists.txt
@@ -159,6 +159,7 @@ install(TARGETS ${TARGET_NAME}
 target_sources(${TARGET_NAME} PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/executor_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/compiler_option_support_helper_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/npu/dynamic_graph_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/option_support_cache_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npu/state_tensor_binding_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/npuw/llm_compiled_model_graph_options_test.cpp

--- a/src/plugins/intel_npu/tests/unit/npu/dynamic_graph_test.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/dynamic_graph_test.cpp
@@ -1,0 +1,79 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "dynamic_graph.hpp"
+
+#include <gtest/gtest.h>
+
+#include <iterator>
+#include <limits>
+
+#include "common_test_utils/test_assertions.hpp"
+#include "openvino/core/except.hpp"
+
+namespace {
+
+ze_graph_argument_properties_3_t makeArgument() {
+    ze_graph_argument_properties_3_t arg = {};
+    arg.type = ZE_GRAPH_ARGUMENT_TYPE_INPUT;
+    arg.devicePrecision = ZE_GRAPH_ARGUMENT_PRECISION_FP32;
+    arg.dims_count = 1;
+    arg.dims[0] = 4;
+    return arg;
+}
+
+ze_graph_argument_metadata_t makeMetadata() {
+    ze_graph_argument_metadata_t metadata = {};
+    metadata.shape_size = 1;
+    metadata.shape[0] = 4;
+    return metadata;
+}
+
+TEST(DynamicGraphTests, RejectsMetadataRankGreaterThanCompilerRank) {
+    auto arg = makeArgument();
+    auto metadata = makeMetadata();
+    metadata.shape_size = 2;
+    metadata.shape[1] = std::numeric_limits<uint64_t>::max();
+
+    OV_EXPECT_THROW_HAS_SUBSTRING(intel_npu::getIODescriptor(arg, metadata),
+                                  ov::Exception,
+                                  "Inconsistent tensor ranks in dynamic graph metadata");
+}
+
+TEST(DynamicGraphTests, RejectsAssociatedTensorNameCountGreaterThanCapacity) {
+    auto arg = makeArgument();
+    arg.associated_tensor_names_count = static_cast<uint32_t>(std::size(arg.associated_tensor_names) + 1);
+
+    OV_EXPECT_THROW_HAS_SUBSTRING(intel_npu::getIODescriptor(arg, makeMetadata()),
+                                  ov::Exception,
+                                  "Associated tensor name count exceeds dynamic graph metadata capacity");
+}
+
+TEST(DynamicGraphTests, RejectsCompilerRankGreaterThanCapacity) {
+    auto arg = makeArgument();
+    arg.dims_count = static_cast<uint32_t>(std::size(arg.dims) + 1);
+
+    OV_EXPECT_THROW_HAS_SUBSTRING(intel_npu::getIODescriptor(arg, makeMetadata()),
+                                  ov::Exception,
+                                  "Compiler shape rank exceeds dynamic graph metadata capacity");
+}
+
+TEST(DynamicGraphTests, RejectsMetadataRankGreaterThanCapacity) {
+    auto metadata = makeMetadata();
+    metadata.shape_size = static_cast<uint32_t>(std::size(metadata.shape) + 1);
+
+    OV_EXPECT_THROW_HAS_SUBSTRING(intel_npu::getIODescriptor(makeArgument(), metadata),
+                                  ov::Exception,
+                                  "IR shape rank exceeds dynamic graph metadata capacity");
+}
+
+TEST(DynamicGraphTests, AcceptsMatchingCompilerAndMetadataRanks) {
+    const auto descriptor = intel_npu::getIODescriptor(makeArgument(), makeMetadata());
+
+    ASSERT_TRUE(descriptor.shapeFromIRModel.has_value());
+    EXPECT_EQ(descriptor.shapeFromCompiler, ov::PartialShape({4}));
+    EXPECT_EQ(descriptor.shapeFromIRModel.value(), ov::PartialShape({4}));
+}
+
+}  // namespace


### PR DESCRIPTION
### Details:
Reject dynamic dimensions beyond the compiler-provided shape rank and add regression coverage for malformed metadata.

### Tickets:
- [CVS-194428](https://jira.devtools.intel.com/browse/CVS-194428)

### AI Assistance:
- AI assistance used: yes
- Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
