### PR TITLE
[GPU] Force event creation for shape-infer-dep and wait on event

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/custom_primitive.cpp
@@ -182,7 +182,7 @@ struct custom_gpu_primitive_impl : typed_primitive_impl<custom_gpu_primitive> {
         for (const auto& buf : instance.get_intermediates_memories()) {
             args.intermediates.push_back(buf);
         }
-        return stream.enqueue_kernel(*_kernels.front(), cl_kernel.get()->params, args, events, instance.is_output());
+        return stream.enqueue_kernel(*_kernels.front(), cl_kernel.get()->params, args, events, instance.needs_completion_event());
     }
 
     std::vector<kernel::ptr> get_kernels() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -579,6 +579,8 @@ protected:
                 if (instance.needs_completion_event())
                     event = stream.enqueue_marker({});
             }
+        } else if (instance.needs_completion_event()) {
+            event = stream.enqueue_marker({});
         }
 
         return event;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -453,8 +453,7 @@ void primitive_inst::update_shape() {
         !(dep->get_node().get_selected_impl() ? dep->get_node().get_selected_impl()->is_cpu() : dep->get_node().get_preferred_impl_type() == impl_types::cpu)) {
             has_runtime_deps = true;
 
-            // Events may be not created for in-order queue, so take them for OOO queue only
-            if (queue_type == QueueTypes::out_of_order && dep->get_impl_params()->out_event) {
+            if (dep->get_impl_params()->out_event) {
                 dependencies_events.push_back(dep->get_impl_params()->out_event);
 
                 GPU_DEBUG_TRACE_DETAIL << id() << ": shape infer waits for " << i << " dependency\n";
@@ -465,9 +464,9 @@ void primitive_inst::update_shape() {
     if (has_runtime_deps) {
         OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, openvino::itt::handle("update_shape_sync: " + id()));
         GPU_DEBUG_TRACE_DETAIL << "runtime synchronization for " << id() << " shape inference\n";
-        if (!dependencies_events.empty() && queue_type == QueueTypes::out_of_order) {
+        if (!dependencies_events.empty()) {
             get_network().get_stream().wait_for_events(dependencies_events);
-        } else if (queue_type == QueueTypes::in_order) {
+        } else {
             get_network().get_stream().finish();
         }
     }
@@ -2457,7 +2456,7 @@ primitive_inst::primitive_inst(network & network, program_node const& node, bool
     , _can_be_optimized(node.can_be_optimized())
     , _can_share_buffer(node.can_share_buffer())
     , _is_constant(node.is_constant())
-    , _needs_completion_event(is_any_user_cpu(node.get_users()) || node.is_output()) {
+    , _needs_completion_event(is_any_user_cpu(node.get_users()) || node.is_output() || node.is_shape_infer_dep()) {
     // When dynamic shape node has huge upper boundary which causes bigger mem size than system max allocable mem size, do not allocate in build time.
     auto output_layout = node.get_output_layout();
     auto& engine = network.get_engine();


### PR DESCRIPTION
### Details:
 - follow up of #37638 
 - When oneDNN enabled, OCL queue becomes in-order, shape infer dependency simply uses clFinish to wait, not waiting for the actual node(even when it's already finished), causing bubbles in pipeline.
<img width="993" height="227" alt="image" src="https://github.com/user-attachments/assets/3f457927-ecf3-43de-acc9-8dac9a6d22c8" />

This PR is doing following change:
- Force event creation for shape-infer-dep node even in in-order queue
- When no event collected for the dependencies, fallback to clFinish (even for OoO queue, original code seems to be buggy)

### Tickets:
 - *CVS-193368*

### AI Assistance:
 - AI assistance used: yes
 - AI helped finding event creating positions.
