### PR TITLE
[GPU] Fix under-counted SDPA partitions for sliding window decode

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -1485,11 +1485,13 @@ public:
         auto effective_context_len = rt_params->max_context_len;
         // scores_output is only used in SnapKV path, and it doesn't yet handle the SWA block skip offset
         if (desc->sliding_window > 0 && rt_params->stage == PagedAttentionStage::GENERATE && !desc->has_scores_output()) {
-            auto total_blocks = ceil_div(rt_params->max_context_len, paged_attention_block_size);
-            auto swa_start_block =
-                rt_params->max_context_len > desc->sliding_window ? (rt_params->max_context_len - desc->sliding_window) / paged_attention_block_size : 0;
-            auto effective_blocks = total_blocks - swa_start_block;
-            effective_context_len = effective_blocks * paged_attention_block_size;
+            // The window straddles one extra block when the length is not block-aligned:
+            //     aligned      |####|####|####|      3 blocks
+            //     unaligned      |##|####|####|##|   4 blocks
+            // num_of_partitions is shared by the batch, so size it for the unaligned case.
+            const auto total_blocks = ceil_div(rt_params->max_context_len, paged_attention_block_size);
+            const auto max_window_blocks = ceil_div(desc->sliding_window, paged_attention_block_size) + 1;
+            effective_context_len = std::min(total_blocks, max_window_blocks) * paged_attention_block_size;
         }
         rt_params->num_of_partitions = ceil_div(effective_context_len, rt_params->partition_size);
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -496,6 +496,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_paged_attention, paged_attention_test, ::testing:
     paged_attention_test_params{ {{1, 4096}}, 8, 2, 128, 128, 16, 512, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // GQA decode, triggers GQA kernel path (context>=4096)
     paged_attention_test_params{ {{1, 2048}}, 8, 2, 128, 128, 16, 512, ENABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // GQA decode + KV compression + SWA
     paged_attention_test_params{ {{1, 1024}, {1, 2048}}, 8, 2, 128, 128, 16, 512, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // multi-seq GQA decode with SWA
+    // The window covers one more block when a length is not block-aligned, so the longest sequence is
+    // not always the one that needs the most partitions. Here the longest one is aligned (2047 + 1 = 2048)
+    // while the shorter one ends 15 tokens into a block (1038 + 1 = 1039) and needs one partition more.
+    // Sizing the dispatch from the longest sequence drops those 15 tokens, the newest ones it must attend.
+    paged_attention_test_params{ {{1, 2047}, {1, 1038}}, 8, 2, 128, 128, 16, 512, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // multi-seq SWA decode, mixed block alignment
+    paged_attention_test_params{ {{1, 1023}, {1, 526}}, 2, 2, 64, 64, 16, 256, DISABLE_CACHE_COMPRESSION, ov::internal::CacheQuantMode::BY_TOKEN, STATIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION, DISABLE_FA_V2, false, 0, {}, false }, // same, non-GQA
 }));
 
 INSTANTIATE_TEST_SUITE_P(smoke_cm_xattention, xattention_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
Below, `W` is `sliding_window` and `B` is `paged_attention_block_size` (16).
 - Symptom: corrupted output tokens with sliding-window models, only when several requests decode in one batch.
 - Cause: `num_of_partitions` is shared by the batch, but was computed from `max_context_len` alone. The in-window block count is `ceil(W/B)` when the sequence length is a multiple of `B` and `ceil(W/B)+1` when it is not, so the longest sequence does not always need the most partitions.
 - Effect: a shorter, unaligned sequence loses its last partition. That partition holds the newest tokens, so up to `B-1` of them are dropped from attention.
 - Fix: use an alignment-independent bound, `min(total_blocks, ceil(W/B)+1)`. No sequence can need more, whatever its alignment.

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp`, `update_rt_params()` - from f84db88dc3 (#37064).
 - It mirrors the per-sequence formula in `paged_attention_opt.cl:185`, but with `max_context_len` in place of the kernel's own `seq_len`.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - `$ ov_gpu_unit_tests --gtest_filter='smoke_paged_attention/paged_attention_test.basic/149'` - fails without the fix.
 - End-to-end, 4 concurrent requests: malformed tool calls 2.4% -> 0.9% of turns, matching the pre-#37064 rate. No accuracy or latency regression.

#### Problematic graph
 - N/A - not graph related.

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
       Two cases in `smoke_paged_attention`, each mixing an aligned sequence length with an unaligned one. 149 fails without the fix.
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
       The SWA decode cases from #37064 (`paged_attention_gpu_test.cpp:493-498`). All lengths there share one alignment, so they cannot hit this.


### Tickets:
 - *192880*