### PR TITLE
[GPU] Fix Bucketize output not written when boundaries tensor is empty

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
@@ -23,6 +23,17 @@ struct bucketize_impl : typed_primitive_impl_ocl<bucketize> {
         return make_deep_copy<bucketize_impl, kernel_params_t>(*this);
     }
 
+    event::ptr execute_impl(const std::vector<event::ptr>& events, bucketize_inst& instance) override {
+        // Empty buckets still gives a full output of zeros, but the generic skip logic drops the kernel.
+        if (instance.get_input_layout(1).count() == 0) {
+            stream& stream = instance.get_network().get_stream();
+            stream.enqueue_barrier();
+            return instance.output_memory_ptr()->fill(stream, {}, false);
+        }
+
+        return parent::execute_impl(events, instance);
+    }
+
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {
         const auto& primitive = impl_param.typed_desc<bucketize>();
         auto params = get_default_params<kernel_selector::bucketize_params>(impl_param);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
@@ -27,8 +27,8 @@ struct bucketize_impl : typed_primitive_impl_ocl<bucketize> {
         // Empty buckets still gives a full output of zeros, but the generic skip logic drops the kernel.
         if (instance.get_input_layout(1).count() == 0) {
             stream& stream = instance.get_network().get_stream();
-            stream.enqueue_barrier();
-            return instance.output_memory_ptr()->fill(stream, {}, false);
+            auto dep = stream.enqueue_marker(events, instance.needs_completion_event());
+            return instance.output_memory_ptr()->fill(stream, {dep}, false);
         }
 
         return parent::execute_impl(events, instance);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/bucketize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/bucketize_gpu_test.cpp
@@ -151,4 +151,44 @@ INSTANTIATE_TEST_SUITE_P(export_import,
 
 #undef INSTANTIATE_BUCKETIZE_TEST_SUITE
 
+// Empty buckets must still produce a full zero output.
+// Dirty the output first, otherwise a zeroed fresh buffer hides the bug.
+TEST(bucketize_gpu, empty_buckets_produces_zero_output) {
+    auto& engine = get_test_engine();
+
+    const std::vector<float> input_values = {8.f, 1.f, 2.f, 1.1f, 8.f, 10.f, 1.f, 10.2f, 0.f, 20.f};
+    auto input = engine.allocate_memory(layout(ov::PartialShape{1, 1, 1, static_cast<int64_t>(input_values.size())}, data_types::f32, format::bfyx));
+    set_values(input, input_values);
+
+    // Reinterpret a 1-element buffer to avoid a zero-byte allocation.
+    auto buckets_storage = engine.allocate_memory(layout(ov::PartialShape{1}, data_types::f32, format::bfyx));
+    auto empty_buckets = engine.reinterpret_buffer(*buckets_storage, layout(ov::PartialShape{0}, data_types::f32, format::bfyx));
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(input_layout("buckets", empty_buckets->get_layout()));
+    topology.add(bucketize("bucketize", {input_info("input"), input_info("buckets")}, data_types::i32, true));
+
+    cldnn::network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input);
+    network.set_input_data("buckets", empty_buckets);
+
+    {
+        auto dirty = network.get_output_memory("bucketize");
+        mem_lock<int32_t, mem_lock_type::write> dirty_ptr(dirty, get_test_stream());
+        for (size_t i = 0; i < dirty_ptr.size(); ++i) {
+            dirty_ptr[i] = static_cast<int32_t>(0xDEADBEEFu);
+        }
+    }
+
+    const auto outputs = network.execute();
+
+    auto output = outputs.at("bucketize").get_memory();
+    mem_lock<int32_t, mem_lock_type::read> output_ptr(output, get_test_stream());
+    ASSERT_EQ(output_ptr.size(), input_values.size());
+    for (size_t i = 0; i < output_ptr.size(); ++i) {
+        ASSERT_EQ(0, output_ptr[i]) << "at index " << i;
+    }
+}
+
 }  // namespace


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - **Symptom**: `smoke_Bucketize_empty_boundary_*` fails randomly. Expected `0`, actual is garbage. Wrong element count changes every run. Does not reproduce when run alone.
 - **Root cause**: `KernelData::Default()` skips a kernel when any input is empty. Bucketize output shape comes from input0 only, so empty boundaries (input1) still needs a full output. The kernel is never enqueued and the output buffer keeps old memory pool data. A fresh buffer is zeroed and passes, a recycled one shows garbage.
 - **Fix**: Added `execute_impl()` to `bucketize_impl`. When boundaries is empty, fill the output with `0` instead of running the kernel. Same as the op spec and the CPU reference.

#### The code and line that caused this issue (if it is not changed directly)
 - `intel_gpu/src/kernel_selector/kernel_selector_common.h:123` — `SkipKernelExecution()` returns true if any input is empty
 - `intel_gpu/src/kernel_selector/kernels/bucketize/bucketize_kernel_ref.cpp:58` — uses `KernelData::Default()`
 - `intel_gpu/src/graph/impls/ocl/primitive_base.hpp:263` — skips every kernel, so nothing is enqueued

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - `$ ./ov_gpu_unit_tests --gtest_filter=bucketize_gpu.empty_buckets_produces_zero_output`
 - Before the fix: `Expected: 0, Which is: -559038737` (0xDEADBEEF, the buffer was never touched)

#### Problematic graph
 - Not a graph issue. Single `Bucketize` node: data `[6,7,3,2,8,5]`, boundaries `[0]` (empty).

#### Checklist
 - [x] Is it a proper fix? (not a workaround) — Yes, matches the op spec and the CPU reference.
 - [x] Did you include test case for this fix, if necessary? — Added `bucketize_gpu.empty_buckets_produces_zero_output`.
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? — Reviewed `bucketize_gpu_test.cpp`. All cases use non-empty boundaries, so a new test was added.

### Tickets:
 - *175200*