### PR TITLE
[NPU] Support cross compilation correctly when NPU_PLATFORM is set by the user

### DIFF
--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/compiler_adapter_factory.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/compiler_adapter_factory.hpp
@@ -21,8 +21,6 @@ namespace intel_npu {
 
 class CompilerAdapterFactory final {
 public:
-    ov::intel_npu::CompilerType determineAppropriateCompilerTypeBasedOnPlatform(std::string_view platform) const;
-
     std::unique_ptr<ICompilerAdapter> getCompiler(
         const ov::SoPtr<IEngineBackend>& engineBackend,
         ov::intel_npu::CompilerType& compilerType,
@@ -36,6 +34,8 @@ public:
     static const std::vector<ov::intel_npu::CompilerType>& getKnownCompilerTypes();
 
 private:
+    ov::intel_npu::CompilerType determineAppropriateCompilerTypeBasedOnPlatform(std::string_view platform) const;
+
     std::pair<std::unique_ptr<ICompilerAdapter>, ov::intel_npu::CompilerType> resolvePreferPluginCompiler(
         const ov::SoPtr<IEngineBackend>& engineBackend,
         const std::shared_ptr<OptionSupportCache>& optionSupportCache,

--- a/src/plugins/intel_npu/src/compiler_adapter/src/compiler_adapter_factory.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/compiler_adapter_factory.cpp
@@ -10,16 +10,6 @@
 
 namespace intel_npu {
 
-ov::intel_npu::CompilerType CompilerAdapterFactory::determineAppropriateCompilerTypeBasedOnPlatform(
-    std::string_view platform) const {
-    if (platform == ov::intel_npu::Platform::NPU4000 || platform == ov::intel_npu::Platform::NPU5010 ||
-        platform == ov::intel_npu::Platform::NPU5020 || platform == ov::intel_npu::Platform::NPU6010) {
-        return ov::intel_npu::CompilerType::PLUGIN;
-    }
-
-    return ov::intel_npu::CompilerType::DRIVER;
-}
-
 std::unique_ptr<ICompilerAdapter> CompilerAdapterFactory::getCompiler(
     const ov::SoPtr<IEngineBackend>& engineBackend,
     ov::intel_npu::CompilerType& compilerType,
@@ -72,28 +62,39 @@ void CompilerAdapterFactory::decideCompilerType(ov::intel_npu::CompilerType& com
     compilerType = resolvePreferPluginCompiler({}, nullptr, device, platform).second;
 }
 
+ov::intel_npu::CompilerType CompilerAdapterFactory::determineAppropriateCompilerTypeBasedOnPlatform(
+    std::string_view platform) const {
+    if (platform == ov::intel_npu::Platform::NPU4000 || platform == ov::intel_npu::Platform::NPU5010 ||
+        platform == ov::intel_npu::Platform::NPU5020 || platform == ov::intel_npu::Platform::NPU6010) {
+        return ov::intel_npu::CompilerType::PLUGIN;
+    }
+
+    return ov::intel_npu::CompilerType::DRIVER;
+}
+
 std::pair<std::unique_ptr<ICompilerAdapter>, ov::intel_npu::CompilerType>
 CompilerAdapterFactory::resolvePreferPluginCompiler(const ov::SoPtr<IEngineBackend>& engineBackend,
                                                     const std::shared_ptr<OptionSupportCache>& optionSupportCache,
                                                     const std::shared_ptr<intel_npu::IDevice>& device,
                                                     std::string_view platform) const {
-    if (!device) {
-        return {nullptr, ov::intel_npu::CompilerType::PLUGIN};
-    }
-
-    if (determineAppropriateCompilerTypeBasedOnPlatform(platform) == ov::intel_npu::CompilerType::DRIVER) {
-        return {nullptr, ov::intel_npu::CompilerType::DRIVER};
-    }
-
     const auto pluginCompilerPresence = _pluginCompilerPresence.load(std::memory_order_acquire);
-    if (pluginCompilerPresence == PluginCompilerPresence::ABSENT) {
+    const bool onlineCompilation = device && (platform.empty() || device->getName() == platform);
+
+    if (onlineCompilation &&
+        determineAppropriateCompilerTypeBasedOnPlatform(platform) == ov::intel_npu::CompilerType::DRIVER) {
         return {nullptr, ov::intel_npu::CompilerType::DRIVER};
     }
 
     if (pluginCompilerPresence == PluginCompilerPresence::PRESENT) {
-        // Compiler is present, return compiler type as PLUGIN. The actual compiler will be created in getCompiler()
-        // method.
+        // The actual compiler will be created in getCompiler().
         return {nullptr, ov::intel_npu::CompilerType::PLUGIN};
+    }
+
+    if (pluginCompilerPresence == PluginCompilerPresence::ABSENT) {
+        if (onlineCompilation) {
+            return {nullptr, ov::intel_npu::CompilerType::DRIVER};
+        }
+        OPENVINO_THROW("Plugin compiler is absent for offline or cross compilation.");
     }
 
     if (pluginCompilerPresence == PluginCompilerPresence::UNKNOWN) {
@@ -106,7 +107,10 @@ CompilerAdapterFactory::resolvePreferPluginCompiler(const ov::SoPtr<IEngineBacke
             return {std::move(pluginCompiler), ov::intel_npu::CompilerType::PLUGIN};
         } catch (...) {
             _pluginCompilerPresence.store(PluginCompilerPresence::ABSENT, std::memory_order_release);
-            return {nullptr, ov::intel_npu::CompilerType::DRIVER};
+            if (onlineCompilation) {
+                return {nullptr, ov::intel_npu::CompilerType::DRIVER};
+            }
+            OPENVINO_THROW("Failed to create plugin compiler for offline or cross compilation.");
         }
     }
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin_property_manager.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin_property_manager.cpp
@@ -138,17 +138,6 @@ PluginPropertyManager::PluginPropertyManager(const std::shared_ptr<OptionsDesc>&
     }
 
     _config.parseEnvVars();
-    if (_config.get<COMPILER_TYPE>() == ov::intel_npu::CompilerType::PREFER_PLUGIN && _backend != nullptr) {
-        auto device = _backend->getDevice();
-        if (device) {
-            auto platformName = device->getName();
-            CompilerAdapterFactory compilerFactory;
-            auto compileType = compilerFactory.determineAppropriateCompilerTypeBasedOnPlatform(platformName);
-            if (compileType == ov::intel_npu::CompilerType::DRIVER) {
-                _config.update(ov::intel_npu::compiler_type.name(), COMPILER_TYPE::toString(compileType));
-            }
-        }
-    }
 
     registerProperties();
 }

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.cpp
@@ -279,45 +279,32 @@ TEST_P(ClassExecutableNetworkInvalidDeviceIDTestSuite, InvalidNPUdeviceIDTest) {
 
     auto backend = std::make_shared<::intel_npu::ZeroEngineBackend>();
     auto device = backend->getDevice();
-    if (device != nullptr && device->getName() == ov::intel_npu::Platform::AUTO_DETECT) {
-        if (is_non_negative_numeric_device_id) {
-            GTEST_SKIP()
-                << "Skip since AUTO_DETECT platform should ignore numeric suffix and find the device successfully\n";
-        }
-
-        OV_EXPECT_THROW_HAS_SUBSTRING(ov::CompiledModel compiled_model = ie.compile_model(model, deviceName),
-                                      ov::Exception,
-                                      "Compilation failed.");
-        return;
+    if (device != nullptr && device->getName() == ov::intel_npu::Platform::AUTO_DETECT &&
+        is_non_negative_numeric_device_id) {
+        GTEST_SKIP()
+            << "Skip since AUTO_DETECT platform should ignore numeric suffix and find the device successfully\n";
     }
 
-    OV_EXPECT_THROW_HAS_SUBSTRING(ov::CompiledModel compiled_model = ie.compile_model(model, deviceName),
-                                  ov::Exception,
-                                  "Could not find a valid NPU device for the provided configuration.");
+    OV_EXPECT_THROW_HAS_SUBSTRING(ie.compile_model(model, deviceName), ov::Exception, "Compilation failed.");
 }
 
 using CheckCompilerTypeProperty = ClassExecutableNetworkGetPropertiesTestNPU;
 
 TEST_P(CheckCompilerTypeProperty, CheckCompilerTypePropertyFromCompiledModel) {
-    std::string platform = ov::test::utils::getTestsPlatformFromEnvironmentOr(deviceName);
-    const std::vector<std::string> plugin_compiler_platforms = {"4000", "5010", "5020", "6010"};
-    bool is_plugin_compiler_platform = false;
-    for (const auto& p : plugin_compiler_platforms) {
-        if (platform.find(p) != std::string::npos) {
-            is_plugin_compiler_platform = true;
-            break;
-        }
-    }
     ov::Core core;
-
     ov::CompiledModel compiled_model;
+
+    auto backend = std::make_shared<::intel_npu::ZeroEngineBackend>();
+    auto device = backend->getDevice();
+    auto platform = device->getName();
+
     OV_ASSERT_NO_THROW(compiled_model = core.compile_model(model, deviceName));
     auto compiler_type = compiled_model.get_property(ov::intel_npu::compiler_type);
 
-    if (is_plugin_compiler_platform) {
-        ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::PLUGIN);
-    } else {
+    if (platform == ov::intel_npu::Platform::NPU3720 || platform == ov::intel_npu::Platform::AUTO_DETECT) {
         ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::DRIVER);
+    } else {
+        ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::PLUGIN);
     }
 
     OV_ASSERT_NO_THROW(
@@ -326,27 +313,19 @@ TEST_P(CheckCompilerTypeProperty, CheckCompilerTypePropertyFromCompiledModel) {
     compiler_type = compiled_model.get_property(ov::intel_npu::compiler_type);
     ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::DRIVER);
 
-    if (is_plugin_compiler_platform) {
-        OV_ASSERT_NO_THROW(compiled_model =
-                               core.compile_model(model,
-                                                  deviceName,
-                                                  {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN)}));
-        compiler_type = compiled_model.get_property(ov::intel_npu::compiler_type);
-        ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::PLUGIN);
-    }
+    OV_ASSERT_NO_THROW(
+        compiled_model =
+            core.compile_model(model, deviceName, {ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::PLUGIN)}));
+    compiler_type = compiled_model.get_property(ov::intel_npu::compiler_type);
+    ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::PLUGIN);
 }
 
 TEST_P(CheckCompilerTypeProperty, CheckCompilerTypePropertyAfterSettingExtraConfigToGetProperty) {
-    std::string platform = ov::test::utils::getTestsPlatformFromEnvironmentOr(deviceName);
-    const std::vector<std::string> plugin_compiler_platforms = {"4000", "5010", "5020", "6010"};
-    bool is_plugin_compiler_platform = false;
-    for (const auto& p : plugin_compiler_platforms) {
-        if (platform.find(p) != std::string::npos) {
-            is_plugin_compiler_platform = true;
-            break;
-        }
-    }
     ov::Core core;
+
+    auto backend = std::make_shared<::intel_npu::ZeroEngineBackend>();
+    auto device = backend->getDevice();
+    auto platform = device->getName();
 
     auto test_custom_compiler_type =
         core.get_property(deviceName,
@@ -355,20 +334,16 @@ TEST_P(CheckCompilerTypeProperty, CheckCompilerTypePropertyAfterSettingExtraConf
     ASSERT_TRUE(test_custom_compiler_type == ov::intel_npu::CompilerType::DRIVER);
 
     test_custom_compiler_type = core.get_property(deviceName, ov::intel_npu::compiler_type);
-    if (is_plugin_compiler_platform) {
-        ASSERT_TRUE(test_custom_compiler_type == ov::intel_npu::CompilerType::PREFER_PLUGIN);
-    } else {
-        ASSERT_TRUE(test_custom_compiler_type == ov::intel_npu::CompilerType::DRIVER);
-    }
+    ASSERT_TRUE(test_custom_compiler_type == ov::intel_npu::CompilerType::PREFER_PLUGIN);
 
     ov::CompiledModel compiled_model;
     OV_ASSERT_NO_THROW(compiled_model = core.compile_model(model, deviceName));
     auto compiler_type = compiled_model.get_property(ov::intel_npu::compiler_type);
 
-    if (is_plugin_compiler_platform) {
-        ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::PLUGIN);
-    } else {
+    if (platform == ov::intel_npu::Platform::NPU3720 || platform == ov::intel_npu::Platform::AUTO_DETECT) {
         ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::DRIVER);
+    } else {
+        ASSERT_TRUE(compiler_type == ov::intel_npu::CompilerType::PLUGIN);
     }
 }
 

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/cross_compilation.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/cross_compilation.cpp
@@ -76,7 +76,8 @@ TEST_P(CrossCompilationNPU, CrossCompilationTest) {
             compiledModel.get_property(ov::intel_npu::compiler_type.name()).as<ov::intel_npu::CompilerType>());
 
     if (target_platform == ov::intel_npu::Platform::AUTO_DETECT &&
-        device_platform == ov::intel_npu::Platform::NPU3720) {
+        (device_platform == ov::intel_npu::Platform::NPU3720 ||
+         device_platform == ov::intel_npu::Platform::AUTO_DETECT)) {
         EXPECT_EQ(compiler_type, ov::intel_npu::CompilerType::DRIVER);
     } else {
         EXPECT_EQ(compiler_type, ov::intel_npu::CompilerType::PLUGIN);
@@ -102,7 +103,8 @@ TEST_P(CrossCompilationNPU, OnlineCompilationTest) {
 
     if (target_platform == ov::intel_npu::Platform::NPU3720 ||
         (target_platform == ov::intel_npu::Platform::AUTO_DETECT &&
-         device_platform == ov::intel_npu::Platform::NPU3720)) {
+         (device_platform == ov::intel_npu::Platform::NPU3720 ||
+          device_platform == ov::intel_npu::Platform::AUTO_DETECT))) {
         EXPECT_EQ(compiler_type, ov::intel_npu::CompilerType::DRIVER);
     } else {
         EXPECT_EQ(compiler_type, ov::intel_npu::CompilerType::PLUGIN);

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/cross_compilation.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/cross_compilation.cpp
@@ -1,0 +1,127 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
+#include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
+#include "intel_npu/common/npu.hpp"
+#include "intel_npu/npu_private_properties.hpp"
+#include "openvino/runtime/intel_npu/properties.hpp"
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
+#include "zero_backend.hpp"
+
+namespace ov {
+namespace test {
+namespace behavior {
+
+using CrossCompilationParams = std::tuple<std::string, ov::AnyMap>;
+
+class CrossCompilationNPU : public OVPluginTestBase, public testing::WithParamInterface<CrossCompilationParams> {
+public:
+    void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
+        std::tie(target_device, config) = this->GetParam();
+
+        model = ov::test::utils::make_multi_single_conv();
+
+        APIBaseTest::SetUp();
+    }
+
+    static std::string getTestCaseName(const testing::TestParamInfo<CrossCompilationParams>& obj) {
+        std::string target_device;
+        ov::AnyMap config;
+        std::tie(target_device, config) = obj.param;
+        std::ostringstream result;
+        result << "targetDevice=" << target_device << "_";
+
+        if (!config.empty()) {
+            for (auto& configItem : config) {
+                result << "configItem=" << configItem.first << "_";
+                configItem.second.print(result);
+            }
+        }
+        return result.str();
+    }
+
+    void TearDown() override {
+        APIBaseTest::TearDown();
+    }
+
+protected:
+    ov::Core core;
+    ov::AnyMap config;
+    std::shared_ptr<ov::Model> model;
+};
+
+TEST_P(CrossCompilationNPU, CrossCompilationTest) {
+    auto backend = std::make_shared<::intel_npu::ZeroEngineBackend>();
+    auto device_platform = backend->getDevice()->getName();
+    auto target_platform = config[ov::intel_npu::platform.name()].as<std::string>();
+
+    if (device_platform == target_platform) {
+        GTEST_SKIP() << "Device platform matches target platform.";
+    }
+
+    ov::CompiledModel compiledModel;
+    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(model, target_device, config));
+
+    ov::intel_npu::CompilerType compiler_type = ov::intel_npu::CompilerType::PREFER_PLUGIN;
+    OV_ASSERT_NO_THROW(
+        compiler_type =
+            compiledModel.get_property(ov::intel_npu::compiler_type.name()).as<ov::intel_npu::CompilerType>());
+
+    if (target_platform == ov::intel_npu::Platform::AUTO_DETECT &&
+        device_platform == ov::intel_npu::Platform::NPU3720) {
+        EXPECT_EQ(compiler_type, ov::intel_npu::CompilerType::DRIVER);
+    } else {
+        EXPECT_EQ(compiler_type, ov::intel_npu::CompilerType::PLUGIN);
+    }
+}
+
+TEST_P(CrossCompilationNPU, OnlineCompilationTest) {
+    auto backend = std::make_shared<::intel_npu::ZeroEngineBackend>();
+    auto device_platform = backend->getDevice()->getName();
+    auto target_platform = config[ov::intel_npu::platform.name()].as<std::string>();
+
+    if (device_platform != target_platform && target_platform != ov::intel_npu::Platform::AUTO_DETECT) {
+        GTEST_SKIP() << "Device platform does not match target platform.";
+    }
+
+    ov::CompiledModel compiledModel;
+    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(model, target_device, config));
+
+    ov::intel_npu::CompilerType compiler_type = ov::intel_npu::CompilerType::PREFER_PLUGIN;
+    OV_ASSERT_NO_THROW(
+        compiler_type =
+            compiledModel.get_property(ov::intel_npu::compiler_type.name()).as<ov::intel_npu::CompilerType>());
+
+    if (target_platform == ov::intel_npu::Platform::NPU3720 ||
+        (target_platform == ov::intel_npu::Platform::AUTO_DETECT &&
+         device_platform == ov::intel_npu::Platform::NPU3720)) {
+        EXPECT_EQ(compiler_type, ov::intel_npu::CompilerType::DRIVER);
+    } else {
+        EXPECT_EQ(compiler_type, ov::intel_npu::CompilerType::PLUGIN);
+    }
+}
+
+const std::vector<ov::AnyMap> config = {{ov::intel_npu::platform(ov::intel_npu::Platform::AUTO_DETECT)},
+                                        {ov::intel_npu::platform(ov::intel_npu::Platform::NPU3720)},
+                                        {ov::intel_npu::platform(ov::intel_npu::Platform::NPU4000)},
+                                        {ov::intel_npu::platform(ov::intel_npu::Platform::NPU5010)},
+                                        {ov::intel_npu::platform(ov::intel_npu::Platform::NPU5020)},
+                                        {ov::intel_npu::platform(ov::intel_npu::Platform::NPU6010)}};
+
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
+                         CrossCompilationNPU,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(config)),
+                         ov::test::utils::appendPlatformTypeTestName<CrossCompilationNPU>);
+
+}  // namespace behavior
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - *Support cross compilation correctly when NPU_PLATFORM is set by the user*
 - NPU_PLATFORM will override any other existing configuration related to the online device during compilation and will try to compile for that platform using Compiler In Plugin.
 
### Tickets:
 - *CVS-194377*

### AI Assistance:
 - *AI assistance used: no*