### PR TITLE
[core] Add util to define common interface OV internal memory representation

### DIFF
--- a/src/common/util/CMakeLists.txt
+++ b/src/common/util/CMakeLists.txt
@@ -71,13 +71,14 @@ target_sources(${TARGET_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/src/log.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/memory_prefetch.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/memory_prefetch.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/mmap_object.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/native_stream.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/native_streambuf.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/parallel_read_streambuf.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/xml_parse_utils.cpp
         # Windows specific sources
         "$<$<BOOL:${WIN32}>:${WIN32_SOURCES}>"
-         # Unix specific sources
+        # Unix specific sources
         "$<$<BOOL:${UNIX}>:${UNIX_SOURCES}>"
 )
 

--- a/src/common/util/include/openvino/util/memory.hpp
+++ b/src/common/util/include/openvino/util/memory.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 #include <system_error>
 
@@ -122,9 +123,7 @@ void vm_release(void* ptr, size_t size) noexcept;
  * @brief Queryable facts about a memory buffer's allocation, set once at construction/mapping time.
  */
 struct MemoryProperties {
-    /// @brief Opaque id of the buffer's ultimate backing allocation (e.g. weight-sharing/mmap root). 0 == unknown.
-    size_t source_id = 0;
-    /// @brief This buffer's byte offset within the source_id allocation. Meaningless when source_id == 0.
+    /// @brief This buffer's byte offset within the buffer identified by IBuffer::get_id().
     size_t offset = 0;
 };
 
@@ -153,32 +152,43 @@ private:
 };
 
 /**
+ * @brief Optional capability: hints for managing a buffer's physical-memory residency.
+ */
+class IMemoryHints {
+public:
+    virtual ~IMemoryHints() = default;
+
+    /// @brief Hint to release the underlying memory if possible (e.g. unmaps/decommits).
+    virtual void hint_evict() noexcept = 0;
+    /// @brief Hint to fetch the data to memory.
+    virtual void hint_prefetch() const = 0;
+};
+
+/**
  * @brief Common, read-only access to a contiguous block of memory plus its properties.
  */
-class IBuffer {
+class IBuffer : public IMemoryHints {
 public:
-    // Declared first so new virtual methods always append after it, keeping this slot stable.
     virtual ~IBuffer() = default;
 
-    virtual const void* data() const noexcept = 0;
+    virtual const std::byte* data() const noexcept = 0;
     virtual size_t size() const noexcept = 0;
     virtual const MemoryProperties& get_properties() const noexcept = 0;
 
-    /// @brief Read-only view for bulk reads/copies (e.g. memcpy, std::copy); not virtual, built on data()/size().
-    MemoryView view() const noexcept {
-        return {static_cast<const std::byte*>(data()), size()};
+    /// @brief Typed reinterpretation of data(), e.g. data_as<char>() for APIs needing pointer arithmetic.
+    template <typename T>
+    const T* data_as() const noexcept {
+        return reinterpret_cast<const T*>(data());
     }
 
-    /// @brief Hint to release the underlying memory if possible (e.g. unmaps/decommits); no-op by default.
-    virtual void hint_evict() noexcept {}
-    /**
-     * @brief Hint to fetch the data to memory. No-op by default.
-     */
-    virtual void hint_prefetch() const {}
+    /// @brief Read-only view for bulk reads/copies (e.g. memcpy, std::copy); not virtual, built on data()/size().
+    MemoryView view() const noexcept {
+        return {data(), size()};
+    }
 
-    /// @brief Buffer this one is a view into (see MemoryProperties::source_id/offset), if any. Default: none.
-    virtual std::shared_ptr<IBuffer> get_source_buffer() const {
-        return nullptr;
+    /// @brief Buffer ID, Default: no id.
+    virtual std::optional<uint64_t> get_id() const noexcept {
+        return std::nullopt;
     }
 };
 
@@ -188,23 +198,12 @@ public:
 class IMutableBuffer : public IBuffer {
 public:
     using IBuffer::data;
-    virtual void* data() noexcept = 0;
-};
+    using IBuffer::data_as;
+    virtual std::byte* data() noexcept = 0;
 
-/**
- * @brief CRTP mixin adding typed pointer-cast convenience (data_as<T>()) to a type exposing data()/data()
- * const.
- */
-template <typename Derived>
-class TypedMemoryAccessor {
-public:
     template <typename T>
-    constexpr const T* data_as() const noexcept {
-        return reinterpret_cast<const T*>(static_cast<const Derived*>(this)->Derived::data());
-    }
-    template <typename T>
-    constexpr T* data_as() noexcept {
-        return reinterpret_cast<T*>(static_cast<Derived*>(this)->Derived::data());
+    T* data_as() noexcept {
+        return reinterpret_cast<T*>(data());
     }
 };
 

--- a/src/common/util/include/openvino/util/memory.hpp
+++ b/src/common/util/include/openvino/util/memory.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <memory>
 #include <string>
 #include <system_error>
 
@@ -116,4 +117,95 @@ void vm_decommit(void* ptr, size_t size) noexcept;
  * @pre  ptr != nullptr && size > 0; violated preconditions are a programming error (assert fires in debug).
  */
 void vm_release(void* ptr, size_t size) noexcept;
+
+/**
+ * @brief Queryable facts about a memory buffer's allocation, set once at construction/mapping time.
+ */
+struct MemoryProperties {
+    /// @brief Opaque id of the buffer's ultimate backing allocation (e.g. weight-sharing/mmap root). 0 == unknown.
+    size_t source_id = 0;
+    /// @brief This buffer's byte offset within the source_id allocation. Meaningless when source_id == 0.
+    size_t offset = 0;
+};
+
+/// @brief Read-only, non-owning view (pointer + size) of a buffer's contents.
+class MemoryView {
+public:
+    constexpr MemoryView() noexcept = default;
+    constexpr MemoryView(const std::byte* data, size_t size) noexcept : m_data{data}, m_size{size} {}
+
+    constexpr const std::byte* data() const noexcept {
+        return m_data;
+    }
+    constexpr size_t size() const noexcept {
+        return m_size;
+    }
+    constexpr const std::byte* begin() const noexcept {
+        return data();
+    }
+    constexpr const std::byte* end() const noexcept {
+        return data() + size();
+    }
+
+private:
+    const std::byte* m_data = nullptr;
+    size_t m_size = 0;
+};
+
+/**
+ * @brief Common, read-only access to a contiguous block of memory plus its properties.
+ */
+class IBuffer {
+public:
+    // Declared first so new virtual methods always append after it, keeping this slot stable.
+    virtual ~IBuffer() = default;
+
+    virtual const void* data() const noexcept = 0;
+    virtual size_t size() const noexcept = 0;
+    virtual const MemoryProperties& get_properties() const noexcept = 0;
+
+    /// @brief Read-only view for bulk reads/copies (e.g. memcpy, std::copy); not virtual, built on data()/size().
+    MemoryView view() const noexcept {
+        return {static_cast<const std::byte*>(data()), size()};
+    }
+
+    /// @brief Hint to release the underlying memory if possible (e.g. unmaps/decommits); no-op by default.
+    virtual void hint_evict() noexcept {}
+    /**
+     * @brief Hint to fetch the data to memory. No-op by default.
+     */
+    virtual void hint_prefetch() const {}
+
+    /// @brief Buffer this one is a view into (see MemoryProperties::source_id/offset), if any. Default: none.
+    virtual std::shared_ptr<IBuffer> get_source_buffer() const {
+        return nullptr;
+    }
+};
+
+/**
+ * @brief Extends IBuffer with mutable access.
+ */
+class IMutableBuffer : public IBuffer {
+public:
+    using IBuffer::data;
+    virtual void* data() noexcept = 0;
+};
+
+/**
+ * @brief CRTP mixin adding typed pointer-cast convenience (data_as<T>()) to a type exposing data()/data()
+ * const.
+ */
+template <typename Derived>
+class TypedMemoryAccessor {
+public:
+    template <typename T>
+    constexpr const T* data_as() const noexcept {
+        return reinterpret_cast<const T*>(static_cast<const Derived*>(this)->Derived::data());
+    }
+    template <typename T>
+    constexpr T* data_as() noexcept {
+        return reinterpret_cast<T*>(static_cast<Derived*>(this)->Derived::data());
+    }
+};
+
 }  // namespace ov::util

--- a/src/common/util/include/openvino/util/mmap_object.hpp
+++ b/src/common/util/include/openvino/util/mmap_object.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <filesystem>
 #include <fstream>
 #include <limits>
@@ -52,13 +53,22 @@ inline constexpr uint64_t no_mapping_id = 0;
  * Instead of reading files, we can map the memory via mmap for Linux or MapViewOfFile for Windows.
  * The MappedMemory class is a abstraction to handle such memory with os-dependent details.
  */
-class MappedMemory {
+class MappedMemory : public util::IMutableBuffer {
 public:
-    virtual char* data() noexcept = 0;
-    virtual size_t size() const noexcept = 0;
-    virtual uint64_t get_id() const noexcept = 0;
-    virtual ~MappedMemory() = default;
+    using util::IMemoryHints::hint_prefetch;
+    using util::IMutableBuffer::data;
+
+    ~MappedMemory() override = default;
+
+    virtual const std::byte* data() const noexcept override = 0;
+    virtual std::byte* data() noexcept override = 0;
+
+    virtual size_t size() const noexcept override = 0;
+    const util::MemoryProperties& get_properties() const noexcept final;
+
     virtual void hint_evict(size_t offset = 0, size_t size = auto_size) noexcept = 0;
+    void hint_evict() noexcept final;
+
     /**
      * @brief Hint that the given region of the mapping will be accessed soon.
      *
@@ -67,9 +77,10 @@ public:
      *               mapping when set to auto_size.
      */
     virtual void hint_prefetch(size_t offset = 0, size_t size = auto_size) = 0;
+    void hint_prefetch() const final;
 
     /**
-     * @brief Asynchronous variant of @ref hint_prefetch: starts populating the given region in the
+     * @brief Asynchronous variant of @ref hint_prefetch: starts populating the region in the
      * background and returns immediately. Any background work is joined before this object is
      * destroyed.
      *

--- a/src/common/util/src/mmap_object.cpp
+++ b/src/common/util/src/mmap_object.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/util/mmap_object.hpp"
+
+namespace ov {
+
+const util::MemoryProperties& MappedMemory::get_properties() const noexcept {
+    static const util::MemoryProperties instance{};
+    return instance;
+}
+
+void MappedMemory::hint_evict() noexcept {
+    hint_evict(0, auto_size);
+}
+
+// A hint may always no-op; the ranged, stateful hint_prefetch(offset, size) is the real API.
+void MappedMemory::hint_prefetch() const {}
+
+}  // namespace ov

--- a/src/common/util/src/os/lin/lin_mmap_object.cpp
+++ b/src/common/util/src/os/lin/lin_mmap_object.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <future>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <tuple>
 
@@ -108,9 +109,9 @@ public:
 class MapHolder final : public MappedMemory {
     void* m_mapped_view = MAP_FAILED;
     size_t m_mapped_view_size = 0;
-    void* m_data = nullptr;
+    std::byte* m_data = nullptr;
     size_t m_size = 0;
-    uint64_t m_id = std::numeric_limits<uint64_t>::max();
+    std::optional<uint64_t> m_id;
     HandleHolder m_handle;
     // Tasks adopted from hint_prefetch_async()'s token; joined before unmapping (see ~MapHolder).
     std::mutex m_pending_prefetch_mutex;
@@ -153,7 +154,8 @@ public:
                                      " for mapping. Ensure that file exists and has appropriate permissions.");
         }
         set_from_fd(fd, offset, size, mmap_mode);
-        m_id = (mmap_mode == MmapMode::READ_WRITE) ? no_mapping_id : util::get_id_for_file(path, offset, size);
+        m_id = (mmap_mode == MmapMode::READ_WRITE) ? std::nullopt
+                                                   : std::optional<uint64_t>(util::get_id_for_file(path, offset, size));
     }
 
     void set_from_fd(const int fd, const size_t offset, const size_t size, const MmapMode mmap_mode = MmapMode::READ) {
@@ -178,16 +180,16 @@ public:
                 throw std::runtime_error("Can not create file mapping for " + std::to_string(fd) +
                                          ", err=" + std::strerror(errno));
             }
-            m_data = static_cast<char*>(m_mapped_view) + gap;
+            m_data = static_cast<std::byte*>(m_mapped_view) + gap;
         }
         // A read-write mapping is not an immutable data source, so it must not be shared through id-based caches.
         m_id = (mmap_mode == MmapMode::READ_WRITE)
-                   ? no_mapping_id
-                   : util::u64_hash_combine(static_cast<uint64_t>(sb.st_ino),
-                                            {static_cast<uint64_t>(sb.st_dev), offset, size});
+                   ? std::nullopt
+                   : std::optional<uint64_t>(util::u64_hash_combine(static_cast<uint64_t>(sb.st_ino),
+                                                                    {static_cast<uint64_t>(sb.st_dev), offset, size}));
     }
 
-    uint64_t get_id() const noexcept override {
+    std::optional<uint64_t> get_id() const noexcept override {
         return m_id;
     }
 
@@ -199,11 +201,15 @@ public:
         }
     }
 
-    char* data() noexcept override {
-        return static_cast<char*>(m_data);
+    const std::byte* data() const noexcept override final {
+        return m_data;
     }
 
-    size_t size() const noexcept override {
+    std::byte* data() noexcept override final {
+        return m_data;
+    }
+
+    size_t size() const noexcept override final {
         return m_size;
     }
 

--- a/src/common/util/src/os/win/win_mmap_object.cpp
+++ b/src/common/util/src/os/win/win_mmap_object.cpp
@@ -8,6 +8,7 @@
 #include <future>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <stdexcept>
 #include <thread>
@@ -283,7 +284,7 @@ public:
     }
 };
 
-class MapHolder : public ov::MappedMemory {
+class MapHolder final : public ov::MappedMemory {
 public:
     MapHolder() = default;
     ~MapHolder() override;
@@ -297,14 +298,17 @@ public:
     bool try_remap_slot(uintptr_t fault_addr);
 
     // ov::MappedMemory interface
-    char* data() noexcept override {
-        return static_cast<char*>(m_data);
+    const std::byte* data() const noexcept override final {
+        return m_data;
     }
-    size_t size() const noexcept override {
+    std::byte* data() noexcept override final {
+        return m_data;
+    }
+    size_t size() const noexcept override final {
         return m_size;
     }
 
-    uint64_t get_id() const noexcept override {
+    std::optional<uint64_t> get_id() const noexcept override {
         return m_id;
     }
 
@@ -375,9 +379,9 @@ private:
                                 size_t file_tail_offset,
                                 size_t tail_data_size);
 
-    void* m_data{};   //!< pointer exposed to callers
-    size_t m_size{};  //!< user-visible byte count
-    uint64_t m_id{std::numeric_limits<uint64_t>::max()};
+    std::byte* m_data{};  //!< pointer exposed to callers
+    size_t m_size{};      //!< user-visible byte count
+    std::optional<uint64_t> m_id;
 
     HandleHolder m_handle{};       //!< section object from CreateFileMappingW
     HandleHolder m_file_handle{};  //!< file HANDLE kept open to block DeleteFile (set-by-path only)
@@ -614,7 +618,7 @@ bool MapHolder::try_placeholder_setup(size_t aligned_offset, size_t head_pad, si
     m_view_base = base;
     m_total_va_size = total_va_size;
     m_file_mapped_size = actual_map_size;
-    m_data = base + head_pad;
+    m_data = reinterpret_cast<std::byte*>(base + head_pad);
     return true;
 }
 
@@ -626,7 +630,7 @@ void MapHolder::legacy_setup(size_t aligned_offset, size_t head_pad, size_t size
                                     static_cast<DWORD>(aligned_offset & 0xFFFFFFFF),
                                     head_pad + size)) {
         m_view_base = static_cast<char*>(view);
-        m_data = m_view_base + head_pad;
+        m_data = reinterpret_cast<std::byte*>(m_view_base + head_pad);
     } else {
         throw std::runtime_error{"MapViewOfFile failed: " + std::to_string(::GetLastError())};
     }
@@ -653,7 +657,7 @@ void MapHolder::setup(HANDLE file_handle, size_t offset, size_t size, bool no_pl
     set_id(file_handle, offset, size);
     if (mode == MmapMode::READ_WRITE) {
         // A read-write mapping is not an immutable data source, so it must not be shared through id-based caches.
-        m_id = no_mapping_id;
+        m_id = std::nullopt;
     }
 
     if (m_size == 0) {
@@ -860,7 +864,7 @@ std::pair<char*, char*> MapHolder::compute_evict_range(size_t offset, size_t siz
     const auto gran = util::get_system_alloc_granularity();
 
     // Convert user [offset, size) to a VA range relative to m_view_base.
-    const size_t head_pad = static_cast<size_t>(static_cast<char*>(m_data) - m_view_base);
+    const size_t head_pad = static_cast<size_t>(reinterpret_cast<char*>(m_data) - m_view_base);
     const size_t va_begin_raw = head_pad + clamped_offset;
     if (va_begin_raw >= m_total_va_size)
         return {};

--- a/src/core/dev_api/openvino/runtime/shared_buffer.hpp
+++ b/src/core/dev_api/openvino/runtime/shared_buffer.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <type_traits>
 
 #include "openvino/runtime/aligned_buffer.hpp"
@@ -140,6 +141,16 @@ public:
 
     SharedBuffer(char* data, size_t size, const T& shared_object)
         : SharedBuffer(data, size, shared_object, get_or_make_descriptor(shared_object)) {}
+
+    // std::byte* overloads so callers holding an IBuffer::data()-style pointer don't need to cast.
+    SharedBuffer(std::byte* data,
+                 size_t size,
+                 const T& shared_object,
+                 const std::shared_ptr<IBufferDescriptor>& descriptor)
+        : SharedBuffer(reinterpret_cast<char*>(data), size, shared_object, descriptor) {}
+
+    SharedBuffer(std::byte* data, size_t size, const T& shared_object)
+        : SharedBuffer(reinterpret_cast<char*>(data), size, shared_object) {}
 };
 
 /// \brief SharedStreamBuffer class to store pointer to pre-allocated buffer and provide streambuf interface.

--- a/src/core/src/runtime/shared_buffer.cpp
+++ b/src/core/src/runtime/shared_buffer.cpp
@@ -66,6 +66,6 @@ protected:
 std::shared_ptr<ov::IBufferDescriptor> ov::detail::create_mmap_descriptor(
     const std::shared_ptr<ov::MappedMemory>& mmap) {
     return std::make_shared<MMapDescriptor>(std::weak_ptr<ov::MappedMemory>(mmap),
-                                            mmap ? static_cast<size_t>(mmap->get_id()) : 0);
+                                            mmap ? static_cast<size_t>(mmap->get_id().value_or(0)) : 0);
 }
 }  // namespace ov

--- a/src/core/src/runtime/tensor.cpp
+++ b/src/core/src/runtime/tensor.cpp
@@ -233,7 +233,7 @@ Tensor read_tensor_data_mmap_impl(std::shared_ptr<MappedMemory> mapped_memory,
                                                                                              mapped_memory->size(),
                                                                                              mapped_memory);
     auto tensor = wrap_obj_to_viewtensor(shared_buffer, shared_buffer->get_ptr(), element_type, static_shape);
-    set_tensor_source_id(tensor, mapped_memory->get_id());
+    set_tensor_source_id(tensor, mapped_memory->get_id().value_or(0));
     return tensor;
 }
 }  // namespace

--- a/src/core/src/weight_sharing_util.cpp
+++ b/src/core/src/weight_sharing_util.cpp
@@ -159,15 +159,16 @@ std::shared_ptr<ov::AlignedBuffer> get_buffer(const Context& shared_context,
                                               const std::shared_ptr<ov::MappedMemory>& source_buffer,
                                               const DataID constant_id) {
     if (source_buffer) {
-        if (const auto meta_data =
-                get_constant_meta(shared_context.m_weight_registry, source_buffer->get_id(), constant_id)) {
-            OPENVINO_ASSERT(meta_data->m_offset <= source_buffer->size() &&
-                                meta_data->m_size <= source_buffer->size() - meta_data->m_offset,
-                            "WeightlessCacheAttribute offset/size is out of bounds for source buffer");
-            return std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
-                source_buffer->data() + meta_data->m_offset,
-                meta_data->m_size,
-                source_buffer);
+        if (const auto source_id = source_buffer->get_id()) {
+            if (const auto meta_data = get_constant_meta(shared_context.m_weight_registry, *source_id, constant_id)) {
+                OPENVINO_ASSERT(meta_data->m_offset <= source_buffer->size() &&
+                                    meta_data->m_size <= source_buffer->size() - meta_data->m_offset,
+                                "WeightlessCacheAttribute offset/size is out of bounds for source buffer");
+                return std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
+                    source_buffer->data() + meta_data->m_offset,
+                    meta_data->m_size,
+                    source_buffer);
+            }
         }
     }
     return nullptr;

--- a/src/core/tests/file_load_benchmark.cpp
+++ b/src/core/tests/file_load_benchmark.cpp
@@ -206,7 +206,7 @@ void sync_vm_prefetch_mem_lock(const std::filesystem::path& path, size_t /*file_
 void loop_touch_mem_lock(const std::filesystem::path& path, size_t /*file_size*/) {
     auto mapped = load_mmap_object(path);
     volatile uint8_t sink = 0;
-    for (auto first = mapped->data(), last = first + mapped->size(); first < last; first += page_size) {
+    for (auto *first = mapped->data_as<uint8_t>(), *last = first + mapped->size(); first < last; first += page_size) {
         sink += *first;
     }
     ensure_memory_resident(mapped);  // should be near no-op and just lock/unlock resident pages

--- a/src/core/tests/mmap_object.cpp
+++ b/src/core/tests/mmap_object.cpp
@@ -175,8 +175,10 @@ TEST_P(RangedMappingTest, compare_data) {
 
     EXPECT_EQ(mm_1->size(), m_sector_1.size());
     EXPECT_EQ(mm_2->size(), m_sector_2.size());
-    EXPECT_EQ(m_sector_1, std::vector<char>(mm_1->data(), mm_1->data() + mm_1->size()));
-    EXPECT_EQ(m_sector_2, std::vector<char>(mm_2->data(), mm_2->data() + mm_2->size()));
+    const auto mm_1_data = mm_1->data_as<char>();
+    const auto mm_2_data = mm_2->data_as<char>();
+    EXPECT_EQ(m_sector_1, std::vector<char>(mm_1_data, mm_1_data + mm_1->size()));
+    EXPECT_EQ(m_sector_2, std::vector<char>(mm_2_data, mm_2_data + mm_2->size()));
 }
 
 TEST_P(RangedMappingTest, compare_id) {
@@ -287,8 +289,8 @@ TEST_F(ReadWriteMappingTest, read_write_mappings_report_no_mapping_id) {
     ASSERT_NE(rw_whole, nullptr);
     ASSERT_NE(rw_part, nullptr);
 
-    EXPECT_EQ(rw_whole->get_id(), no_mapping_id);
-    EXPECT_EQ(rw_part->get_id(), no_mapping_id);
+    EXPECT_EQ(rw_whole->get_id(), std::nullopt);
+    EXPECT_EQ(rw_part->get_id(), std::nullopt);
 }
 
 class HintEvictTest : public ::testing::Test {
@@ -515,9 +517,9 @@ TEST_F(HintPrefetchTest, hint_prefetch_sequential_eviction_check) {
     }
 
     auto mapped = load_mmap_object(m_file_path);
-    volatile char sink = 0;
+    volatile std::byte sink{};
     for (size_t i = 0; i < prefix_size; i += page) {
-        sink += mapped->data()[i];
+        sink = sink | mapped->data()[i];
     }
     const size_t pages_before = utils::count_resident_pages(mapped->data(), prefix_size);
     ASSERT_EQ(pages_before, total_prefix_pages)
@@ -590,7 +592,7 @@ TEST_F(HintPrefetchAsyncTest, pages_resident_eventually) {
 
     mapped->hint_prefetch_async();
 
-    const size_t pages_resident = wait_for_resident_pages(mapped->data(), file_size, total_pages);
+    const size_t pages_resident = wait_for_resident_pages(mapped->data_as<char>(), file_size, total_pages);
     EXPECT_EQ(pages_resident, total_pages) << "Expected all pages resident after hint_prefetch_async().";
 }
 
@@ -631,7 +633,7 @@ TEST_F(HintPrefetchAsyncTest, partial_region_populated_and_correct) {
     mapped->hint_prefetch_async(prefetch_offset, prefetch_size);
 
     const size_t pages_resident =
-        wait_for_resident_pages(mapped->data() + prefetch_offset, prefetch_size, region_pages);
+        wait_for_resident_pages(mapped->data_as<char>() + prefetch_offset, prefetch_size, region_pages);
     EXPECT_EQ(pages_resident, region_pages) << "Expected the requested region to be fully resident.";
 
     EXPECT_EQ(read_mapped(*mapped), data);

--- a/src/core/tests/shared_buffer.cpp
+++ b/src/core/tests/shared_buffer.cpp
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <sstream>
 #include <vector>
 
@@ -519,17 +520,20 @@ TEST_F(SharedBufferTest, specialization_overload_resolution) {
     }
 }
 
-class MockMappedMemory : public ov::MappedMemory {
+class MockMappedMemory final : public ov::MappedMemory {
 public:
     explicit MockMappedMemory(size_t size) : m_data(size, '\0'), m_id(1) {}
 
-    char* data() noexcept override {
-        return m_data.data();
+    const std::byte* data() const noexcept override final {
+        return reinterpret_cast<const std::byte*>(m_data.data());
     }
-    size_t size() const noexcept override {
+    std::byte* data() noexcept override final {
+        return reinterpret_cast<std::byte*>(m_data.data());
+    }
+    size_t size() const noexcept override final {
         return m_data.size();
     }
-    uint64_t get_id() const noexcept override {
+    std::optional<uint64_t> get_id() const noexcept override {
         return m_id;
     }
 

--- a/src/core/tests/weight_sharing_util_test.cpp
+++ b/src/core/tests/weight_sharing_util_test.cpp
@@ -422,8 +422,10 @@ TEST_F(WeightShareExtensionTest, get_buffer_by_mmap_oob_throws) {
     weight_sharing::Context ctx;
     auto mmap = ov::load_mmap_object(weights_path);
     ASSERT_TRUE(mmap);
+    const auto mmap_id = mmap->get_id();
+    ASSERT_TRUE(mmap_id.has_value());
     const weight_sharing::DataID const_id = 0;
-    ctx.m_weight_registry[mmap->get_id()][const_id] = {0, 0x1000000000ULL, element::f32};
+    ctx.m_weight_registry[mmap_id.value()][const_id] = {0, 0x1000000000ULL, element::f32};
 
     OV_EXPECT_THROW(weight_sharing::get_buffer(ctx, mmap, const_id), ov::Exception, testing::_);
 }

--- a/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph_iterator_proto.cpp
@@ -374,8 +374,7 @@ bool extract_tensor_external_data(ov::frontend::onnx::TensorMetaInfo& tensor_met
             (*cache)[full_path] = mapped_memory;
         }
         tensor_meta_info.m_is_raw = true;
-        tensor_meta_info.m_tensor_data =
-            static_cast<uint8_t*>(static_cast<void*>(mapped_memory->data() + ext_data_offset));
+        tensor_meta_info.m_tensor_data = mapped_memory->data_as<uint8_t>() + ext_data_offset;
         tensor_meta_info.m_tensor_data_size = resolved_data_length;
         return true;
     } else if (memory_mode == External_Stream) {

--- a/src/frontends/tensorflow/src/variables_index.cpp
+++ b/src/frontends/tensorflow/src/variables_index.cpp
@@ -191,7 +191,7 @@ void VariablesIndex::read_checkpointable_object_graph() {
     ::tensorflow::TrackableObjectGraph tog;
 
     if (m_mmap_enabled) {
-        auto srcPtr = static_cast<char*>(shard->second.mmap->data() + entry.offset() + chg);
+        auto srcPtr = shard->second.mmap->data_as<char>() + entry.offset() + chg;
         std::copy(srcPtr, srcPtr + entry.size() - chg, data.data());
     } else {
         shard->second.stream->seekg(entry.offset() + chg);


### PR DESCRIPTION
### Details:
 - Add interface for buffer, mutable buffer, memory view.
 - The interface allow unification of used object which represent memory in OV like mmap buffer aligned buffer shared buffer etc.
 - It replace use AlignedBuffer as interface and it will be in future just implementation of interface
 - Use this interface in ov::MappedMemory and apply changes in related code.

### Tickets:
 - CVS-186713

### AI Assistance:
 - *yes*
