### PR TITLE
[GHA] Stop setting PIP_CACHE_DIR when pip caching proxy is used

### DIFF
--- a/.github/workflows/job_llm_accuracy_tests.yml
+++ b/.github/workflows/job_llm_accuracy_tests.yml
@@ -88,7 +88,7 @@ jobs:
         uses: ./.github/actions/setup_python
         with:
           version: '3.12'
-          pip-cache-path: '/mnt/caches/pip'
+          pip-cache-path: ${{ inputs.use-pip-proxy && '' || '/mnt/caches/pip' }}
           set-pip-install-path: 'false'
           self-hosted-runner: true
           use-pip-proxy: ${{ inputs.use-pip-proxy }}

--- a/.github/workflows/job_npu_tests.yml
+++ b/.github/workflows/job_npu_tests.yml
@@ -27,7 +27,6 @@ permissions: read-all
 
 env:
   PYTHON_VERSION: '3.11'
-  PIP_CACHE_PATH: "C:\\mount\\caches\\pip\\win"
   # To debug NPU compiler, set OV_NPU_LOG_LEVEL=LOG_INFO or higher
   # OV_NPU_LOG_LEVEL: 'LOG_INFO'
 
@@ -87,7 +86,6 @@ jobs:
         uses: ./openvino/.github/actions/setup_python
         with:
           version: ${{ env.PYTHON_VERSION }}
-          pip-cache-path: ${{ env.PIP_CACHE_PATH }}
           set-pip-install-path: 'false'
           self-hosted-runner: ${{ contains(inputs.runner, 'aks') }}
           use-pip-proxy: ${{ contains(inputs.runner, 'aks') }}


### PR DESCRIPTION
### Details:
 - Remove `pip-cache-path` / `PIP_CACHE_PATH` from `job_npu_tests.yml`; NPU model tests run on AKS Windows runners with `use-pip-proxy` enabled.
 - In `job_llm_accuracy_tests.yml`, set `pip-cache-path` only when `use-pip-proxy` is false (iGPU/dGPU runners); leave it unset on AKS so `setup_python` does not set `PIP_CACHE_DIR`.
 - Aligns with other reusable jobs that rely on the internal pip caching proxy instead of mounted share caches.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - Cursor agent identified remaining `pip-cache-path` usages, applied the changes, and opened this PR; human review of workflow YAML and CI behavior is expected on merge.