### PR TITLE
[GHA] Align CodeQL analyze step with init action version

### DIFF
--- a/.github/workflows/workflows_scans.yml
+++ b/.github/workflows/workflows_scans.yml
@@ -39,13 +39,13 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: "actions"
           build-mode: "none"
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:actions"
 


### PR DESCRIPTION
### Details:
 - Bump `github/codeql-action/analyze` from v4.36.2 to v4.37.9 so it matches `github/codeql-action/init` (v4.37.9).
 - Fixes workflow scan failure: `Error: Loaded a configuration file for version '4.37.8', but running version '4.36.2'`.

### Tickets:
 - N/A

### AI Assistance:
 - AI assistance used: yes
 - Used to align pinned CodeQL action SHAs in `.github/workflows/workflows_scans.yml` and open this PR; change is limited to two `uses:` lines.