### PR TITLE
[NPU] Validate imported NPU batch metadata

### DIFF
--- a/src/plugins/intel_npu/src/plugin/include/blob_format_importers.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/blob_format_importers.hpp
@@ -22,6 +22,8 @@ class ICore;
 
 namespace intel_npu {
 
+void validate_imported_batch_size(const NetworkMetadata& metadata, size_t batch_size);
+
 /**
  * @brief Abstract class used as the base for importing blobs of different formats.
  */

--- a/src/plugins/intel_npu/src/plugin/src/blob_format_importers.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/blob_format_importers.cpp
@@ -402,6 +402,27 @@ private:
 
 namespace intel_npu {
 
+void validate_imported_batch_size(const NetworkMetadata& metadata, size_t batch_size) {
+    if (batch_size <= utils::DEFAULT_BATCH_SIZE) {
+        return;
+    }
+
+    const auto validate_descriptors = [batch_size](const std::vector<IODescriptor>& descriptors) {
+        for (const auto& descriptor : descriptors) {
+            const auto& shape = descriptor.shapeFromCompiler;
+            OPENVINO_ASSERT(shape.is_static() && shape.rank().get_length() > 0 &&
+                                shape[0].get_length() == utils::DEFAULT_BATCH_SIZE,
+                            "Imported batch size ",
+                            batch_size,
+                            " is incompatible with native I/O shape ",
+                            shape);
+        }
+    };
+
+    validate_descriptors(metadata.inputs);
+    validate_descriptors(metadata.outputs);
+}
+
 IBlobFormatImporter::IBlobFormatImporter(const std::shared_ptr<const ov::Model>& original_model,
                                          const FilteredConfig& config,
                                          const Logger& logger)
@@ -457,6 +478,7 @@ std::shared_ptr<IGraph> IBlobFormatImporter::create_graph(const ov::SoPtr<IEngin
     m_graph->update_network_name(network_name);
     if (m_batch_size.has_value() && m_batch_size.value() > 0) {
         // Initial batch setup for static cases
+        validate_imported_batch_size(m_graph->get_metadata(), m_batch_size.value());
         m_graph->set_batch_size(m_batch_size.value());
     }
 

--- a/src/plugins/intel_npu/tests/unit/npu/blob_format_importers.cpp
+++ b/src/plugins/intel_npu/tests/unit/npu/blob_format_importers.cpp
@@ -48,6 +48,12 @@ std::shared_ptr<ov::Model> create_simple_model() {
     return std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input}, "Simple with weights");
 }
 
+IODescriptor make_descriptor(const ov::PartialShape& shape) {
+    IODescriptor descriptor;
+    descriptor.shapeFromCompiler = shape;
+    return descriptor;
+}
+
 }  // namespace
 
 using testing::_;
@@ -153,4 +159,28 @@ TEST_F(BlobFormatImportersTest, CannotCreateModelBeforeGraph) {
 
     OV_ASSERT_NO_THROW(importer = blob_format_importer_factory::create(source, true, nullptr, config));
     OV_EXPECT_THROW(importer->create_dummy_model(), ov::Exception, _);
+}
+
+TEST_F(BlobFormatImportersTest, RejectsImportedBatchSizeForBatchedNativeOutput) {
+    NetworkMetadata metadata;
+    metadata.inputs.push_back(make_descriptor(ov::PartialShape{1, 64}));
+    metadata.outputs.push_back(make_descriptor(ov::PartialShape{2, 64}));
+
+    OV_EXPECT_THROW(validate_imported_batch_size(metadata, 2), ov::Exception, _);
+}
+
+TEST_F(BlobFormatImportersTest, AcceptsImportedBatchSizeForUnbatchedNativeIO) {
+    NetworkMetadata metadata;
+    metadata.inputs.push_back(make_descriptor(ov::PartialShape{1, 64}));
+    metadata.outputs.push_back(make_descriptor(ov::PartialShape{1, 64}));
+
+    OV_ASSERT_NO_THROW(validate_imported_batch_size(metadata, 2));
+}
+
+TEST_F(BlobFormatImportersTest, RejectsImportedBatchSizeForDynamicNativeShape) {
+    NetworkMetadata metadata;
+    metadata.inputs.push_back(make_descriptor(ov::PartialShape{1, -1}));
+    metadata.outputs.push_back(make_descriptor(ov::PartialShape{1, 64}));
+
+    OV_EXPECT_THROW(validate_imported_batch_size(metadata, 2), ov::Exception, _);
 }


### PR DESCRIPTION
### Details:
Reject imported batching when native I/O descriptors are dynamic or do not have a batch dimension of one. Add regression coverage for valid and invalid metadata.

### Tickets:
- [CVS-194515](https://jira.devtools.intel.com/browse/CVS-194515)

### AI Assistance:
- AI assistance used: yes
- Bug root cause was found by AI. Fix and unit-test were generated by AI. Logic validation and manual checks were performed by developer.
