### PR TITLE
[GPU] Fix Gemma3n E2B accuracy in Tile and decomposed RMS paths

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -34,21 +34,30 @@ struct tile_impl : typed_primitive_impl_ocl<tile> {
 
 public:
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, bool is_shape_agnostic = false) {
-        const auto& primitive = impl_param.typed_desc<tile>();
-        auto params = get_default_params<kernel_selector::tile_params>(impl_param, is_shape_agnostic);
+        return get_default_params<kernel_selector::tile_params>(impl_param, is_shape_agnostic);
+    }
 
-        auto repeats = primitive->repeats;
-        auto in_layout = impl_param.get_input_layout(0);
-        auto in_shape = in_layout.get_partial_shape();
+    static kernel_impl_params static_canonicalize_shapes(const kernel_impl_params& impl_params) {
+        auto updated_impl_params = canonicalize_fused_shapes(impl_params);
 
-        // Extend input shape by prepending ones if repeats rank is higher than input rank.
-        if (in_shape.size() < repeats.size()) {
-            in_shape.insert(in_shape.begin(), repeats.size() - in_shape.size(), 1);
-            in_layout.set_partial_shape(in_shape);
-            params.inputs[0] = convert_data_tensor(in_layout);
-        }
+        auto& input_layout = updated_impl_params.input_layouts[0];
+        auto& output_layout = updated_impl_params.output_layouts[0];
+        auto input_pshape = input_layout.get_partial_shape();
+        auto output_pshape = output_layout.get_partial_shape();
+        const auto target_rank = std::max<size_t>(4, output_pshape.size());
 
-        return params;
+        input_pshape = extend_shape_to_rank_from_begin(input_pshape, output_pshape.size());
+        input_layout.set_partial_shape(extend_shape_to_rank_from_end(input_pshape, target_rank));
+        input_layout.format = format::adjust_to_rank(input_layout.format, target_rank);
+
+        output_layout.set_partial_shape(extend_shape_to_rank_from_end(output_pshape, target_rank));
+        output_layout.format = format::adjust_to_rank(output_layout.format, target_rank);
+
+        return updated_impl_params;
+    }
+
+    kernel_impl_params canonicalize_shapes(const kernel_impl_params& impl_params) const override {
+        return static_canonicalize_shapes(impl_params);
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {

--- a/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
@@ -5,8 +5,6 @@
 #include "openvino/op/tile.hpp"
 #include "openvino/op/constant.hpp"
 
-#include <numeric>
-
 #include "intel_gpu/plugin/program_builder.hpp"
 #include "intel_gpu/plugin/common_utils.hpp"
 #include "intel_gpu/primitives/tile.hpp"
@@ -20,41 +18,29 @@ static void CreateTileOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::Ti
     std::string layerName = layer_type_name_ID(op);
     if (auto repeats_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1))) {
         std::vector<int64_t> repeats = repeats_const->cast_vector<int64_t>();
-        const auto input_pshape = op->get_input_partial_shape(0);
 
-        if (input_pshape.rank().is_static() && repeats.size() > input_pshape.size()) {
-            const auto rank_diff = repeats.size() - input_pshape.size();
-            std::string reshapeName = layerName + "_reshape";
-
-            if (op->is_dynamic() || p.use_new_shape_infer()) {
-                auto output_pshape = input_pshape;
-                output_pshape.insert(output_pshape.begin(), rank_diff, 1);
-
-                std::vector<int64_t> axes(rank_diff);
-                std::iota(axes.begin(), axes.end(), 0);
-
-                auto reshapePrim = cldnn::reshape(reshapeName,
-                                                  inputs[0],
-                                                  false,
-                                                  axes,
-                                                  output_pshape,
-                                                  cldnn::reshape::reshape_mode::unsqueeze);
-                p.add_primitive(*op, reshapePrim);
-            } else {
-                auto inputDims = op->get_input_shape(0);
-                inputDims.insert(inputDims.begin(), rank_diff, 1);
-
-                auto targetShape = tensor_from_dims(inputDims);
-                auto reshapePrim = cldnn::reshape(reshapeName, inputs[0], targetShape);
-                p.add_primitive(*op, reshapePrim);
-            }
-
-            inputs[0] = cldnn::input_info(reshapeName);
-        } else if (!op->is_dynamic() && !p.use_new_shape_infer()) {
+        // TODO: Remove code below once new shape infer is enabled
+        if (!op->is_dynamic() && !p.use_new_shape_infer()) {
             size_t rank = op->get_input_shape(0).size();
             int64_t defaultSize = 1;
             for (size_t i = repeats.size(); i < rank; ++i) {
                 repeats.insert(repeats.begin(), defaultSize);
+            }
+
+            if (repeats.size() > rank) {
+                std::string reshapeName = layerName + "_reshape";
+                auto inputDims = op->get_input_shape(0);
+
+                // Extend input dimensions to the same size as repeats dimensions by prepending ones
+                inputDims.insert(inputDims.begin(), repeats.size() - rank, defaultSize);
+
+                auto targetShape = tensor_from_dims(inputDims);
+
+                auto reshapePrim = cldnn::reshape(reshapeName, inputs[0], targetShape);
+
+                p.add_primitive(*op, reshapePrim);
+
+                inputs[0] = cldnn::input_info(reshapeName);
             }
         }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
@@ -5,6 +5,8 @@
 #include "openvino/op/tile.hpp"
 #include "openvino/op/constant.hpp"
 
+#include <numeric>
+
 #include "intel_gpu/plugin/program_builder.hpp"
 #include "intel_gpu/plugin/common_utils.hpp"
 #include "intel_gpu/primitives/tile.hpp"
@@ -18,29 +20,41 @@ static void CreateTileOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::Ti
     std::string layerName = layer_type_name_ID(op);
     if (auto repeats_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1))) {
         std::vector<int64_t> repeats = repeats_const->cast_vector<int64_t>();
+        const auto input_pshape = op->get_input_partial_shape(0);
 
-        // TODO: Remove code below once new shape infer is enabled
-        if (!op->is_dynamic() && !p.use_new_shape_infer()) {
+        if (input_pshape.rank().is_static() && repeats.size() > input_pshape.size()) {
+            const auto rank_diff = repeats.size() - input_pshape.size();
+            std::string reshapeName = layerName + "_reshape";
+
+            if (op->is_dynamic() || p.use_new_shape_infer()) {
+                auto output_pshape = input_pshape;
+                output_pshape.insert(output_pshape.begin(), rank_diff, 1);
+
+                std::vector<int64_t> axes(rank_diff);
+                std::iota(axes.begin(), axes.end(), 0);
+
+                auto reshapePrim = cldnn::reshape(reshapeName,
+                                                  inputs[0],
+                                                  false,
+                                                  axes,
+                                                  output_pshape,
+                                                  cldnn::reshape::reshape_mode::unsqueeze);
+                p.add_primitive(*op, reshapePrim);
+            } else {
+                auto inputDims = op->get_input_shape(0);
+                inputDims.insert(inputDims.begin(), rank_diff, 1);
+
+                auto targetShape = tensor_from_dims(inputDims);
+                auto reshapePrim = cldnn::reshape(reshapeName, inputs[0], targetShape);
+                p.add_primitive(*op, reshapePrim);
+            }
+
+            inputs[0] = cldnn::input_info(reshapeName);
+        } else if (!op->is_dynamic() && !p.use_new_shape_infer()) {
             size_t rank = op->get_input_shape(0).size();
             int64_t defaultSize = 1;
             for (size_t i = repeats.size(); i < rank; ++i) {
                 repeats.insert(repeats.begin(), defaultSize);
-            }
-
-            if (repeats.size() > rank) {
-                std::string reshapeName = layerName + "_reshape";
-                auto inputDims = op->get_input_shape(0);
-
-                // Extend input dimensions to the same size as repeats dimensions by prepending ones
-                inputDims.insert(inputDims.begin(), repeats.size() - rank, defaultSize);
-
-                auto targetShape = tensor_from_dims(inputDims);
-
-                auto reshapePrim = cldnn::reshape(reshapeName, inputs[0], targetShape);
-
-                p.add_primitive(*op, reshapePrim);
-
-                inputs[0] = cldnn::input_info(reshapeName);
             }
         }
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_rms.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_rms.cpp
@@ -7,6 +7,12 @@
 #include "ov_ops/rms.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/convolution.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/power.hpp"
+#include "openvino/op/reduce_mean.hpp"
+#include "openvino/op/sqrt.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations/utils/utils.hpp"
@@ -47,6 +53,38 @@ DisableFP16CompForGemma3RMSPattern::DisableFP16CompForGemma3RMSPattern() {
 
     auto m = std::make_shared<ov::pass::pattern::Matcher>(rms_m, "DisableFP16CompForGemma3RMSPattern");
     this->register_matcher(m, callback);
+}
+
+DisableFP16CompForDecomposedRMSPattern::DisableFP16CompForDecomposedRMSPattern() {
+    using namespace ov::pass::pattern;
+
+    auto convolution_m = wrap_type<ov::op::v1::Convolution>({any_input(), any_input()}, type_matches(element::f32));
+    auto power_m = wrap_type<ov::op::v1::Power>({convolution_m, wrap_type<ov::op::v0::Constant>()},
+                                                type_matches(element::f32));
+    auto reduce_mean_m = wrap_type<ov::op::v1::ReduceMean>({power_m, wrap_type<ov::op::v0::Constant>()},
+                                                            type_matches(element::f32));
+    auto add_m = wrap_type<ov::op::v1::Add>({reduce_mean_m, wrap_type<ov::op::v0::Constant>()},
+                                             type_matches(element::f32));
+    auto sqrt_m = wrap_type<ov::op::v0::Sqrt>({add_m}, type_matches(element::f32));
+    auto divide_m = wrap_type<ov::op::v1::Divide>({wrap_type<ov::op::v0::Constant>(), sqrt_m},
+                                                   type_matches(element::f32));
+    auto multiply_m = wrap_type<ov::op::v1::Multiply>({convolution_m, divide_m}, type_matches(element::f32));
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto multiply = pattern_map.at(multiply_m).get_node_shared_ptr();
+        if (transformation_callback(multiply)) {
+            return false;
+        }
+
+        for (const auto& pattern : {convolution_m, power_m, reduce_mean_m, add_m, sqrt_m, divide_m, multiply_m}) {
+            ov::disable_conversion(pattern_map.at(pattern).get_node_shared_ptr(), element::f16);
+        }
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(multiply_m, "DisableFP16CompForDecomposedRMSPattern");
+    register_matcher(m, callback);
 }
 
 }  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_rms.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_rms.cpp
@@ -59,14 +59,16 @@ DisableFP16CompForDecomposedRMSPattern::DisableFP16CompForDecomposedRMSPattern()
     using namespace ov::pass::pattern;
 
     auto convolution_m = wrap_type<ov::op::v1::Convolution>({any_input(), any_input()}, type_matches(element::f32));
-    auto power_m = wrap_type<ov::op::v1::Power>({convolution_m, wrap_type<ov::op::v0::Constant>()},
+    auto power_const_m = wrap_type<ov::op::v0::Constant>(value_matches("2"));
+    auto power_m = wrap_type<ov::op::v1::Power>({convolution_m, power_const_m},
                                                 type_matches(element::f32));
     auto reduce_mean_m = wrap_type<ov::op::v1::ReduceMean>({power_m, wrap_type<ov::op::v0::Constant>()},
                                                             type_matches(element::f32));
     auto add_m = wrap_type<ov::op::v1::Add>({reduce_mean_m, wrap_type<ov::op::v0::Constant>()},
                                              type_matches(element::f32));
     auto sqrt_m = wrap_type<ov::op::v0::Sqrt>({add_m}, type_matches(element::f32));
-    auto divide_m = wrap_type<ov::op::v1::Divide>({wrap_type<ov::op::v0::Constant>(), sqrt_m},
+    auto divide_const_m = wrap_type<ov::op::v0::Constant>(value_matches("1"));
+    auto divide_m = wrap_type<ov::op::v1::Divide>({divide_const_m, sqrt_m},
                                                    type_matches(element::f32));
     auto multiply_m = wrap_type<ov::op::v1::Multiply>({convolution_m, divide_m}, type_matches(element::f32));
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_rms.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_rms.hpp
@@ -40,4 +40,17 @@ public:
     DisableFP16CompForGemma3RMSPattern();
 };
 
+/**
+ * @brief Disables fp16 compression for a Convolution followed by a decomposed RMS normalization.
+ *
+ * The Convolution output may exceed the fp16 range before normalization. Keeping the complete
+ * Convolution -> Power -> ReduceMean -> Add -> Sqrt -> Divide -> Multiply chain in fp32 prevents
+ * Inf values from turning into NaN during normalization.
+ */
+class DisableFP16CompForDecomposedRMSPattern : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("DisableFP16CompForDecomposedRMSPattern");
+    DisableFP16CompForDecomposedRMSPattern();
+};
+
 }   // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -801,6 +801,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         });
         manager.register_pass<ov::pass::RMSFusion>(false, true);
         manager.register_pass<DisableFP16CompForGemma3RMSPattern>();
+        manager.register_pass<DisableFP16CompForDecomposedRMSPattern>();
         const bool fp16_activation_scaling_enabled =
             config.get_activations_scale_factor() > 0.f && infer_precision == ov::element::f16;
         // Gated residuals need FP32 protection only when FP16 activation scaling is enabled.

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/tile.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/tile.cpp
@@ -157,6 +157,18 @@ const std::vector<std::vector<ov::test::InputShape>> dynamic_input_shapes4D = {
     }
 };
 
+const std::vector<std::vector<ov::test::InputShape>> dynamic_input_shapes3D = {
+    {
+        {
+            {-1, -1, 2048},
+            {
+                {1, 16, 2048},
+                {2, 7, 2048}
+            }
+        }
+    }
+};
+
 const std::vector<std::vector<ov::test::InputShape>> dynamic_input_shapes5D = {
     {
         { // Origin dynamic shapes
@@ -206,6 +218,15 @@ INSTANTIATE_TEST_SUITE_P(DynamicShape4D, TileLayerGPUTest,
                                         ::testing::Values(true, false),
                                         ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         TileLayerGPUTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(DynamicShape3DWith4DRepeats, TileLayerGPUTest,
+                         ::testing::Combine(
+                             ::testing::ValuesIn(dynamic_input_shapes3D),
+                             ::testing::Values(std::vector<int64_t>{4, 1, 1, 1}),
+                             ::testing::ValuesIn(model_types),
+                             ::testing::Values(true),
+                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                         TileLayerGPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(DynamicShape5D, TileLayerGPUTest,
                                 ::testing::Combine(

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/tile.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/tile.cpp
@@ -224,7 +224,7 @@ INSTANTIATE_TEST_SUITE_P(DynamicShape3DWith4DRepeats, TileLayerGPUTest,
                              ::testing::ValuesIn(dynamic_input_shapes3D),
                              ::testing::Values(std::vector<int64_t>{4, 1, 1, 1}),
                              ::testing::ValuesIn(model_types),
-                             ::testing::Values(true),
+                             ::testing::Values(true, false),
                              ::testing::Values(ov::test::utils::DEVICE_GPU)),
                          TileLayerGPUTest::getTestCaseName);
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/disable_fp16_compression_rms_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/disable_fp16_compression_rms_test.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <memory>
 
+#include "common_test_utils/ov_test_utils.hpp"
 #include <openvino/core/model.hpp>
 #include <openvino/pass/manager.hpp>
 #include <transformations/utils/utils.hpp>
@@ -143,58 +144,82 @@ TEST(TransformationTests, DisableFP16CompForRMS_Negative) {
     run_test(model, expected_status);
 }
 
-TEST(TransformationTests, DisableFP16CompForDecomposedRMS_Positive) {
-    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 1, 2, 2});
-    auto weights = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {1.0f});
-    auto convolution = std::make_shared<ov::op::v1::Convolution>(input,
-                                                                 weights,
-                                                                 ov::Strides{1, 1},
-                                                                 ov::CoordinateDiff{0, 0},
-                                                                 ov::CoordinateDiff{0, 0},
-                                                                 ov::Strides{1, 1});
-    auto power = std::make_shared<ov::op::v1::Power>(
-        convolution,
-        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.0f}));
-    auto reduce_mean = std::make_shared<ov::op::v1::ReduceMean>(
-        power,
-        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1}),
-        true);
-    auto add = std::make_shared<ov::op::v1::Add>(
-        reduce_mean,
-        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1e-6f}));
-    auto sqrt = std::make_shared<ov::op::v0::Sqrt>(add);
-    auto divide = std::make_shared<ov::op::v1::Divide>(
-        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f}),
-        sqrt);
-    auto multiply = std::make_shared<ov::op::v1::Multiply>(convolution, divide);
+namespace {
 
-    const std::vector<std::shared_ptr<ov::Node>> protected_nodes = {
-        convolution, power, reduce_mean, add, sqrt, divide, multiply};
-    for (size_t index = 0; index < protected_nodes.size(); ++index) {
-        protected_nodes[index]->set_friendly_name("decomposed_rms_" + std::to_string(index));
+class DisableFP16CompForDecomposedRMSTest : public TransformationTestsF {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        manager.register_pass<DisableFP16CompForDecomposedRMSPattern>();
     }
 
-    auto model = std::make_shared<ov::Model>(ov::OutputVector{multiply}, ov::ParameterVector{input});
-    ov::pass::Manager manager;
-    manager.register_pass<DisableFP16CompForDecomposedRMSPattern>();
-    manager.register_pass<ov::pass::ConvertPrecision>(precisions_map{{ov::element::f32, ov::element::f16}});
-    manager.run_passes(model);
+    static std::shared_ptr<ov::Model> getModel(float power_value = 2.0f,
+                                               float numerator_value = 1.0f,
+                                               bool is_reference = false) {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 1, 2, 2});
+        auto weights = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {1.0f});
+        auto convolution = std::make_shared<ov::op::v1::Convolution>(input,
+                                                                     weights,
+                                                                     ov::Strides{1, 1},
+                                                                     ov::CoordinateDiff{0, 0},
+                                                                     ov::CoordinateDiff{0, 0},
+                                                                     ov::Strides{1, 1});
+        auto power = std::make_shared<ov::op::v1::Power>(
+            convolution,
+            ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {power_value}));
+        auto reduce_mean = std::make_shared<ov::op::v1::ReduceMean>(
+            power,
+            ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1}),
+            true);
+        auto add = std::make_shared<ov::op::v1::Add>(
+            reduce_mean,
+            ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1e-6f}));
+        auto sqrt = std::make_shared<ov::op::v0::Sqrt>(add);
+        auto divide = std::make_shared<ov::op::v1::Divide>(
+            ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {numerator_value}),
+            sqrt);
+        auto multiply = std::make_shared<ov::op::v1::Multiply>(convolution, divide);
 
-    for (const auto& node : protected_nodes) {
-        EXPECT_TRUE(ov::is_conversion_disabled(node, ov::element::f16)) << node->get_friendly_name();
+        if (is_reference) {
+            for (const auto& node : ov::NodeVector{convolution, power, reduce_mean, add, sqrt, divide, multiply}) {
+                ov::disable_conversion(node, ov::element::f16);
+            }
+        }
+
+        return std::make_shared<ov::Model>(ov::OutputVector{multiply}, ov::ParameterVector{input});
     }
+};
+
+struct DecomposedRMSConstants {
+    float power;
+    float numerator;
+    std::string name;
+};
+
+class DisableFP16CompForDecomposedRMSNegativeTest
+    : public DisableFP16CompForDecomposedRMSTest,
+      public testing::WithParamInterface<DecomposedRMSConstants> {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<DecomposedRMSConstants>& info) {
+        return info.param.name;
+    }
+};
+
+}  // namespace
+
+TEST_F(DisableFP16CompForDecomposedRMSTest, CanonicalConstants) {
+    model = getModel();
+    model_ref = getModel(2.0f, 1.0f, true);
 }
 
-TEST(TransformationTests, DisableFP16CompForDecomposedRMS_Negative) {
-    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 1, 2, 2});
-    auto power = std::make_shared<ov::op::v1::Power>(
-        input,
-        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.0f}));
-    auto model = std::make_shared<ov::Model>(ov::OutputVector{power}, ov::ParameterVector{input});
-
-    ov::pass::Manager manager;
-    manager.register_pass<DisableFP16CompForDecomposedRMSPattern>();
-    manager.run_passes(model);
-
-    EXPECT_FALSE(ov::is_conversion_disabled(power, ov::element::f16));
+TEST_P(DisableFP16CompForDecomposedRMSNegativeTest, NearMissConstant_NoOp) {
+    const auto& params = GetParam();
+    model = getModel(params.power, params.numerator);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    DecomposedRMSConstants,
+    DisableFP16CompForDecomposedRMSNegativeTest,
+    testing::Values(DecomposedRMSConstants{2.1f, 1.0f, "PowerExponentNotTwo"},
+                    DecomposedRMSConstants{2.0f, 1.1f, "DivideNumeratorNotOne"}),
+    DisableFP16CompForDecomposedRMSNegativeTest::getTestCaseName);

--- a/src/plugins/intel_gpu/tests/unit/transformations/disable_fp16_compression_rms_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/disable_fp16_compression_rms_test.cpp
@@ -18,6 +18,12 @@
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/convolution.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/power.hpp"
+#include "openvino/op/reduce_mean.hpp"
+#include "openvino/op/sqrt.hpp"
 
 using namespace testing;
 using namespace ov::intel_gpu;
@@ -135,4 +141,60 @@ TEST(TransformationTests, DisableFP16CompForRMS_Negative) {
         {name_rms_2, false}
     };
     run_test(model, expected_status);
+}
+
+TEST(TransformationTests, DisableFP16CompForDecomposedRMS_Positive) {
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 1, 2, 2});
+    auto weights = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {1.0f});
+    auto convolution = std::make_shared<ov::op::v1::Convolution>(input,
+                                                                 weights,
+                                                                 ov::Strides{1, 1},
+                                                                 ov::CoordinateDiff{0, 0},
+                                                                 ov::CoordinateDiff{0, 0},
+                                                                 ov::Strides{1, 1});
+    auto power = std::make_shared<ov::op::v1::Power>(
+        convolution,
+        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.0f}));
+    auto reduce_mean = std::make_shared<ov::op::v1::ReduceMean>(
+        power,
+        ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1}),
+        true);
+    auto add = std::make_shared<ov::op::v1::Add>(
+        reduce_mean,
+        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1e-6f}));
+    auto sqrt = std::make_shared<ov::op::v0::Sqrt>(add);
+    auto divide = std::make_shared<ov::op::v1::Divide>(
+        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.0f}),
+        sqrt);
+    auto multiply = std::make_shared<ov::op::v1::Multiply>(convolution, divide);
+
+    const std::vector<std::shared_ptr<ov::Node>> protected_nodes = {
+        convolution, power, reduce_mean, add, sqrt, divide, multiply};
+    for (size_t index = 0; index < protected_nodes.size(); ++index) {
+        protected_nodes[index]->set_friendly_name("decomposed_rms_" + std::to_string(index));
+    }
+
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{multiply}, ov::ParameterVector{input});
+    ov::pass::Manager manager;
+    manager.register_pass<DisableFP16CompForDecomposedRMSPattern>();
+    manager.register_pass<ov::pass::ConvertPrecision>(precisions_map{{ov::element::f32, ov::element::f16}});
+    manager.run_passes(model);
+
+    for (const auto& node : protected_nodes) {
+        EXPECT_TRUE(ov::is_conversion_disabled(node, ov::element::f16)) << node->get_friendly_name();
+    }
+}
+
+TEST(TransformationTests, DisableFP16CompForDecomposedRMS_Negative) {
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 1, 2, 2});
+    auto power = std::make_shared<ov::op::v1::Power>(
+        input,
+        ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.0f}));
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{power}, ov::ParameterVector{input});
+
+    ov::pass::Manager manager;
+    manager.register_pass<DisableFP16CompForDecomposedRMSPattern>();
+    manager.run_passes(model);
+
+    EXPECT_FALSE(ov::is_conversion_disabled(power, ov::element::f16));
 }


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
  - `gemma-3n-e2b-it` produced corrupted text and image-irrelevant responses on GPU. Both `OV_FP16-4BIT_DEFAULT` and `OV_FP16-INT8_ASYM` were affected.
  - Two independent root causes were identified:
    - Dynamic Tile rank alignment
      - The model applies rank-4 repeats to a dynamic rank-3 input.
      - The GPU canonicalization interpreted `[N, S, D]` as `[N, S, D, 1]`.
      - Tile semantics require the missing dimension to be prepended: `[1, N, S, D]`.
      - The output shape was correct, but the OCL kernel received incorrectly aligned input metadata and produced corrupted values.
      - Added Tile-specific OCL shape canonicalization and applied it consistently during static kernel setup and dynamic runtime dispatch.
    - FP16 overflow in convolution-fed decomposed RMS
      - The vision encoder contains a `Convolution -> decomposed RMS` pattern.
      - The producer convolution generated values down to approximately `-76101`, exceeding the finite FP16 limit of `-65504`.
      - Lowering the convolution output to FP16 produced `Inf` before RMS normalization.
      - Promoting only the downstream RMS operations to FP32 could not recover values already corrupted at the convolution output.
      - Added a targeted transformation that keeps the producer convolution and the complete decomposed RMS chain in FP32.

#### The code and line that caused this issue (if it is not changed directly)
  - `src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp`
    - Generic shape canonicalization did not preserve Tile's leading-dimension alignment semantics.
  - `src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp`
    - GPU `ConvertPrecision` lowered the FP32 convolution and decomposed RMS operations to FP16.
  - `src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_rms.cpp`
    - Existing precision protection did not cover convolution-fed decomposed RMS patterns.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
```bash
OV_GPU_DYNAMIC_QUANTIZATION_THRESHOLD=1 \
python genai/tools/llm_bench/benchmark.py \
  -d GPU.1 \
  -m <gemma-3n-e2b-it-model>/OV_FP16-4BIT_DEFAULT \
  -i <input-image> \
  -p "Is the train long?" \
  -t visual_text_gen \
  --apply_chat_template \
  --disable_prompt_permutation
```

#### Problematic graph
  - Dynamic Tile path
    ```text
    Input:   [N, S, D]
    Repeats: [4, 1, 1, 1]

    Incorrect GPU alignment:
    [N, S, D] -> [N, S, D, 1]

    Required Tile alignment:
    [N, S, D] -> [1, N, S, D]
    ```
  - Vision encoder path
    - Decomposed RMS graph:
      ```text
      Convolution
        |
        +------------------------------+
        |                              |
        v                              |
      Power(x, 2)                      |
        -> ReduceMean(axis=1)          |
        -> Add(epsilon)                |
        -> Sqrt                        |
        -> Divide(1, sqrt_result)      |
        -> Multiply(convolution_output, reciprocal_rms)
      ```

#### Checklist
  - [x] Is it a proper fix? (not a workaround)
  - [x] Did you include test case for this fix, if necessary?
  - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
    - Extended the dynamic GPU Tile functional tests with rank-3 input/rank-4 repeats.
    - Covered both constant and runtime repeats with `f32` and `f16`.
    - Extended the RMS precision transformation tests with positive and negative decomposed RMS cases.

### Tickets:
  - [CVS-193756](https://jira.devtools.intel.com/browse/CVS-193756)