### PR TITLE
[GPU] Fix type punning errors in microkernel code

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/tile_ops.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/tile_ops.cl
@@ -17,6 +17,17 @@
 #ifndef GPU_OCL_TILE_OPS_H
 #define GPU_OCL_TILE_OPS_H
 
+// oneDNN microkernel shims use named low-precision types. Map to OpenCL's
+// storage types. These are storage aliases; the microkernel handles numerical
+// interpretation.
+typedef ushort bf16;
+typedef uchar f8_e5m2;
+typedef uchar f8_e4m3;
+typedef uchar e8m0;
+typedef uchar f4_e2m1;
+typedef uchar s4;
+typedef uchar u4;
+
 float __builtin_IB_atomic_max_local_f32(__local float *, float);
 
 __attribute__((overloadable)) float local_atomic_max(local float *p, float v) {


### PR DESCRIPTION
### Details:
This PR address a build error with the latest changes to the microkernel generated interface. The microkernel shim layer uses structs to represent u4/s8 and f8/f4 data types. These types are missing from the tile_ops code so typedefs are defined to represent these as uchar and ushort data types. 

### Tickets:
 - MFDNN-15549
 
### AI Assistance:
 - AI assistance used: yes
 - AI was used to recreate the build errors though the llm_bench tool