### PR TITLE
[core] Fix segmentation fault by correcting in_offset calculation

### DIFF
--- a/src/core/reference/src/op/concat.cpp
+++ b/src/core/reference/src/op/concat.cpp
@@ -55,9 +55,9 @@ void concat(const std::vector<const char*>& args,
     for (size_t step = 0; step < steps; ++step) {
         for (size_t in_index = 0; in_index < args.size(); ++in_index) {
             size_t size = shape_sizes[in_index] / steps;
-            const size_t in_offset = step * size;
             if (elem_type == ov::element::u4 || elem_type == ov::element::i4)
                 size /= 2;
+            const size_t in_offset = step * size;
             copy_func(args[in_index], out, in_offset, out_offset, size, elem_size);
 
             out_offset += size;

--- a/src/plugins/template/tests/functional/op_reference/concat.cpp
+++ b/src/plugins/template/tests/functional/op_reference/concat.cpp
@@ -209,6 +209,23 @@ std::vector<ConcatParams> generateStringParams() {
     return params;
 }
 
+template <element::Type_t ET>
+std::vector<ConcatParams> generateParams4Bit() {
+    static_assert(ET == element::Type_t::u4 || ET == element::Type_t::i4,
+                  "generateParams4Bit is only valid for packed 4-bit types (u4/i4)");
+    using T = typename element_type_traits<ET>::value_type;
+    std::vector<ConcatParams> params{
+        ConcatParams({},
+                     reference_tests::Tensor(ET, {2, 2}, std::vector<T>{0x12, 0x34}),
+                     reference_tests::Tensor(ET, {2, 2}, std::vector<T>{0x56, 0x78}),
+                     reference_tests::Tensor(ET, {2, 2}, std::vector<T>{0x1A, 0x2C}),
+                     1,
+                     reference_tests::Tensor(ET, {2, 6}, std::vector<T>{0x12, 0x56, 0x1A, 0x34, 0x78, 0x2C}),
+                     "concat_4bit_non_outermost_axis"),
+    };
+    return params;
+}
+
 std::vector<ConcatParams> generateCombinedParams() {
     const std::vector<std::vector<ConcatParams>> generatedParams{
         generateParams<element::Type_t::i8>(),
@@ -224,6 +241,8 @@ std::vector<ConcatParams> generateCombinedParams() {
         generateParams<element::Type_t::f32>(),
         generateParams<element::Type_t::f64>(),
         generateStringParams(),
+        generateParams4Bit<element::Type_t::i4>(),
+        generateParams4Bit<element::Type_t::u4>(),
     };
     std::vector<ConcatParams> combinedParams;
 


### PR DESCRIPTION
### Details:
 - Fix Concat's evaluate implementation for u4, i4 precision

### Tickets:
 - #38057 

### AI Assistance:
 - *yes*
