### PR TITLE
[GPU] Fix recursive format lookup for Reshape users

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -69,12 +69,6 @@ static size_t get_post_ops_count(const program_node& node) {
     return onednn_post_ops_count;
 }
 
-static bool has_reshape_user(const program_node& node) {
-    return std::any_of(node.get_users().begin(), node.get_users().end(), [](const program_node* user) {
-        return user->is_type<reshape>();
-    });
-}
-
 // A rank-reducing reorder may be fused into a producer only when every higher-rank external eltwise
 // peer has the same provable lower-rank representation that OCL fused-op canonicalization will use.
 //
@@ -1409,11 +1403,6 @@ format layout_optimizer::get_preferred_format(program_node& node) {
         // Let reorder_input pass to check input format instead of output_format in forward investigation, vice versa
         auto out_lay_rank = node.get_output_layout(false).get_rank();
 
-        // Use a plain format for static producers with a Reshape user to avoid recursive format propagation.
-        // Keep Deconvolution on its type-specific path so it can retain an optimized blocked format.
-        if (!node.is_dynamic() && !node.is_type<deconvolution>() && has_reshape_user(node))
-            return format::get_default_format(out_lay_rank);
-
         if (node.is_type<shape_of>())
             return format::get_default_format(node.get_input_layout(0).get_rank());
 
@@ -1569,7 +1558,9 @@ bool layout_optimizer::all_users_simple_format_until_output(program_node& origin
             return false;
     }
 
-    if (cur_node.is_in_data_flow() && (cur_node.type() != origin_node.type())) {
+    // Reshape intrinsically requires plain input and output formats. Continue through it without
+    // recursively querying its dependency's preferred format.
+    if (cur_node.is_in_data_flow() && !cur_node.is_type<reshape>() && (cur_node.type() != origin_node.type())) {
         const auto& fmt = get_preferred_format(cur_node);
         if (fmt != format::any && !format::is_simple_data_format(fmt)) {
             return false;

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -18,7 +18,6 @@
 #include "select_inst.h"
 #include "condition_inst.h"
 #include "strided_slice_inst.h"
-#include <sstream>
 
 #include "gated_mlp_inst.h"
 #include "gemm_inst.h"
@@ -68,6 +67,12 @@ static size_t get_post_ops_count(const program_node& node) {
     }
 
     return onednn_post_ops_count;
+}
+
+static bool has_reshape_user(const program_node& node) {
+    return std::any_of(node.get_users().begin(), node.get_users().end(), [](const program_node* user) {
+        return user->is_type<reshape>();
+    });
 }
 
 // A rank-reducing reorder may be fused into a producer only when every higher-rank external eltwise
@@ -1403,6 +1408,11 @@ format layout_optimizer::get_preferred_format(program_node& node) {
     if (allow_new_shape_infer) {
         // Let reorder_input pass to check input format instead of output_format in forward investigation, vice versa
         auto out_lay_rank = node.get_output_layout(false).get_rank();
+
+        // Use a plain format for static producers with a Reshape user to avoid recursive format propagation.
+        // Keep Deconvolution on its type-specific path so it can retain an optimized blocked format.
+        if (!node.is_dynamic() && !node.is_type<deconvolution>() && has_reshape_user(node))
+            return format::get_default_format(out_lay_rank);
 
         if (node.is_type<shape_of>())
             return format::get_default_format(node.get_input_layout(0).get_rank());

--- a/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
@@ -679,8 +679,8 @@ TEST(reorder_inputs, static_resample_with_rank_changing_reshape_no_recursion) {
     // input -> Resample -> Reshape (Unsqueeze) --+
     //                                            +-> Concat -> Reduce -> Convolution
     // skip -------------> Reshape (Unsqueeze) ---+
-    // Without the static Reshape-user guard, the downstream format lookup reaches the rank-changing
-    // Reshape, which queries its Resample dependency's preferred format and re-enters the same lookup.
+    // The downstream format lookup must treat the rank-changing Reshape as an intrinsic plain-format
+    // boundary instead of querying its Resample dependency's preferred format and re-entering the same lookup.
     auto& engine = get_test_engine();
     auto weights = engine.allocate_memory({data_types::f16, format::bfyx, {512, 384, 1, 1}});
 
@@ -716,6 +716,7 @@ TEST(reorder_inputs, static_resample_with_rank_changing_reshape_no_recursion) {
     topology.add(concatenation("concat", {input_info("reshape"), input_info("skip_reshape")}, 0));
     topology.add(reduce("reduce", input_info("concat"), reduce_mode::sum, {0}, false));
     topology.add(convolution("output", input_info("reduce"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(reorder("sink", input_info("output"), format::bfyx, data_types::f16));
 
     ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
@@ -740,6 +741,17 @@ TEST(reorder_inputs, static_resample_with_rank_changing_reshape_no_recursion) {
     ASSERT_EQ(prog->get_node("reshape").get_input_layout(0).format, format::bfyx);
     ASSERT_EQ(prog->get_node("reshape").get_output_layout().format, format::bfzyx);
     ASSERT_EQ(prog->get_node("reduce").get_output_layout().format, format::bfyx);
+
+    auto blocked_prog = program::build_program(engine, topology, config, false, true);
+    ASSERT_NE(blocked_prog, nullptr);
+    program_wrapper::apply_opt_pass<mark_nodes>(*blocked_prog);
+    blocked_prog->get_layout_optimizer().set_implementation_forcing(
+        ov::intel_gpu::ImplForcingMap{{"output", {format::b_fs_yx_fsv16, ""}}});
+
+    // Reshape is a non-recursive plain-format boundary, not a traversal stop. The blocked consumer
+    // after it must still prevent the Resample from being forced to a plain format.
+    ASSERT_EQ(blocked_prog->get_layout_optimizer().get_preferred_format(blocked_prog->get_node("resample")),
+              format::any);
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU

--- a/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
@@ -22,6 +22,8 @@
 #include "concatenation_inst.h"
 #include "fully_connected_inst.h"
 #include "mvn_inst.h"
+#include "reduce_inst.h"
+#include "resample_inst.h"
 #include "pass_manager.h"
 #include "to_string_utils.h"
 
@@ -669,6 +671,75 @@ TEST(reorder_inputs, dynamic_conv_chain_no_throw) {
     program::ptr prog = nullptr;
     OV_ASSERT_NO_THROW(prog = program::build_program(engine, topology, config));
     ASSERT_NE(prog, nullptr);
+}
+
+TEST(reorder_inputs, static_resample_with_rank_changing_reshape_no_recursion) {
+    // Topology:
+    //
+    // input -> Resample -> Reshape (Unsqueeze) --+
+    //                                            +-> Concat -> Reduce -> Convolution
+    // skip -------------> Reshape (Unsqueeze) ---+
+    // Without the static Reshape-user guard, the downstream format lookup reaches the rank-changing
+    // Reshape, which queries its Resample dependency's preferred format and re-enters the same lookup.
+    auto& engine = get_test_engine();
+    auto weights = engine.allocate_memory({data_types::f16, format::bfyx, {512, 384, 1, 1}});
+
+    topology topology;
+    topology.add(data("weights", weights));
+    topology.add(input_layout("input", layout{{1, 384, 20, 20}, data_types::f16, format::bfyx}));
+    topology.add(input_layout("skip", layout{{1, 384, 40, 40}, data_types::f16, format::bfyx}));
+    topology.add(resample("resample",
+                          input_info("input"),
+                          std::vector<int64_t>{},
+                          std::vector<float>{2.0f, 2.0f},
+                          std::vector<int64_t>{2, 3},
+                          std::vector<size_t>{0, 0, 0, 0},
+                          std::vector<size_t>{0, 0, 0, 0},
+                          0,
+                          -0.75f,
+                          resample::InterpolateOp::InterpolateMode::NEAREST,
+                          resample::InterpolateOp::ShapeCalcMode::SCALES,
+                          resample::InterpolateOp::CoordinateTransformMode::ASYMMETRIC,
+                          resample::InterpolateOp::NearestMode::SIMPLE));
+    topology.add(reshape("reshape",
+                         input_info("resample"),
+                         false,
+                         {1},
+                         {1, 1, 384, 40, 40},
+                         reshape::reshape_mode::unsqueeze));
+    topology.add(reshape("skip_reshape",
+                         input_info("skip"),
+                         false,
+                         {1},
+                         {1, 1, 384, 40, 40},
+                         reshape::reshape_mode::unsqueeze));
+    topology.add(concatenation("concat", {input_info("reshape"), input_info("skip_reshape")}, 0));
+    topology.add(reduce("reduce", input_info("concat"), reduce_mode::sum, {0}, false));
+    topology.add(convolution("output", input_info("reduce"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    program::ptr prog = nullptr;
+    OV_ASSERT_NO_THROW(prog = program::build_program(engine, topology, config, false, true));
+    ASSERT_NE(prog, nullptr);
+
+    program_wrapper::apply_opt_pass<mark_nodes>(*prog);
+    ASSERT_TRUE(prog->is_new_shape_infer());
+    ASSERT_FALSE(prog->get_node("resample").is_dynamic());
+    ASSERT_TRUE(prog->get_node("reshape").is_in_data_flow());
+    ASSERT_NE(prog->get_node("reshape").get_input_layout(0).get_rank(),
+              prog->get_node("reshape").get_output_layout().get_rank());
+    OV_ASSERT_NO_THROW(prog->get_layout_optimizer().get_preferred_format(prog->get_node("resample")));
+
+    reorder_factory rf;
+    OV_ASSERT_NO_THROW(program_wrapper::apply_opt_pass<reorder_inputs>(*prog, rf));
+
+    ASSERT_EQ(prog->get_node("resample").get_output_layout().format, format::bfyx);
+    ASSERT_EQ(prog->get_node("reshape").get_input_layout(0).format, format::bfyx);
+    ASSERT_EQ(prog->get_node("reshape").get_output_layout().format, format::bfzyx);
+    ASSERT_EQ(prog->get_node("reduce").get_output_layout().format, format::bfyx);
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - This PR fixes a regression introduced by https://github.com/openvinotoolkit/openvino/pull/37756, which removed plain-format selection for static nodes with a Reshape user
 - Compiling a new model on the Intel GPU plugin caused a segmentation fault due to unbounded recursion in `layout_optimizer::get_preferred_format()`
 - For a static Resample followed by a rank-changing Reshape:
   - Resample inspected its downstream users through `all_users_simple_format_until_output()`
   - The traversal requested the preferred format of the Reshape
   - New shape inference requested the preferred format of the Reshape dependency because its input and output ranks differed
   - This re-entered preferred-format selection for the original Resample and repeated until stack overflow
 - Plain-format selection was restored for static nodes with a direct Reshape user, preventing recursive downstream format propagation
 - Deconvolution nodes are excluded from this rule so they retain their type-specific blocked-format selection and the performance improvement delivered by https://github.com/openvinotoolkit/openvino/pull/37756
 - Added a regression test reproducing the static, scale-based Resample and rank-changing Reshape topology

#### The code and line that caused this issue (if it is not changed directly)
 - `src/plugins/intel_gpu/src/graph/layout_optimizer.cpp`
 - `layout_optimizer::get_preferred_format()`
 - `layout_optimizer::all_users_simple_format_until_output()`

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - regression test:
   ```bash
   ./bin/intel64/Debug/ov_gpu_unit_tests \
       --gtest_filter='reorder_inputs.static_resample_with_rank_changing_reshape_no_recursion'
   ```

#### Problematic graph
 - The optimized graph contains the following pattern:
   ```text
   input -> Resample -> Reshape (Unsqueeze) --+
                                              +-> Concat -> Reduce -> Convolution
   skip --------------> Reshape (Unsqueeze) --+
   ```
 - The Resample output is static rank 4 (`bfyx`), while the Unsqueeze changes it to rank 5 (`bfzyx`).
 - The recursive preferred-format lookup was:
   ```text
   Resample
     -> all_users_simple_format_until_output()
     -> Reshape
     -> get_preferred_format(Reshape dependency)
     -> Resample
   ```

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - Reviewed `reorder_inputs.has_reshape_user`. A separate test, `reorder_inputs.static_resample_with_rank_changing_reshape_no_recursion`, was added because the existing test does not reproduce the Resample/Reshape recursion.

### Tickets:
- CVS-194462