### PR TITLE
Mang/eagle3 similarity

### DIFF
--- a/src/common/transformations/tests/pa_kv_reorder_fusion_test.cpp
+++ b/src/common/transformations/tests/pa_kv_reorder_fusion_test.cpp
@@ -80,10 +80,10 @@ TEST(PaKVReorderFusionTest, FusionPattern) {
     auto value_scatter = std::make_shared<op::v3::ScatterUpdate>(value_cache, block_indices, value_gather, axis);
     value_scatter->set_friendly_name("updated_value_cache_0");
 
-    auto concat = std::make_shared<op::v0::Concat>(OutputVector{key_scatter, value_scatter}, 0);
-    auto result = std::make_shared<op::v0::Result>(concat);
+    auto key_result = std::make_shared<op::v0::Result>(key_scatter);
+    auto value_result = std::make_shared<op::v0::Result>(value_scatter);
 
-    auto model = std::make_shared<Model>(ResultVector{result},
+    auto model = std::make_shared<Model>(ResultVector{key_result, value_result},
                                          ParameterVector{key_cache,
                                                          value_cache,
                                                          block_indices,
@@ -114,6 +114,11 @@ TEST(PaKVReorderFusionTest, FusionPattern) {
     ASSERT_TRUE(found_pa_kv_reorder) << "PaKVReorder op should be created after fusion";
     ASSERT_EQ(gather_count, 0) << "Gather ops should be removed after fusion";
     ASSERT_EQ(scatter_count, 0) << "ScatterUpdate ops should be removed after fusion";
+    ASSERT_TRUE(std::dynamic_pointer_cast<op::internal::PaKVReorder>(key_result->input_value(0).get_node_shared_ptr()));
+    ASSERT_EQ(key_result->input_value(0).get_index(), 0);
+    ASSERT_TRUE(
+        std::dynamic_pointer_cast<op::internal::PaKVReorder>(value_result->input_value(0).get_node_shared_ptr()));
+    ASSERT_EQ(value_result->input_value(0).get_index(), 1);
 }
 
 TEST_F(TransformationTestsF, PaKVReorderFusion_basic) {
@@ -181,7 +186,9 @@ TEST_F(TransformationTestsF, PaKVReorderFusion_basic) {
                                                                          block_update_indices,
                                                                          block_update_indices_begins);
         pa_kv_reorder->set_friendly_name("pa_kv_reorder_0");
-        auto result = std::make_shared<op::v0::Result>(pa_kv_reorder);
+        auto concat =
+            std::make_shared<op::v0::Concat>(OutputVector{pa_kv_reorder->output(0), pa_kv_reorder->output(1)}, 0);
+        auto result = std::make_shared<op::v0::Result>(concat);
 
         model_ref = std::make_shared<Model>(ResultVector{result},
                                             ParameterVector{key_cache,
@@ -258,7 +265,7 @@ TEST(PaKVReorderOpTest, OpCreation) {
 
     ASSERT_NE(pa_kv_reorder, nullptr);
     ASSERT_EQ(pa_kv_reorder->get_input_size(), 6);
-    ASSERT_EQ(pa_kv_reorder->get_output_size(), 1);
+    ASSERT_EQ(pa_kv_reorder->get_output_size(), 2);
 }
 
 TEST(PaKVReorderOpTest, ModelWithOp) {

--- a/src/core/shape_inference/include/pa_kv_reorder_shape_inference.hpp
+++ b/src/core/shape_inference/include/pa_kv_reorder_shape_inference.hpp
@@ -18,6 +18,6 @@ std::vector<TRShape> shape_infer(const PaKVReorder* op, const std::vector<T>& in
         NODE_SHAPE_INFER_CHECK(op, input_shapes, input_shapes[i].rank().compatible(1));
     }
 
-    return {TRShape{1}};
+    return {input_shapes[0], input_shapes[1]};
 }
 }  // namespace ov::op::internal

--- a/src/core/src/op/pa_kv_reorder.cpp
+++ b/src/core/src/op/pa_kv_reorder.cpp
@@ -42,7 +42,8 @@ void PaKVReorder::validate_and_infer_types() {
     }
 
     const auto output_shapes = shape_infer(this, ov::util::get_node_input_partial_shapes(*this));
-    set_output_type(0, ov::element::u8, output_shapes[0]);
+    set_output_type(0, get_input_element_type(0), output_shapes[0]);
+    set_output_type(1, get_input_element_type(1), output_shapes[1]);
 }
 
 std::shared_ptr<Node> PaKVReorder::clone_with_new_inputs(const ov::OutputVector& new_args) const {

--- a/src/core/src/pass/pa_kv_reorder_fusion.cpp
+++ b/src/core/src/pass/pa_kv_reorder_fusion.cpp
@@ -170,6 +170,15 @@ std::vector<std::shared_ptr<ov::op::v0::Concat>> get_joint_concat_consumers(
     return concats;
 }
 
+bool is_model_result_output(const std::shared_ptr<ov::Model>& model, const ov::Output<ov::Node>& output) {
+    for (const auto& result : model->get_results()) {
+        if (same_output(result->input_value(0), output)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 }  // namespace
 
 PaKVReorderFusion::PaKVReorderFusion(ov::element::Type cache_precision) : m_cache_precision(cache_precision) {}
@@ -213,7 +222,8 @@ bool PaKVReorderFusion::run_on_model(const std::shared_ptr<ov::Model>& m) {
 
         const auto concat_consumers =
             get_joint_concat_consumers(key_path.scatter->output(0), value_path.scatter->output(0));
-        if (concat_consumers.empty()) {
+        if (concat_consumers.empty() && !(is_model_result_output(m, key_path.scatter->output(0)) &&
+                                          is_model_result_output(m, value_path.scatter->output(0)))) {
             continue;
         }
 
@@ -237,16 +247,15 @@ bool PaKVReorderFusion::run_on_model(const std::shared_ptr<ov::Model>& m) {
         }
         ov::copy_runtime_info(runtime_info_nodes, pa_kv_reorder);
 
-        pa_kv_reorder->output(0).get_tensor().set_names(concat_consumers.front()->output(0).get_tensor().get_names());
-
-        for (const auto& concat : concat_consumers) {
-            for (const auto& target_input : concat->output(0).get_target_inputs()) {
-                if (auto result = ov::as_type_ptr<ov::op::v0::Result>(target_input.get_node()->shared_from_this())) {
-                    result->set_argument(0, pa_kv_reorder->output(0));
-                }
+        for (const auto& result : m->get_results()) {
+            if (same_output(result->input_value(0), key_path.scatter->output(0))) {
+                result->set_argument(0, pa_kv_reorder->output(0));
+            } else if (same_output(result->input_value(0), value_path.scatter->output(0))) {
+                result->set_argument(0, pa_kv_reorder->output(1));
             }
-            ov::replace_output_update_name(concat->output(0), pa_kv_reorder->output(0));
         }
+        ov::replace_output_update_name(key_path.scatter->output(0), pa_kv_reorder->output(0));
+        ov::replace_output_update_name(value_path.scatter->output(0), pa_kv_reorder->output(1));
         rewritten = true;
     }
 

--- a/src/core/tests/type_prop/pa_kv_reorder.cpp
+++ b/src/core/tests/type_prop/pa_kv_reorder.cpp
@@ -29,9 +29,11 @@ TEST_F(TypePropPaKVReorderTest, static_shapes) {
                             block_update_indices,
                             block_update_indices_begins);
 
-    EXPECT_EQ(op->get_output_element_type(0), element::u8);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1}));
-    EXPECT_EQ(op->get_output_size(), 1);
+    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{100, 8, 64, 16}));
+    EXPECT_EQ(op->get_output_element_type(1), element::f16);
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{100, 8, 16, 64}));
+    EXPECT_EQ(op->get_output_size(), 2);
 }
 
 TEST_F(TypePropPaKVReorderTest, dynamic_batch) {
@@ -54,8 +56,10 @@ TEST_F(TypePropPaKVReorderTest, dynamic_batch) {
                             block_update_indices,
                             block_update_indices_begins);
 
-    EXPECT_EQ(op->get_output_element_type(0), element::u8);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1}));
+    EXPECT_EQ(op->get_output_element_type(0), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{Dimension::dynamic(), 8, 64, 16}));
+    EXPECT_EQ(op->get_output_element_type(1), element::f32);
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{Dimension::dynamic(), 8, 16, 64}));
 }
 
 TEST_F(TypePropPaKVReorderTest, fully_dynamic_shapes) {
@@ -74,8 +78,10 @@ TEST_F(TypePropPaKVReorderTest, fully_dynamic_shapes) {
                             block_update_indices,
                             block_update_indices_begins);
 
-    EXPECT_EQ(op->get_output_element_type(0), element::u8);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1}));
+    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape::dynamic(4)));
+    EXPECT_EQ(op->get_output_element_type(1), element::f16);
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape::dynamic(4)));
 }
 
 TEST_F(TypePropPaKVReorderTest, dynamic_rank) {
@@ -93,8 +99,10 @@ TEST_F(TypePropPaKVReorderTest, dynamic_rank) {
                             block_update_indices,
                             block_update_indices_begins);
 
-    EXPECT_EQ(op->get_output_element_type(0), element::u8);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1}));
+    EXPECT_EQ(op->get_output_element_type(0), element::f16);
+    EXPECT_EQ(op->get_output_partial_shape(0), PartialShape::dynamic());
+    EXPECT_EQ(op->get_output_element_type(1), element::f16);
+    EXPECT_EQ(op->get_output_partial_shape(1), PartialShape::dynamic());
 }
 
 TEST_F(TypePropPaKVReorderTest, invalid_key_cache_rank) {
@@ -184,8 +192,10 @@ TEST_F(TypePropPaKVReorderTest, i8_cache) {
                             block_update_indices,
                             block_update_indices_begins);
 
-    EXPECT_EQ(op->get_output_element_type(0), element::u8);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{1}));
+    EXPECT_EQ(op->get_output_element_type(0), element::i8);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{100, 8, 64, 16}));
+    EXPECT_EQ(op->get_output_element_type(1), element::i8);
+    EXPECT_EQ(op->get_output_partial_shape(1), (PartialShape{100, 8, 16, 64}));
 }
 
 }  // namespace ov::test

--- a/src/plugins/intel_cpu/src/nodes/pa_kv_reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pa_kv_reorder.cpp
@@ -4,7 +4,6 @@
 
 #include "pa_kv_reorder.hpp"
 
-#include <cstring>
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <string>
@@ -39,8 +38,8 @@ bool PaKVReorder::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
             return false;
         }
 
-        if (op->get_output_size() != 1) {
-            errorMessage = "PaKVReorder expects 1 output.";
+        if (op->get_output_size() != 2) {
+            errorMessage = "PaKVReorder expects 2 outputs.";
             return false;
         }
     } catch (...) {
@@ -75,14 +74,15 @@ void PaKVReorder::initSupportedPrimitiveDescriptors() {
     const auto key_cache_precision = getOriginalInputPrecisionAtPort(0);
     const auto value_cache_precision = getOriginalInputPrecisionAtPort(1);
 
-    addSupportedPrimDesc({{LayoutType::ncsp, key_cache_precision},
-                          {LayoutType::ncsp, value_cache_precision},
-                          {LayoutType::ncsp, ov::element::i32},
-                          {LayoutType::ncsp, ov::element::i32},
-                          {LayoutType::ncsp, ov::element::i32},
-                          {LayoutType::ncsp, ov::element::i32}},
-                         {{LayoutType::ncsp, ov::element::u8}},
-                         impl_desc_type::ref_any);
+    addSupportedPrimDesc(
+        {{LayoutType::ncsp, key_cache_precision, false, 0},
+         {LayoutType::ncsp, value_cache_precision, false, 1},
+         {LayoutType::ncsp, ov::element::i32},
+         {LayoutType::ncsp, ov::element::i32},
+         {LayoutType::ncsp, ov::element::i32},
+         {LayoutType::ncsp, ov::element::i32}},
+        {{LayoutType::ncsp, key_cache_precision, false, 0}, {LayoutType::ncsp, value_cache_precision, false, 1}},
+        impl_desc_type::ref_any);
 }
 
 void PaKVReorder::createPrimitive() {
@@ -117,10 +117,6 @@ void PaKVReorder::execute([[maybe_unused]] const dnnl::stream& strm) {
     CPU_NODE_ASSERT(block_indices_begins.size(0) == block_update_indices_begins.size(0),
                     "expects block_indices_begins and block_update_indices_begins to have same length");
 
-    // The KV cache tensors are modified in-place: PaKVReorder rewrites tokens within key_cache and
-    // value_cache and produces only a dummy [1] u8 status output. This violates the usual immutable-input
-    // contract and is a special case intended exclusively for the GenAI paged-attention backend, where the
-    // cache is owned by the runtime and the reorder is applied between main/draft decoding steps.
     ov::Extensions::Cpu::XARCH::reorder_kv_cache(key_cache,
                                                  value_cache,
                                                  block_indices,
@@ -130,19 +126,6 @@ void PaKVReorder::execute([[maybe_unused]] const dnnl::stream& strm) {
                                                  m_key_by_channel,
                                                  m_value_by_channel,
                                                  context->getCpuParallel());
-
-    if (getChildEdges().empty()) {
-        return;
-    }
-
-    auto* out = getDstDataAtPort(0);
-    const auto& outputMemory = getDstMemoryAtPort(0);
-    const auto& outputShape = outputMemory->getShape();
-    if (out != nullptr && outputShape.isStatic() && !outputShape.hasZeroDims()) {
-        const auto outputSize = outputMemory->getDesc().getCurrentMemSize();
-        CPU_NODE_ASSERT(outputSize != MemoryDesc::UNDEFINED_SIZE, "KV output tensor size is undefined");
-        std::memset(out, 0, outputSize);
-    }
 }
 
 void PaKVReorder::executeDynamicImpl(const dnnl::stream& strm) {

--- a/src/plugins/intel_cpu/tests/unit/pa_kv_reorder_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/pa_kv_reorder_test.cpp
@@ -312,6 +312,59 @@ TEST_F(PaKVReorderFloatCacheTest, CrossBlock) {
     expect_token_payload_equals(value_data, value_data_copy, 1, 10, 0, 5);
 }
 
+TEST_F(PaKVReorderFloatCacheTest, F16TreeCompactionUsesOriginalSourceTokens) {
+    constexpr size_t num_blocks = 1;
+    const size_t cache_size = num_blocks * kNumHeads * kBlockSize * kHeadSize;
+
+    std::vector<ov::float16> key_data(cache_size);
+    std::vector<ov::float16> value_data(cache_size);
+    for (size_t h = 0; h < kNumHeads; h++) {
+        for (size_t t = 0; t < kBlockSize; t++) {
+            for (size_t d = 0; d < kHeadSize; d++) {
+                const size_t offset = cache_offset(0, h, t) + d;
+                key_data[offset] = ov::float16(static_cast<float>(t * 100 + h * 10 + d));
+                value_data[offset] = ov::float16(static_cast<float>(t * 100 + h * 10 + d + 10000));
+            }
+        }
+    }
+    const auto key_data_copy = key_data;
+    const auto value_data_copy = value_data;
+
+    PlainTensor key_cache;
+    key_cache.resize<ov::float16>({num_blocks, kNumHeads, kBlockSize, kHeadSize}, key_data.data());
+    PlainTensor value_cache;
+    value_cache.resize<ov::float16>({num_blocks, kNumHeads, kBlockSize, kHeadSize}, value_data.data());
+
+    std::vector<int32_t> block_indices_data = {0};
+    std::vector<int32_t> block_indices_begins_data = {0, 1};
+    std::vector<int32_t> block_update_indices_data = {15, 13, 18, 14};
+    std::vector<int32_t> block_update_indices_begins_data = {0, 2};
+
+    auto block_indices = make_index_tensor(block_indices_data);
+    auto block_indices_begins = make_index_tensor(block_indices_begins_data);
+    auto block_update_indices = make_index_tensor(block_update_indices_data);
+    auto block_update_indices_begins = make_index_tensor(block_update_indices_begins_data);
+
+    reorder_kv_cache(key_cache,
+                     value_cache,
+                     block_indices,
+                     block_indices_begins,
+                     block_update_indices,
+                     block_update_indices_begins,
+                     /*key_by_channel=*/false,
+                     /*value_by_channel=*/false,
+                     make_cpu_parallel());
+
+    for (size_t h = 0; h < kNumHeads; h++) {
+        for (size_t d = 0; d < kHeadSize; d++) {
+            EXPECT_EQ(key_data[cache_offset(0, h, 13) + d], key_data_copy[cache_offset(0, h, 15) + d]);
+            EXPECT_EQ(key_data[cache_offset(0, h, 14) + d], key_data_copy[cache_offset(0, h, 18) + d]);
+            EXPECT_EQ(value_data[cache_offset(0, h, 13) + d], value_data_copy[cache_offset(0, h, 15) + d]);
+            EXPECT_EQ(value_data[cache_offset(0, h, 14) + d], value_data_copy[cache_offset(0, h, 18) + d]);
+        }
+    }
+}
+
 // ----------------------------------------------------------------------------
 // Quantized cache tests
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
### Details:
 - *Root cause: EAGLE3 needs to reorder and compact the KV cache after it selects the valid tokens from a speculative token tree.
Previously, PaKVReorder changed the Key and Value cache tensors in place, but exposed only a dummy output tensor. In other words, the graph did not explicitly say that the updated K/V caches were results of the operation.
Because of this, the runtime could execute the reorder using temporary internal buffers. The reorder operation modified those buffers, but the updated data was not guaranteed to be written back to the external KV cache used by the next decoding step.
As a result, EAGLE3 could select the correct branch but then continue decoding with stale cache data. This caused token divergence, especially in the FP16 configuration where a small cache difference can more easily change the next selected token.*
 - *Fix: We changed PaKVReorder to produce two real outputs:
output 0: updated Key cache
output 1: updated Value cache
The CPU plugin marks each output as in-place with its corresponding input:
Key cache input  <-> Key cache output
Value cache input <-> Value cache output
Therefore, no additional full-cache copy is needed.
We also changed the EAGLE3 helper graph and fusion pass so that Key and Value cache updates are separate model outputs. GenAI explicitly binds these outputs to the external KV cache tensors.
Now the runtime knows that the reordered K/V caches are real results that must be preserved for the next decoding step. After the fix, FP16 EAGLE3 produces the same token IDs as target-only decoding in the tested deterministic cases, and the full WWB similarity improved from 0.88574980 to 0.97614926.*

### Tickets:
 - *CVS-191948*

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
