### PR TITLE
[DO NOT REVIEW] [Transformations] Fuse dynamic SAME padding into convolutions

### DIFF
--- a/src/common/transformations/include/sources.cmake
+++ b/src/common/transformations/include/sources.cmake
@@ -75,6 +75,7 @@ set(COMMON_OPTIMIZATIONS_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/disable_shapeof_constant_folding.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/divide_fusion.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/dropout_with_random_uniform_replacer.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/dynamic_same_padding_fusion.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/eliminate_duplicate_ti_inputs.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/eliminate_loop_inputs_outputs.hpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/eliminate_unsqueeze_gather.hpp

--- a/src/common/transformations/include/transformations/common_optimizations/dynamic_same_padding_fusion.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/dynamic_same_padding_fusion.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "openvino/pass/matcher_pass.hpp"
+#include "transformations_visibility.hpp"
+
+namespace ov::pass {
+
+/**
+ * @brief Absorb explicit, dynamically computed SAME_UPPER padding into a forward convolution.
+ *
+ * Recognizes spatial padding computed from ShapeOf of the unpadded input, including the
+ * scalar arithmetic and padding-vector rearrangements produced by PyTorch/timm exports.
+ * Supports Convolution and GroupConvolution, preserving other users of the Pad and its
+ * shape subgraph. Only constant zero padding and convolutions without existing padding
+ * are eligible.
+ */
+class TRANSFORMATIONS_API DynamicSamePaddingFusion : public MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("DynamicSamePaddingFusion");
+    DynamicSamePaddingFusion();
+};
+
+}  // namespace ov::pass

--- a/src/common/transformations/src/sources.cmake
+++ b/src/common/transformations/src/sources.cmake
@@ -38,6 +38,7 @@ set(COMMON_OPTIMIZATIONS_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/disable_shapeof_constant_folding.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/divide_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/dropout_with_random_uniform_replacer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/dynamic_same_padding_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/eliminate_duplicate_ti_inputs.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/eliminate_loop_inputs_outputs.cpp
     ${CMAKE_CURRENT_LIST_DIR}/transformations/common_optimizations/eliminate_unsqueeze_gather.cpp

--- a/src/common/transformations/src/transformations/common_optimizations/dynamic_same_padding_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/dynamic_same_padding_fusion.cpp
@@ -1,0 +1,396 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transformations/common_optimizations/dynamic_same_padding_fusion.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <numeric>
+
+#include "itt.hpp"
+#include "openvino/core/graph_util.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/ceiling.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/convolution.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/floor.hpp"
+#include "openvino/op/group_conv.hpp"
+#include "openvino/op/maximum.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/split.hpp"
+#include "openvino/op/squeeze.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/gather_base.hpp"
+#include "openvino/op/util/pad_base.hpp"
+#include "openvino/op/util/shape_of_base.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+namespace {
+using namespace ov;
+
+// A single element of a small shape tensor. Follow only operations that rearrange
+// elements; arithmetic is checked separately, without evaluating sample input sizes.
+struct Scalar {
+    Output<Node> value;
+    size_t index = 0;
+};
+
+size_t small_tensor_size(const Output<Node>& value) {
+    const auto& shape = value.get_partial_shape();
+    if (shape.is_dynamic())
+        return 0;
+    size_t count = 1;
+    for (const auto& dim : shape) {
+        const auto length = static_cast<size_t>(dim.get_length());
+        if (length == 0 || length > 64 / count)
+            return 0;
+        count *= length;
+    }
+    return count;
+}
+
+bool resolve(Scalar& scalar) {
+    for (size_t depth = 0; depth < 64; ++depth) {
+        if (scalar.index >= small_tensor_size(scalar.value))
+            return false;
+        const auto node = scalar.value.get_node_shared_ptr();
+        if (is_type<op::v1::Reshape>(node) || is_type<op::v0::Squeeze>(node) || is_type<op::v0::Unsqueeze>(node)) {
+            if (small_tensor_size(node->input_value(0)) != small_tensor_size(scalar.value))
+                return false;
+            scalar.value = node->input_value(0);
+        } else if (const auto concat = as_type_ptr<op::v0::Concat>(node)) {
+            if (scalar.value.get_shape().size() != 1 || (concat->get_axis() != 0 && concat->get_axis() != -1))
+                return false;
+            bool found = false;
+            for (const auto& input : concat->input_values()) {
+                const auto size = small_tensor_size(input);
+                if (scalar.index < size) {
+                    scalar.value = input;
+                    found = true;
+                    break;
+                }
+                scalar.index -= size;
+            }
+            if (!found)
+                return false;
+        } else if (const auto gather = as_type_ptr<op::util::GatherBase>(node)) {
+            const auto indices = as_type_ptr<op::v0::Constant>(gather->input_value(1).get_node_shared_ptr());
+            const auto axis = as_type_ptr<op::v0::Constant>(gather->input_value(2).get_node_shared_ptr());
+            const auto& input = gather->input_value(0);
+            const auto size = small_tensor_size(input);
+            if (!indices || !axis || shape_size(axis->get_shape()) != 1 || size == 0 || input.get_shape().size() != 1 ||
+                gather->get_batch_dims() != 0)
+                return false;
+            const auto axis_value = axis->cast_vector<int64_t>()[0];
+            if (axis_value != 0 && axis_value != -1)
+                return false;
+            const auto values = indices->cast_vector<int64_t>();
+            if (scalar.index >= values.size())
+                return false;
+            auto index = values[scalar.index];
+            if (index < 0)
+                index += static_cast<int64_t>(size);
+            if (index < 0 || static_cast<size_t>(index) >= size)
+                return false;
+            scalar = {input, static_cast<size_t>(index)};
+        } else if (const auto split = as_type_ptr<op::v1::Split>(node)) {
+            const auto axis = as_type_ptr<op::v0::Constant>(split->input_value(1).get_node_shared_ptr());
+            const auto& input = split->input_value(0);
+            if (!axis || shape_size(axis->get_shape()) != 1 || small_tensor_size(input) == 0)
+                return false;
+            const auto shape = input.get_shape();
+            auto axis_value = axis->cast_vector<int64_t>()[0];
+            if (axis_value < 0)
+                axis_value += static_cast<int64_t>(shape.size());
+            if (axis_value < 0 || static_cast<size_t>(axis_value) >= shape.size())
+                return false;
+            const auto inner =
+                std::accumulate(shape.begin() + axis_value + 1, shape.end(), size_t{1}, std::multiplies<size_t>());
+            const auto chunk = scalar.value.get_shape()[axis_value] * inner;
+            scalar.index = scalar.index / chunk * shape[axis_value] * inner + scalar.value.get_index() * chunk +
+                           scalar.index % chunk;
+            scalar.value = input;
+        } else {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool constant(Scalar scalar, double& value) {
+    if (!resolve(scalar))
+        return false;
+    const auto c = as_type_ptr<op::v0::Constant>(scalar.value.get_node_shared_ptr());
+    if (!c)
+        return false;
+    value = c->cast_vector<double>()[scalar.index];
+    return std::isfinite(value);
+}
+
+bool constant_is(const Scalar& scalar, double expected) {
+    double value;
+    return constant(scalar, value) && value == expected;
+}
+
+bool input_scalar(const Scalar& scalar, size_t port, Scalar& input) {
+    const auto& value = scalar.value.get_node_shared_ptr()->input_value(port);
+    const auto size = small_tensor_size(value);
+    if (size == 0 || (size != 1 && value.get_shape() != scalar.value.get_shape()))
+        return false;
+    input = {value, size == 1 ? 0 : scalar.index};
+    return resolve(input);
+}
+
+bool is_shape_float(const element::Type& type) {
+    return type == element::f32 || type == element::f64;
+}
+
+bool unwrap_integer_convert(Scalar& scalar) {
+    if (!resolve(scalar))
+        return false;
+    if (const auto convert = as_type_ptr<op::v0::Convert>(scalar.value.get_node_shared_ptr())) {
+        const auto type = convert->get_destination_type();
+        if ((type != element::i32 && type != element::i64) || !is_shape_float(convert->get_input_element_type(0)))
+            return false;
+        return input_scalar(scalar, 0, scalar);
+    }
+    return true;
+}
+
+bool is_dimension(Scalar scalar, const Output<Node>& data, size_t axis) {
+    if (!resolve(scalar))
+        return false;
+    if (const auto convert = as_type_ptr<op::v0::Convert>(scalar.value.get_node_shared_ptr())) {
+        if (!is_shape_float(convert->get_destination_type()) ||
+            (convert->get_input_element_type(0) != element::i32 &&
+             convert->get_input_element_type(0) != element::i64) ||
+            !input_scalar(scalar, 0, scalar))
+            return false;
+    }
+    const auto shape = as_type_ptr<op::util::ShapeOfBase>(scalar.value.get_node_shared_ptr());
+    return shape && shape->input_value(0) == data && scalar.index == axis;
+}
+
+bool divided_by(Scalar scalar, double divisor, Scalar& numerator) {
+    if (!resolve(scalar) || !is_shape_float(scalar.value.get_element_type()))
+        return false;
+    Scalar a, b;
+    const auto node = scalar.value.get_node_shared_ptr();
+    if ((!is_type<op::v1::Divide>(node) && !is_type<op::v1::Multiply>(node)) || !input_scalar(scalar, 0, a) ||
+        !input_scalar(scalar, 1, b))
+        return false;
+    if (is_type<op::v1::Divide>(node)) {
+        if (!constant_is(b, divisor))
+            return false;
+        numerator = a;
+        return true;
+    }
+    // Only accept an exact reciprocal (in particular, division by two in the
+    // padding split). Do not approximate a precision-sensitive shape division.
+    int exponent;
+    if (std::frexp(divisor, &exponent) != 0.5)
+        return false;
+    if (constant_is(a, 1.0 / divisor)) {
+        numerator = b;
+        return true;
+    }
+    if (constant_is(b, 1.0 / divisor)) {
+        numerator = a;
+        return true;
+    }
+    return false;
+}
+
+using Coefficients = std::array<double, 3>;
+using Atom = std::function<bool(const Scalar&, Coefficients&)>;
+
+// Recognize affine combinations of two explicitly checked atoms and a constant.
+// This handles both (ceil(I/S)-1)*S+Keff-I and constant-folded/reassociated exports.
+bool affine(Scalar scalar, const Atom& atom, Coefficients& result, size_t& budget) {
+    if (budget == 0 || !resolve(scalar))
+        return false;
+    --budget;
+    if (atom(scalar, result))
+        return true;
+    double value;
+    if (constant(scalar, value)) {
+        result = {0, 0, value};
+        return true;
+    }
+    Scalar a, b;
+    const auto node = scalar.value.get_node_shared_ptr();
+    if ((!is_type<op::v1::Add>(node) && !is_type<op::v1::Subtract>(node) && !is_type<op::v1::Multiply>(node)) ||
+        !input_scalar(scalar, 0, a) || !input_scalar(scalar, 1, b))
+        return false;
+    if (is_type<op::v1::Multiply>(node)) {
+        if (constant(a, value))
+            std::swap(a, b);
+        else if (!constant(b, value))
+            return false;
+        if (!affine(a, atom, result, budget))
+            return false;
+        for (auto& coefficient : result)
+            coefficient *= value;
+    } else {
+        Coefficients lhs, rhs;
+        if (!affine(a, atom, lhs, budget) || !affine(b, atom, rhs, budget))
+            return false;
+        const auto sign = is_type<op::v1::Add>(node) ? 1 : -1;
+        for (size_t i = 0; i < result.size(); ++i)
+            result[i] = lhs[i] + sign * rhs[i];
+    }
+    return true;
+}
+
+bool matches_affine(const Scalar& scalar, const Atom& atom, const Coefficients& expected) {
+    size_t budget = 128;
+    Coefficients result;
+    return affine(scalar, atom, result, budget) && result == expected;
+}
+
+class SamePadding {
+public:
+    SamePadding(const Output<Node>& data, size_t axis, size_t stride, size_t effective_kernel)
+        : m_data(data),
+          m_axis(axis),
+          m_stride(static_cast<double>(stride)),
+          m_kernel(static_cast<double>(effective_kernel)) {}
+
+    bool begin(Scalar scalar) const {
+        return unwrap_integer_convert(scalar) && half(scalar);
+    }
+
+    bool end(Scalar scalar) const {
+        if (!unwrap_integer_convert(scalar))
+            return false;
+        return matches_affine(scalar,
+                              [this](const Scalar& s, Coefficients& c) {
+                                  if (total(s)) {
+                                      c = {1, 0, 0};
+                                      return true;
+                                  }
+                                  if (half(s)) {
+                                      c = {0, 1, 0};
+                                      return true;
+                                  }
+                                  return false;
+                              },
+                              {1, -1, 0});
+    }
+
+private:
+    bool total(Scalar scalar) const {
+        if (!resolve(scalar) || !is_type<op::v1::Maximum>(scalar.value.get_node()))
+            return false;
+        Scalar a, b;
+        if (!input_scalar(scalar, 0, a) || !input_scalar(scalar, 1, b))
+            return false;
+        if (constant_is(a, 0))
+            std::swap(a, b);
+        if (!constant_is(b, 0))
+            return false;
+        return matches_affine(a,
+                              [this](Scalar s, Coefficients& c) {
+                                  if (is_dimension(s, m_data, m_axis)) {
+                                      c = {1, 0, 0};
+                                      return true;
+                                  }
+                                  Scalar numerator;
+                                  if (is_type<op::v0::Ceiling>(s.value.get_node()) && input_scalar(s, 0, s) &&
+                                      divided_by(s, m_stride, numerator) && is_dimension(numerator, m_data, m_axis)) {
+                                      c = {0, 1, 0};
+                                      return true;
+                                  }
+                                  return false;
+                              },
+                              {-1, m_stride, m_kernel - m_stride});
+    }
+
+    bool half(Scalar scalar) const {
+        Scalar numerator;
+        return resolve(scalar) && is_type<op::v0::Floor>(scalar.value.get_node()) && input_scalar(scalar, 0, scalar) &&
+               divided_by(scalar, 2, numerator) && total(numerator);
+    }
+
+    Output<Node> m_data;
+    size_t m_axis;
+    double m_stride;
+    double m_kernel;
+};
+}  // namespace
+
+ov::pass::DynamicSamePaddingFusion::DynamicSamePaddingFusion() {
+    MATCHER_SCOPE(DynamicSamePaddingFusion);
+    const auto root_pattern = pattern::wrap_type<op::v1::Convolution, op::v1::GroupConvolution>();
+    matcher_pass_callback callback = [this](pattern::Matcher& matcher) {
+        const auto conv = as_type_ptr<op::util::ConvolutionFwdPropBase>(matcher.get_match_root());
+        if (transformation_callback(conv))
+            return false;
+        const auto pad = as_type_ptr<op::util::PadBase>(conv->input_value(0).get_node_shared_ptr());
+        if (!pad || pad->get_pad_mode() != op::PadMode::CONSTANT ||
+            (pad->get_input_size() == 4 && !constant_is({pad->input_value(3)}, 0)))
+            return false;
+        if (conv->get_auto_pad() != op::PadType::EXPLICIT && conv->get_auto_pad() != op::PadType::VALID)
+            return false;
+        const auto is_zero = [](ptrdiff_t value) {
+            return value == 0;
+        };
+        if (!std::all_of(conv->get_pads_begin().begin(), conv->get_pads_begin().end(), is_zero) ||
+            !std::all_of(conv->get_pads_end().begin(), conv->get_pads_end().end(), is_zero))
+            return false;
+        const auto& data = pad->input_value(0);
+        const auto& shape = data.get_partial_shape();
+        const auto& weights = conv->get_input_partial_shape(1);
+        if (shape.rank().is_dynamic() || weights.rank().is_dynamic())
+            return false;
+        const auto rank = static_cast<size_t>(shape.rank().get_length());
+        const auto offset = is_type<op::v1::GroupConvolution>(conv) ? 3u : 2u;
+        if (rank < 3 || rank > 5 || weights.size() != rank + offset - 2 || conv->get_strides().size() != rank - 2 ||
+            conv->get_dilations().size() != rank - 2 ||
+            pad->get_input_partial_shape(1) != PartialShape{static_cast<int64_t>(rank)} ||
+            pad->get_input_partial_shape(2) != PartialShape{static_cast<int64_t>(rank)})
+            return false;
+        for (size_t axis = 0; axis < rank; ++axis) {
+            const Scalar begin{pad->input_value(1), axis};
+            const Scalar end{pad->input_value(2), axis};
+            if (axis < 2) {
+                if (!constant_is(begin, 0) || !constant_is(end, 0))
+                    return false;
+                continue;
+            }
+            const auto& kernel = weights[axis - 2 + offset];
+            if (kernel.is_dynamic() || kernel.get_length() <= 0)
+                return false;
+            const auto stride = conv->get_strides()[axis - 2];
+            const auto dilation = conv->get_dilations()[axis - 2];
+            if (stride == 0 || dilation == 0 ||
+                static_cast<size_t>(kernel.get_length()) - 1 > (std::numeric_limits<size_t>::max() - 1) / dilation)
+                return false;
+            const auto effective_kernel = (static_cast<size_t>(kernel.get_length()) - 1) * dilation + 1;
+            const SamePadding same(data, axis, stride, effective_kernel);
+            if (!same.begin(begin) || !same.end(end))
+                return false;
+        }
+        // Clone first, so Pad users with different convolution attributes or other
+        // consumers of the shape arithmetic retain their original inputs.
+        const auto replacement =
+            as_type_ptr<op::util::ConvolutionFwdPropBase>(conv->clone_with_new_inputs(conv->input_values()));
+        replacement->set_argument(0, data);
+        replacement->set_auto_pad(op::PadType::SAME_UPPER);
+        replacement->validate_and_infer_types();
+        replacement->set_friendly_name(conv->get_friendly_name());
+        copy_runtime_info({pad, conv}, replacement);
+        replace_node(conv, replacement);
+        return true;
+    };
+    register_matcher(std::make_shared<pattern::Matcher>(root_pattern, matcher_name), callback);
+}

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -31,6 +31,7 @@
 #include "transformations/common_optimizations/disable_random_uniform_constant_folding.hpp"
 #include "transformations/common_optimizations/disable_shapeof_constant_folding.hpp"
 #include "transformations/common_optimizations/divide_fusion.hpp"
+#include "transformations/common_optimizations/dynamic_same_padding_fusion.hpp"
 #include "transformations/common_optimizations/eliminate_duplicate_ti_inputs.hpp"
 #include "transformations/common_optimizations/eliminate_loop_inputs_outputs.hpp"
 #include "transformations/common_optimizations/eliminate_unsqueeze_gather.hpp"
@@ -233,6 +234,7 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     ADD_MATCHER(common_fusions, HSigmoidFusion)
     ADD_MATCHER(common_fusions, NormalizeL2Fusion)
     ADD_MATCHER(common_fusions, ClampFusion)
+    ADD_MATCHER(common_fusions, DynamicSamePaddingFusion)
     ADD_MATCHER(common_fusions, PadFusion)
     ADD_MATCHER(common_fusions, SoftmaxFusion)
     ADD_MATCHER(common_fusions, ReduceReshapeFusion)

--- a/src/common/transformations/tests/common_optimizations/dynamic_same_padding_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/dynamic_same_padding_fusion.cpp
@@ -1,0 +1,421 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transformations/common_optimizations/dynamic_same_padding_fusion.hpp"
+
+#include <gtest/gtest.h>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/opsets/opset13.hpp"
+#include "transformations/common_optimizations/moc_transformations.hpp"
+
+namespace {
+using namespace ov;
+using namespace ov::opset13;
+
+struct Config {
+    PartialShape shape{1, 3, -1, -1};
+    Shape kernel{3, 3};
+    Strides strides{2, 2};
+    Strides dilations{1, 1};
+    element::Type math_type = element::f32;
+    element::Type shape_type = element::i64;
+    bool grouped = false;
+    bool pad_v1 = false;
+    bool expanded = false;
+    bool decompose_subtract = false;
+    bool reciprocal = true;
+    bool reciprocal_stride = false;
+    bool timm_layout = true;
+    bool wrong_axis = false;
+    bool wrong_source = false;
+    bool same_lower = false;
+    bool shared_conv = false;
+    bool different_consumer_stride = false;
+    bool output_pad = false;
+    bool output_shape = false;
+    bool implicit_pad_value = false;
+    double pad_value = 0;
+    double batch_pad = 0;
+    double kernel_adjustment = 0;
+    double split_divisor = 2;
+    op::PadMode pad_mode = op::PadMode::CONSTANT;
+    op::PadType auto_pad = op::PadType::EXPLICIT;
+    CoordinateDiff conv_pads{0, 0};
+};
+
+Output<Node> scalar_constant(const Config& c, double value) {
+    return Constant::create(c.math_type, Shape{}, {value});
+}
+
+Output<Node> subtract(const Output<Node>& a, const Output<Node>& b, const Config& c) {
+    if (c.decompose_subtract)
+        return std::make_shared<Add>(a, std::make_shared<Multiply>(b, scalar_constant(c, -1)));
+    return std::make_shared<Subtract>(a, b);
+}
+
+std::shared_ptr<op::util::PadBase> make_pad(const Output<Node>& data, const Output<Node>& shape, const Config& c) {
+    const auto axis_zero = Constant::create(element::i32, Shape{}, {0});
+    OutputVector begins, ends;
+    for (size_t i = 0; i < c.kernel.size(); ++i) {
+        const auto axis = c.wrong_axis ? 2 + (i + 1) % c.kernel.size() : 2 + i;
+        const auto size = std::make_shared<Convert>(
+            std::make_shared<Gather>(shape, Constant::create(element::i64, Shape{}, {axis}), axis_zero),
+            c.math_type);
+        const auto stride = scalar_constant(c, c.strides[i]);
+        Output<Node> divided;
+        if (c.reciprocal_stride)
+            divided = std::make_shared<Multiply>(size, scalar_constant(c, 1.0 / c.strides[i]));
+        else
+            divided = std::make_shared<Divide>(size, stride);
+        const auto ceil = std::make_shared<Ceiling>(divided);
+        const auto effective = (c.kernel[i] - 1) * c.dilations[i] + 1 + c.kernel_adjustment;
+        Output<Node> extent;
+        if (c.expanded) {
+            extent = std::make_shared<Add>(std::make_shared<Multiply>(subtract(ceil, scalar_constant(c, 1), c), stride),
+                                           scalar_constant(c, effective));
+        } else {
+            extent = std::make_shared<Add>(std::make_shared<Multiply>(stride, ceil),
+                                           scalar_constant(c, effective - c.strides[i]));
+        }
+        const auto total = std::make_shared<Maximum>(scalar_constant(c, 0), subtract(extent, size, c));
+        Output<Node> half;
+        if (c.reciprocal)
+            half = std::make_shared<Multiply>(scalar_constant(c, 1 / c.split_divisor), total);
+        else
+            half = std::make_shared<Divide>(total, scalar_constant(c, c.split_divisor));
+        half = std::make_shared<Floor>(half);
+        Output<Node> before = std::make_shared<Convert>(half, c.shape_type);
+        Output<Node> after = std::make_shared<Convert>(subtract(total, half, c), c.shape_type);
+        if (c.same_lower)
+            std::swap(before, after);
+        begins.push_back(std::make_shared<Unsqueeze>(before, axis_zero));
+        ends.push_back(std::make_shared<Unsqueeze>(after, axis_zero));
+    }
+    Output<Node> begin, end;
+    if (c.timm_layout) {
+        // F.pad uses [W_begin, W_end, H_begin, H_end, ...]. Its frontend
+        // translation splits the pairs and reverses the spatial axes.
+        OutputVector pairs;
+        std::vector<int64_t> reverse;
+        for (size_t i = begins.size(); i-- > 0;) {
+            pairs.push_back(begins[i]);
+            pairs.push_back(ends[i]);
+            reverse.push_back(i);
+        }
+        const auto packed = std::make_shared<Concat>(pairs, 0);
+        const auto matrix = std::make_shared<Reshape>(packed, Constant::create(element::i32, Shape{2}, {-1, 2}), false);
+        const auto axis_one = Constant::create(element::i32, Shape{}, {1});
+        const auto split = std::make_shared<Split>(matrix, axis_one, 2);
+        const auto indices = Constant::create(element::i64, Shape{reverse.size()}, reverse);
+        begin = std::make_shared<Gather>(std::make_shared<Squeeze>(split->output(0), axis_one), indices, axis_zero);
+        end = std::make_shared<Gather>(std::make_shared<Squeeze>(split->output(1), axis_one), indices, axis_zero);
+    } else {
+        begin = std::make_shared<Concat>(begins, 0);
+        end = std::make_shared<Concat>(ends, 0);
+    }
+    const auto zeros = Constant::create(c.shape_type, Shape{2}, {c.batch_pad, 0.0});
+    begin = std::make_shared<Concat>(OutputVector{zeros, begin}, 0);
+    end = std::make_shared<Concat>(OutputVector{zeros, end}, 0);
+    const auto value = Constant::create(element::f32, Shape{}, {c.pad_value});
+    if (c.pad_v1) {
+        if (c.implicit_pad_value)
+            return std::make_shared<op::v1::Pad>(data, begin, end, c.pad_mode);
+        return std::make_shared<op::v1::Pad>(data, begin, end, value, c.pad_mode);
+    }
+    if (c.implicit_pad_value)
+        return std::make_shared<Pad>(data, begin, end, c.pad_mode);
+    return std::make_shared<Pad>(data, begin, end, value, c.pad_mode);
+}
+
+std::shared_ptr<Node> make_conv(const Output<Node>& data, const Config& c, bool same, const std::string& name) {
+    Shape weight_shape = c.grouped ? Shape{3, 1, 1} : Shape{4, 3};
+    weight_shape.insert(weight_shape.end(), c.kernel.begin(), c.kernel.end());
+    const auto weights = Constant::create(element::f32, weight_shape, {0.25f});
+    weights->output(0).get_tensor().set_names({name + "_weights"});
+    const auto auto_pad = same ? op::PadType::SAME_UPPER : c.auto_pad;
+    std::shared_ptr<Node> conv;
+    if (c.grouped)
+        conv = std::make_shared<GroupConvolution>(data,
+                                                  weights,
+                                                  c.strides,
+                                                  c.conv_pads,
+                                                  c.conv_pads,
+                                                  c.dilations,
+                                                  auto_pad);
+    else
+        conv = std::make_shared<Convolution>(data, weights, c.strides, c.conv_pads, c.conv_pads, c.dilations, auto_pad);
+    conv->set_friendly_name(name);
+    conv->output(0).get_tensor().set_names({name + "_output"});
+    return conv;
+}
+
+Output<Node> spatial_shape(const Output<Node>& shape) {
+    return std::make_shared<Gather>(shape,
+                                    Constant::create(element::i64, Shape{2}, {2, 3}),
+                                    Constant::create(element::i64, Shape{}, {0}));
+}
+
+std::shared_ptr<Model> get_model(const Config& c) {
+    const auto data = std::make_shared<Parameter>(element::f32, c.shape);
+    data->output(0).get_tensor().set_names({"input"});
+    ParameterVector parameters{data};
+    Output<Node> shape_source = data;
+    if (c.wrong_source) {
+        const auto other = std::make_shared<Parameter>(element::f32, c.shape);
+        parameters.push_back(other);
+        shape_source = other;
+    }
+    const auto shape = std::make_shared<ShapeOf>(shape_source, c.shape_type);
+    const auto pad = make_pad(data, shape, c);
+    OutputVector outputs{make_conv(pad, c, false, "conv")};
+    if (c.shared_conv) {
+        auto other = c;
+        if (c.different_consumer_stride)
+            other.strides[0] = 1;
+        outputs.push_back(make_conv(pad, other, false, "other_conv"));
+    }
+    if (c.output_pad)
+        outputs.push_back(pad);
+    if (c.output_shape)
+        outputs.push_back(spatial_shape(shape));
+    return std::make_shared<Model>(outputs, parameters);
+}
+
+std::shared_ptr<Model> get_model_ref(const Config& c) {
+    const auto data = std::make_shared<Parameter>(element::f32, c.shape);
+    data->output(0).get_tensor().set_names({"input"});
+    const auto shape = std::make_shared<ShapeOf>(data, c.shape_type);
+    OutputVector outputs{make_conv(data, c, true, "conv")};
+    std::shared_ptr<op::util::PadBase> pad;
+    if (c.output_pad || c.different_consumer_stride)
+        pad = make_pad(data, shape, c);
+    if (c.shared_conv) {
+        auto other = c;
+        if (c.different_consumer_stride) {
+            other.strides[0] = 1;
+            outputs.push_back(make_conv(pad, other, false, "other_conv"));
+        } else {
+            outputs.push_back(make_conv(data, other, true, "other_conv"));
+        }
+    }
+    if (c.output_pad)
+        outputs.push_back(pad);
+    if (c.output_shape)
+        outputs.push_back(spatial_shape(shape));
+    return std::make_shared<Model>(outputs, ParameterVector{data});
+}
+
+class DynamicSamePaddingFusionTests : public TransformationTestsF {
+protected:
+    void SetUp() override {
+        TransformationTestsF::SetUp();
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+        comparator.enable(FunctionsComparator::CONST_VALUES);
+        manager.register_pass<pass::DynamicSamePaddingFusion>();
+    }
+};
+
+using TestParams = std::tuple<bool, bool, bool, size_t>;
+class DynamicSamePaddingFusionParameterized : public DynamicSamePaddingFusionTests,
+                                              public testing::WithParamInterface<TestParams> {
+public:
+    static std::string get_test_name(const testing::TestParamInfo<TestParams>& info) {
+        const auto& [grouped, pad_v1, expanded, spatial_rank] = info.param;
+        return std::string(grouped ? "GroupConv" : "Conv") + (pad_v1 ? "_Pad1" : "_Pad12") +
+               (expanded ? "_Expanded" : "_Folded") + "_" + std::to_string(spatial_rank) + "D";
+    }
+};
+
+TEST_P(DynamicSamePaddingFusionParameterized, SpatialPadding) {
+    const auto& [grouped, pad_v1, expanded, spatial_rank] = GetParam();
+    Config c;
+    c.grouped = grouped;
+    c.pad_v1 = pad_v1;
+    c.expanded = expanded;
+    c.reciprocal = !expanded;
+    c.reciprocal_stride = !expanded;
+    c.shape = PartialShape::dynamic(spatial_rank + 2);
+    c.shape[1] = 3;
+    c.kernel.assign(spatial_rank, 3);
+    c.strides.assign(spatial_rank, 2);
+    c.dilations.assign(spatial_rank, 1);
+    c.conv_pads.assign(spatial_rank, 0);
+    model = get_model(c);
+    model_ref = get_model_ref(c);
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke,
+                         DynamicSamePaddingFusionParameterized,
+                         testing::Combine(testing::Bool(), testing::Bool(), testing::Bool(), testing::Values(1, 2, 3)),
+                         DynamicSamePaddingFusionParameterized::get_test_name);
+
+TEST_F(DynamicSamePaddingFusionTests, DecomposedSubtractAndDirectPaddingVectors) {
+    Config c;
+    c.decompose_subtract = true;
+    c.timm_layout = false;
+    c.shape_type = element::i32;
+    c.math_type = element::f64;
+    c.kernel = {2, 5};
+    c.strides = {3, 2};
+    c.dilations = {2, 3};
+    model = get_model(c);
+    model_ref = get_model_ref(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, SharedKeyValueConvolutions) {
+    Config c;
+    c.grouped = true;
+    c.shared_conv = true;
+    c.output_shape = true;
+    comparator.enable(FunctionsComparator::CONSUMERS_COUNT);
+    model = get_model(c);
+    model_ref = get_model_ref(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, PreservePadForIncompatibleConsumer) {
+    Config c;
+    c.shared_conv = true;
+    c.different_consumer_stride = true;
+    c.output_pad = true;
+    model = get_model(c);
+    model_ref = get_model_ref(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, ImplicitZeroPaddingValue) {
+    Config c;
+    c.implicit_pad_value = true;
+    model = get_model(c);
+    model_ref = get_model_ref(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, PreserveTensorNames) {
+    comparator.enable(FunctionsComparator::TENSOR_NAMES);
+    model = get_model(Config{});
+    model_ref = get_model_ref(Config{});
+}
+
+TEST_F(DynamicSamePaddingFusionTests, UnknownKernelShape) {
+    model = get_model(Config{});
+    const auto weights = std::make_shared<Parameter>(element::f32, PartialShape{4, 3, -1, -1});
+    model->get_results()[0]->input_value(0).get_node_shared_ptr()->set_argument(1, weights);
+    model->add_parameters({weights});
+    model->validate_nodes_and_infer_types();
+}
+
+TEST_F(DynamicSamePaddingFusionTests, UnknownInputRank) {
+    Config c;
+    c.shape = PartialShape::dynamic();
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, StaticOddEvenInputsAccuracy) {
+    Config c;
+    c.shape = {1, 3, 7, 8};
+    c.kernel = {2, 5};
+    c.dilations = {2, 1};
+    comparator.enable(FunctionsComparator::ACCURACY);
+    model = get_model(c);
+    model_ref = get_model_ref(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, InputSmallerThanEffectiveKernelAccuracy) {
+    Config c;
+    c.shape = {1, 3, 1, 2};
+    c.grouped = true;
+    c.dilations = {2, 2};
+    comparator.enable(FunctionsComparator::ACCURACY);
+    model = get_model(c);
+    model_ref = get_model_ref(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, NonzeroPaddingValue) {
+    Config c;
+    c.pad_value = 1;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, EdgePadding) {
+    Config c;
+    c.pad_mode = op::PadMode::EDGE;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, NonSpatialPadding) {
+    Config c;
+    c.batch_pad = 1;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, ExistingConvolutionPadding) {
+    Config c;
+    c.conv_pads = {1, 0};
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, ExistingAutoPadding) {
+    Config c;
+    c.auto_pad = op::PadType::SAME_UPPER;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, DifferentShapeSource) {
+    Config c;
+    c.wrong_source = true;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, SwappedSpatialAxes) {
+    Config c;
+    c.wrong_axis = true;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, DifferentEffectiveKernel) {
+    Config c;
+    c.kernel_adjustment = 1;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, DifferentPaddingSplit) {
+    Config c;
+    c.split_divisor = 3;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, SameLowerPadding) {
+    Config c;
+    c.same_lower = true;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, LowPrecisionShapeArithmetic) {
+    Config c;
+    c.math_type = element::f16;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, RoundedReciprocalStride) {
+    Config c;
+    c.math_type = element::f64;
+    c.strides = {3, 2};
+    c.reciprocal_stride = true;
+    model = get_model(c);
+}
+
+TEST_F(DynamicSamePaddingFusionTests, TransformationCallback) {
+    manager.get_pass_config()->set_callback<pass::DynamicSamePaddingFusion>([](const std::shared_ptr<const Node>&) {
+        return true;
+    });
+    model = get_model(Config{});
+}
+
+TEST_F(TransformationTestsF, DynamicSamePaddingFusionInMOCTransformations) {
+    const Config c;
+    model = get_model(c);
+    model_ref = get_model_ref(c);
+    comparator.enable(FunctionsComparator::ATTRIBUTES);
+    comparator.enable(FunctionsComparator::CONST_VALUES);
+    manager.register_pass<pass::MOCTransformations>(true, false);
+}
+}  // namespace

--- a/src/common/transformations/tests/sources.cmake
+++ b/src/common/transformations/tests/sources.cmake
@@ -53,6 +53,7 @@ set(COMMON_OPTIMIZATIONS_TESTS_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/disable_shapeof_constant_folding_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/divide_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/dropout_with_random_uniform_replacer_test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/dynamic_same_padding_fusion.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/eliminate_duplicate_ti_inputs.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/eliminate_loop_inputs_outputs_test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/common_optimizations/eliminate_split_test.cpp


### PR DESCRIPTION
### Details:
PyTorch/timm exports of dynamic SAME padding leave shape arithmetic and an explicit Pad before convolutions. Add `DynamicSamePaddingFusion` to recognize the SAME_UPPER padding formula and replace eligible Pad → Convolution/GroupConvolution paths with a convolution using `auto_pad=SAME_UPPER`.

The pass handles 1D/2D/3D convolutions, Pad v1/v12, and the scalar arithmetic and padding-vector rearrangements used by timm exports. It validates the input shape source, stride, dilation, effective kernel, zero fill, and padding split, and preserves other consumers of shared Pad/shape nodes. Register it before PadFusion in MOCTransformations.

### Tickets:
 - 193756

### AI Assistance:
 - AI assistance used: yes