### PR TITLE
[GPU] Fix invalid axis in scatter_elements_update test parameters

### DIFF
--- a/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/scatter_elements_update_gpu_test.cpp
@@ -101,6 +101,8 @@ TEST(scatter_elements_update_gpu_fp16, d2411_axisF) {
 namespace {
 template<typename T, typename T_IND>
 struct ScatterElementsUpdateParams {
+    // Axis follows the logical (ov::Shape) order of the plain format, i.e. bfyx / bfzyx / bfwzyx,
+    // not the cldnn tensor argument order (b, f, x, y, z, w). So for bfzyx axis 2 is z and axis 4 is x.
     int64_t axis;
     tensor data_tensor;
     std::vector<T> data;
@@ -199,7 +201,7 @@ std::vector<ScatterElementsUpdateParams<T, T_IND>> generateScatterElementsUpdate
             getValues<T_IND>({ 0, 3, 1, 2 }),
             getValues<T>({ -100, -110, -120, -130 }),
         },
-        {   4,
+        {   2,  // bfzyx axis 2 is z, the only dimension the indices tensor reduces (3 -> 2)
             tensor{2, 4, 1, 1, 3},
             getValues<T>({ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23 }),
             tensor{2, 1, 1, 1, 2},
@@ -222,12 +224,14 @@ std::vector<ScatterElementsUpdateParams<T, T_IND>> generateScatterElementsUpdate
 template<typename T, typename T_IND>
 std::vector<ScatterElementsUpdateParams<T, T_IND>> generateScatterElementsUpdateParams4D() {
     const std::vector<ScatterElementsUpdateParams<T, T_IND>> result = {
-        {   5,
+        {   2,  // bfwzyx axis 2 is w, whose size 3 is what the index values (max 2) address
             tensor{2, 4, 2, 1, 1, 3},
             getValues<T>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
                           24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47}),
             tensor{2, 1, 1, 1, 1, 2},
-            getValues<T_IND>({2, 1, 1, 1}),
+            // distinct per batch: duplicates would make the NONE reduction order-dependent,
+            // and the GPU scatters in parallel while the reference writes sequentially
+            getValues<T_IND>({2, 1, 1, 0}),
             getValues<T>({-100, -110, -120, -130}),
         },
         {


### PR DESCRIPTION
### Details:

56 `scatter_elements_update_gpu_*` cases fail in `ov_gpu_unit_tests` with `ScatterElementsUpdate index 1 is out of bounds for the axis of size 1`.

`ScatterElementsUpdateParams::axis` is a logical (`ov::Shape`) axis: `tensorToShape()` reverses the spatial dimensions, and the plugin maps the axis back to cldnn order in `convert_axis()`. Two entries were written in cldnn order (`b, f, x, y, z, w`) instead, so both pointed at `x` rather than the dimension the indices tensor reduces:

| Entry | Was | Points at | Should be |
|---|---|---|---|
| 3D (bfzyx) | 4 | `x`, size 1 | 2 (`z`, size 3) |
| 4D (bfwzyx) | 5 | `x`, size 2 | 2 (`w`, size 3) |

Their index values did not fit those sizes, so the reference read out of bounds. This stayed hidden until #37917 added index validation to the reference kernel. The plugin is fine — the test parameters were wrong.

Fixing the 4D axis then exposed duplicate indices within a batch: two elements wrote to the same offset, so the sequential reference gave `-130` while the parallel GPU kernel gave `-120`. The indices are now distinct per batch.

### Tickets:
 - 194433

### AI Assistance:
 - AI assistance used: yes
 - AI: root cause analysis, fix
 - Human: review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
