### PR TITLE
[TRANSFORMATIONS] Preserve bias output precision during activation scaling

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/activations_scaling.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/activations_scaling.cpp
@@ -168,6 +168,7 @@ activations_scaling::ScaleDownSingleLayer::ScaleDownSingleLayer(float scale_fact
 
         if (has_bias) {
             auto add = child_node->shared_from_this();
+            output_prec = add->get_output_element_type(0);
             target_inputs = add->get_output_target_inputs(0);
             insert_scale_down_layer(add, bias_index);
             add->revalidate_and_infer_types();

--- a/src/common/transformations/tests/common_optimizations/activations_scaling_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/activations_scaling_test.cpp
@@ -14,6 +14,7 @@
 #include "openvino/op/add.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convolution.hpp"
+#include "openvino/op/gelu.hpp"
 #include "openvino/op/group_normalization.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/multiply.hpp"
@@ -24,6 +25,7 @@
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/manager.hpp"
 #include "ov_ops/moe_compressed.hpp"
+#include "ov_ops/type_relaxed.hpp"
 #include "transformations/common_optimizations/lin_op_sequence_fusion.hpp"
 #include "transformations/common_optimizations/nop_elimination.hpp"
 #include "transformations/utils/utils.hpp"
@@ -112,6 +114,38 @@ TEST_F(TransformationTestsF, ScaleDownSingleLayerTest_f32) {
 
         model_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
     }
+}
+
+TEST(ScaleDownSingleLayerRegression, PreserveF32OutputOfTypeRelaxedBiasAdd) {
+    constexpr float scale_factor = 8.f;
+
+    auto input = std::make_shared<v0::Parameter>(element::f16, PartialShape{1, 4});
+    auto weights0 = v0::Constant::create(element::f16, Shape{8, 4}, {1.f});
+    auto matmul0 = std::make_shared<v0::MatMul>(input, weights0, false, true);
+    auto bias = v0::Constant::create(element::f32, Shape{8}, {1.f});
+    auto add =
+        std::make_shared<ov::op::TypeRelaxed<v1::Add>>(element::TypeVector{element::f32, element::f32},
+                                                       element::TypeVector{element::f32},
+                                                       ov::op::TemporaryReplaceOutputType(matmul0, element::f32).get(),
+                                                       bias);
+    auto gelu = std::make_shared<ov::op::v7::Gelu>(add);
+    auto weights1 = v0::Constant::create(element::f32, Shape{4, 8}, {1.f});
+    auto matmul1 = std::make_shared<v0::MatMul>(gelu, weights1, false, true);
+    auto model = std::make_shared<Model>(OutputVector{matmul1}, ParameterVector{input});
+
+    pass::Manager manager;
+    manager.set_per_pass_validation(false);
+    manager.register_pass<pass::activations_scaling::ScaleDownSingleLayer>(scale_factor, element::f16);
+    manager.get_pass_config()->set_callback<pass::activations_scaling::ScaleDownSingleLayer>(
+        [](const std::shared_ptr<const Node>& node) {
+            return node->input(0).get_element_type() != element::f16;
+        });
+    manager.register_pass<pass::Validate>();
+
+    EXPECT_NO_THROW(manager.run_passes(model));
+    EXPECT_EQ(gelu->get_output_element_type(0), element::f32);
+    EXPECT_EQ(matmul1->get_input_element_type(0), element::f32);
+    EXPECT_EQ(matmul1->get_input_element_type(1), element::f32);
 }
 
 namespace {


### PR DESCRIPTION
### Details:
 - Fix `ScaleDownSingleLayer` incorrectly restoring the MatMul output precision when a supported bias `Add` extends the scaled region.
 - Original graph
   ```mermaid
   flowchart LR
       A["MatMul<br/>output: FP16"] --> B["TypeRelaxed Add<br/>output contract: FP32"]
       Bias["Bias<br/>FP32"] --> B
       B --> C["GELU<br/>FP32"]
       C --> D["Downstream MatMul<br/>activation: FP32<br/>weights: FP32"]
       W["Decompressed weights<br/>FP32"] --> D
   ```
     - The first MatMul computes in FP16, while its type-relaxed bias Add intentionally exposes an FP32 output.
     - The downstream GELU and MatMul therefore receive FP32 activations.
 - Graph before the fix
   ```mermaid
   flowchart LR
       A["MatMul<br/>output: FP16"] --> B["TypeRelaxed Add<br/>output: FP32"]
       Bias["Scaled bias<br/>FP32"] --> B
       B --> X["Convert<br/>FP32 to FP16"]
       X --> S["Scale-up Multiply<br/>FP16"]
       S --> C["GELU<br/>FP16"]
       C --> D["Downstream MatMul<br/>INVALID"]
       W["Decompressed weights<br/>FP32"] --> D

       style C fill:#fff3cd,stroke:#b58105,color:#24292f
       style W fill:#fff3cd,stroke:#b58105,color:#24292f
       style D fill:#ffebe9,stroke:#cf222e,stroke-width:2px,color:#24292f
   ```
     - `ScaleDownSingleLayer` captured `output_prec` from the first MatMul before detecting that the bias Add extended the scaled region.
     - It consequently inserted an FP16 conversion after the FP32 Add and changed the downstream activation to FP16.
     - The downstream MatMul was left with incompatible input types:
       ```text
       Arguments do not have the same element type
       (arg0 element type: f16, arg1 element type: f32)
       ```
 - Graph after the fix
   ```mermaid
   flowchart LR
       A["MatMul<br/>output: FP16"] --> B["TypeRelaxed Add<br/>output: FP32"]
       Bias["Scaled bias<br/>FP32"] --> B
       B --> S["Scale-up Multiply<br/>FP32"]
       S --> C["GELU<br/>FP32"]
       C --> D["Downstream MatMul<br/>VALID"]
       W["Decompressed weights<br/>FP32"] --> D

       style S fill:#ddf4ff,stroke:#0969da,color:#24292f
       style D fill:#dafbe1,stroke:#1a7f37,stroke-width:2px,color:#24292f
   ```
     - When a supported bias Add extends the scaled region, use the Add's original output element type as the scale-up restoration precision:
       ```cpp
       if (has_bias) {
           auto add = child_node->shared_from_this();
           output_prec = add->get_output_element_type(0);
           // ...
       }
       ```
     - This preserves the FP32 output contract of the type-relaxed Add while retaining FP16 computation and activation scaling in the first MatMul.
 
### Tickets:
 - CVS-194558

### AI Assistance:
 - *AI assistance used: yes*
 - *AI was used to help analyze transformation-pass traces, isolate the minimal failing graph, draft the source change and regression test. Human validation included reviewing the source diff, building the targets, running common transformation and GPU functional tests, and completing the end-to-end WWB evaluation*
