### PR TITLE
[DO NOT REVIEW][GPU] Fuse channel-axis RMSNorm for NCHW vision tensors

### DIFF
--- a/src/common/transformations/include/ov_ops/rms.hpp
+++ b/src/common/transformations/include/ov_ops/rms.hpp
@@ -24,17 +24,23 @@ public:
     /// \param gamma Gamma values for weight
     /// \param eps Epsilon for not dividing by zero while normalizing the value
     /// \param output_type Output element type
+    /// \param axis Axis along which normalization is performed (default -1)
     RMS(const Output<Node>& data,
         const Output<Node>& gamma,
         double epsilon,
-        const ov::element::Type output_type = ov::element::dynamic);
+        const ov::element::Type output_type = ov::element::dynamic,
+        int64_t axis = -1);
 
     /// @brief Constructs an RMS operation without gamma.
     ///
     /// @param data Input tensor with data
     /// @param eps Epsilon for not dividing by zero while normalizing the value
     /// @param output_type Output element type
-    RMS(const Output<Node>& data, double epsilon, const ov::element::Type output_type = ov::element::dynamic);
+    /// \param axis Axis along which normalization is performed (default -1)
+    RMS(const Output<Node>& data,
+        double epsilon,
+        const ov::element::Type output_type = ov::element::dynamic,
+        int64_t axis = -1);
 
     bool visit_attributes(ov::AttributeVisitor& visitor) override;
 
@@ -62,10 +68,19 @@ public:
         m_elementwise_affine = elementwise_affine;
     }
 
+    int64_t get_axis() const {
+        return m_axis;
+    }
+
+    void set_axis(int64_t axis) {
+        m_axis = axis;
+    }
+
 private:
     double m_epsilon{0};
     ov::element::Type m_output_type;
     bool m_elementwise_affine{true};
+    int64_t m_axis{-1};
 };
 
 }  // namespace internal

--- a/src/common/transformations/src/ov_ops/rms.cpp
+++ b/src/common/transformations/src/ov_ops/rms.cpp
@@ -8,19 +8,25 @@ namespace ov {
 namespace op {
 namespace internal {
 
-RMS::RMS(const Output<Node>& data, const Output<Node>& gamma, double epsilon, const ov::element::Type output_type)
+RMS::RMS(const Output<Node>& data,
+         const Output<Node>& gamma,
+         double epsilon,
+         const ov::element::Type output_type,
+         int64_t axis)
     : Op({data, gamma}),
       m_epsilon(epsilon),
       m_output_type(output_type),
-      m_elementwise_affine(true) {
+      m_elementwise_affine(true),
+      m_axis(axis) {
     validate_and_infer_types();
 }
 
-RMS::RMS(const Output<Node>& data, double epsilon, const ov::element::Type output_type)
+RMS::RMS(const Output<Node>& data, double epsilon, const ov::element::Type output_type, int64_t axis)
     : Op({data}),
       m_epsilon(epsilon),
       m_output_type(output_type),
-      m_elementwise_affine(false) {
+      m_elementwise_affine(false),
+      m_axis(axis) {
     validate_and_infer_types();
 }
 
@@ -28,6 +34,7 @@ bool RMS::visit_attributes(ov::AttributeVisitor& visitor) {
     visitor.on_attribute("epsilon", m_epsilon);
     visitor.on_attribute("output_type", m_output_type);
     visitor.on_attribute("elementwise_affine", m_elementwise_affine);
+    visitor.on_attribute("axis", m_axis);
     return true;
 }
 
@@ -39,9 +46,9 @@ void RMS::validate_and_infer_types() {
 std::shared_ptr<Node> RMS::clone_with_new_inputs(const ov::OutputVector& new_args) const {
     check_new_args_count(this, new_args);
     if (new_args.size() == 1) {
-        return std::make_shared<RMS>(new_args.at(0), m_epsilon, m_output_type);
+        return std::make_shared<RMS>(new_args.at(0), m_epsilon, m_output_type, m_axis);
     }
-    return std::make_shared<RMS>(new_args.at(0), new_args.at(1), m_epsilon, m_output_type);
+    return std::make_shared<RMS>(new_args.at(0), new_args.at(1), m_epsilon, m_output_type, m_axis);
 }
 
 }  // namespace internal

--- a/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/rms_fusion.cpp
@@ -6,6 +6,7 @@
 
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/op/add.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/divide.hpp"
@@ -142,17 +143,43 @@ RMSFusionMatcher::RMSFusionMatcher(bool force_tail_convert, bool enable_without_
         const auto& axes = pattern_map.at(mean_axes).get_node_shared_ptr();
         auto axes_constant = ov::as_type_ptr<v0::Constant>(axes);
         auto axes_val = axes_constant->cast_vector<int64_t>();
-        // allow last dimension only
-        if ((axes_val[0] != -1) &&
-            (axes_val[0] != (static_cast<int64_t>(mean_node->get_input_partial_shape(0).size()) - 1))) {
-            return false;
+
+        const auto& in_pshape = mean_node->get_input_partial_shape(0);
+        int64_t raw_axis = axes_val[0];
+        int64_t rms_axis = -1;
+
+        if (in_pshape.rank().is_static()) {
+            const auto rank = static_cast<int64_t>(in_pshape.rank().get_length());
+            int64_t norm_axis = raw_axis;
+            try {
+                norm_axis = ov::util::normalize_axis(raw_axis, rank);
+            } catch (...) {
+                return false;
+            }
+
+            const bool is_last_dim = (norm_axis == rank - 1);
+            const bool is_nchw_channel = (rank == 4 && norm_axis == 1);
+
+            if (!is_last_dim && !is_nchw_channel) {
+                return false;
+            }
+
+            // Keep default -1 for last dimension to preserve compatibility with existing tests/callers,
+            // or explicit axis=1 for 4D NCHW channel axis.
+            rms_axis = is_last_dim ? -1 : norm_axis;
+        } else {
+            if (raw_axis != -1) {
+                return false;
+            }
+            rms_axis = -1;
         }
 
         auto output_type = elementwise_affine ? m.get_match_root()->get_output_element_type(0)
                                               : mul_or_div_node->get_output_element_type(0);
         std::shared_ptr<ov::op::internal::RMS> rms =
-            elementwise_affine ? std::make_shared<ov::op::internal::RMS>(x_output, gamma_node, eps_value, output_type)
-                               : std::make_shared<ov::op::internal::RMS>(x_output, eps_value, output_type);
+            elementwise_affine
+                ? std::make_shared<ov::op::internal::RMS>(x_output, gamma_node, eps_value, output_type, rms_axis)
+                : std::make_shared<ov::op::internal::RMS>(x_output, eps_value, output_type, rms_axis);
         if (elementwise_affine) {
             rms->set_friendly_name(m.get_match_root()->get_friendly_name());
             ov::copy_runtime_info(m.get_matched_nodes(), rms);

--- a/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
@@ -692,3 +692,115 @@ TEST_F(TransformationTestsF, RMSNormFusionTest20_PowerNegHalf_NoGamma) {
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
+
+TEST_F(TransformationTestsF, RMSNormFusion_NCHWChannelAxis) {
+    // Gemma-3n vision RmsNorm2d reduces C in NCHW, fusing into internal RMS with axis=1.
+    const std::string scope = "__module.model.model.vision_tower.timm_model.conv_stem.bn/";
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, 64, -1, -1});
+    {
+        auto power_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {2.f});
+        auto power = std::make_shared<ov::op::v1::Power>(input, power_const);
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+        auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+        mean->set_friendly_name(scope + "aten::mean/ReduceMean");
+        auto eps = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {1e-6f});
+        auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);
+        auto sqrt = std::make_shared<ov::op::v0::Sqrt>(add_eps);
+        auto one = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {1.f});
+        auto reciprocal = std::make_shared<ov::op::v1::Divide>(one, sqrt);
+        auto normalized = std::make_shared<ov::op::v1::Multiply>(input, reciprocal);
+        normalized->set_friendly_name(scope + "aten::mul/Multiply");
+        auto gamma = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 64, 1, 1}, {0.5f});
+        auto scaled = std::make_shared<ov::op::v1::Multiply>(normalized, gamma);
+        scaled->set_friendly_name(scope + "aten::mul/Multiply_1");
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{scaled}, ov::ParameterVector{input});
+        manager.register_pass<RMSFusion>(/*force_tail_convert=*/false, /*enable_without_gamma=*/true);
+    }
+    {
+        auto gamma = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 64, 1, 1}, {0.5f});
+        auto rms = std::make_shared<ov::op::internal::RMS>(input, gamma, 1e-6f, ov::element::f32, 1);
+        rms->set_friendly_name(scope + "aten::mul/Multiply_1");
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, RMSNormFusion_NCHWChannelAxis_NegativeAxis) {
+    const std::string scope = "test/";
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 32, 16, 16});
+    {
+        auto power_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.f});
+        auto power = std::make_shared<ov::op::v1::Power>(input, power_const);
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {-3});
+        auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+        auto eps = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1e-5f});
+        auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);
+        auto sqrt = std::make_shared<ov::op::v0::Sqrt>(add_eps);
+        auto one = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.f});
+        auto reciprocal = std::make_shared<ov::op::v1::Divide>(one, sqrt);
+        auto normalized = std::make_shared<ov::op::v1::Multiply>(input, reciprocal);
+        auto gamma = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 32, 1, 1}, {1.0f});
+        auto scaled = std::make_shared<ov::op::v1::Multiply>(normalized, gamma);
+        scaled->set_friendly_name(scope + "out");
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{scaled}, ov::ParameterVector{input});
+        manager.register_pass<RMSFusion>(false, true);
+    }
+    {
+        auto gamma = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 32, 1, 1}, {1.0f});
+        auto rms = std::make_shared<ov::op::internal::RMS>(input, gamma, 1e-5f, ov::element::f32, 1);
+        rms->set_friendly_name(scope + "out");
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, RMSNormFusion_UnsupportedAxis_NoFusion) {
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{1, 32, 16, 16});
+    auto power_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {2.f});
+    auto power = std::make_shared<ov::op::v1::Power>(input, power_const);
+    auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});
+    auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+    auto eps = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1e-5f});
+    auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);
+    auto sqrt = std::make_shared<ov::op::v0::Sqrt>(add_eps);
+    auto one = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{}, {1.f});
+    auto reciprocal = std::make_shared<ov::op::v1::Divide>(one, sqrt);
+    auto normalized = std::make_shared<ov::op::v1::Multiply>(input, reciprocal);
+    auto gamma = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 16, 1}, {1.0f});
+    auto scaled = std::make_shared<ov::op::v1::Multiply>(normalized, gamma);
+
+    model = std::make_shared<ov::Model>(ov::OutputVector{scaled}, ov::ParameterVector{input});
+    manager.register_pass<RMSFusion>(false, true);
+}
+
+TEST_F(TransformationTestsF, RMSNormFusion_NCHWChannelAxis_NoGamma) {
+    const std::string scope = "test_no_gamma/";
+    auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, 64, -1, -1});
+    {
+        auto power_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {2.f});
+        auto power = std::make_shared<ov::op::v1::Power>(input, power_const);
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+        auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
+        auto eps = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {1e-6f});
+        auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);
+        auto sqrt = std::make_shared<ov::op::v0::Sqrt>(add_eps);
+        auto one = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1, 1, 1, 1}, {1.f});
+        auto reciprocal = std::make_shared<ov::op::v1::Divide>(one, sqrt);
+        auto normalized = std::make_shared<ov::op::v1::Multiply>(input, reciprocal);
+        normalized->set_friendly_name(scope + "aten::mul/Multiply");
+
+        model = std::make_shared<ov::Model>(ov::OutputVector{normalized}, ov::ParameterVector{input});
+        manager.register_pass<RMSFusion>(/*force_tail_convert=*/false, /*enable_without_gamma=*/true);
+    }
+    {
+        auto rms = std::make_shared<ov::op::internal::RMS>(input, 1e-6f, ov::element::f32, 1);
+        rms->set_friendly_name(scope + "aten::mul/Multiply");
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}

--- a/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
@@ -21,6 +21,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/validation_util.hpp"
 #include "openvino/runtime/system_conf.hpp"
 #include "ov_ops/rms.hpp"
 #include "shape_inference/custom/rms_norm.hpp"
@@ -214,6 +215,17 @@ bool RMSNorm::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, st
             const auto& data_rank = op->get_input_partial_shape(0).rank().get_length();
             if (data_rank <= 1) {
                 errorMessage = "RMSNorm data rank must be greater than 1.";
+                return false;
+            }
+            auto norm_axis = rms->get_axis();
+            try {
+                norm_axis = ov::util::normalize_axis(norm_axis, data_rank);
+            } catch (...) {
+                errorMessage = "RMSNorm axis is out of bounds.";
+                return false;
+            }
+            if (norm_axis != data_rank - 1) {
+                errorMessage = "RMSNorm only supports normalization along the last dimension.";
                 return false;
             }
             if (data_pshape[data_rank - 1].is_dynamic()) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_rms_norm.cpp
@@ -42,7 +42,7 @@ DecomposeRMSNorm::DecomposeRMSNorm() {
 
         auto power_const = ov::op::v0::Constant::create(data_precision, {}, std::vector<float>{2.F});
         auto power = std::make_shared<ov::op::v1::Power>(data, power_const);
-        auto mean_axes = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {-1});
+        auto mean_axes = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {node->get_axis()});
         auto mean = std::make_shared<ov::op::v1::ReduceMean>(power, mean_axes, true);
         auto eps = ov::op::v0::Constant::create(data_precision, {}, {node->get_epsilon()});
         auto add_eps = std::make_shared<ov::op::v1::Add>(mean, eps);

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/rms.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/rms.hpp
@@ -19,34 +19,36 @@ struct rms : public primitive_base<rms> {
     /// @param input Input primitive id
     /// @param gamma Gamma values for weight
     /// @param epsilon Epsilon for not dividing by zero while normalizing
-    rms(const primitive_id& id,
-        const input_info& input,
-        const input_info& gamma,
-        const float epsilon)
+    /// @param axis Axis along which normalization is performed (default -1)
+    rms(const primitive_id& id, const input_info& input, const input_info& gamma, const float epsilon, const int64_t axis = -1)
         : primitive_base(id, {input, gamma}),
           epsilon(epsilon),
-          elementwise_affine(true) {}
+          elementwise_affine(true),
+          axis(axis) {}
 
     /// @brief Constructs rms primitive without gamma
     /// @param id This primitive id
     /// @param input Input primitive id
     /// @param epsilon Epsilon for not dividing by zero while normalizing
-    rms(const primitive_id& id,
-        const input_info& input,
-        const float epsilon)
+    /// @param axis Axis along which normalization is performed (default -1)
+    rms(const primitive_id& id, const input_info& input, const float epsilon, const int64_t axis = -1)
         : primitive_base(id, {input}),
           epsilon(epsilon),
-          elementwise_affine(false) {}
+          elementwise_affine(false),
+          axis(axis) {}
 
     /// @brief Epsilon for not dividing by zero while normalizing
     float epsilon;
     /// @brief A boolean value that when set to True, RMS has learnable affine parameters (gamma)
     bool elementwise_affine;
+    /// @brief Normalization axis
+    int64_t axis{-1};
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, epsilon);
         seed = hash_combine(seed, elementwise_affine);
+        seed = hash_combine(seed, axis);
         return seed;
     }
 
@@ -57,20 +59,21 @@ struct rms : public primitive_base<rms> {
 
         auto rhs_casted = downcast<const rms>(rhs);
 
-        return epsilon == rhs_casted.epsilon &&
-               elementwise_affine == rhs_casted.elementwise_affine;
+        return epsilon == rhs_casted.epsilon && elementwise_affine == rhs_casted.elementwise_affine && axis == rhs_casted.axis;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
         primitive_base<rms>::save(ob);
         ob << epsilon;
         ob << elementwise_affine;
+        ob << axis;
     }
 
     void load(BinaryInputBuffer& ib) override {
         primitive_base<rms>::load(ib);
         ib >> epsilon;
         ib >> elementwise_affine;
+        ib >> axis;
     }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rms.cpp
@@ -42,6 +42,7 @@ struct rms_impl : typed_primitive_impl_ocl<rms> {
         params.epsilon = primitive->epsilon;
         params.ov_input_rank = static_cast<int32_t>(impl_param.get_input_layout().get_partial_shape().size());
         params.elementwise_affine = primitive->elementwise_affine;
+        params.axis = primitive->axis;
         return params;
     }
 

--- a/src/plugins/intel_gpu/src/graph/rms.cpp
+++ b/src/plugins/intel_gpu/src/graph/rms.cpp
@@ -32,6 +32,7 @@ std::string rms_inst::to_string(rms_node const& node) {
     json_composite rms_info;
     rms_info.add("input_id", node.input(0).id());
     rms_info.add("epsilon", desc->epsilon);
+    rms_info.add("axis", desc->axis);
 
     node_info->add("rms_info", rms_info);
     node_info->dump(primitive_description);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_ref.cl
@@ -31,6 +31,44 @@ KERNEL(rms_gpu_ref)(
     #endif
 )
 {
+#if NORMALIZE_FEATURE && INPUT_RANK >= 4
+    const uint x = get_global_id(0);
+    const uint y = get_global_id(1);
+    const uint bz = get_global_id(2);
+    const uint z = bz % INPUT0_SIZE_Z;
+    const uint b = bz / INPUT0_SIZE_Z;
+
+    if (x >= INPUT0_SIZE_X || y >= INPUT0_SIZE_Y || b >= INPUT0_BATCH_NUM)
+        return;
+
+    ACCUMULATOR_TYPE rms = ACCUMULATOR_VAL_ZERO;
+    for (uint n = 0; n < NORM_SIZE; n++) {
+        uint f = n;
+        const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, 0, z, y, x);
+        const ACCUMULATOR_TYPE value = TO_ACCUMULATOR_TYPE(input[input_idx]);
+        rms += value * value;
+    }
+
+    rms /= NORM_SIZE;
+    rms = pow(sqrt(rms + EPSILON), -1);
+
+    for (uint n = 0; n < NORM_SIZE; n++) {
+        uint f = n;
+        const uint input_idx = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, 0, z, y, x);
+        const uint output_idx = FUNC_CALL(get_output_index)(OPTIONAL_SHAPE_INFO_TENSOR b, f, 0, z, y, x);
+#if ELEMENTWISE_AFFINE
+        const uint gamma_idx = INPUT1_OFFSET + (INPUT1_LENGTH == 1 ? 0 : n);
+        OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms * TO_ACCUMULATOR_TYPE(input[input_idx]) * TO_ACCUMULATOR_TYPE(gamma[gamma_idx]));
+#else
+        OUTPUT_TYPE result = TO_OUTPUT_TYPE(rms * TO_ACCUMULATOR_TYPE(input[input_idx]));
+#endif
+        #if HAS_FUSED_OPS
+            FUSED_OPS;
+            result = FUSED_OPS_RESULT;
+        #endif
+        output[output_idx] = result;
+    }
+#else
 #if NORMALIZE_X
     const uint outer_z_size = INPUT0_SIZE_Z;
     const uint outer_y_size = INPUT0_SIZE_Y;
@@ -76,6 +114,7 @@ KERNEL(rms_gpu_ref)(
             }
         }
     }
+#endif
 }
 
 #undef NORM_SIZE

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.cpp
@@ -46,6 +46,15 @@ JitConstants RMSKernelBase::GetJitConstants(const rms_params& params, RMSKernelB
 }
 
 Tensor::DataChannelName RMSKernelBase::GetNormalizationAxis(const rms_params& params) {
+    if (params.axis != -1) {
+        int64_t norm_axis = params.axis;
+        if (params.ov_input_rank > 0) {
+            norm_axis = (norm_axis % params.ov_input_rank + params.ov_input_rank) % params.ov_input_rank;
+        }
+        if (params.ov_input_rank == 4 && norm_axis == 1) {
+            return Tensor::DataChannelName::FEATURE;
+        }
+    }
     switch (params.ov_input_rank) {
         case 1: return Tensor::DataChannelName::BATCH;
         case 2: return Tensor::DataChannelName::FEATURE;
@@ -73,7 +82,11 @@ RMSKernelBase::DispatchData RMSKernelBase::SetDefault(const rms_params& params) 
             dispatchData.gws = {1, 1, 1};
             break;
         case Tensor::DataChannelName::FEATURE:
-            dispatchData.gws = {output.Batch().v, 1, 1};
+            if (params.ov_input_rank >= 4) {
+                dispatchData.gws = {output.X().v, output.Y().v, output.Batch().v * output.Z().v};
+            } else {
+                dispatchData.gws = {output.Batch().v, 1, 1};
+            }
             break;
         default:
             dispatchData.gws = {output.Batch().v, output.Feature().v, 1};

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_base.h
@@ -15,6 +15,7 @@ struct rms_params : public base_params {
     float epsilon = 0.0f;
     int32_t ov_input_rank = -1;
     bool elementwise_affine = true;
+    int64_t axis = -1;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
@@ -215,6 +215,12 @@ bool RMSKernelBfyxOpt::Validate(const Params& p) const {
     }
 
     const rms_params& params = static_cast<const rms_params&>(p);
+    // bfyx_opt only reduces along the contiguous innermost dimension (X for rank >= 4).
+    // Channel axis (FEATURE) in 4D/5D is non-contiguous across spatial dimensions and must use rms_gpu_ref.
+    if (params.ov_input_rank >= 4 && GetNormalizationAxis(params) != Tensor::DataChannelName::X) {
+        DO_NOT_USE_THIS_KERNEL(p.layerID);
+    }
+
     if (params.elementwise_affine) {
         const auto& gamma = params.inputs[1];
 

--- a/src/plugins/intel_gpu/src/plugin/ops/rms.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/rms.cpp
@@ -17,9 +17,8 @@ static void CreateRMSOp(ProgramBuilder& p, const std::shared_ptr<RMS>& op) {
     std::string primitive_name = layer_type_name_ID(op);
     const float epsilon = static_cast<float>(op->get_epsilon());
 
-    auto rms = op->get_elementwise_affine()
-        ? cldnn::rms(primitive_name, inputs[0], inputs[1], epsilon)
-        : cldnn::rms(primitive_name, inputs[0], epsilon);
+    auto rms = op->get_elementwise_affine() ? cldnn::rms(primitive_name, inputs[0], inputs[1], epsilon, op->get_axis())
+                                            : cldnn::rms(primitive_name, inputs[0], epsilon, op->get_axis());
     rms.output_data_types = get_output_data_types(op);
     p.add_primitive(*op, rms);
 }

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -8,20 +8,22 @@
 #include <cctype>
 #include <cmath>
 #include <deque>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <unordered_set>
 #include <vector>
-#include <type_traits>
 
+#include "intel_gpu/op/fully_connected.hpp"
+#include "intel_gpu/op/indirect_sdpa.hpp"
+#include "intel_gpu/op/read_value.hpp"
+#include "intel_gpu/op/sdpa.hpp"
+#include "intel_gpu/primitives/paged_attention.hpp"
 #include "intel_gpu/runtime/debug_configuration.hpp"
 #include "intel_gpu/runtime/itt.hpp"
-#include "intel_gpu/primitives/paged_attention.hpp"
-#include "intel_gpu/op/indirect_sdpa.hpp"
-#include "intel_gpu/op/sdpa.hpp"
-#include "intel_gpu/op/read_value.hpp"
 #include "low_precision/add.hpp"
 #include "low_precision/concat.hpp"
 #include "low_precision/convolution.hpp"
@@ -29,29 +31,32 @@
 #include "low_precision/fold_convert.hpp"
 #include "low_precision/fuse_convert.hpp"
 #include "low_precision/group_convolution.hpp"
-#include "low_precision/qdq_stripping.hpp"
 #include "low_precision/low_precision.hpp"
 #include "low_precision/mat_mul.hpp"
 #include "low_precision/multiply_to_group_convolution.hpp"
 #include "low_precision/mvn.hpp"
 #include "low_precision/network_helper.hpp"
+#include "low_precision/prelu.hpp"
+#include "low_precision/qdq_stripping.hpp"
 #include "low_precision/recurrent_cell.hpp"
 #include "low_precision/reshape.hpp"
-#include "low_precision/prelu.hpp"
 #include "low_precision/transpose.hpp"
 #include "low_precision/variadic_split.hpp"
+#include "openvino/core/partial_shape.hpp"
+#include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/validation_util.hpp"
-#include "openvino/core/partial_shape.hpp"
-#include "openvino/core/shape.hpp"
+#include "openvino/op/abs.hpp"
+#include "openvino/op/ceiling.hpp"
+#include "openvino/op/clamp.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convolution.hpp"
 #include "openvino/op/gated_delta_net.hpp"
 #include "openvino/op/gather.hpp"
-#include "openvino/op/grouped_matmul.hpp"
 #include "openvino/op/group_conv.hpp"
+#include "openvino/op/grouped_matmul.hpp"
 #include "openvino/op/gru_cell.hpp"
 #include "openvino/op/gru_sequence.hpp"
 #include "openvino/op/lstm_cell.hpp"
@@ -59,10 +64,9 @@
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/mvn.hpp"
 #include "openvino/op/normalize_l2.hpp"
+#include "openvino/op/paged_attention.hpp"
+#include "openvino/op/paged_gated_delta_net.hpp"
 #include "openvino/op/reduce_max.hpp"
-#include "openvino/op/abs.hpp"
-#include "openvino/op/ceiling.hpp"
-#include "openvino/op/clamp.hpp"
 #include "openvino/op/reduce_mean.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/reshape.hpp"
@@ -70,13 +74,11 @@
 #include "openvino/op/rnn_sequence.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/squeeze.hpp"
-#include "openvino/op/paged_attention.hpp"
-#include "openvino/op/paged_gated_delta_net.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/util/read_value_base.hpp"
 #include "openvino/op/util/sub_graph_base.hpp"
-#include "openvino/opsets/opset1_decl.hpp"
 #include "openvino/opsets/opset10_decl.hpp"
+#include "openvino/opsets/opset1_decl.hpp"
 #include "openvino/pass/backward_graph_rewrite.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
@@ -87,77 +89,73 @@
 #include "plugin/transformations/clamp_fp16_output.hpp"
 #include "plugin/transformations/convert_convolution.hpp"
 #include "plugin/transformations/convert_fc_to_compressed.hpp"
-#include "transformations/op_conversions/convert_grouped_matmul_to_compressed.hpp"
 #include "plugin/transformations/convert_matmul_to_fc.hpp"
-#include "plugin/transformations/fuse_moe_shared_expert.hpp"
-#include "transformations/common_optimizations/moe_op_fusion.hpp"
-#include "transformations/op_conversions/convert_gather_matmul_to_compressed.hpp"
 #include "plugin/transformations/convert_stridedslices_to_variadicsplit.hpp"
 #include "plugin/transformations/decompose_one_hot_non_const_values.hpp"
 #include "plugin/transformations/decompose_reduce_scalar_output.hpp"
+#include "plugin/transformations/disable_fp16_comp_cumsum_sin_gen.hpp"
+#include "plugin/transformations/disable_fp16_comp_direct_multiply_sin_cos.hpp"
+#include "plugin/transformations/disable_fp16_comp_gated_residual.hpp"
+#include "plugin/transformations/disable_fp16_comp_rms.hpp"
+#include "plugin/transformations/disable_fp16_comp_sin_gen.hpp"
 #include "plugin/transformations/dynamic_quantize_fully_connected.hpp"
+#include "plugin/transformations/expand_broadcast_reshape_sdpa_fusion.hpp"
 #include "plugin/transformations/fc_convert_fusion.hpp"
 #include "plugin/transformations/fc_horizontal_fusion.hpp"
 #include "plugin/transformations/fold_activation_transpose.hpp"
-#include "plugin/transformations/fuse_gated_mlp.hpp"
 #include "plugin/transformations/fuse_atan2_decomposed.hpp"
+#include "plugin/transformations/fuse_gated_mlp.hpp"
 #include "plugin/transformations/fuse_moe_router.hpp"
 #include "plugin/transformations/fuse_moe_router_scale.hpp"
+#include "plugin/transformations/fuse_moe_shared_expert.hpp"
 #include "plugin/transformations/group_query_attention_decomposition.hpp"
 #include "plugin/transformations/increase_position_ids_precision.hpp"
+#include "plugin/transformations/increase_rms_input_precision.hpp"
 #include "plugin/transformations/indirect_kv_cache.hpp"
 #include "plugin/transformations/keep_gqa_kv_scale_precision.hpp"
 #include "plugin/transformations/keep_moe_3gemm_const_precision.hpp"
 #include "plugin/transformations/keep_xattention_threshold_precision.hpp"
-#include "plugin/transformations/preserve_single_selective_ssm_output.hpp"
 #include "plugin/transformations/kv_cache_compression.hpp"
 #include "plugin/transformations/kv_cache_fusion.hpp"
 #include "plugin/transformations/lora_horizontal_fusion.hpp"
 #include "plugin/transformations/lora_subgraph_horizontal_fusion.hpp"
-#include "intel_gpu/op/fully_connected.hpp"
-#include "transformations/common_optimizations/move_fc_reshape_to_weights.hpp"
 #include "plugin/transformations/optimize_subsequent_reshapes.hpp"
+#include "plugin/transformations/preserve_single_selective_ssm_output.hpp"
 #include "plugin/transformations/print_model_statistics.hpp"
 #include "plugin/transformations/reduce_fc_dimensions.hpp"
 #include "plugin/transformations/remove_fq_before_dw_conv.hpp"
-#include "plugin/transformations/sink_reshape.hpp"
-#include "plugin/transformations/transpose_fusion.hpp"
 #include "plugin/transformations/sdpa_transpose_fusion.hpp"
-#include "plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.hpp"
-#include "plugin/transformations/expand_broadcast_reshape_sdpa_fusion.hpp"
-#include "plugin/transformations/disable_fp16_comp_direct_multiply_sin_cos.hpp"
-#include "plugin/transformations/disable_fp16_comp_gated_residual.hpp"
-#include "plugin/transformations/disable_fp16_comp_rms.hpp"
+#include "plugin/transformations/sink_reshape.hpp"
 #include "plugin/transformations/swiglu_fusion_with_clamp.hpp"
-#include "plugin/transformations/disable_fp16_comp_cumsum_sin_gen.hpp"
-#include "plugin/transformations/disable_fp16_comp_sin_gen.hpp"
-#include "plugin/transformations/increase_rms_input_precision.hpp"
+#include "plugin/transformations/transpose_fusion.hpp"
+#include "plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.hpp"
 #include "transformations/common_optimizations/activations_scaling.hpp"
 #include "transformations/common_optimizations/broadcast_elementwise_fusion.hpp"
 #include "transformations/common_optimizations/broadcast_transition.hpp"
 #include "transformations/common_optimizations/common_optimizations.hpp"
+#include "transformations/common_optimizations/constants_reduce.hpp"
 #include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
-#include "transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp"
+#include "transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp"
 #include "transformations/common_optimizations/fuse_gated_delta_net.hpp"
+#include "transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp"
 #include "transformations/common_optimizations/glu_fusion.hpp"
 #include "transformations/common_optimizations/group_normalization_fusion.hpp"
 #include "transformations/common_optimizations/lin_op_sequence_fusion.hpp"
 #include "transformations/common_optimizations/lora_subgraph_fusion.hpp"
 #include "transformations/common_optimizations/lstm_cell_fusion.hpp"
+#include "transformations/common_optimizations/moe_op_fusion.hpp"
 #include "transformations/common_optimizations/move_eltwise_up_data_movement.hpp"
+#include "transformations/common_optimizations/move_fc_reshape_to_weights.hpp"
 #include "transformations/common_optimizations/mvn_fusion.hpp"
-#include "transformations/common_optimizations/convert_tiled_moe_block_to_gather_matmuls.hpp"
-#include "transformations/op_conversions/convert_grouped_matmul_to_gather_matmul.hpp"
 #include "transformations/common_optimizations/nop_elimination.hpp"
 #include "transformations/common_optimizations/rms_fusion.hpp"
 #include "transformations/common_optimizations/sdpa_scale_fusion.hpp"
 #include "transformations/common_optimizations/shared_ops_optimization.hpp"
 #include "transformations/common_optimizations/softmax_fusion.hpp"
-#include "transformations/common_optimizations/transpose_to_reshape.hpp"
 #include "transformations/common_optimizations/transpose_sinking.hpp"
+#include "transformations/common_optimizations/transpose_to_reshape.hpp"
 #include "transformations/common_optimizations/weights_dequantize_to_fake_quantize.hpp"
 #include "transformations/common_optimizations/wrap_interpolate_into_transposes.hpp"
-#include "transformations/common_optimizations/constants_reduce.hpp"
 #include "transformations/control_flow/unroll_tensor_iterator.hpp"
 #include "transformations/convert_pooling_to_reduce.hpp"
 #include "transformations/convert_precision.hpp"
@@ -167,8 +165,11 @@
 #include "transformations/fp16_compression/convert_compression_only_to_legacy.hpp"
 #include "transformations/fp16_compression/mark_decompression_convert_constant_folding.hpp"
 #include "transformations/init_node_info.hpp"
-#include "transformations/normalize_l2_decomposition.hpp"
 #include "transformations/low_precision/mark_dequantization_subgraph.hpp"
+#include "transformations/normalize_l2_decomposition.hpp"
+#include "transformations/op_conversions/convert_gather_matmul_to_compressed.hpp"
+#include "transformations/op_conversions/convert_grouped_matmul_to_compressed.hpp"
+#include "transformations/op_conversions/convert_grouped_matmul_to_gather_matmul.hpp"
 #ifdef OV_GPU_MLIR_BACKEND_LINKED
 #    include "transformations/mlir/interface/convert.hpp"
 #endif  // OV_GPU_MLIR_BACKEND_LINKED
@@ -795,9 +796,40 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             if (!root->get_input_partial_shape(0).is_static()) {
                 return false;
             }
-            const auto& gamma_shape = root->get_input_partial_shape(0).to_shape();
+            const auto& input_shape = root->get_input_partial_shape(0).to_shape();
+            size_t reduction_dim_size = input_shape.back();
+
+            std::function<std::shared_ptr<const ov::op::v1::ReduceMean>(const std::shared_ptr<const ov::Node>&, int)> find_reduce_mean =
+                [&find_reduce_mean](const std::shared_ptr<const ov::Node>& node, int depth) -> std::shared_ptr<const ov::op::v1::ReduceMean> {
+                if (!node || depth > 5) {
+                    return nullptr;
+                }
+                if (auto rm = ov::as_type_ptr<const ov::op::v1::ReduceMean>(node)) {
+                    return rm;
+                }
+                for (size_t i = 0; i < node->get_input_size(); ++i) {
+                    auto res = find_reduce_mean(node->get_input_node_shared_ptr(i), depth + 1);
+                    if (res) {
+                        return res;
+                    }
+                }
+                return nullptr;
+            };
+
+            auto reduce_mean = find_reduce_mean(root, 0);
+            if (reduce_mean && reduce_mean->get_input_size() > 1) {
+                if (auto axes_const = ov::as_type_ptr<const ov::op::v0::Constant>(reduce_mean->get_input_node_shared_ptr(1))) {
+                    auto axes_vec = axes_const->cast_vector<int64_t>();
+                    if (!axes_vec.empty() && input_shape.size() > 0) {
+                        auto rank = static_cast<int64_t>(input_shape.size());
+                        auto norm_axis = (axes_vec[0] % rank + rank) % rank;
+                        reduction_dim_size = input_shape[norm_axis];
+                    }
+                }
+            }
+
             const int32_t vec_size = 8;
-            return static_cast<int32_t>((gamma_shape.back() / vec_size)) > static_cast<int32_t>(device_info.max_work_group_size);
+            return static_cast<int32_t>((reduction_dim_size / vec_size)) > static_cast<int32_t>(device_info.max_work_group_size);
         });
         manager.register_pass<ov::pass::RMSFusion>(false, true);
         manager.register_pass<DisableFP16CompForGemma3RMSPattern>();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
@@ -923,3 +923,227 @@ TEST(rms_gpu_test, rms_test_bf16_bfyx_opt_near_zero) {
                  /*epsilon=*/1e-5f, /*in_min=*/0.001f, /*in_max=*/0.003f,
                  /*abs_floor=*/0.01f, /*rel_tol=*/0.05f);
 }
+
+// ============================================================================
+// Channel axis (axis=1) NCHW RMS tests
+// ============================================================================
+template <typename T>
+void rms_channel_ref(const memory::ptr input, const memory::ptr gamma, memory::ptr output, float epsilon) {
+    auto input_layout = input->get_layout();
+    uint32_t batch_size = input_layout.batch();
+    uint32_t feature_size = input_layout.feature();
+    uint32_t y_size = input_layout.spatial(1);
+    uint32_t x_size = input_layout.spatial(0);
+
+    cldnn::mem_lock<T> src(input, get_test_stream());
+    cldnn::mem_lock<T> dst(output, get_test_stream());
+
+    std::unique_ptr<cldnn::mem_lock<T>> weight;
+    if (gamma) {
+        weight = std::make_unique<cldnn::mem_lock<T>>(gamma, get_test_stream());
+    }
+    const bool scalar_gamma = gamma && gamma->count() == 1;
+
+    for (uint32_t b = 0; b < batch_size; ++b) {
+        for (uint32_t y = 0; y < y_size; ++y) {
+            for (uint32_t x = 0; x < x_size; ++x) {
+                float sum_sq = 0.f;
+                for (uint32_t c = 0; c < feature_size; ++c) {
+                    auto t = tensor(batch(b), feature(c), spatial(x, y, 0, 0));
+                    float val = static_cast<float>(src[input_layout.get_linear_offset(t)]);
+                    sum_sq += val * val;
+                }
+                float rms = 1.0f / std::sqrt(sum_sq / feature_size + epsilon);
+
+                for (uint32_t c = 0; c < feature_size; ++c) {
+                    auto t = tensor(batch(b), feature(c), spatial(x, y, 0, 0));
+                    size_t offset = input_layout.get_linear_offset(t);
+                    float gamma_val = weight ? static_cast<float>((*weight)[scalar_gamma ? 0 : c]) : 1.0f;
+                    dst[offset] = static_cast<T>(rms * static_cast<float>(src[offset]) * gamma_val);
+                }
+            }
+        }
+    }
+}
+
+TEST(rms_gpu_test, rms_test_channel_axis_ref) {
+    auto& engine = get_test_engine();
+
+    // Use odd spatial dimensions (H=7, W=5) distinct from channel count (C=64)
+    // to ensure C and spatial dimensions are not confused.
+    const ov::PartialShape in_shape{1, 64, 7, 5};
+    auto input = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+    auto gamma = engine.allocate_memory({ov::PartialShape{1, 64, 1, 1}, data_types::f32, format::bfyx});
+    auto output_ref = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+
+    tests::set_random_values<float>(input, true, 8, 100);
+    tests::set_random_values<float>(gamma, true, 8, 100);
+
+    const float eps = 1e-6f;
+    rms_channel_ref<float>(input, gamma, output_ref, eps);
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(input_layout("gamma", gamma->get_layout()));
+    topology.add(rms("rms", input_info("input"), input_info("gamma"), eps, /*axis=*/1));
+
+    network network(engine, topology, get_test_default_config(engine));
+
+    // Verify rms_gpu_ref is selected for channel axis
+    auto impl = network.get_primitive("rms")->get_impl();
+    ASSERT_NE(impl, nullptr);
+    ASSERT_EQ(impl->get_kernel_name(), "rms_gpu_ref");
+
+    network.set_input_data("input", input);
+    network.set_input_data("gamma", gamma);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+
+    auto output = outputs.at("rms").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
+
+    for (unsigned int i = 0; i < output_ref->count(); ++i) {
+        EXPECT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-4) << "Mismatch at index=" << i;
+    }
+}
+
+TEST(rms_gpu_test, rms_test_channel_axis_ref_unaligned_channels) {
+    auto& engine = get_test_engine();
+
+    // Channel size not a multiple of 8 or 16
+    const ov::PartialShape in_shape{2, 13, 3, 5};
+    auto input = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+    auto gamma = engine.allocate_memory({ov::PartialShape{1, 13, 1, 1}, data_types::f32, format::bfyx});
+    auto output_ref = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+
+    tests::set_random_values<float>(input, true, 8, 100);
+    tests::set_random_values<float>(gamma, true, 8, 100);
+
+    const float eps = 1e-5f;
+    rms_channel_ref<float>(input, gamma, output_ref, eps);
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(input_layout("gamma", gamma->get_layout()));
+    topology.add(rms("rms", input_info("input"), input_info("gamma"), eps, /*axis=*/1));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input);
+    network.set_input_data("gamma", gamma);
+
+    auto outputs = network.execute();
+    auto output = outputs.at("rms").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
+
+    for (unsigned int i = 0; i < output_ref->count(); ++i) {
+        EXPECT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-4) << "Mismatch at index=" << i;
+    }
+}
+
+TEST(rms_gpu_test, rms_test_channel_axis_ref_dyn) {
+    auto& engine = get_test_engine();
+
+    auto input_layout_dynamic = layout{ov::PartialShape{-1, 64, -1, -1}, data_types::f32, format::bfyx};
+    const ov::PartialShape in_shape{1, 64, 8, 8};
+    auto input = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+    auto gamma = engine.allocate_memory({ov::PartialShape{1, 64, 1, 1}, data_types::f32, format::bfyx});
+    auto output_ref = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+
+    tests::set_random_values<float>(input, true, 8, 100);
+    tests::set_random_values<float>(gamma, true, 8, 100);
+
+    const float eps = 1e-6f;
+    rms_channel_ref<float>(input, gamma, output_ref, eps);
+
+    topology topology;
+    topology.add(input_layout("input", input_layout_dynamic));
+    topology.add(input_layout("gamma", gamma->get_layout()));
+    topology.add(rms("rms", input_info("input"), input_info("gamma"), eps, /*axis=*/1));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+    network.set_input_data("gamma", gamma);
+
+    auto impl = network.get_primitive("rms")->get_impl();
+    ASSERT_NE(impl, nullptr);
+    ASSERT_TRUE(impl->is_dynamic());
+
+    auto outputs = network.execute();
+    auto output = outputs.at("rms").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
+
+    for (unsigned int i = 0; i < output_ref->count(); ++i) {
+        EXPECT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-4) << "Mismatch at index=" << i;
+    }
+}
+
+TEST(rms_gpu_test, rms_test_channel_axis_no_gamma) {
+    auto& engine = get_test_engine();
+
+    const ov::PartialShape in_shape{1, 32, 4, 4};
+    auto input = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+    auto output_ref = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+
+    tests::set_random_values<float>(input, true, 8, 100);
+
+    const float eps = 1e-6f;
+    rms_channel_ref<float>(input, nullptr, output_ref, eps);
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(rms("rms", input_info("input"), eps, /*axis=*/1));
+
+    network network(engine, topology, get_test_default_config(engine));
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+    auto output = outputs.at("rms").get_memory();
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
+
+    for (unsigned int i = 0; i < output_ref->count(); ++i) {
+        EXPECT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-4) << "Mismatch at index=" << i;
+    }
+}
+
+TEST(rms_gpu_test, rms_test_channel_axis_cache) {
+    auto& engine = get_test_engine();
+
+    const ov::PartialShape in_shape{1, 64, 4, 4};
+    auto input = engine.allocate_memory({in_shape, data_types::f32, format::bfyx});
+    auto gamma = engine.allocate_memory({ov::PartialShape{1, 64, 1, 1}, data_types::f32, format::bfyx});
+
+    tests::set_random_values<float>(input, true, 8, 100);
+    tests::set_random_values<float>(gamma, true, 8, 100);
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(input_layout("gamma", gamma->get_layout()));
+    topology.add(rms("rms", input_info("input"), input_info("gamma"), 1e-6f, /*axis=*/1));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    auto net_orig = get_network(engine, topology, config, get_test_stream_ptr(), false);
+    net_orig->set_input_data("input", input);
+    net_orig->set_input_data("gamma", gamma);
+    auto orig_outputs = net_orig->execute();
+    auto orig_out_mem = orig_outputs.at("rms").get_memory();
+
+    auto net_cached = get_network(engine, topology, config, get_test_stream_ptr(), true);
+    net_cached->set_input_data("input", input);
+    net_cached->set_input_data("gamma", gamma);
+    auto cached_outputs = net_cached->execute();
+    auto cached_out_mem = cached_outputs.at("rms").get_memory();
+
+    cldnn::mem_lock<float> orig_ptr(orig_out_mem, get_test_stream());
+    cldnn::mem_lock<float> cached_ptr(cached_out_mem, get_test_stream());
+    for (size_t i = 0; i < orig_out_mem->count(); ++i) {
+        EXPECT_EQ(orig_ptr[i], cached_ptr[i]) << "Cache mismatch at index=" << i;
+    }
+}

--- a/src/plugins/template/backend/ops/rms_internal.cpp
+++ b/src/plugins/template/backend/ops/rms_internal.cpp
@@ -18,7 +18,7 @@ bool evaluate(const std::shared_ptr<ov::op::internal::RMS>& node,
               ov::TensorVector& outputs,
               const ov::TensorVector& inputs) {
     using ET = typename ov::element_type_traits<T>::value_type;
-    const auto normalized_axes = AxisSet{ov::util::normalize_axis(-1, inputs[0].get_shape().size())};
+    const auto normalized_axes = AxisSet{ov::util::normalize_axis(node->get_axis(), inputs[0].get_shape().size())};
 
     outputs[0].set_shape(inputs[0].get_shape());
 

--- a/src/plugins/template/tests/functional/op_reference/rms_internal.cpp
+++ b/src/plugins/template/tests/functional/op_reference/rms_internal.cpp
@@ -40,7 +40,7 @@ public:
         auto params = GetParam();
         const auto output_type =
             params.expected.type == params.input.type ? ov::element::dynamic : params.expected.type;
-        function = CreateFunction(params.input, params.eps, params.scale, output_type);
+        function = CreateFunction(params.input, params.eps, params.scale, output_type, params.reductionAxes);
         if (!params.scale.data) {
             inputData = {params.input.data};
         } else {
@@ -71,16 +71,21 @@ private:
     static std::shared_ptr<Model> CreateFunction(const reference_tests::Tensor& input,
                                                  const double eps,
                                                  const reference_tests::Tensor& scale,
-                                                 const ov::element::Type& output_type) {
+                                                 const ov::element::Type& output_type,
+                                                 const reference_tests::Tensor& reductionAxes) {
         const auto in = std::make_shared<op::v0::Parameter>(input.type, input.shape);
+        int64_t axis = -1;
+        if (reductionAxes.data) {
+            axis = op::v0::Constant(reductionAxes.data).cast_vector<int64_t>()[0];
+        }
 
         if (!scale.data) {
             const auto scale_const = std::make_shared<op::v0::Constant>(input.type, input.shape, 1.0);
-            const auto rms_norm = std::make_shared<op::internal::RMS>(in, scale_const, eps, output_type);
+            const auto rms_norm = std::make_shared<op::internal::RMS>(in, scale_const, eps, output_type, axis);
             return std::make_shared<ov::Model>(OutputVector{rms_norm}, ParameterVector{in});
         }
         const auto scale_param = std::make_shared<op::v0::Parameter>(scale.type, scale.shape);
-        const auto rms_norm = std::make_shared<op::internal::RMS>(in, scale_param, eps, output_type);
+        const auto rms_norm = std::make_shared<op::internal::RMS>(in, scale_param, eps, output_type, axis);
         return std::make_shared<ov::Model>(OutputVector{rms_norm}, ParameterVector{in, scale_param});
     }
 };
@@ -433,5 +438,20 @@ INSTANTIATE_TEST_SUITE_P(
                                                0.3818359375,  0.0000549555,  0.9018554688,  -1.0996093750, 0.0776977539,
                                                -0.6708984375, -0.1179199219, 1.5468750000,  0.0331726074,  3.3847656250,
                                                0.0784912109,  -2.2246093750, -0.1185913086, 2.4902343750}},
-                  reference_tests::Tensor{Shape{4}, ov::element::f32, std::vector<float>{0.5, 1.5, 0.25, 2.0}})),
+                  reference_tests::Tensor{Shape{4}, ov::element::f32, std::vector<float>{0.5, 1.5, 0.25, 2.0}}),
+        RMSParams(reference_tests::Tensor{Shape{1, 2, 2, 2},
+                                          ov::element::f32,
+                                          std::vector<float>{1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f}},
+                  reference_tests::Tensor{Shape{1}, ov::element::i64, std::vector<int64_t>({1})},
+                  1e-5,
+                  reference_tests::Tensor{Shape{1, 2, 2, 2},
+                                          ov::element::f32,
+                                          std::vector<float>{0.27734998f,
+                                                             0.4472135f,
+                                                             0.55708593f,
+                                                             0.6324554f,
+                                                             1.38675f,
+                                                             1.3416405f,
+                                                             1.2998672f,
+                                                             1.2649108f}})),
     ReferenceRMSLayerTest::getTestCaseName);


### PR DESCRIPTION
### Details:
 - Extend internal RMS operation with normalization axis attribute (default -1).
 - Update RMSFusionMatcher to support rank-4 NCHW channel-axis normalization (axis=1) in addition to the last axis.
 - Update Intel GPU plugin RMS primitive and kernel selector to support axis=1 via rms_gpu_ref.
 - Maintain Template plugin evaluate and Intel CPU fallback correctness for channel-axis RMS.
 - Add positive fusion unit tests and GPU kernel test cases (odd spatial, unaligned channels, dynamic shapes, caching).

### AI Assistance:
 - AI assistance used: yes