### PR TITLE
[NPU][IE-MDK] Update Latest driver to WW38

### DIFF
--- a/src/plugins/intel_npu/tests/driver_version.json
+++ b/src/plugins/intel_npu/tests/driver_version.json
@@ -1,9 +1,9 @@
 {
     "windows10": {
-        "MTL": "windows/unified/integration/ci_tag_driver_rc_config1_20260902_1230/npu-driver-ci-master-13805-Driver-RelWithDebInfo-64-bit.zip",
-        "LNL": "windows/unified/integration/ci_tag_driver_rc_config1_20260902_1230/npu-driver-ci-master-13805-Driver-RelWithDebInfo-64-bit.zip",
-        "PTL": "windows/unified/integration/ci_tag_driver_rc_config1_20260902_1230/npu-driver-ci-master-13805-Driver-RelWithDebInfo-64-bit.zip",
-        "NVL": "windows/unified/integration/ci_tag_driver_rc_config1_20260902_1230/npu-driver-ci-master-13805-Driver-RelWithDebInfo-64-bit.zip",
+        "MTL": "windows/unified/integration/ci_tag_driver_rc_config1_20260910_1901/npu-driver-ci-master-13977-RelWithDebInfo.zip",
+        "LNL": "windows/unified/integration/ci_tag_driver_rc_config1_20260910_1901/npu-driver-ci-master-13977-RelWithDebInfo.zip",
+        "PTL": "windows/unified/integration/ci_tag_driver_rc_config1_20260910_1901/npu-driver-ci-master-13977-RelWithDebInfo.zip",
+        "NVL": "windows/unified/integration/ci_tag_driver_rc_config1_20260910_1901/npu-driver-ci-master-13977-RelWithDebInfo.zip",
         "MTL_release": "windows/unified/UD202638/ci_tag_driver_rc_ud202638_20260820_1901/npu-driver-ci-releases_26ww32-ci-master-13301-700-RelWithDebInfo.zip",
         "LNL_release": "windows/unified/UD202638/ci_tag_driver_rc_ud202638_20260820_1901/npu-driver-ci-releases_26ww32-ci-master-13301-700-RelWithDebInfo.zip",
         "PTL_release": "windows/unified/UD202638/ci_tag_driver_rc_ud202638_20260820_1901/npu-driver-ci-releases_26ww32-ci-master-13301-700-RelWithDebInfo.zip",
@@ -11,7 +11,7 @@
         "MTL_PV": "windows/MTL/PV2/ci_tag_mtl_pv2_driver_rc_20231031_2101/npu_win_31.0.100.1688.zip"
     },
     "ubuntu24": {
-        "MTL": "ubuntu24/unified/integration/npu-linux-driver-ci-1.39.0.20260810-31423273404/npu-linux-driver-ci-1.39.0.20260810-31423273404-ubuntu2404-release.tar.gz",
+        "MTL": "ubuntu24/unified/integration/npu-linux-driver-ci-1.39.0.20260910-34523462333/npu-linux-driver-ci-1.39.0.20260910-34523462333-ubuntu2404-release.tar.gz",
         "MTL_release": "ubuntu24/unified/1.35.0/npu-linux-driver-ci-1.35.0.20260722-29947505341/npu-linux-driver-ci-1.35.0.20260722-29947505341-ubuntu2404-opensource.tar.gz",
         "PTL_release": "ubuntu24/unified/1.35.0/npu-linux-driver-ci-1.35.0.20260722-29947505341/npu-linux-driver-ci-1.35.0.20260722-29947505341-ubuntu2404-opensource.tar.gz"
     }


### PR DESCRIPTION
### Details:
Updating NPU drivers used in OV Integration under LATEST tag
Picking latest drivers for Windows and Linux posted in 1Click builds

### Tickets:
 - E234181

### AI Assistance:
 - *AI assistance used: no / yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
