### PR TITLE
[PT FE] Support aten::ravel operator

### DIFF
--- a/src/frontends/pytorch/src/op/ravel.cpp
+++ b/src/frontends/pytorch/src/op/ravel.cpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/complex_type_mark.hpp"
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert_like.hpp"
+#include "openvino/op/reshape.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+using namespace ov::op;
+
+OutputVector translate_ravel(const NodeContext& context) {
+    // Schema: aten::ravel(Tensor self) -> Tensor
+    num_inputs_check(context, 1, 1);
+    auto tensor = context.get_input(0);
+    Output<Node> shape = context.mark_node(v0::Constant::create(element::i32, Shape{1}, {-1}));
+
+    auto complex_type_mark = as_type_ptr<ComplexTypeMark>(tensor.get_node_shared_ptr());
+    if (complex_type_mark) {
+        tensor = complex_type_mark->get_data();
+        auto const_2 = context.mark_node(v0::Constant::create(element::i32, Shape{1}, {2}));
+        const_2 = context.mark_node(std::make_shared<v1::ConvertLike>(const_2, shape));
+        shape = context.mark_node(std::make_shared<v0::Concat>(OutputVector{shape, const_2}, 0));
+    }
+
+    auto reshape = context.mark_node(std::make_shared<v1::Reshape>(tensor, shape, false));
+
+    if (complex_type_mark) {
+        const auto& complex_dtype = complex_type_mark->get_complex_part_type();
+        return {context.mark_node(std::make_shared<ComplexTypeMark>(reshape, complex_dtype))};
+    } else {
+        return {reshape};
+    }
+};
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -228,6 +228,7 @@ OP_CONVERTER(translate_randn);
 OP_CONVERTER(translate_randint);
 OP_CONVERTER(translate_rand_like);
 OP_CONVERTER(translate_randn_like);
+OP_CONVERTER(translate_ravel);
 OP_CONVERTER(translate_reciprocal);
 OP_CONVERTER(translate_reflection_pad_nd);
 OP_CONVERTER(translate_relu6);
@@ -699,6 +700,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::randint", op::translate_randint},
         {"aten::randn", op::translate_randn},
         {"aten::randn_like", op::translate_randn_like},
+        {"aten::ravel", op::translate_ravel},
         {"aten::real", common_translators::translate_real},
         {"aten::reciprocal", op::optional_out<op::translate_reciprocal, 1>},
         {"aten::reciprocal_", op::inplace_op<op::translate_reciprocal>},
@@ -1091,6 +1093,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.prod.default", op::translate_prod_fx},
         {"aten.prod.dim_int", op::translate_prod_fx},
         {"aten.rand.default", op::translate_rand},
+        {"aten.ravel.default", op::translate_ravel},
         {"aten.reciprocal.default", op::translate_reciprocal},
         {"aten.reflection_pad1d.default", op::translate_reflection_pad_nd},
         {"aten.reflection_pad2d.default", op::translate_reflection_pad_nd},

--- a/tests/layer_tests/pytorch_tests/test_ravel.py
+++ b/tests/layer_tests/pytorch_tests/test_ravel.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import numpy as np
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestRavel(PytorchLayerTest):
+    def _prepare_input(self, shape, dtype="float32"):
+        if dtype.startswith("int"):
+            return (self.random.randint(-100, 100, size=shape).astype(dtype),)
+        return (self.random.randn(*shape).astype(dtype),)
+
+    def create_model(self):
+        import torch
+
+        class aten_ravel(torch.nn.Module):
+            def forward(self, x):
+                return torch.ravel(x)
+
+        return aten_ravel(), "aten::ravel"
+
+    @pytest.mark.parametrize("shape", [
+        [2, 3],
+        [2, 3, 4],
+        [2, 3, 4, 5],
+        [1],
+        [5],
+        [1, 1, 1],
+    ])
+    @pytest.mark.parametrize("dtype", ["float32", "float64", "int32", "int64", "int8"])
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    def test_ravel(self, shape, dtype, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model(),
+            ie_device,
+            precision,
+            ir_version,
+            kwargs_to_prepare_input={"shape": shape, "dtype": dtype},
+        )


### PR DESCRIPTION
### Details:
 - Implemented `translate_ravel` in `src/frontends/pytorch/src/op/ravel.cpp` converting `aten::ravel` to OpenVINO `v1::Reshape` targeting `[-1]`, including support for complex tensors via `ComplexTypeMark`.
 - Registered `aten::ravel` in TorchScript operations (`get_supported_ops_ts()`) and `aten.ravel.default` in FX operations (`get_supported_ops_fx()`) in `src/frontends/pytorch/src/op_table.cpp`.
 - Added layer tests in `tests/layer_tests/pytorch_tests/test_ravel.py` covering various ranks (`1D`, `2D`, `3D`, `4D`), scalar shapes, and multiple data types (`float32`, `float64`, `int32`, `int64`, `int8`).

### Tickets:
 - #28584
 - #28902

### AI Assistance:
 - AI assistance used: yes
 - If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks):
 AI was used to draft the operator translation following existing PyTorch frontend patterns (`op/reshape.cpp`) and generate test cases. Python syntax checks and local failure reproduction tests were performed.