### PR TITLE
[AUTO] Implement device selection before each inference

### DIFF
--- a/src/plugins/auto/src/auto_schedule.cpp
+++ b/src/plugins/auto/src/auto_schedule.cpp
@@ -14,6 +14,30 @@
 namespace ov {
 namespace auto_plugin {
 bool AutoSchedule::select_other_device(const std::string& cur_dev_name) {
+    if (m_context->m_dynamic_device_selection) {
+        bool can_retry = false;
+        {
+            std::lock_guard<std::mutex> lock(m_context->m_fallback_mutex);
+            const auto iter = deviceChecker().check_and_return_if_device_in_list<DeviceInformation>(
+                cur_dev_name, m_context->m_device_priorities, true);
+            if (iter != m_context->m_device_priorities.end()) {
+                if (m_context->m_device_priorities.size() == 1) {
+                    LOG_WARNING_TAG("[dynamic] inference failed on device:%s, no other device left to retry",
+                                    cur_dev_name.c_str());
+                    return false;
+                }
+                m_context->m_device_priorities.erase(iter);
+                LOG_WARNING_TAG("[dynamic] inference failed on device:%s, exclude it and retry on another device",
+                                cur_dev_name.c_str());
+            }
+            can_retry = !m_context->m_device_priorities.empty();
+        }
+        std::lock_guard<std::mutex> lock(m_gate_mutex);
+        if (m_gate_current_device == cur_dev_name) {
+            m_gate_current_device.clear();
+        }
+        return can_retry;
+    }
     {
         std::lock_guard<std::mutex> lock(m_context->m_fallback_mutex);
         // a recursive function to select other devices
@@ -83,6 +107,13 @@ bool AutoSchedule::select_other_device(const std::string& cur_dev_name) {
 void AutoSchedule::init() {
     if (m_context->m_bind_buffer) {
         LOG_INFO_TAG("bind buffer supported only under cumulative mode, ignoring");
+    }
+    if (m_context->m_dynamic_device_selection) {
+        // the model has to stay alive to be compiled on demand once the target device changes
+        m_dynamic_model = m_context->m_model;
+        m_dynamic_executor = m_plugin->get_executor_manager()->get_idle_cpu_streams_executor(
+            ov::threading::IStreamsExecutor::Config{"AutoDynamicSchedule", 1, 0});
+        LOG_INFO_TAG("[dynamic] device is re-selected for every inference, inference is serialized per compiled model");
     }
     // initialize cpuHelpReleasetime
     m_cpuhelp_release_time = std::chrono::steady_clock::now();
@@ -268,8 +299,9 @@ void AutoSchedule::init() {
             }
         };
         m_executor->run(std::move(recycleTask));
-    } else if (m_context->m_device_priorities.size() != 1 && m_context->m_str_devices_initial.size() != 1 &&
-               m_context->m_runtime_fallback) {
+    } else if (m_context->m_dynamic_device_selection ||
+               (m_context->m_device_priorities.size() != 1 && m_context->m_str_devices_initial.size() != 1 &&
+                m_context->m_runtime_fallback)) {
         // The performance will has some drop then m_passthrough_compiled_model when enable ENABLE_RUNTIME_FALLBACK
         for (auto&& device : m_context->m_device_priorities) {
             // initialize containers before run async task
@@ -278,6 +310,12 @@ void AutoSchedule::init() {
             m_infer_pipeline_tasks_device_specific[device.device_name] = nullptr;
         }
         m_compile_context[ACTUALDEVICE].m_task();
+        if (m_context->m_dynamic_device_selection && m_compile_context[ACTUALDEVICE].m_is_already) {
+            const auto& initial_device = m_compile_context[ACTUALDEVICE].m_device_info.device_name;
+            m_dynamic_compiled_models[initial_device] = m_compile_context[ACTUALDEVICE].m_compiled_model;
+            m_gate_current_device = initial_device;
+            LOG_INFO_TAG("[dynamic] initial target device:%s", initial_device.c_str());
+        }
     } else {
         // Only one device, or multiple devices of the same type (e.g., all GPU devices, including iGPU and dGPU), can
         // use passthrough model; no need to compile asynchronously
@@ -451,6 +489,9 @@ void AutoSchedule::wait_actual_compiled_model_ready() const {
 }
 
 bool AutoSchedule::schedule_to_worker_infer_request(ov::threading::Task pipeline_task, DeviceName preferred_device) {
+    if (m_context->m_dynamic_device_selection) {
+        return schedule_dynamic_task(std::move(pipeline_task), preferred_device);
+    }
     std::vector<DeviceInformation> devices;
     // AUTO work mode
     // Devices that fail infer will be removed from the priority list in the callback, need lock here
@@ -497,7 +538,153 @@ bool AutoSchedule::schedule_to_worker_infer_request(ov::threading::Task pipeline
     return false;
 }
 
+bool AutoSchedule::schedule_dynamic_task(ov::threading::Task pipeline_task, const DeviceName& preferred_device) {
+    {
+        std::lock_guard<std::mutex> lock(m_gate_mutex);
+        if (m_gate_busy) {
+            m_gate_pending_tasks.emplace_back(std::move(pipeline_task), preferred_device);
+            LOG_DEBUG_TAG("[dynamic] an inference is still running, request queued, queue size:%ld",
+                          static_cast<long>(m_gate_pending_tasks.size()));
+            return false;
+        }
+        m_gate_busy = true;
+    }
+    // dispatching is offloaded so that neither start_async() nor the completion callback of a device is blocked
+    // by the device re-selection and by the compilation of the model on a newly selected device
+    m_dynamic_executor->run([this, task = std::move(pipeline_task), preferred_device]() mutable {
+        dispatch_dynamic_task(std::move(task), preferred_device);
+    });
+    return true;
+}
+
+void AutoSchedule::dispatch_dynamic_task(ov::threading::Task pipeline_task, const DeviceName& preferred_device) {
+    try {
+        DeviceInformation device;
+        if (!preferred_device.empty()) {
+            std::lock_guard<std::mutex> lock(m_context->m_fallback_mutex);
+            const auto iter = deviceChecker().check_and_return_if_device_in_list<DeviceInformation>(
+                preferred_device, m_context->m_device_priorities, true);
+            OPENVINO_ASSERT(iter != m_context->m_device_priorities.end(),
+                            "The preferred device should be one of the candidate devices");
+            device = *iter;
+            LOG_DEBUG_TAG("[dynamic] request is pinned to device:%s by a remote tensor, skip device re-selection",
+                          device.device_name.c_str());
+        } else {
+            device = select_dynamic_device();
+        }
+        OPENVINO_ASSERT(ensure_device_ready(device),
+                        "[",
+                        get_log_tag(),
+                        "] failed to compile the model on the selected device ",
+                        device.device_name);
+        const auto& device_name = device.device_name;
+        {
+            std::lock_guard<std::mutex> lock(m_gate_mutex);
+            if (m_gate_current_device == device_name) {
+                LOG_DEBUG_TAG("[dynamic] target device:%s is unchanged, reuse its idle worker", device_name.c_str());
+            } else {
+                LOG_INFO_TAG("[dynamic] target device switched from %s to %s",
+                             m_gate_current_device.empty() ? "none" : m_gate_current_device.c_str(),
+                             device_name.c_str());
+                m_gate_current_device = device_name;
+                m_dynamic_switch_count++;
+            }
+        }
+        m_dynamic_infer_count++;
+        OPENVINO_ASSERT(run_pipeline_task(pipeline_task, m_idle_worker_requests[device_name], device_name),
+                        "[",
+                        get_log_tag(),
+                        "] no idle infer request available on device ",
+                        device_name);
+    } catch (...) {
+        // report the failure through the pipeline, otherwise the request would never complete
+        m_this_scheduling_exception = std::current_exception();
+        m_this_worker_infer_request = nullptr;
+        pipeline_task();
+        release_execution_slot();
+    }
+}
+
+DeviceInformation AutoSchedule::select_dynamic_device() {
+    const auto start_time = std::chrono::steady_clock::now();
+    DeviceInformation device;
+    {
+        std::lock_guard<std::mutex> lock(m_context->m_fallback_mutex);
+        OPENVINO_ASSERT(!m_context->m_device_priorities.empty(),
+                        "[", get_log_tag(), "] no candidate device left to run the inference");
+        device = m_plugin->select_device(m_context->m_device_priorities,
+                                        m_context->m_model_precision,
+                                        m_context->m_model_priority,
+                                        m_context->m_selection_policy,
+                                        m_context->m_low_power_device);
+    }
+    // select_device registers the picked device under the model priority, only the registration done when the model
+    // was compiled must survive, so the transient one added by this per inference selection is dropped right away
+    m_plugin->unregister_priority(m_context->m_model_priority, device.unique_name);
+    LOG_DEBUG_TAG("[dynamic] re-selected device:%s in %lf ms",
+                  device.device_name.c_str(),
+                  std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start_time).count());
+    return device;
+}
+
+bool AutoSchedule::ensure_device_ready(DeviceInformation& device) {
+    if (m_dynamic_compiled_models.find(device.device_name) != m_dynamic_compiled_models.end()) {
+        return true;
+    }
+    const auto start_time = std::chrono::steady_clock::now();
+    AutoCompileContext context;
+    context.m_device_info = device;
+    context.m_model_precision = m_context->m_model_precision;
+    {
+        std::lock_guard<std::mutex> lock(m_context->m_fallback_mutex);
+        context.m_meta_devices = m_context->m_device_priorities;
+    }
+    LOG_INFO_TAG("[dynamic] device:%s is used for the first time, compiling the model", device.device_name.c_str());
+    try_to_compile_model(context, m_dynamic_model ? m_dynamic_model->clone() : nullptr);
+    if (!context.m_is_load_success) {
+        LOG_WARNING_TAG("[dynamic] compiling the model on device:%s failed, %s",
+                        device.device_name.c_str(),
+                        context.m_err_message.c_str());
+        return false;
+    }
+    device = context.m_device_info;
+    m_dynamic_compiled_models[device.device_name] = context.m_compiled_model;
+    generate_workers(device.device_name, context.m_compiled_model);
+    LOG_INFO_TAG("[dynamic] device:%s is ready in %lf ms",
+                 device.device_name.c_str(),
+                 std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start_time).count());
+    return true;
+}
+
+void AutoSchedule::release_execution_slot() {
+    std::pair<ov::threading::Task, DeviceName> next;
+    {
+        std::lock_guard<std::mutex> lock(m_gate_mutex);
+        m_gate_busy = false;
+        if (!m_gate_pending_tasks.empty()) {
+            next = std::move(m_gate_pending_tasks.front());
+            m_gate_pending_tasks.pop_front();
+            m_gate_busy = true;
+        }
+    }
+    if (!next.first) {
+        LOG_DEBUG_TAG("[dynamic] inference finished, no request is waiting");
+        return;
+    }
+    LOG_DEBUG_TAG("[dynamic] inference finished, dispatching the next queued request");
+    m_dynamic_executor->run([this, task = std::move(next.first), device = std::move(next.second)]() mutable {
+        dispatch_dynamic_task(std::move(task), device);
+    });
+}
+
 AutoSchedule::~AutoSchedule() {
+    if (m_dynamic_executor) {
+        LOG_INFO_TAG("[dynamic] total inference:%ld, device switch:%ld",
+                     static_cast<long>(m_dynamic_infer_count.load()),
+                     static_cast<long>(m_dynamic_switch_count.load()));
+        m_plugin->get_executor_manager()->clear("AutoDynamicSchedule");
+        m_dynamic_executor.reset();
+    }
     // this is necessary to guarantee member destroyed after getting future
     if (m_compile_context[CPU].m_is_enabled) {
         m_exitflag = true;

--- a/src/plugins/auto/src/auto_schedule.hpp
+++ b/src/plugins/auto/src/auto_schedule.hpp
@@ -5,6 +5,8 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include <deque>
+
 #include "schedule.hpp"
 #include "async_infer_request.hpp"
 
@@ -31,6 +33,19 @@ private:
     SoCompiledModel wait_first_compiled_model_ready() override;
     void try_to_compile_model(AutoCompileContext& context, const std::shared_ptr<ov::Model>& model) override;
     bool select_other_device(const std::string& cur_dev_name) override;
+    void release_execution_slot() override;
+    /**
+     * @brief Serialize the incoming request behind the execution gate when per inference device selection is on.
+     * @return true if the request was handed over for dispatching, false if it was queued.
+     */
+    bool schedule_dynamic_task(ov::threading::Task pipeline_task, const DeviceName& preferred_device);
+    void dispatch_dynamic_task(ov::threading::Task pipeline_task, const DeviceName& preferred_device);
+    DeviceInformation select_dynamic_device();
+    /**
+     * @brief Compile the model on the given device unless it is already cached, and create its workers.
+     * @note device is updated in place when the compilation falls back to another candidate device.
+     */
+    bool ensure_device_ready(DeviceInformation& device);
     size_t                                                               m_cpuhelp_infer_count = 0;
     double                                                               m_cpuhelp_fps = 0.0;
     mutable std::once_flag                                               m_oc;
@@ -38,6 +53,15 @@ private:
     std::future<void>                                                    m_firstload_future;
     std::promise<void>                                                   m_firstload_promise;
     bool                                                                 m_exitflag = {false};
+    std::shared_ptr<ov::threading::IStreamsExecutor>                     m_dynamic_executor;
+    std::shared_ptr<ov::Model>                                           m_dynamic_model;
+    std::mutex                                                           m_gate_mutex;
+    bool                                                                 m_gate_busy = false;
+    DeviceName                                                           m_gate_current_device;
+    std::deque<std::pair<ov::threading::Task, DeviceName>>               m_gate_pending_tasks;
+    DeviceMap<SoCompiledModel>                                           m_dynamic_compiled_models;
+    std::atomic<size_t>                                                  m_dynamic_infer_count = {0};
+    std::atomic<size_t>                                                  m_dynamic_switch_count = {0};
 };
 } // namespace auto_plugin
 } // namespace ov

--- a/src/plugins/auto/src/common.hpp
+++ b/src/plugins/auto/src/common.hpp
@@ -232,6 +232,8 @@ public:
     std::string                                    m_model_precision;
     DeviceSelectionPolicy                          m_selection_policy;
     std::string                                    m_low_power_device;
+    // re-select the target device for every incoming inference, turned on by the resource aware selection properties
+    bool                                           m_dynamic_device_selection = false;
     // hold the resource of static variable to avoid the unexpected destruction.
     std::shared_ptr<std::mutex>                                          m_mtx;
     std::shared_ptr<std::map<unsigned int, std::list<std::string>>>      m_priority_map;

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -499,6 +499,15 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model_impl(const std::filesy
     }
     auto_s_context->m_startup_fallback = load_config.get_property(ov::intel_auto::enable_startup_fallback);
     auto_s_context->m_runtime_fallback = load_config.get_property(ov::intel_auto::enable_runtime_fallback);
+    auto_s_context->m_dynamic_device_selection =
+        !is_cumulative && (!auto_s_context->m_selection_policy.utilization_thresholds.empty() ||
+                           !auto_s_context->m_selection_policy.perf_curve_table.empty() ||
+                           !auto_s_context->m_low_power_device.empty());
+    if (auto_s_context->m_dynamic_device_selection) {
+        LOG_INFO_TAG("[dynamic] per inference device selection enabled by the resource aware selection properties");
+        // the CPU accelerator assumes a fixed target device for the whole model lifetime
+        auto_s_context->m_startup_fallback = false;
+    }
     // in case of mismatching shape conflict when AUTO creates the infer requests for actual device with reshaped model
     auto_s_context->m_model = model_path.empty() ? std::const_pointer_cast<ov::Model>(model) : nullptr;
     auto_s_context->m_model_path = model_path;

--- a/src/plugins/auto/src/schedule.cpp
+++ b/src/plugins/auto/src/schedule.cpp
@@ -9,6 +9,7 @@ namespace auto_plugin {
 thread_local WorkerInferRequest* Schedule::m_this_worker_infer_request = nullptr;
 // TODO: revert to the plain variable (see header file), when we moved to the next CentOS 8.x in our support matrix
 thread_local const char* Schedule::m_this_preferred_device_name = "";
+thread_local std::exception_ptr Schedule::m_this_scheduling_exception = nullptr;
 
 void Schedule::launch(const ScheduleContext::Ptr& context) {
     m_context = context;
@@ -89,7 +90,14 @@ void Schedule::generate_workers(const std::string& device, const SoCompiledModel
         (m_context->m_device_priorities.end() == it_numrequests || it_numrequests->num_requests_per_devices == -1)
             ? optimal_num
             : it_numrequests->num_requests_per_devices;
-    num_requests = (num_requests == 1) ? 2 : num_requests;
+    if (m_context->m_dynamic_device_selection) {
+        // inference is serialized per compiled model in this mode, so a single worker per device is enough and it
+        // guarantees the device carries no other inference when the next target device is re-selected
+        num_requests = 1;
+        LOG_DEBUG_TAG("device:%s, worker infer request number:%d", device.c_str(), static_cast<int>(num_requests));
+    } else {
+        num_requests = (num_requests == 1) ? 2 : num_requests;
+    }
     auto& worker_requests = m_worker_requests[device];
     auto& idle_worker_requests = m_idle_worker_requests[device];
     worker_requests.resize(num_requests);
@@ -132,7 +140,12 @@ void Schedule::generate_workers(const std::string& device, const SoCompiledModel
                         stop_retry_and_continue();
                     }
                     // try to return the request to the idle list (fails if the overall object destruction has began)
-                    if (idleGuard.release()->try_push(std::make_pair(worker_request_ptr->m_index, worker_request_ptr))) {
+                    bool returned_to_idle =
+                        idleGuard.release()->try_push(std::make_pair(worker_request_ptr->m_index, worker_request_ptr));
+                    if (m_context->m_dynamic_device_selection) {
+                        // released unconditionally, otherwise queued requests would hang once destruction has began
+                        release_execution_slot();
+                    } else if (returned_to_idle) {
                         // let's try to pop a task, as we know there is at least one idle request, schedule if succeeded
                         // if no device-agnostic tasks, let's try pop the device specific task, schedule if succeeded
                         ov::threading::Task t;
@@ -234,6 +247,11 @@ Pipeline Schedule::get_async_pipeline(const ISyncInferPtr& infer_request, Worker
             // then sets the device-agnostic tensors to the actual (device-specific) request
             Stage {
                 /*TaskExecutor*/std::dynamic_pointer_cast<ov::threading::ITaskExecutor>(shared_from_this()), /*task*/ [&infer_request, worker_infer_request]() {
+                    if (m_this_scheduling_exception) {
+                        auto scheduling_exception = m_this_scheduling_exception;
+                        m_this_scheduling_exception = nullptr;
+                        std::rethrow_exception(scheduling_exception);
+                    }
                     *worker_infer_request = m_this_worker_infer_request;
                     auto auto_request = std::dynamic_pointer_cast<InferRequest>(infer_request);
                     auto_request->set_tensors_to_another_request(m_this_worker_infer_request->m_inferrequest);

--- a/src/plugins/auto/src/schedule.hpp
+++ b/src/plugins/auto/src/schedule.hpp
@@ -26,9 +26,12 @@ public:
     // the bug is e.g. manifesting on the old CentOS (and it's 4.8.x gcc) used in our testing
     // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81880
     static thread_local const char*         m_this_preferred_device_name;
+    // set when the scheduler cannot dispatch a request, rethrown by the scheduling stage of the pipeline
+    static thread_local std::exception_ptr  m_this_scheduling_exception;
 
 protected:
     virtual void init() = 0;
+    virtual void release_execution_slot() {}
     static bool run_pipeline_task(ov::threading::Task& pipeline_task, NotBusyPriorityWorkerRequests& idle_worker_request,
                                   const DeviceName& preferred_device);
     virtual void generate_workers(const std::string& device, const SoCompiledModel& compiled_model);

--- a/src/plugins/auto/tests/unit/dynamic_device_selection_test.cpp
+++ b/src/plugins/auto/tests/unit/dynamic_device_selection_test.cpp
@@ -1,0 +1,147 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "include/auto_unit_test.hpp"
+#include "openvino/runtime/auto/properties.hpp"
+
+using namespace ov::mock_auto_plugin;
+
+// Covers the per inference device selection which AUTO turns on as soon as one of the resource aware
+// selection properties is set: the target device is re-selected for every incoming inference, inference is
+// serialized per compiled model and every device is given a single worker infer request.
+class AutoDynamicDeviceSelectionTest : public tests::AutoTest, public ::testing::Test {
+public:
+    void SetUp() override {
+        plugin->set_device_name("AUTO");
+        ON_CALL(*core,
+                compile_model(::testing::Matcher<const std::shared_ptr<const ov::Model>&>(_),
+                              ::testing::Matcher<const std::string&>(StrEq("GPU.0")),
+                              _))
+            .WillByDefault(Return(mockExeNetworkActual));
+        ON_CALL(*core,
+                compile_model(::testing::Matcher<const std::shared_ptr<const ov::Model>&>(_),
+                              ::testing::Matcher<const std::string&>(StrEq(ov::test::utils::DEVICE_CPU)),
+                              _))
+            .WillByDefault(Return(mockExeNetwork));
+        config.insert(ov::device::priorities("GPU.0,CPU"));
+    }
+
+    void TearDown() override {
+        testing::Mock::VerifyAndClearExpectations(core.get());
+        testing::Mock::VerifyAndClearExpectations(plugin.get());
+    }
+
+    // Pins the device returned by every select_device() call, so that the schedule behavior can be driven
+    // from the test instead of depending on the real telemetry backend.
+    void expect_selected_devices(const std::vector<std::string>& device_names) {
+        ON_CALL(*plugin, select_device)
+            .WillByDefault([this, device_names](const std::vector<DeviceInformation>& meta_devices,
+                                                const std::string&,
+                                                unsigned int,
+                                                const ov::auto_plugin::DeviceSelectionPolicy&,
+                                                const std::string&) {
+                const auto& expected = device_names[m_select_device_count++ % device_names.size()];
+                for (const auto& device : meta_devices) {
+                    if (device.device_name == expected) {
+                        return device;
+                    }
+                }
+                return meta_devices.front();
+            });
+    }
+
+    void run_inferences(const std::shared_ptr<ov::ICompiledModel>& compiled_model, size_t count) {
+        std::shared_ptr<ov::IAsyncInferRequest> infer_request;
+        OV_ASSERT_NO_THROW(infer_request = compiled_model->create_infer_request());
+        for (size_t i = 0; i < count; i++) {
+            OV_ASSERT_NO_THROW(infer_request->infer());
+        }
+    }
+
+    size_t m_select_device_count = 0;
+};
+
+TEST_F(AutoDynamicDeviceSelectionTest, disabled_by_default_keeps_more_than_one_worker) {
+    config.insert(ov::intel_auto::enable_startup_fallback(false));
+    // optimal_number_of_infer_requests is mocked to 1, which AUTO promotes to 2 in the classic schedule
+    EXPECT_CALL(*mockIExeNetActual.get(), create_infer_request()).Times(2).WillRepeatedly([this]() {
+        return mockIExeNetActual->ICompiledModel::create_infer_request();
+    });
+    std::shared_ptr<ov::ICompiledModel> compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = plugin->compile_model(model, config));
+}
+
+TEST_F(AutoDynamicDeviceSelectionTest, utilization_threshold_forces_single_worker) {
+    config.insert(ov::intel_auto::devices_utilization_threshold(std::map<std::string, unsigned>{{"GPU.0", 80}}));
+    EXPECT_CALL(*mockIExeNetActual.get(), create_infer_request()).Times(1).WillRepeatedly([this]() {
+        return mockIExeNetActual->ICompiledModel::create_infer_request();
+    });
+    std::shared_ptr<ov::ICompiledModel> compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = plugin->compile_model(model, config));
+}
+
+TEST_F(AutoDynamicDeviceSelectionTest, low_power_device_forces_single_worker) {
+    config.insert(ov::intel_auto::low_power_device("CPU"));
+    EXPECT_CALL(*mockIExeNetActual.get(), create_infer_request()).Times(1).WillRepeatedly([this]() {
+        return mockIExeNetActual->ICompiledModel::create_infer_request();
+    });
+    std::shared_ptr<ov::ICompiledModel> compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = plugin->compile_model(model, config));
+}
+
+TEST_F(AutoDynamicDeviceSelectionTest, perf_curve_table_forces_single_worker) {
+    config.insert(ov::intel_auto::perf_curve_table(ov::intel_auto::PerfCurveTable{{"iGPU", {{0, 1.0f}, {100, 5.0f}}}}));
+    EXPECT_CALL(*mockIExeNetActual.get(), create_infer_request()).Times(1).WillRepeatedly([this]() {
+        return mockIExeNetActual->ICompiledModel::create_infer_request();
+    });
+    std::shared_ptr<ov::ICompiledModel> compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = plugin->compile_model(model, config));
+}
+
+TEST_F(AutoDynamicDeviceSelectionTest, device_is_reselected_for_every_inference) {
+    config.insert(ov::intel_auto::devices_utilization_threshold(std::map<std::string, unsigned>{{"GPU.0", 80}}));
+    expect_selected_devices({"GPU.0"});
+    constexpr size_t infer_num = 3;
+    // one selection while compiling the model plus one selection per incoming inference
+    EXPECT_CALL(*plugin, select_device).Times(1 + infer_num);
+    std::shared_ptr<ov::ICompiledModel> compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = plugin->compile_model(model, config));
+    run_inferences(compiled_model, infer_num);
+}
+
+TEST_F(AutoDynamicDeviceSelectionTest, staying_on_the_same_device_does_not_recompile) {
+    config.insert(ov::intel_auto::devices_utilization_threshold(std::map<std::string, unsigned>{{"GPU.0", 80}}));
+    expect_selected_devices({"GPU.0"});
+    EXPECT_CALL(*core,
+                compile_model(::testing::Matcher<const std::shared_ptr<const ov::Model>&>(_),
+                              ::testing::Matcher<const std::string&>(_),
+                              ::testing::Matcher<const ov::AnyMap&>(_)))
+        .Times(1);
+    std::shared_ptr<ov::ICompiledModel> compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = plugin->compile_model(model, config));
+    run_inferences(compiled_model, 3);
+}
+
+TEST_F(AutoDynamicDeviceSelectionTest, each_device_is_compiled_only_once_when_switching_back_and_forth) {
+    config.insert(ov::intel_auto::devices_utilization_threshold(std::map<std::string, unsigned>{{"GPU.0", 80}}));
+    expect_selected_devices({"GPU.0", "CPU"});
+    EXPECT_CALL(*core,
+                compile_model(::testing::Matcher<const std::shared_ptr<const ov::Model>&>(_),
+                              ::testing::Matcher<const std::string&>(_),
+                              ::testing::Matcher<const ov::AnyMap&>(_)))
+        .Times(2);
+    std::shared_ptr<ov::ICompiledModel> compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = plugin->compile_model(model, config));
+    run_inferences(compiled_model, 4);
+}
+
+// A single worker per device used to be forbidden because the classic schedule could stall, the execution gate
+// makes it safe again, so a long sequence of inferences must keep completing.
+TEST_F(AutoDynamicDeviceSelectionTest, repeated_inferences_with_a_single_worker_do_not_stall) {
+    config.insert(ov::intel_auto::devices_utilization_threshold(std::map<std::string, unsigned>{{"GPU.0", 80}}));
+    expect_selected_devices({"GPU.0", "GPU.0", "CPU"});
+    std::shared_ptr<ov::ICompiledModel> compiled_model;
+    OV_ASSERT_NO_THROW(compiled_model = plugin->compile_model(model, config));
+    run_inferences(compiled_model, 20);
+}


### PR DESCRIPTION
This pull request introduces a new "dynamic device selection" mode to the AUTO plugin, allowing per-inference device selection based on resource-aware properties. The changes add infrastructure to serialize inference requests, queue and dispatch them as devices are re-selected, and ensure models are compiled on-demand for target devices. The implementation also handles device failures and ensures proper resource cleanup.

### Details:
 - Added the `m_dynamic_device_selection` flag to `ScheduleContext`, enabling per-inference device selection when resource-aware properties are set.
 - In `AutoSchedule`, added members and logic to serialize inference requests, queue them if a device is busy, and re-select or recompile models for each inference as needed.
 - Modified `schedule_to_worker_infer_request` to use dynamic scheduling when enabled, ensuring requests are queued and dispatched properly.
 - In `generate_workers`, limited the number of worker requests per device to one in dynamic mode to guarantee serialized execution and safe device switching.
 - Ensured that models are kept alive for on-demand compilation, and added detailed logging for device selection, compilation, and device switching events to aid debugging and profiling.

### Tickets:
 - CVS-193488

### AI Assistance:
 - *AI assistance used:  yes*
 - *If yes, summarize how AI was used and what human validation was performed (build/tests/manual checks).*
